### PR TITLE
Error handling overhaul, includes CC#1743

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -18,7 +18,9 @@ Throw: [
 	code: 0
 	type: "throw error"
 	break:              {no loop to break}
+	parse-break:		{parse BREAK not in PARSE (impossible!)}
 	return:             {return or exit not in function}
+	parse-return:		{parse RETURN not in PARSE (impossible!)}
 	throw:              [{no catch for throw:} :arg1]
 	continue:           {no loop to continue}
 	halt:               [{halted by user or script}]

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -17,6 +17,7 @@ REBOL [
 Throw: [
 	code: 0
 	type: "throw error"
+	null:				{invalid error code zero}
 	break:              {no loop to break}
 	parse-break:		{parse BREAK not in PARSE (impossible!)}
 	return:             {return or exit not in function}

--- a/src/boot/task.r
+++ b/src/boot/task.r
@@ -19,9 +19,8 @@ self
 stack			; data stack
 ballast			; current memory ballast (used for GC)
 max-ballast		; ballast reset value
-this-error		; current error
-this-value		; for holding an error argument during throw back
-stack-error		; special stack error object
+thrown-arg		; for holding an error argument during throw back
+stack-error		; special stack overlow error object
 this-context	; current context
 buf-emit		; temporary emit output block
 buf-words		; temporary word cache
@@ -30,5 +29,4 @@ buf-print		; temporary print output - used by raw print
 buf-form		; temporary form buffer - used by raw print
 buf-mold		; temporary mold buffer - used by mold
 mold-loop		; mold loop detection
-err-temps		; error temporaries
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -207,10 +207,6 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		// Save error for EXPLAIN and return it
 		*Get_System(SYS_STATE, STATE_LAST_ERROR) = *error;
 
-		// Error codes of zero should not be possible, and if we returned
-		// zero that would mean success.
-		assert(VAL_ERR_NUM(error) != 0);
-
 		Print_Value(error, 1024, FALSE);
 
 		// !!! Whether or not the Rebol interpreter just throws and quits
@@ -223,7 +219,8 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		// that option!
 
 		// For RE_HALT and all other errors we return the error
-		// number.  Error numbers can be unstable.
+		// number.  Error numbers are not set in stone (currently), but
+		// are never zero...which is why we can use 0 for success.
 		return VAL_ERR_NUM(error);
 	}
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -152,8 +152,12 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	REBVAL *val;
 	REBSER *ser;
 
-	REBSER spec;
-	CLEARS(&spec);
+	REBOL_STATE state;
+	const REBVAL *error;
+
+	REBVAL start_result;
+
+	int result;
 
 	if (bin) {
 		ser = Decompress(bin, len, 10000000, 0);
@@ -187,7 +191,63 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		Set_Binary(val, ser);
 	}
 
-	return Init_Mezz(0);
+	PUSH_CATCH_ANY(&error, &state);
+
+// The first time through the following code 'error' will be NULL, but...
+// Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
+
+	if (error) {
+		if (VAL_ERR_NUM(error) == RE_QUIT) {
+			int status = VAL_ERR_STATUS(error);
+			Shutdown_Core();
+			OS_EXIT(status);
+			DEAD_END;
+		}
+
+		// Save error for EXPLAIN and return it
+		*Get_System(SYS_STATE, STATE_LAST_ERROR) = *error;
+
+		// Error codes of zero should not be possible, and if we returned
+		// zero that would mean success.
+		assert(VAL_ERR_NUM(error) != 0);
+
+		Print_Value(error, 1024, FALSE);
+
+		// !!! Whether or not the Rebol interpreter just throws and quits
+		// in an error case with a bad error code or breaks you into the
+		// console to debug the environment should be controlled by
+		// a command line option.  Defaulting to returning an error code
+		// seems better, because kicking into an interactive session can
+		// cause logging systems to hang.  For now we throw instead of
+		// just quietly returning a code if the script fails, but add
+		// that option!
+
+		// For RE_HALT and all other errors we return the error
+		// number.  Error numbers can be unstable.
+		return VAL_ERR_NUM(error);
+	}
+
+	Do_Sys_Func(SYS_CTX_FINISH_RL_START, 0);
+
+	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
+
+	// The convention in the API was to return 0 for success.  We use the
+	// convention (as for FINISH_INIT_CORE) that any non-none! result from
+	// FINISH_RL_START indicates something went wrong.
+
+	if (IS_NONE(DS_TOP))
+		result = 0;
+	else {
+		assert(FALSE); // should not happen (raise an error instead)
+		Debug_Fmt("** finish-rl-start returned non-NONE!:");
+		Debug_Fmt("%r", DS_TOP);
+		result = RE_MISC;
+	}
+
+	// Drop the result of the Do_Sys_Func call
+	DS_DROP;
+
+	return result;
 }
 
 
@@ -206,7 +266,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **
 ***********************************************************************/
 {
-	DS_RESET;
+	Panic(RP_NA);
 }
 
 
@@ -288,14 +348,122 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **
 ***********************************************************************/
 {
-	REBVAL *val;
+	REBSER *code;
+	REBSER *resolve;
+	REBCNT len;
+	REBVAL vali;
 
-	val = Do_String(text, 0);
+	REBVAL temp;
+
+	REBOL_STATE state;
+	const REBVAL *error;
+
+	assert(DSP == 0);
+
+	PUSH_CATCH_ANY(&error, &state);
+
+// The first time through the following code 'error' will be NULL, but...
+// Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
+
+	if (error) {
+		if (VAL_ERR_NUM(error) == RE_QUIT) {
+			int status = VAL_ERR_STATUS(error);
+			Shutdown_Core();
+			OS_EXIT(status);
+			DEAD_END;
+		}
+
+		// !!! Through this interface we have no way to distinguish an error
+		// returned as a value from one that was thrown.  Yet by contract
+		// we must return some sort of value--we try and patch over this
+		// by printing out the error and returning an UNSET!.  RenC has
+		// a stronger answer of offering the actual error catching interface
+		// to clients directly.
+
+		DS_PUSH_UNSET;
+
+		// !!! If the user halted during a Do_String what should we return?
+		// For now, assume the halt printed a message and don't do it again.
+		// Otherwise, we should print the FORMed error
+		if (VAL_ERR_NUM(error) != RE_HALT) {
+			// !!! statics are not safe for multithreading.
+			static REBOOL why_alert = TRUE;
+
+			Out_Value(error, 640, FALSE, 0);
+
+			// Save error for WHY?
+			*Get_System(SYS_STATE, STATE_LAST_ERROR) = *error;
+
+			// Tell them about why on the first error only
+			if (why_alert) {
+				Out_Str(
+					cb_cast("** Note: use WHY? for more error information"), 2
+				);
+				why_alert = FALSE;
+			}
+		}
+
+		if (result) {
+			REBRXT type = Reb_To_RXT[VAL_TYPE(DS_TOP)];
+			*result = Value_To_RXI(DS_TOP);
+
+			SET_TRASH(DS_TOP);
+			DS_DROP;
+
+			return type;
+		}
+
+		return -VAL_ERR_NUM(error);
+	}
+
+	code = Scan_Source(text, LEN_BYTES(text));
+	SAVE_SERIES(code);
+
+	// Bind into lib or user spaces?
+	if (flags) {
+		// Top words will be added to lib:
+		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_SET);
+		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_DEEP);
+	} else {
+		resolve = VAL_OBJ_FRAME(Get_System(SYS_CONTEXTS, CTX_USER));
+		len = resolve->tail;
+		Bind_Block(resolve, BLK_HEAD(code), BIND_ALL | BIND_DEEP);
+		SET_INTEGER(&vali, len);
+		Resolve_Context(resolve, Lib_Context, &vali, FALSE, 0);
+	}
+
+	Do_Blk(code, 0);
+	DSP++; // shift to use TOS semantics (not TOS1)
+
+	UNSAVE_SERIES(code);
+
+	if (THROWN(DS_TOP)) {
+		assert(IS_ERROR(DS_TOP));
+		Throw(DS_TOP, NULL);
+		DEAD_END;
+	}
+
+	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
 
 	if (result) {
-		*result = Value_To_RXI(val);
-		return Reb_To_RXT[VAL_TYPE(val)];
+		// Grab the result off the top of the stack and convert it to RXT
+		// and RXI if that was requested.
+
+		REBRXT type = Reb_To_RXT[VAL_TYPE(DS_TOP)];
+		*result = Value_To_RXI(DS_TOP);
+
+		// Protocol was we do not leave TOS value if result requested
+		// Overwrite with trash to ensure TOS1 semantics not used
+		SET_TRASH(DS_TOP);
+		DS_DROP;
+
+		return type;
 	}
+
+	// Value is just left on top of stack if no result parameter.  :-/
+	// (The RL API was written with ideas like "print the top of stack"
+	// while not exposing ways to analyze it unless converted to RXT/RXI)
+
 	return 0;
 }
 
