### PR TITLE
Forward-port all missing changes from mainline rebol/rebol to Ren/C

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -272,7 +272,6 @@ remove-each: native [
 return: native [
 	{Returns a value from a function.}
 	value [any-type!]
-	/redo {Upon return, re-evaluate the returned result. (Used for DO)}
 ]
 
 switch: native [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -187,10 +187,10 @@ halt: native [
 ]
 
 if: native [
-	{If TRUE condition, return arg; evaluate block args by default}
+	{If TRUE condition, return arg; evaluate blocks by default.}
 	condition
 	true-branch
-	/only "Return block branch instead of evaluating it."
+	/only "Return block arg instead of evaluating it."
 ]
 
 loop: native [
@@ -306,10 +306,10 @@ try: native [
 ]
 
 unless: native [
-	{If FALSE condition, return arg; evaluate block args by default.}
+	{If FALSE condition, return arg; evaluate blocks by default.}
 	condition
 	false-branch
-	/only "Return block branch instead of evaluating it."
+	/only "Return block arg instead of evaluating it."
 ]
 
 until: native [

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -388,16 +388,14 @@ enum {
 
 	if (D_REF(4)) {	//QUIT
 		if (Try_Block_Halt(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
-			// We can be here for 2 reasons:
-			// 1. a QUIT/HALT condition
-			// 2. an error condition
+			// We are here because of a QUIT/HALT condition.
 			ret = DS_NEXT;
 			if (VAL_ERR_NUM(ret) == RE_QUIT)
 				ret = VAL_ERR_VALUE(ret);
 			else if (VAL_ERR_NUM(ret) == RE_HALT)
 				Halt_Code(RE_HALT, 0);
 			else
-				Throw_Error(VAL_ERR_OBJECT(ret));
+				Panic(RP_NO_CATCH);
 			*DS_OUT = *ret;
 			return R_OUT;
 		}

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -666,7 +666,6 @@ got_err:
 {
 	REBVAL *arg = D_ARG(1);
 
-	if (D_REF(2)) VAL_SET_OPT(arg, OPTS_REVAL);
 	SET_THROW(ds, RE_RETURN, arg);
 	return R_OUT;
 }

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -248,8 +248,7 @@ enum {SINE, COSINE, TANGENT};
 **
 */	REBNATIVE(shift)
 /*
-**		shift int bits /logical
-**		Clip shift at 64 bits.
+**		shift int bits arithmetic or logical
 **
 ***********************************************************************/
 {

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -159,12 +159,15 @@ static REBCNT *CRC_Table;
 {
 	REBINT m, n;
 	REBINT hash;
+	REBCNT ulen;
 
 	hash = (REBINT)len + (REBINT)((REBYTE)LO_CASE(*str));
 
-	for (; len > 0; str++, len--) {
+	ulen = (REBCNT)len; // so the & operation later isn't for the wrong type
+
+	for (; ulen > 0; str++, ulen--) {
 		n = *str;
-		if (n > 127 && (m = Decode_UTF8_Char(&str, &len))) n = m; // mods str, len
+		if (n > 127 && (m = Decode_UTF8_Char(&str, &ulen))) n = m; // mods str, ulen
 		if (n < UNICODE_CASES) n = LO_CASE(n);
 		n = (REBYTE)((hash >> CRCSHIFTS) ^ (REBYTE)n); // drop upper 8 bits
 		hash = MASK_CRC(hash << 8) ^ (REBINT)CRC_Table[n];

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -257,7 +257,7 @@
 **			-3: no match, s2 > s1
 **			-1: no match, s1 > s2
 **			 0: exact match
-**		     1: non-case match, s2 > s1
+**			 1: non-case match, s2 > s1
 **			 3: non-case match, s1 > s2
 **
 **		So, result + 2 for no-match gives proper sort order.
@@ -271,7 +271,7 @@
 	REBCNT l1 = LEN_BYTES(s1);
 	REBINT result = 0;
 
-	for (; l2 > 0; s1++, s2++, l2--) {
+	for (; l1 > 0 && l2 > 0; s1++, s2++, l1--, l2--) {
 		c1 = (REBYTE)*s1;
 		c2 = (REBYTE)*s2;
 		if (c1 > 127) c1 = Decode_UTF8_Char(&s1, &l1); //!!! can return 0 on error!
@@ -284,6 +284,7 @@
 			if (!result) result = (c1 > c2) ? 3 : 1;
 		}
 	}
+	if (l1 != l2) result = (l1 > l2) ? -1 : -3;
 
 	return result;
 }

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -855,7 +855,7 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
-*/	int Decode_UTF16(REBUNI *dst, REBYTE *src, REBINT len, REBFLG lee, REBFLG ccr)
+*/	int Decode_UTF16(REBUNI *dst, REBYTE *src, REBCNT len, REBFLG lee, REBFLG ccr)
 /*
 **		dst: the desination array, must always be large enough!
 **		src: source binary data

--- a/src/include/sys-dec-to-char.h
+++ b/src/include/sys-dec-to-char.h
@@ -2,8 +2,9 @@
 **
 **  REBOL [R3] Language Interpreter and Run-time Environment
 **
-**  Copyright 2012 REBOL Technologies
 **  REBOL is a trademark of REBOL Technologies
+**
+**  Copyright 2012 Saphirion AG
 **
 **  Licensed under the Apache License, Version 2.0 (the "License");
 **  you may not use this file except in compliance with the License.

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -42,7 +42,7 @@ function: funct: func [
 	body: copy/deep body
 	; Collect all set-words in the body as words to be used as locals, and add
 	; them to the spec. Don't include the words already in the spec or object.
-	append spec collect-words/deep/set/ignore body either with [
+	insert find/tail spec /local collect-words/deep/set/ignore body either with [
 		; Make our own local object if a premade one is not provided
 		unless object? object [object: make object! object]
 		bind body object  ; Bind any object words found in the body

--- a/src/mezz/mezz-func.r
+++ b/src/mezz/mezz-func.r
@@ -35,7 +35,7 @@ closure: func [
 	body: copy/deep body
 	; Collect all set-words in the body as words to be used as locals, and add
 	; them to the spec. Don't include the words already in the spec or object.
-	append spec collect-words/deep/set/ignore body either with [
+	insert find/tail spec /local collect-words/deep/set/ignore body either with [
 		; Make our own local object if a premade one is not provided
 		unless object? object [object: make object! object]
 		bind body object  ; Bind any object words found in the body

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -422,7 +422,7 @@ say-browser: does [
 	print "Opening web browser..."
 ]
 
-upgrade: funct [
+upgrade: function [
 	"Check for newer versions (update REBOL)."
 ][
 	print "Fetching upgrade check ..."

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -986,7 +986,7 @@ tls-read-data: func [
 	return false
 ]
 
-tls-awake: funct [event [event!]] [
+tls-awake: function [event [event!]] [
 	debug ["TLS Awake-event:" event/type]
 	port: event/port
 	tls-port: port/locals

--- a/src/os/windows/dev-event.c
+++ b/src/os/windows/dev-event.c
@@ -155,8 +155,9 @@ extern HINSTANCE App_Instance;	// From Main module.
 **
 */	DEVICE_CMD Query_Events(REBREQ *req)
 /*
-**		Wait for an event or a timeout sepecified by req->length.
-**		This is used by WAIT as the main timing method.
+**		Wait for an event, or a timeout (in milliseconds) specified by
+**		req->length. The latter is used by WAIT as the main timing
+**		method.
 **
 ***********************************************************************/
 {


### PR DESCRIPTION
This pull request incorporates all (_except one_) missing changes that were previously applied to mainline rebol/rebol but up to now missing from Atronix (and then mostly removed from Ren/C during the Atronix merge).

The following three pull requests were missing completely:

- rebol/rebol#186 (BrianHawley/fix-2109-function-local-not-at-end)
- rebol/rebol#198 (BrianHawley/wish-2121-no-return-redo)
- rebol/rebol#193 (BrianHawley/fix-2113-hash-collision)

Parts of the following six pull requests were missing (mostly just comment changes):

- rebol/rebol#185 (BrianHawley/wish-2077-no-if-else)
- rebol/rebol#167 (earl/fix-851-try-catch-quit)
- rebol/rebol#149 (ladislav/shift)
- rebol/rebol#144 (ladislav/STRTOD)
- rebol/rebol#109 (BrianHawley/wish-1973-function)
- rebol/rebol#168 (earl/fix-posix-wait-rate)

Finally, the one exception, which is _not_ contained in this pull request. The following change was merged but then reverted in Atronix:

- rebol/rebol#183 (BrianHawley/wish-2005-find-all-speedup)

--

Also see zsx/r3#26 for the corresponding pull request submitted to Atronix.