### PR TITLE
Fix multiplication of negative and zero

### DIFF
--- a/src/core/f-int.c
+++ b/src/core/f-int.c
@@ -98,6 +98,11 @@ REBOOL reb_i64_mul_overflow(i64 x, i64 y, i64 *prod)
 	REBFLG sgn;
 	u64 p = 0;
 
+	if (!x || !y) {
+		*prod = 0;
+		return FALSE;
+	}
+
 	sgn = (x < 0);
 	if (sgn) {
 		if (x == MIN_I64) {


### PR DESCRIPTION
As pointed out by hostilfork:

I'm having a problem with multiply -1 0 not working:

>> multiply -1 0
** Math error: math or number overflow
** Where: multiply
** Near: multiply -1 0
Took a look, got here. REB_U64_MUL_OF gives back p as zero which we expect, and p is an unsigned 64-bit quantity (superfluous cast). sgn is true because x is -1, and it says sgn = x < 0. So the condition on line 140 becomes:

TRUE && (u64)0 - 1 > MAX_I64
So you wind up with MAX_U64 > MAX_I64, which it is. So it returns TRUE which means Trap:

https://github.com/zsx/r3/blob/f41fb690a0f6fa3a6bbf69e6087d8afb0604494f/src/core/t-integer.c#L124

The Atronix dev download (64-bit Linux) doesn't complain, so I don't know if that's because it got compiled with builtins or something else...