@@ -418,7 +586,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **
 */	RL_API void RL_Print_TOS(REBCNT flags, const REBYTE *marker)
 /*
-**	Print top REBOL stack value to the console. (pending changes)
+**	Print top REBOL stack value to the console and drop it.
 **
 **	Returns:
 **		Nothing
@@ -431,52 +599,24 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **		The REBOL data stack is an abstract structure that can
 **		change between releases. This function allows the host
 **		to print the result of processed functions.
-**		Note that what is printed is actually TOS+1.
 **		Marker is usually "==" to show output.
 **		The system/options/result-types determine which values
 **		are automatically printed.
 **
 ***********************************************************************/
 {
-	REBINT dsp = DSP;
-	REBVAL *top = DS_VALUE(dsp+1);
-	REBOL_STATE state;
-	REBVAL *types;
+	if (DSP != 1)
+		Debug_Fmt(Str_Stack_Misaligned, DSP);
 
-	if (dsp != 0) Debug_Fmt(Str_Stack_Misaligned, dsp);
+	// We shouldn't get any THROWN() errors exposed to the user
+	assert(!IS_ERROR(DS_TOP) || !THROWN(DS_TOP));
 
-	PUSH_STATE(state, Saved_State);
-	if (SET_JUMP(state)) {
-		POP_STATE(state, Saved_State);
-		Catch_Error(DS_NEXT); // Stores error value here
-		Out_Value(DS_NEXT, 0, FALSE, 0); // error
-		DSP = 0;
-		return;
-	}
-	SET_STATE(state, Saved_State);
-
-	if (!IS_UNSET(top)) {
-		if (!IS_ERROR(top)) {
-			types = Get_System(SYS_OPTIONS, OPTIONS_RESULT_TYPES);
-			if (IS_TYPESET(types) && TYPE_CHECK(types, VAL_TYPE(top))) {
-				if (marker) Out_Str(marker, 0);
-				Out_Value(top, 500, TRUE, 1); // limit, molded
-			}
-//			else {
-//				Out_Str(Get_Type_Name(top), 1);
-//			}
-		} else {
-			if (VAL_ERR_NUM(top) != RE_HALT) {
-				Out_Value(top, 640, FALSE, 0); // error FORMed
-//				if (VAL_ERR_NUM(top) > RE_THROW_MAX) {
-//					Out_Str("** Note: use WHY? for more about this error", 1);
-//				}
-			}
-		}
+	if (!IS_UNSET(DS_TOP)) {
+		if (marker) Out_Str(marker, 0);
+		Out_Value(DS_TOP, 500, TRUE, 1); // limit, molded
 	}
 
-	POP_STATE(state, Saved_State);
-	DSP = 0;
+	DS_DROP;
 }
 
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -503,7 +503,9 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	_close(f);
 #endif
 
+	SAVE_SERIES(text);
 	rxt = RL_Do_String(text->data, flags, result);
+	UNSAVE_SERIES(text);
 
 	Free_Series(text);
 	return rxt;

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -349,7 +349,6 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 ***********************************************************************/
 {
 	REBSER *code;
-	REBSER *resolve;
 	REBCNT len;
 	REBVAL vali;
 
@@ -425,11 +424,11 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_SET);
 		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_DEEP);
 	} else {
-		resolve = VAL_OBJ_FRAME(Get_System(SYS_CONTEXTS, CTX_USER));
-		len = resolve->tail;
-		Bind_Block(resolve, BLK_HEAD(code), BIND_ALL | BIND_DEEP);
+		REBSER *user = VAL_OBJ_FRAME(Get_System(SYS_CONTEXTS, CTX_USER));
+		len = user->tail;
+		Bind_Block(user, BLK_HEAD(code), BIND_ALL | BIND_DEEP);
 		SET_INTEGER(&vali, len);
-		Resolve_Context(resolve, Lib_Context, &vali, FALSE, 0);
+		Resolve_Context(user, Lib_Context, &vali, FALSE, 0);
 	}
 
 	Do_Blk(code, 0);

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -703,7 +703,8 @@ more_path:
 	if (GET_FLAG(sigs, SIG_ESCAPE) && PG_Boot_Phase >= BOOT_MEZZ) {
 		CLR_SIGNAL(SIG_ESCAPE);
 		Eval_Sigmask = mask;
-		Halt_Code(RE_HALT, 0); // Throws!
+		Halt();
+		DEAD_END_VOID;
 	}
 
 	Eval_Sigmask = mask;
@@ -1031,7 +1032,7 @@ more_path:
 	while (index < BLK_LEN(series)) {
 		index = Do_Next(series, index, 0);
 		tos = DS_POP;
-		if (THROWN(tos)) Throw_Break(tos);
+		if (THROWN(tos)) Throw(tos, NULL);
 	}
 	// If series was empty:
 	if (!tos) {
@@ -1044,50 +1045,6 @@ more_path:
 	if (start != DSP || tos != &DS_Base[start+1]) Trap_DEAD_END(RE_MISSING_ARG);
 
 	return tos;
-}
-
-
-/***********************************************************************
-**
-*/	REBFLG Try_Block(REBSER *block, REBCNT index)
-/*
-**		Evaluate a block from the index position specified in the value.
-**		TOS+1 holds the result.
-**
-***********************************************************************/
-{
-	REBOL_STATE state;
-	REBVAL *tos;
-	jmp_buf *Last_Halt_State = Halt_State;
-
-	PUSH_STATE(state, Saved_State);
-	if (SET_JUMP(state)) {
-		/* Halt_State might become invalid, restore the one above */
-		Halt_State = Last_Halt_State;
-		POP_STATE(state, Saved_State);
-		Catch_Error(DS_NEXT); // Stores error value here
-		return TRUE;
-	}
-	SET_STATE(state, Saved_State);
-
-	tos = 0;
-	while (index < BLK_LEN(block)) {
-		index = Do_Next(block, index, 0);
-		tos = DS_POP;
-		if (THROWN(tos)) break;
-	}
-	if (!tos) {
-		// CC#2229 - respond to Halt() in code like 'forever []'
-		if (--Eval_Count <= 0 || Eval_Signals) Do_Signals();
-
-		tos = DS_NEXT; SET_UNSET(tos);
-	}
-
-	// Restore data stack and return value at TOS+1:
-	DS_Base[state.dsp+1] = *tos;
-	POP_STATE(state, Saved_State);
-
-	return FALSE;
 }
 
 
@@ -1711,149 +1668,6 @@ more_path:
 
 /***********************************************************************
 **
-*/	REBOOL Try_Block_Halt(REBSER *block, REBCNT index)
-/*
-**		Evaluate a block from the index position specified in the value,
-**		with a handler for quit conditions (QUIT, HALT) set up.
-**
-***********************************************************************/
-{
-	REBOL_STATE state;
-	REBVAL *val;
-	jmp_buf *Last_Saved_State = Saved_State;
-//	static D = 0;
-//	int depth = D++;
-
-//	Debug_Fmt("Set Halt %d", depth);
-
-	PUSH_STATE(state, Halt_State);
-	if (SET_JUMP(state)) {
-//		Debug_Fmt("Throw Halt %d", depth);
-		/* Saved_State might become invalid, restore the one above */
-		Saved_State = Last_Saved_State;
-		POP_STATE(state, Halt_State);
-		Catch_Error(DS_NEXT); // Stores error value here
-		return TRUE;
-	}
-	SET_STATE(state, Halt_State);
-
-	SAVE_SERIES(block);
-	val = Do_Blk(block, index);
-	UNSAVE_SERIES(block);
-
-	DS_Base[state.dsp+1] = *val;
-	POP_STATE(state, Halt_State);
-
-//	Debug_Fmt("Ret Halt %d", depth);
-
-	return FALSE;
-}
-
-
-/***********************************************************************
-**
-*/	REBVAL *Do_String(const REBYTE *text, REBCNT flags)
-/*
-**		Do a string. Convert it to code, then evaluate it with
-**		the ability to catch errors and also alow HALT if needed.
-**
-***********************************************************************/
-{
-	REBOL_STATE state;
-	REBSER *code;
-	REBVAL *val;
-	REBSER *rc;
-	REBCNT len;
-	REBVAL vali;
-
-	PUSH_STATE(state, Halt_State);
-	if (SET_JUMP(state)) {
-		POP_STATE(state, Halt_State);
-		Saved_State = Halt_State;
-		Catch_Error(DS_NEXT); // Stores error value here
-		val = Get_System(SYS_STATE, STATE_LAST_ERROR); // Save it for EXPLAIN
-		*val = *DS_NEXT;
-		if (VAL_ERR_NUM(val) == RE_QUIT) {
-			OS_EXIT(VAL_INT32(VAL_ERR_VALUE(DS_NEXT))); // console quit
-		}
-
-		// !!! Current weak API can't distinguish between returning an error
-		// value and evaluating to an error.  So print the error if we catch
-		// one.  (Don't worry--this function is going away.)
-		Out_Value(DS_NEXT, 640, FALSE, 0); // error FORMed
-		SET_UNSET(DS_NEXT);
-		return UNSET_VALUE;
-	}
-	SET_STATE(state, Halt_State);
-	// Use this handler for both, halt conditions (QUIT, HALT) and error
-	// conditions. As this is a top-level handler, simply overwriting
-	// Saved_State is safe.
-	Saved_State = Halt_State;
-
-	code = Scan_Source(text, LEN_BYTES(text));
-	SAVE_SERIES(code);
-
-	// Bind into lib or user spaces?
-	if (flags) {
-		// Top words will be added to lib:
-		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_SET);
-		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_DEEP);
-	}
-	else {
-		rc = VAL_OBJ_FRAME(Get_System(SYS_CONTEXTS, CTX_USER));
-		len = rc->tail;
-		Bind_Block(rc, BLK_HEAD(code), BIND_ALL | BIND_DEEP);
-		SET_INTEGER(&vali, len);
-		Resolve_Context(rc, Lib_Context, &vali, FALSE, 0);
-	}
-
-	Do_Blk(code, 0);
-	UNSAVE_SERIES(code);
-
-	POP_STATE(state, Halt_State);
-	Saved_State = Halt_State;
-
-	return DS_NEXT; // result is volatile
-}
-
-
-/***********************************************************************
-**
-*/	void Halt_Code(REBINT kind, REBVAL *arg)
-/*
-**		Halts execution by throwing back to the above Do_String.
-**		Kind is RE_HALT or RE_QUIT
-**		Arg is the optional return value.
-**
-**		Future versions may not reset the stack, but leave it as is
-**		to allow for examination and a RESUME operation.
-**
-***********************************************************************/
-{
-	REBVAL *err = TASK_THIS_ERROR;
-
-	if (!Halt_State) return;
-
-	if (arg) {
-		if (IS_NONE(arg)) {
-			SET_INTEGER(TASK_THIS_VALUE, 0);
-		} else
-			*TASK_THIS_VALUE = *arg;	// save the value
-	} else {
-		SET_NONE(TASK_THIS_VALUE);
-	}
-
-	VAL_SET(err, REB_ERROR);
-	VAL_ERR_NUM(err) = kind;
-	VAL_ERR_VALUE(err) = TASK_THIS_VALUE;
-	VAL_ERR_SYM(err) = 0;
-
-	LONG_JUMP(*Halt_State, 1);
-}
-
-
-/***********************************************************************
-**
 */	void Call_Func(REBVAL *func_val)
 /*
 **		Calls a REBOL function from C code.
@@ -2015,76 +1829,4 @@ push_arg:
 	}
 
 	return 0; // never happens
-}
-
-
-/***********************************************************************
-**
-*/	REBINT Init_Mezz(REBINT reserved)
-/*
-***********************************************************************/
-{
-	//REBVAL *val;
-	REBOL_STATE state;
-	REBVAL *val;
-	int MERGE_WITH_Do_String;
-//	static D = 0;
-//	int depth = D++;
-
-	//Debug_Fmt("Set Halt");
-
-	if (PG_Boot_Level >= BOOT_LEVEL_MODS) {
-
-		PUSH_STATE(state, Halt_State);
-		if (SET_JUMP(state)) {
-			//Debug_Fmt("Throw Halt");
-			POP_STATE(state, Halt_State);
-			Saved_State = Halt_State;
-			Catch_Error(val = DS_NEXT); // Stores error value here
-			if (IS_ERROR(val)) { // (what else could it be?)
-				val = Get_System(SYS_STATE, STATE_LAST_ERROR); // Save it for EXPLAIN
-				*val = *DS_NEXT;
-				if (VAL_ERR_NUM(val) == RE_QUIT) {
-					//Debug_Fmt("Quit(init)");
-					OS_EXIT(VAL_INT32(VAL_ERR_VALUE(val))); // console quit
-				}
-				if (VAL_ERR_NUM(val) >= RE_THROW_MAX)
-					Print_Value(val, 1000, FALSE);
-			}
-			return -1;
-		}
-		SET_STATE(state, Halt_State);
-		// Use this handler for both, halt conditions (QUIT, HALT) and error
-		// conditions. As this is a top-level handler, simply overwriting
-		// Saved_State is safe.
-		Saved_State = Halt_State;
-
-		// !!! Startup is split into two functions--both called here in a
-		// temporary commit, but separately in RL_Start() and Init_Core() in
-		// a forthcoming modification.  These are in sys-start.r, and the
-		// convention is that NONE! indicates success.
-
-		Do_Sys_Func(SYS_CTX_FINISH_INIT_CORE, NULL);
-		if (!IS_NONE(DS_TOP)) {
-			Debug_Fmt("** 'finish-init-core' returned non-none!: %r", DS_TOP);
-			Panic(RP_EARLY_ERROR);
-		}
-		DS_DROP;
-
-		Do_Sys_Func(SYS_CTX_FINISH_RL_START, NULL);
-		if (!IS_NONE(DS_TOP)) {
-			Debug_Fmt("** 'finish-rl-start' returned non-none!: %r", DS_TOP);
-			Panic(RP_EARLY_ERROR);
-		}
-		DS_DROP;
-
-		//DS_Base[state.dsp+1] = *val;
-		POP_STATE(state, Halt_State);
-		Saved_State = Halt_State;
-	}
-
-	// Cleanup stack and memory:
-	DS_RESET;
-	Recycle();
-	return 0;
 }

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -314,6 +314,8 @@
 **
 ***********************************************************************/
 {
+	ASSERT_ERROR(err);
+
 	if (!Saved_State) {
 		// Print out the error before crashing
 		Print_Value(err, 0, FALSE);
@@ -1035,3 +1037,20 @@ error:
 	flags = Security_Policy(sym, value);
 	Trap_Security(flags[policy], sym, value);
 }
+
+
+#if !defined(NDEBUG)
+
+/***********************************************************************
+**
+*/	void Assert_Error_Debug(const REBVAL *err)
+/*
+**		Debug-only implementation of ASSERT_ERROR
+**
+***********************************************************************/
+{
+	assert(VAL_ERR_NUM(err) != 0);
+	if (!THROWN(err)) ASSERT_FRAME(VAL_ERR_OBJECT(err));
+}
+
+#endif

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -37,7 +37,7 @@
 		Other important state information such as location of error
 		and function context are also saved at this point.
 
-		Throw_Error is called to throw the error back to a prior catch.
+		Throw is called to throw the error back to a prior catch.
 		A catch is defined using a set of C-macros. During the throw
 		the error object is stored in a global: This_Error (because we
 		cannot be sure that the longjmp value is able to hold a pointer
@@ -93,11 +93,22 @@
 
 */
 
+// A NOTE ABOUT "CLOBBERING" WARNINGS
+//
+// With compiler warnings on, it can tell us that values are set
+// before the setjmp and then changed before a potential longjmp.
+// Were we to try and use index in the catch body, it would be
+// undefined.  In this case we don't use it, but for technical
+// reasons GCC can't judge this case:
+//
+//     http://stackoverflow.com/q/7721854/211160
+//
+// Because of this longjmp/setjmp "clobbering", it's a useful warning to
+// have enabled in.  One option for suppressing it would be to mark
+// a parameter as 'volatile', but that is implementation-defined.
+// It is simpler to use a new variable.
 
 #include "sys-core.h"
-
-// Globals or Threaded???
-static REBOL_STATE Top_State; // Boot var: holds error state during boot
 
 
 /***********************************************************************
@@ -113,92 +124,219 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 
 /***********************************************************************
 **
-*/	void Catch_Error(REBVAL *value)
+*/	void Push_Catch_Helper(REBOL_STATE *s)
 /*
-**		Gets the current error and stores it as a value.
-**		Normally the value is on the stack and is returned.
+**		Used by both CATCH and CATCH_ANY, whose differentiation comes
+**		from how they react to the catch vs. from the initial push.
 **
 ***********************************************************************/
 {
-	if (IS_NONE(TASK_THIS_ERROR)) Panic(RP_ERROR_CATCH);
-	*value = *TASK_THIS_ERROR;
-//	Print("CE: %r", value);
-	SET_NONE(TASK_THIS_ERROR);
-	//!!! Reset or ENABLE_GC;
+	assert(Saved_State || ((DSP == 0) && (DSF == 0)));
+
+	s->dsp = DSP;
+	s->dsf = DSF;
+
+	s->hold_tail = GC_Protect->tail;
+	s->gc_disable = GC_Disabled;
+
+	s->last_state = Saved_State;
+	Saved_State = s;
+
+	// !!! garbage collector should probably walk Saved_State stack to
+	// keep the error values alive from GC, so use a "safe" trash.
+	SET_TRASH_SAFE(&s->error);
 }
 
 
 /***********************************************************************
 **
-*/	void Throw_Error(REBSER *err)
+*/	void Drop_Catch_Helper(REBOL_STATE *s, REBOOL caught)
 /*
-**		Throw the C stack.
+**		Pops a CATCH state from the list without changing the actual
+**		state of the data stack or data stack frame.
 **
 ***********************************************************************/
 {
-	if (!Saved_State) Panic(RP_NO_SAVED_STATE);
-	SET_ERROR(TASK_THIS_ERROR, ERR_NUM(err), err);
-	if (Trace_Level) Trace_Error(TASK_THIS_ERROR);
-	LONG_JUMP(*Saved_State, 1);
+	// leave DSP as-is
+	// leave DSF as-is
+
+	// !!! Should anything be done with GC_Protect->tail, s->hold_tail ?
+
+	assert(GC_Disabled == s->gc_disable);
+
+	assert(caught ? !IS_TRASH(&s->error) : IS_TRASH(&s->error));
+
+	Saved_State = s->last_state;
 }
 
 
 /***********************************************************************
 **
-*/	void Throw_Break(REBVAL *val)
+*/	REBOOL Catch_Any_Error_Helper(REBOL_STATE *state)
 /*
-**		Throw a break or return style error (for special cases
-**		where we do not want to unwind the stack).
+**		This is the core handler which is used by Catch_Error_Helper
+**		as well.  It is necessary for the /QUIT refinement of CATCH,
+**		as well as clients like Ren/C++ which need to be told when all
+**		errors happen in order to do C++ stack unwinding.  (If automatic
+**		re-throwing were used there, Ren/C++ would have no way to
+**		insinuate itself as a step in the process when calling Rebol
+**		from within a C++ routine invoked by Rebol.  Ponder that.)
 **
 ***********************************************************************/
 {
-	if (!Saved_State) Panic(RP_NO_SAVED_STATE);
-	*TASK_THIS_ERROR = *val;
-	LONG_JUMP(*Saved_State, 1);
+	// You're only supposed to throw an error.
+	assert(IS_ERROR(&state->error));
+
+	// !!! Reset or ENABLE_GC; ?
+
+	// Restore elements from initial state, like stack position and frame
+	while (DSF != state->dsf) {
+		REBINT dsf = DSF;
+		DSF = PRIOR_DSF(DSF);
+
+		// !!! Do stuff needed for each call stack frame getting blown away
+		// (in StableStack, we must release the stable frame pointer itself)
+		/* something done with dsf... */
+	}
+
+	DSP = state->dsp;
+	GC_Protect->tail = state->hold_tail;
+	GC_Disabled = state->gc_disable;
+
+	// Pop state structure (this alone won't restore DSP/DSF/etc)
+	Drop_Catch_Helper(state, TRUE);
+
+	// Halts should only be caught by the *topmost* level of
+	// execution (generally the interpreter console loop).  There is
+	// likely no good reason for a user-exposed ability to CATCH/HALT
+
+	if ((VAL_ERR_NUM(&state->error) == RE_HALT) && Saved_State)
+		Throw(&state->error, NULL);
+
+	return TRUE;
 }
 
 
 /***********************************************************************
 **
-*/	void Throw_Return_Series(REBCNT type, REBSER *series)
+*/	REBOOL Catch_Error_Helper(REBOL_STATE *state)
 /*
-**		Throws a series value using error temp values.
+**		Pushes a TRY state.  Kept as separate operation because if a
+**      CATCH never happens, you must remember to DROP_CATCH.  (If the
+**      catch does happen, this is done for you automatically.)
 **
 ***********************************************************************/
 {
-	REBVAL *val;
-	REBVAL *err;
-	REBSER *blk = VAL_SERIES(TASK_ERR_TEMPS);
+	// If the state has no parent, then it is the topmost level.  It
+	// *must* use Catch_Any_Error and be able to handle anything.
 
-	RESET_SERIES(blk);
-	val = Alloc_Tail_Blk(blk);
-	Set_Series(type, val, series);
-	err = Alloc_Tail_Blk(blk);
-	SET_THROW(err, RE_RETURN, val);
-	VAL_ERR_SYM(err) = SYM_RETURN; // indicates it is "virtual" (parse return)
-	Throw_Break(err);
+	assert(state->last_state);
+
+	// This is a simple wrapper over Catch_Any_Error, and might even
+	// be better done in the macro.
+
+	Catch_Any_Error_Helper(state);
+
+	// If you want to catch a QUIT, you must be a construct that uses
+	// Catch_Any_Error.  Using Catch_Error_Helper will just rethrow.
+
+	if (VAL_ERR_NUM(&state->error) == RE_QUIT)
+		Throw(&state->error, NULL);
+
+	return TRUE;
 }
 
 
 /***********************************************************************
 **
-*/	void Throw_Return_Value(REBVAL *value)
+*/	void Add_Thrown_Arg_Debug(REBVAL *err, const REBVAL *arg)
 /*
-**		Throws a series value using error temp values.
+***********************************************************************/
+{
+	assert(IS_ERROR(err) && THROWN(err));
+
+	// See notes about assertion in Take_Thrown_Arg_Debug.  TBD.
+
+	/* assert(IS_TRASH(TASK_THROWN_ARG)); */
+
+	*TASK_THROWN_ARG = *arg;
+}
+
+
+/***********************************************************************
+**
+*/	void Take_Thrown_Arg_Debug(REBVAL *out, const REBVAL *err)
+/*
+**		WARNING: 'out' can be the same pointer as 'err'
 **
 ***********************************************************************/
 {
-	REBVAL *val;
-	REBVAL *err;
-	REBSER *blk = VAL_SERIES(TASK_ERR_TEMPS);
+	assert(IS_ERROR(err) && THROWN(err));
 
-	RESET_SERIES(blk);
-	val = Alloc_Tail_Blk(blk);
-	*val = *value;
-	err = Alloc_Tail_Blk(blk);
-	SET_THROW(err, RE_RETURN, val);
-	VAL_ERR_SYM(err) = SYM_RETURN; // indicates it is "virtual" (parse return)
-	Throw_Break(err);
+	// This assertion is a nice idea, but practically speaking we don't
+	// currently have a moment when an error is caught with PUSH_CATCH
+	// to set it to trash...only if it has its value processed as a
+	// function return or loop break, etc.  One way of fixing it would
+	// be to make PUSH_CATCH take 3 arguments instead of 2, and store
+	// the error argument in the Rebol_State if it gets thrown...but
+	// that looks a bit ugly.  Think more on this.
+
+	/* assert(!IS_TRASH(TASK_THROWN_ARG)); */
+
+	*out = *TASK_THROWN_ARG;
+
+	// The THROWN_ARG lives under the root set, and must be a value
+	// that won't trip up the GC.
+	SET_TRASH_SAFE(TASK_THROWN_ARG);
+}
+
+
+/***********************************************************************
+**
+*/	void Throw(const REBVAL *err, const REBVAL *arg_add)
+/*
+**		Throw to the enclosing PUSH_CATCH or PUSH_CATCH_ANY.  Although
+**		the item type being thrown is a value of type "ERROR!", not
+**		all such values represent failures.  The same mechanism is
+**		used to do non-local jumps, so the THROWN() categories of
+**		error can represent e.g. RETURN or BREAK or CONTINUE.
+**
+***********************************************************************/
+{
+	if (!Saved_State) {
+		// Print out the error before crashing
+		Print_Value(err, 0, FALSE);
+		Panic(RP_NO_SAVED_STATE); // or RP_NO_CATCH ?
+	}
+
+	if (Trace_Level) {
+		if (THROWN(err)) {
+			// !!! Write some kind of error tracer for errors that do not
+			// have frames, so you can trace quits/etc.
+		} else
+			Debug_Fmt(
+				cs_cast(BOOT_STR(RS_TRACE, 10)),
+				&VAL_ERR_VALUES(err)->type,
+				&VAL_ERR_VALUES(err)->id
+			);
+	}
+
+	// Error may live in a local variable whose stack is going away,
+	// on the stack, or other unstable location.  Copy before the jump.
+
+	Saved_State->error = *err;
+
+	// Passing an argument will "add" it to the error, if it is a
+	// THROWN-class error like a RETURN that has an associated value.
+	// This will assert if you try to add an argument to an error
+	// that you are passing on which already had an argument added.
+
+	if (arg_add) {
+		assert(THROWN(err));
+		ADD_THROWN_ARG(&Saved_State->error, arg_add);
+	}
+
+	LONG_JUMP(Saved_State->cpu_state, 1);
 }
 
 
@@ -215,9 +353,43 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 {
 	if (!Saved_State) Panic(RP_NO_SAVED_STATE);
 
-	*TASK_THIS_ERROR = *TASK_STACK_ERROR; // pre-allocated
+	Saved_State->error = *TASK_STACK_ERROR; // pre-allocated
 
-	LONG_JUMP(*Saved_State, 1);
+	LONG_JUMP(Saved_State->cpu_state, 1);
+}
+
+
+/***********************************************************************
+**
+*/	void Quit(int status)
+/*
+**		A QUIT is thrown and can't be caught by a normal CATCH, you
+**		have to use a PUSH_CATCH_ANY
+**
+***********************************************************************/
+{
+	REBVAL err;
+	VAL_SET(&err, REB_ERROR);
+	VAL_ERR_NUM(&err) = RE_QUIT;
+	VAL_ERR_STATUS(&err) = status;
+	Throw(&err, NULL);
+}
+
+
+/***********************************************************************
+**
+*/	void Halt(void)
+/*
+**		Halts are designed to go all the way up to the top level of
+**		the CATCH stack.  They cannot be intercepted by any
+**		intermediate stack levels.
+**
+***********************************************************************/
+{
+	REBVAL err;
+	VAL_SET(&err, REB_ERROR);
+	VAL_ERR_NUM(&err) = RE_HALT;
+	Throw(&err, NULL);
 }
 
 
@@ -349,6 +521,8 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 	ERROR_OBJ *error;	// Error object values
 	REBINT code = 0;
 
+	VAL_SET(value, REB_ERROR);
+
 	// Create a new error object from another object, including any non-standard fields:
 	if (IS_ERROR(arg) || IS_OBJECT(arg)) {
 		err = Merge_Frames(VAL_OBJ_FRAME(ROOT_ERROBJ),
@@ -358,7 +532,8 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 			if (!Find_Error_Info(error, &code)) code = RE_INVALID_ERROR;
 			SET_INTEGER(&error->code, code);
 //		}
-		SET_ERROR(value, VAL_INT32(&error->code), err);
+		VAL_ERR_NUM(value) = VAL_INT32(&error->code);
+		VAL_ERR_OBJECT(value) = err;
 		return;
 	}
 
@@ -366,7 +541,8 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 	err = CLONE_OBJECT(VAL_OBJ_FRAME(ROOT_ERROBJ));
 	error = ERR_VALUES(err);
 	SET_NONE(&error->id);
-	SET_ERROR(value, 0, err);
+	VAL_SET(value, REB_ERROR);
+	VAL_ERR_OBJECT(value) = err;
 
 	// If block arg, evaluate object values (checking done later):
 	// If user set error code, use it to setup type and id fields.
@@ -459,8 +635,14 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 /*
 ***********************************************************************/
 {
+	REBVAL error;
+
 	assert(num >= RE_THROW_MAX);
-	Throw_Error(Make_Error(num, 0, 0, 0));
+
+	VAL_SET(&error, REB_ERROR);
+	VAL_ERR_NUM(&error) = num;
+	VAL_ERR_OBJECT(&error) = Make_Error(num, 0, 0, 0);
+	Throw(&error, NULL);
 }
 
 
@@ -470,8 +652,14 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 /*
 ***********************************************************************/
 {
+	REBVAL error;
+
 	assert(num >= RE_THROW_MAX);
-	Throw_Error(Make_Error(num, arg1, 0, 0));
+
+	VAL_SET(&error, REB_ERROR);
+	VAL_ERR_NUM(&error) = num;
+	VAL_ERR_OBJECT(&error) = Make_Error(num, arg1, 0, 0);
+	Throw(&error, NULL);
 }
 
 
@@ -481,8 +669,14 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 /*
 ***********************************************************************/
 {
+	REBVAL error;
+
 	assert(num >= RE_THROW_MAX);
-	Throw_Error(Make_Error(num, arg1, arg2, 0));
+
+	VAL_SET(&error, REB_ERROR);
+	VAL_ERR_NUM(&error) = num;
+	VAL_ERR_OBJECT(&error) = Make_Error(num, arg1, arg2, 0);
+	Throw(&error, NULL);
 }
 
 
@@ -492,8 +686,14 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 /*
 ***********************************************************************/
 {
+	REBVAL error;
+
 	assert(num >= RE_THROW_MAX);
-	Throw_Error(Make_Error(num, arg1, arg2, arg3));
+
+	VAL_SET(&error, REB_ERROR);
+	VAL_ERR_NUM(&error) = num;
+	VAL_ERR_OBJECT(&error) = Make_Error(num, arg1, arg2, arg3);
+	Throw(&error, NULL);
 }
 
 
@@ -643,8 +843,7 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 /*
 **		Process a loop exceptions. Pass in the TOS value, returns:
 **
-**			 2 - if break/return, change val to that set by break
-**			 1 - if break
+**			 1 - break (or break/return, which changes val)
 **			-1 - if continue, change val to unset
 **			 0 - if not break or continue
 **			else: error if not an ERROR value
@@ -657,13 +856,8 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 
 	// If it's a BREAK, check for /return value:
 	if (IS_BREAK(val)) {
-		if (VAL_ERR_VALUE(val)) {
-			*val = *VAL_ERR_VALUE(val);
-			return 2;
-		} else {
-			SET_UNSET(val);
-			return 1;
-		}
+		TAKE_THROWN_ARG(val, val);
+		return 1;
 	}
 
 	if (IS_CONTINUE(val)) {
@@ -690,24 +884,11 @@ static REBOL_STATE Top_State; // Boot var: holds error state during boot
 	errs = Construct_Object(0, VAL_BLK(errors), 0);
 	Set_Object(Get_System(SYS_CATALOG, CAT_ERRORS), errs);
 
-	Set_Root_Series(TASK_ERR_TEMPS, Make_Block(3), "task errors");
-
 	// Create objects for all error types:
 	for (val = BLK_SKIP(errs, 1); NOT_END(val); val++) {
 		errs = Construct_Object(0, VAL_BLK(val), 0);
 		SET_OBJECT(val, errs);
 	}
-
-	// Catch top level errors, to provide decent output:
-	PUSH_STATE(Top_State, Saved_State);
-	if (SET_JUMP(Top_State)) {
-		POP_STATE(Top_State, Saved_State);
-		DSP++; // Room for return value
-		Catch_Error(DS_TOP); // Stores error value here
-		Print_Value(DS_TOP, 0, FALSE);
-		Panic(RP_NO_CATCH);
-	}
-	SET_STATE(Top_State, Saved_State);
 }
 
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -416,7 +416,7 @@
 	result = Do_Blk(VAL_FUNC_BODY(func), 0);
 	ds = DS_OUT;
 
-	if (IS_ERROR(result) && IS_RETURN(result)) {
+	if (IS_ERROR(result) && VAL_ERR_NUM(result) == RE_RETURN) {
 		TAKE_THROWN_ARG(ds, result);
 	}
 	else *ds = *result; // Set return value (atomic)
@@ -455,7 +455,7 @@
 	result = Do_Blk(body, 0); // GC-OK - also, result returned on DS stack
 	ds = DS_OUT;
 
-	if (IS_ERROR(result) && IS_RETURN(result)) {
+	if (IS_ERROR(result) && VAL_ERR_NUM(result) == RE_RETURN) {
 		TAKE_THROWN_ARG(ds, result);
 	}
 	else *ds = *result; // Set return value (atomic)

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -417,12 +417,7 @@
 	ds = DS_OUT;
 
 	if (IS_ERROR(result) && IS_RETURN(result)) {
-		// Value below is kept safe from GC because no-allocation is
-		// done between point of SET_THROW and here.
-		if (VAL_ERR_VALUE(result))
-			*ds = *VAL_ERR_VALUE(result);
-		else
-			SET_UNSET(ds);
+		TAKE_THROWN_ARG(ds, result);
 	}
 	else *ds = *result; // Set return value (atomic)
 }
@@ -461,12 +456,7 @@
 	ds = DS_OUT;
 
 	if (IS_ERROR(result) && IS_RETURN(result)) {
-		// Value below is kept safe from GC because no-allocation is
-		// done between point of SET_THROW and here.
-		if (VAL_ERR_VALUE(result))
-			*ds = *VAL_ERR_VALUE(result);
-		else
-			SET_UNSET(ds);
+		TAKE_THROWN_ARG(ds, result);
 	}
 	else *ds = *result; // Set return value (atomic)
 }

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -212,7 +212,8 @@
 	while (wt) {
 		if (GET_SIGNAL(SIG_ESCAPE)) {
 			CLR_SIGNAL(SIG_ESCAPE);
-			Halt_Code(RE_HALT, 0); // Throws!
+			Halt();
+			DEAD_END;
 		}
 
 		// Process any waiting events:

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -639,7 +639,8 @@
 		return;
 	}
 
-	Throw_Error(frame); // ENABLE_GC implied
+	Throw(&error, NULL); // ENABLE_GC implied
+	DEAD_END_VOID;
 }
 
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -357,7 +357,7 @@ enum {
 **
 ***********************************************************************/
 {
-	REBVAL *value = D_REF(1) ? D_ARG(2) : NONE_VALUE;
+	REBVAL *value = D_REF(1) ? D_ARG(2) : UNSET_VALUE;
 
 	VAL_SET(D_OUT, REB_ERROR);
 	VAL_ERR_NUM(D_OUT) = RE_BREAK;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -323,9 +323,28 @@ enum {
 /*
 ***********************************************************************/
 {
-	Try_Block(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)));
-	if (IS_ERROR(DS_NEXT) && !IS_THROW(DS_NEXT)) return R_NONE;
-	return R_TOS1;
+	REBOL_STATE state;
+	const REBVAL *error;
+
+	PUSH_CATCH(&error, &state);
+
+// The first time through the following code 'error' will be NULL, but...
+// Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
+
+	if (error) {
+		*D_OUT = *error;
+		return R_OUT;
+	}
+
+	Do_Blk(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)));
+	DSP++; // TOS semantics instead of TOS1!
+
+	if (IS_ERROR(DS_TOP) && !IS_THROW(DS_TOP))
+		SET_NONE(DS_TOP); // ignore error
+
+	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
+
+	return R_TOS;
 }
 
 
@@ -333,12 +352,17 @@ enum {
 **
 */	REBNATIVE(break)
 /*
+**		1: /return
+**		2: value
+**
 ***********************************************************************/
 {
-	REBVAL *value = 0;
+	REBVAL *value = D_REF(1) ? D_ARG(2) : NONE_VALUE;
 
-	if (D_REF(1)) value = D_ARG(2);  // /return
-	SET_THROW(ds, RE_BREAK, value);
+	VAL_SET(D_OUT, REB_ERROR);
+	VAL_ERR_NUM(D_OUT) = RE_BREAK;
+	ADD_THROWN_ARG(D_OUT, value);
+
 	return R_OUT;
 }
 
@@ -383,35 +407,55 @@ enum {
 ***********************************************************************/
 {
 	REBVAL *val;
-	REBVAL *ret;
 	REBCNT sym;
+	REBOOL catch_quit = D_REF(4); // Should we catch QUIT too?
 
-	if (D_REF(4)) {	//QUIT
-		if (Try_Block_Halt(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
-			// We are here because of a QUIT/HALT condition.
-			ret = DS_NEXT;
-			if (VAL_ERR_NUM(ret) == RE_QUIT)
-				ret = VAL_ERR_VALUE(ret);
-			else if (VAL_ERR_NUM(ret) == RE_HALT)
-				Halt_Code(RE_HALT, 0);
-			else
-				Panic(RP_NO_CATCH);
-			*DS_OUT = *ret;
+	REBOL_STATE state;
+	const REBVAL *error;
+
+	PUSH_CATCH_ANY(&error, &state);
+
+// The first time through the following code 'error' will be NULL, but...
+// Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
+
+	if (error) {
+		// We don't ever want to catch HALT from inside a native; re-throw
+		if (VAL_ERR_NUM(error) == RE_HALT) {
+			Throw(error, NULL);
+			DEAD_END;
+		}
+
+		if (VAL_ERR_NUM(error) == RE_QUIT) {
+			// If they didn't want to catch quits then re-throw
+			if (!catch_quit) {
+				Throw(error, NULL);
+				DEAD_END;
+			}
+
+			// Otherwise, extract the exit status.
+			// !!! How does CATCH/QUIT know it caught a QUIT?
+			assert(IS_TRASH(TASK_THROWN_ARG));
+			SET_INTEGER(D_OUT, VAL_ERR_STATUS(error));
 			return R_OUT;
 		}
-		return R_TOS1;
+
+		*D_OUT = *error;
+		return R_OUT;
 	}
 
 	// Evaluate the block:
-	ret = DO_BLK(D_ARG(1));
+	Do_Blk(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)));
+	DSP++; // Use TOS semantics, not TOS1
+
+	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
 
 	// If it is a throw, process it:
-	if (IS_ERROR(ret) && VAL_ERR_NUM(ret) == RE_THROW) {
+	if (IS_ERROR(DS_TOP) && VAL_ERR_NUM(DS_TOP) == RE_THROW) {
 
 		// If a named throw, then check it:
 		if (D_REF(2)) { // /name
 
-			sym = VAL_ERR_SYM(ret);
+			sym = VAL_ERR_SYM(DS_TOP);
 			val = D_ARG(3); // name symbol
 
 			// If name is the same word:
@@ -420,17 +464,17 @@ enum {
 			// If it is a block of words:
 			else if (IS_BLOCK(val)) {
 				for (val = VAL_BLK_DATA(val); NOT_END(val); val++) {
-					if (IS_WORD(val) && sym == VAL_WORD_CANON(val)) goto got_err;
+					if (IS_WORD(val) && sym == VAL_WORD_CANON(val))
+						goto got_err;
 				}
 			}
 		} else {
 got_err:
-			*ds = *(VAL_ERR_VALUE(ret));
-			return R_OUT;
+			TAKE_THROWN_ARG(DS_TOP, DS_TOP);
 		}
 	}
 
-	return R_TOS1;
+	return R_TOS;
 }
 
 
@@ -440,9 +484,14 @@ got_err:
 /*
 ***********************************************************************/
 {
-	SET_THROW(ds, RE_THROW, D_ARG(1));
+	VAL_SET(D_OUT, REB_ERROR);
+	VAL_ERR_NUM(D_OUT) = RE_THROW;
 	if (D_REF(2)) // /name
-		VAL_ERR_SYM(ds) = VAL_WORD_SYM(D_ARG(3));
+		VAL_ERR_SYM(D_OUT) = VAL_WORD_SYM(D_ARG(3));
+	else
+		VAL_ERR_SYM(D_OUT) = SYM_NOT_USED;
+	ADD_THROWN_ARG(D_OUT, D_ARG(1));
+
 	return R_OUT;
 }
 
@@ -482,7 +531,9 @@ got_err:
 /*
 ***********************************************************************/
 {
-	SET_THROW(ds, RE_CONTINUE, NONE_VALUE);
+	VAL_SET(D_OUT, REB_ERROR);
+	VAL_ERR_NUM(D_OUT) = RE_CONTINUE;
+
 	return R_OUT;
 }
 
@@ -540,8 +591,13 @@ got_err:
 		return R_OUT;
 
 	case REB_ERROR:
-		if (IS_THROW(value)) return R_ARG1;
-		Throw_Error(VAL_ERR_OBJECT(value));
+		if (IS_THROW(value)) {
+			// @HostileFork wants to know if this happens.  It shouldn't
+			// (but there was code here that seemed to think it could)
+			assert(FALSE);
+			return R_ARG1;
+		}
+		Throw(value, NULL);
 
 	case REB_BINARY:
 	case REB_STRING:
@@ -588,7 +644,10 @@ got_err:
 /*
 ***********************************************************************/
 {
-	SET_THROW(ds, RE_RETURN, 0);
+	VAL_SET(D_OUT, REB_ERROR);
+	VAL_ERR_NUM(D_OUT) = RE_RETURN;
+	ADD_THROWN_ARG(D_OUT, UNSET_VALUE);
+
 	return R_OUT;
 }
 
@@ -666,7 +725,10 @@ got_err:
 {
 	REBVAL *arg = D_ARG(1);
 
-	SET_THROW(ds, RE_RETURN, arg);
+	VAL_SET(D_OUT, REB_ERROR);
+	VAL_ERR_NUM(D_OUT) = RE_RETURN;
+	ADD_THROWN_ARG(D_OUT, arg);
+
 	return R_OUT;
 }
 
@@ -715,33 +777,64 @@ got_err:
 **
 */	REBNATIVE(try)
 /*
+**		1: block
+**		2: /except
+**		3: code
+**
 ***********************************************************************/
 {
 	REBFLG except = D_REF(2);
 	REBVAL handler = *D_ARG(3); // TRY exception will trim the stack
 
-	if (Try_Block(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
+	REBOL_STATE state;
+	const REBVAL *error;
+
+	PUSH_CATCH(&error, &state);
+
+// The first time through the following code 'error' will be NULL, but...
+// Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
+
+	if (error) {
 		if (except) {
-			if (IS_BLOCK(&handler)) {
-				DO_BLK(&handler);
+			if (IS_BLOCK(D_ARG(3))) {
+				// forget the result of the try.
+				Do_Blk(VAL_SERIES(D_ARG(3)), VAL_INDEX(D_ARG(3)));
+				DSP++; // TOS semantics, not TOS1!
+				return R_TOS;
 			}
-			else { // do func[err] error
-				REBVAL error = *DS_NEXT; // will get overwritten
+			else if (ANY_FUNC(D_ARG(3))) {
+				// !!! REVIEW: What about zero arity functions or functions of
+				// arity greater than 1?  What about a function that has
+				// more args via refinements but can still act as an
+				// arity one function without those refinements?
+
 				REBVAL *args = BLK_SKIP(VAL_FUNC_ARGS(&handler), 1);
-				if (NOT_END(args) && !TYPE_CHECK(args, VAL_TYPE(&error))) {
+				if (NOT_END(args) && !TYPE_CHECK(args, VAL_TYPE(error))) {
 					// TODO: This results in an error message such as "action!
 					// does not allow error! for its value1 argument". A better
 					// message would be more like "except handler does not
 					// allow error! for its value1 argument."
-					Trap3_DEAD_END(RE_EXPECT_ARG, Of_Type(&handler), args, Of_Type(&error));
+					Trap3_DEAD_END(RE_EXPECT_ARG, Of_Type(&handler), args, Of_Type(error));
 				}
-				Apply_Func(0, &handler, &error, 0);
+				Apply_Func(NULL, &handler, error, NULL);
 				return R_TOS;
 			}
+			else
+				Panic(RP_MISC); // should not be possible (type-checking)
+
+			DEAD_END;
 		}
+
+		*D_OUT = *error;
+		return R_OUT;
 	}
 
-	return R_TOS1;
+	Do_Blk(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)));
+	DSP++; // TOS semantics, not TOS1!
+
+	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
+
+	return R_TOS;
 }
 
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -710,10 +710,10 @@ got_err:
 **
 */	REBNATIVE(return)
 /*
-**		Returns a value from the current function. The error value
-**		is built in the RETURN slot, with the arg being kept in
-**		the ARG1 slot on the stack.  As long as DSP is greater, both
-**		values are safe from GC.
+**		Returns a value from the current function. This is done by
+**		returning a special "error!" which indicates a return, and
+**		putting the returned value into an associated task-local
+**		variable (only one of these is in effect at a time).
 **
 ***********************************************************************/
 {

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -331,16 +331,10 @@ enum {
 // The first time through the following code 'error' will be NULL, but...
 // Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
 
-	if (error) {
-		*D_OUT = *error;
-		return R_OUT;
-	}
+	if (error) return R_NONE;
 
 	Do_Blk(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)));
 	DSP++; // TOS semantics instead of TOS1!
-
-	if (IS_ERROR(DS_TOP) && !IS_THROW(DS_TOP))
-		SET_NONE(DS_TOP); // ignore error
 
 	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -37,7 +37,7 @@
 /*
 ***********************************************************************/
 {
-	Halt_Code(RE_HALT, 0);
+	Halt();
 	DEAD_END;
 }
 
@@ -48,22 +48,16 @@
 /*
 **		1: /return
 **		2: value
-**		3: /now
 **
 ***********************************************************************/
 {
-	REBVAL *val = D_ARG(2);
-
-	if (D_REF(3)) {
-		REBINT n = 0;
-		if (D_REF(1)) {
-			assert(IS_INTEGER(val));
-			n = Int32(val);
-		}
-		OS_EXIT(n);
+	if (D_REF(1)) {
+		assert(IS_INTEGER(D_ARG(2)));
+		Quit(Int32(D_ARG(2)));
 	}
+	else
+		Quit(0);
 
-	Halt_Code(RE_QUIT, val); // NONE if /return not set
 	DEAD_END;
 }
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -585,7 +585,7 @@ bad_target:
 
 	// Value is on top of stack (volatile!):
 	value = *DS_POP;
-	if (THROWN(&value)) Throw_Break(&value);
+	if (THROWN(&value)) Throw(&value, NULL);
 
 	// Get variable or command:
 	if (IS_WORD(item)) {
@@ -751,10 +751,27 @@ bad_target:
 						SET_FLAG(flags, PF_CHANGE);
 						continue;
 
+					// There are two RETURNs: one is a matching form, so with
+					// 'parse data [return "abc"]' you are not asking to
+					// return the literal string "abc" independent of input.
+					// it will only return if "abc" matches.  This works for
+					// a rule reference as well, such as 'return rule'.
+					//
+					// The second option is if you put the value in parens,
+					// in which case it will just return whatever that value
+					// happens to be, e.g. 'parse data [return ("abc")]'
+
 					case SYM_RETURN:
 						if (IS_PAREN(rules)) {
-							item = Do_Block_Value_Throw(rules); // might GC
-							Throw_Return_Value(item);
+							REBVAL err;
+
+							VAL_SET(&err, REB_ERROR);
+							VAL_ERR_NUM(&err) = RE_PARSE_RETURN;
+
+							item = Do_Block_Value_Throw(rules);
+
+							Throw(&err, item);
+							DEAD_END;
 						}
 						SET_FLAG(flags, PF_RETURN);
 						continue;
@@ -1036,10 +1053,22 @@ post:
 					}
 				}
 				if (GET_FLAG(flags, PF_RETURN)) {
-					REBSER *ser = (IS_BLOCK_INPUT(parse))
-						? Copy_Block_Len(series, begin, count)
-						: Copy_String(series, begin, count); // condenses
-					Throw_Return_Series(parse->type, ser);
+					// See notes on PARSE's return in handling of SYM_RETURN
+					REBVAL err;
+					REBVAL arg;
+
+					VAL_SET(&err, REB_ERROR);
+					VAL_ERR_NUM(&err) = RE_PARSE_RETURN;
+
+					VAL_SET(&arg, parse->type);
+					VAL_SERIES(&arg) =
+						IS_BLOCK_INPUT(parse)
+							? Copy_Block_Len(series, begin, count)
+							: Copy_String(series, begin, count); // condenses
+					VAL_INDEX(&arg) = 0;
+
+					Throw(&err, &arg);
+					DEAD_END;
 				}
 				if (GET_FLAG(flags, PF_REMOVE)) {
 					if (count) Remove_Series(series, begin, count);
@@ -1267,28 +1296,38 @@ bad_end:
 	else {
 		REBCNT n;
 		REBOL_STATE state;
-		// Let user RETURN and THROW out of the PARSE. All other errors should relay.
-		PUSH_STATE(state, Saved_State);
-		if (SET_JUMP(state)) {
-			POP_STATE(state, Saved_State);
-			Catch_Error(arg = DS_OUT); // Stores error value here
-			if (VAL_ERR_NUM(arg) == RE_BREAK) {
-				if (!VAL_ERR_VALUE(arg)) return R_NONE;
-				*DS_OUT = *VAL_ERR_VALUE(arg);
+		const REBVAL *error;
+
+		PUSH_CATCH(&error, &state);
+
+// The first time through the following code 'error' will be NULL, but...
+// Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
+
+		if (error) {
+			// We use a special kind of BREAK and RETURN to be caught by
+			// PARSE so we differentiate between:
+			//
+			//	   foo: func [] [parse "1020" [(return true)]
+			//	   bar: func [] [parse "0304" [return false]]
+			if (
+				(VAL_ERR_NUM(error) == RE_PARSE_BREAK)
+				|| (VAL_ERR_NUM(error) == RE_PARSE_RETURN)
+			) {
+				TAKE_THROWN_ARG(D_OUT, error);
 				return R_OUT;
 			}
-			if (VAL_ERR_NUM(arg) == RE_RETURN && VAL_ERR_SYM(arg) == SYM_RETURN) {
-				*DS_OUT = *VAL_ERR_VALUE(arg);
-				return R_OUT;
-			}
-			// How to handle RETURN, BREAK, etc. ???? does not work !!!!
-			if (THROWN(DS_OUT)) return R_OUT; //Throw_Break(DS_OUT);
-			Throw_Error(VAL_ERR_OBJECT(DS_OUT));
+
+			// Re-throw all other errors.
+			Throw(error, NULL);
+			DEAD_END;
 		}
-		SET_STATE(state, Saved_State);
-		n = Parse_Series(val, VAL_BLK_DATA(arg), (opts & PF_CASE) ? AM_FIND_CASE : 0, 0);
-		SET_LOGIC(DS_OUT, n >= VAL_TAIL(val) && n != NOT_FOUND);
-		POP_STATE(state, Saved_State);
+
+		// opts is volatile across a setjmp/longjmp, so we re-read D_REF(4)
+		// for the casing instead of using opts
+
+		n = Parse_Series(val, VAL_BLK_DATA(arg), D_REF(4) ? AM_FIND_CASE : 0, 0);
+		SET_LOGIC(D_OUT, n >= VAL_TAIL(val) && n != NOT_FOUND);
+		DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
 	}
 
 	return R_OUT;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1324,7 +1324,14 @@ bad_end:
 				return R_OUT;
 			}
 
-			// Re-throw all other errors.
+			// If a THROWN style error, evaluate to that so that it can
+			// bubble up the stack.
+			if (THROWN(error)) {
+				*D_OUT = *error;
+				return R_OUT;
+			}
+
+			// Trap all other errors that aren't implicitly thrown...
 			Throw(error, NULL);
 			DEAD_END;
 		}

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1304,11 +1304,18 @@ bad_end:
 // Throw() can longjmp here, so 'error' won't be NULL *if* that happens!
 
 		if (error) {
-			// We use a special kind of BREAK and RETURN to be caught by
-			// PARSE so we differentiate between:
+			// We use a special kind of RETURN to be caught by PARSE so we
+			// differentiate between:
 			//
 			//	   foo: func [] [parse "1020" [(return true)]
 			//	   bar: func [] [parse "0304" [return false]]
+			//
+			// !!! I added a RE_PARSE_BREAK as a review point, as it seemed
+			// like there was a function Throw_Break which corresponded to
+			// a special Throw_Return used by PARSE.  In the end, BREAK and
+			// ACCEPT (what's the difference?) seem to work another way.
+			// Leaving RE_PARSE_BREAK until all is understood.  --HF
+
 			if (
 				(VAL_ERR_NUM(error) == RE_PARSE_BREAK)
 				|| (VAL_ERR_NUM(error) == RE_PARSE_RETURN)

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -58,8 +58,6 @@ PVAR REBI64 PG_Boot_Time;	// Counter when boot started
 PVAR REBINT Current_Year;
 PVAR REB_OPTS *Reb_Opts;
 
-PVAR jmp_buf *Halt_State;	// Pointer to saved CPU state for HALT/QUIT handlers
-
 /* for memory allocation trouble shooting */
 #ifndef NDEBUG
     PVAR REBOOL PG_Always_Malloc;
@@ -82,7 +80,7 @@ TVAR REBSER *Task_Series;	// Series that holds Task_Context
 
 //-- Memory and GC:
 TVAR REBPOL *Mem_Pools;		// Memory pool array
-TVAR REBCNT	GC_Disabled;	// GC disabled counter for critical sections.
+TVAR REBINT GC_Disabled;	// GC disabled counter for critical sections.
 TVAR REBINT	GC_Ballast;		// Bytes allocated to force automatic GC
 TVAR REBOOL	GC_Active;		// TRUE when recycle is enabled (set by RECYCLE func)
 TVAR REBSER	*GC_Protect;	// A stack of protected series (removed by pop)
@@ -101,7 +99,7 @@ TVAR REBVAL	*DS_Base;		// Data stack base
 TVAR REBINT	DS_Index;		// Data stack "pointer" (index into DS_Base)
 TVAR REBINT	DS_Frame_Index;	// Data stack frame (also index into DS_Base)
 
-TVAR jmp_buf *Saved_State;	// Pointer to saved CPU state for error handlers.
+TVAR REBOL_STATE *Saved_State; // Saved state for Catch (CPU state, etc.)
 
 //-- Evaluation variables:
 TVAR REBI64	Eval_Cycles;	// Total evaluation counter (upward)

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -105,7 +105,6 @@
 
 
 // Special stack controls (used by init and GC):
-#define DS_RESET		(DSP=DSF=0)
 #define DS_TERMINATE	(SERIES_TAIL(DS_Series) = DSP+1);
 
 // Access value at given stack location:

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -21,49 +21,119 @@
 **
 **  Summary: CPU State
 **  Module:  sys-state.h
-**  Author:  Carl Sassenrath
+**  Author:  Carl Sassenrath, @HostileFork
 **  Notes:
+**		Rebol is settled upon a stable and pervasive implementation
+**		baseline of ANSI-C (C89).  That commitment provides certain
+**		advantages.  One of the disadvantages is that there is no safe
+**		way to do non-local jumps with stack unwinding (as in C++).  If
+**		you've written some code that performs a raw malloc and then
+**		wants to "throw" with a longjmp, that will leak the malloc.
+**
+**		Basically all code must be aware of "throws", and if one can
+**		happen then there must be explicit handling of the cleanup.
+**		This must be either at the point of the longjmp, or the moment
+**		when the setjmp runs its "true" branch after a non-local jump:
+**
+**			http://stackoverflow.com/questions/1376085/
+**
+**		(Note:  If you are integrating with C++ and a longjmp crosses
+**		a constructed object, abandon all hope...UNLESS you use Ren/C++.
+**		It is careful to avoid this trap, and you don't want to redo
+**		that work.)
+**
+**		!!! v-- TRIAGE NOT YET INTEGRATED IN REN/C
+**
+**		In order to mitigate the inherent failure of trying to emulate
+**		stack unwinding via longjmp, Rebol wraps the abstraction a bit.
+**		If you had allocated any series and they were in "triage" at
+**		the time the "throw" happened, then those will be automatically
+**		freed (the garbage collector didn't know about them yet).
 **
 ***********************************************************************/
 
-// Create this on your local stack frame or globally:
-typedef struct {		// State variables to save
-	jmp_buf *last_jmp_buf;
-	REBINT	dsp;
-	REBINT	dsf;
-    REBCNT	hold_tail;	// Tail for GC_Protect
-	REBSER	*error;
+
+// "Under FreeBSD 5.2.1 and Mac OS X 10.3, setjmp and longjmp save and restore
+// the signal mask. Linux 2.4.22 and Solaris 9, however, do not do this.
+// FreeBSD and Mac OS X provide the functions _setjmp and _longjmp, which do
+// not save and restore the signal mask."
+//
+// "To allow either form of behavior, POSIX.1 does not specify the effect of
+// setjmp and longjmp on signal masks. Instead, two new functions, sigsetjmp
+// and siglongjmp, are defined by POSIX.1. These two functions should always
+// be used when branching from a signal handler."
+
+#ifdef HAS_POSIX_SIGNAL
+	#define SET_JUMP(s) sigsetjmp((s), 1)
+	#define LONG_JUMP(s, v) siglongjmp((s), (v))
+#else
+	#define SET_JUMP(s) setjmp(s)
+	#define LONG_JUMP(s, v) longjmp((s), (v))
+#endif
+
+
+// Structure holding the information about the last point in the stack that
+// wanted to set up an opportunity to "catch" a DO ERROR! or a THROW.
+
+typedef struct Rebol_State {
+	struct Rebol_State *last_state;
+
+	REBINT dsp;
+	REBINT dsf;
+	REBCNT hold_tail;	// Tail for GC_Protect
+	REBVAL error;
+	REBINT gc_disable;      // Count of GC_Disables at time of Push
+
+#ifdef HAS_POSIX_SIGNAL
+	sigjmp_buf cpu_state;
+#else
 	jmp_buf cpu_state;
+#endif
 } REBOL_STATE;
 
-// Save current state info into a structure:
-// g is Saved_State or Halt_State.
-#define PUSH_STATE(s, g) do {\
-		(s).last_jmp_buf = g;\
-		(s).dsp = DSP;\
-		(s).dsf = DSF;\
-		(s).hold_tail = GC_Protect->tail;\
-		(s).error = 0;\
-	} while(0)
 
-#define POP_STATE(s, g) do {\
-		g = (s).last_jmp_buf;\
-		DSP = (s).dsp;\
-		SET_DSF((s).dsf);\
-		GC_Protect->tail = (s).hold_tail;\
+// You really can't put "setjmp" in arbitrary conditional contexts, such
+// as `setjmp(...) ? x : y`.  That's against the rules.  Although the
+// preprocessor abuse below is a bit ugly, it helps establish that anyone
+// modifying this code later not be able to avoid the truth of the limitation
+// (by removing the return value of setjmp from the caller's view).
+//
+//		http://stackoverflow.com/questions/30416403/
+//
+// IMPORTANT: You must DROP_CATCH from the same scope you PUSH_CATCH from.
+// Do not call PUSH_CATCH in a function, then return from that function and
+// DROP_CATCH at another stack level:
+//
+//		"If the function that called setjmp has exited (whether by return
+//		or by a different longjmp higher up the stack), the behavior is
+//		undefined. In other words, only long jumps up the call stack
+//		are allowed."
+//
+//		http://en.cppreference.com/w/c/program/longjmp
+
+#define PUSH_CATCH(e,s) \
+	do { \
+		Push_Catch_Helper(s); \
+		if (SET_JUMP((s)->cpu_state)) { \
+			if (Catch_Error_Helper(s)) \
+				*(e) = cast(const REBVAL*, &(s)->error); \
+			else \
+				*(e) = NULL; \
+		} else \
+			*(e) = NULL; \
 	} while (0)
 
-// Do not restore prior state:
-#define DROP_STATE(s, g) g = (s).last_state
+#define PUSH_CATCH_ANY(e,s) \
+	do { \
+		Push_Catch_Helper(s); \
+		if (SET_JUMP((s)->cpu_state)) { \
+			if (Catch_Any_Error_Helper(s)) \
+				*(e) = cast(const REBVAL*, &(s)->error); \
+			else \
+				*(e) = NULL; \
+		} else \
+			*(e) = NULL; \
+	} while (0)
 
-// Set the pointer for the prior state:
-#define	SET_STATE(s, g) g = &(s).cpu_state
-
-// Store all CPU registers into the structure:
-#ifdef HAS_POSIX_SIGNAL
-#define	SET_JUMP(s) sigsetjmp((s).cpu_state, 1)
-#define	LONG_JUMP(s, v) siglongjmp((s), (v))
-#else
-#define	SET_JUMP(s) setjmp((s).cpu_state)
-#define	LONG_JUMP(s, v) longjmp((s), (v))
-#endif
+#define DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(s) \
+	Drop_Catch_Helper((s), FALSE);

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -966,24 +966,70 @@ typedef struct Reb_Object {
 
 /***********************************************************************
 **
-**	ERRORS - Error values
+**	ERRORS - Error values (see %boot/errors.r)
+**
+**	Errors do double-duty as a type, because they are also used for
+**	an internal pseudo-type to implement THROW/CATCH/BREAK/etc.  The
+**	rationale for not making a separate THROW! type is that there
+**	are only 64 bits for typesets.  Hence if an internal type can
+**	be finessed another way it is.  (It also confuses the users less
+**	by not seeing an internal type "leak" into their consciousness.)
+**
+**	The way it is decided if an error is a real ERROR! or a "THROW!" is
+**	based on the value of 'num'.  Low numbers indicate that the payload
+**	is a Rebol Value being thrown, and higher numbers indicate that
+**	the payload is an error object frame.
+**
+**	For an actual THROW instruction, there is an optional piece of
+**	information, which is the symbol with which the throw was "named".
+**	A RETURN instruction uses its optional piece of information to
+**	hold the identifying series of the stack it wishes to unwind to
+**	and actually return from (for definitionally-scoped RETURN).
 **
 ***********************************************************************/
 
+union Reb_Error_Data {
+	REBSER *frame;      // error object frame if user-facing ERROR!
+	REBINT status;      // Exit status if QUIT
+};
+
+union Reb_Error_Extra {
+	REBCNT sym;			// if a RE_THROW with /NAME, then symbol, else 0
+	REBSER *unwind;     // identify function series to RETURN from
+};
+
 typedef struct Reb_Error {
-	union Reo {
-		REBSER	*object;
-		REBVAL	*value;		// RETURN value (also BREAK, THROW)
-	} reo;
-	REBCNT	num;			// (Determines value used below.)
-	REBCNT  sym;			// THROW symbol
+	// Possibly nothing in this slot (e.g. for CONTINUE)
+	// Note: all user exposed errors can act like ANY-OBJECT!, hence the
+	// 'frame' field must be at the same offest as Reb_Object's 'frame'.
+	union Reb_Error_Data data;
+
+	 // dictates meaning of fields above (and below)
+	REBCNT num;
+
+	// (nothing in this slot if not THROW or RETURN)
+	union Reb_Error_Extra extra;
 } REBERR;
 
 // Value Accessors:
 #define	VAL_ERR_NUM(v)		((v)->data.error.num)
-#define VAL_ERR_OBJECT(v)	((v)->data.error.reo.object)
-#define VAL_ERR_VALUE(v)	((v)->data.error.reo.value)
-#define VAL_ERR_SYM(v)		((v)->data.error.sym)
+#define VAL_ERR_OBJECT(v)	((v)->data.error.data.frame)
+#define VAL_ERR_STATUS(v)   ((v)->data.error.data.status)
+#define VAL_ERR_SYM(v)		((v)->data.error.extra.sym)
+#define VAL_ERR_UNWIND(v)   ((v)->data.error.extra.unwind)
+
+// A throw-style may need an associated value (such as how a RETURN needs to
+// have a value to be returned).  Yet an ERROR! being a value cannot hold the
+// full spectrum of values inside it and still be an error.  Error arguments
+// are handled specially as a task-local variable, and only *one* can be in
+// effect at a time.  These macros abstract and ensure that condition.
+#ifdef NDEBUG
+	#define ADD_THROWN_ARG(v,a)		(*TASK_ERROR_ARG = *(a))
+	#define TAKE_THROWN_ARG(a, v)	(*(a) = *TASK_ERROR_ARG)
+#else
+	#define ADD_THROWN_ARG(v,a)		Add_Thrown_Arg_Debug(v, a)
+	#define TAKE_THROWN_ARG(a,v)	Take_Thrown_Arg_Debug(a, v)
+#endif
 
 #define	IS_THROW(v)			(VAL_ERR_NUM(v) < RE_THROW_MAX)
 #define	IS_BREAK(v)			(VAL_ERR_NUM(v) == RE_BREAK)
@@ -991,15 +1037,12 @@ typedef struct Reb_Error {
 #define	IS_CONTINUE(v)		(VAL_ERR_NUM(v) == RE_CONTINUE)
 #define THROWN(v)			(IS_ERROR(v) && IS_THROW(v))
 
-#define	SET_ERROR(v,n,a)	VAL_SET(v, REB_ERROR), VAL_ERR_NUM(v)=n, VAL_ERR_OBJECT(v)=a, VAL_ERR_SYM(v)=0
-#define	SET_THROW(v,n,a)	VAL_SET(v, REB_ERROR), VAL_ERR_NUM(v)=n, VAL_ERR_VALUE(v)=a, VAL_ERR_SYM(v)=0
-
-#define VAL_ERR_VALUES(v)	((ERROR_OBJ *)(FRM_VALUES(VAL_ERR_OBJECT(v))))
+#define VAL_ERR_VALUES(v)	cast(ERROR_OBJ*, FRM_VALUES(VAL_ERR_OBJECT(v)))
 #define	VAL_ERR_ARG1(v)		(&VAL_ERR_VALUES(v)->arg1)
 #define	VAL_ERR_ARG2(v)		(&VAL_ERR_VALUES(v)->arg2)
 
 // Error Object (frame) Accessors:
-#define ERR_VALUES(frame)	((ERROR_OBJ *)FRM_VALUES(frame))
+#define ERR_VALUES(frame)	cast(ERROR_OBJ*, FRM_VALUES(frame))
 #define	ERR_NUM(frame)		VAL_INT32(&ERR_VALUES(frame)->code)
 
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1032,9 +1032,6 @@ typedef struct Reb_Error {
 #endif
 
 #define	IS_THROW(v)			(VAL_ERR_NUM(v) < RE_THROW_MAX)
-#define	IS_BREAK(v)			(VAL_ERR_NUM(v) == RE_BREAK)
-#define	IS_RETURN(v)		(VAL_ERR_NUM(v) == RE_RETURN)
-#define	IS_CONTINUE(v)		(VAL_ERR_NUM(v) == RE_CONTINUE)
 #define THROWN(v)			(IS_ERROR(v) && IS_THROW(v))
 
 #define VAL_ERR_VALUES(v)	cast(ERROR_OBJ*, FRM_VALUES(VAL_ERR_OBJECT(v)))

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1042,6 +1042,14 @@ typedef struct Reb_Error {
 #define ERR_VALUES(frame)	cast(ERROR_OBJ*, FRM_VALUES(frame))
 #define	ERR_NUM(frame)		VAL_INT32(&ERR_VALUES(frame)->code)
 
+#ifdef NDEBUG
+	#define ASSERT_ERROR(e) \
+		cast(void, 0)
+#else
+	#define ASSERT_ERROR(e) \
+		Assert_Error_Debug(e)
+#endif
+
 
 /***********************************************************************
 **

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -91,8 +91,12 @@ finish-rl-start: func [
 
 	;-- Set up option/paths for /path, /boot, /home, and script path (for SECURE):
 	path: dirize any [path home]
-	home: dirize home
-	;if slash <> first boot [boot: clean-path boot] ;;;;; HAVE C CODE DO IT PROPERLY !!!!
+
+	;-- !!! this was commented out, and said "HAVE C CODE DO IT PROPERLY !!!!"
+	comment [
+		if slash <> first boot [boot: clean-path boot]
+	]
+
 	home: file: first split-path boot
 	if file? script [ ; Get the path (needed for SECURE setup)
 		script-path: split-path script


### PR DESCRIPTION
**PROMPT REVIEW REQUESTED**...a lot builds on this, and it's 
taking a very long time as it is to try and ramp the code up to where
I'd like it to be.

(Note QUIT now takes an INTEGER! value only, and has no /NOW
refinement.  A small step for now, but ideally EXIT will be shifted to
act as QUIT/RETURN, and QUIT will be arity zero meaning EXIT 0)

This is a major rewrite of the setjmp/longjmp-based error handling,
and it's not really that reasonable or feasible to break it up much
more than this.  These things are all inter-related.

Central ideas are that there aren't two separate saved states
to worry about (Halt_State is integrated into Saved_State) and the
PUSH_CATCH/DROP_CATCH macros are clearer and simpler,
with less chance for making mistakes in usage.

The mechanism for including a REBVAL associated with an error
has been simplified and formalized a little more.  Though simpler,
an attempt to further tighten the grip on this "sneaky" way of having
one error-per-task turned out to complicate the code a bit too much,
and so it could still be improved with some better asserts.