### PR TITLE
Series flag for IS_BLOCK_SERIES, eliminate SER_BARE

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -120,7 +120,6 @@
 
 	//DISABLE_GC;
 	words = Make_Block(len + 1); // size + room for SELF
-	BARE_SERIES(words);
 	frame = Make_Block(len + 1);
 	//ENABLE_GC;
 	// Note: cannot use Append_Frame for first word.
@@ -151,7 +150,6 @@
 	// Expand or copy WORDS block:
 	if (copy) {
 		FRM_WORD_SERIES(frame) = Copy_Expand_Block(words, delta);
-		BARE_SERIES(FRM_WORD_SERIES(frame));
 	} else {
 		Extend_Series(words, delta);
 		BLK_TERM(words);
@@ -251,7 +249,6 @@
 
 	prior = Copy_Series(BUF_WORDS);
 	RESET_TAIL(BUF_WORDS);  // allow reuse
-	BARE_SERIES(prior); // No GC ever needed for word list
 
 	CHECK_BIND_TABLE;
 

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -39,7 +39,7 @@
 **
 ***********************************************************************/
 {
-	REBSER *series = Make_Series(length + 1, sizeof(REBVAL), FALSE);
+	REBSER *series = Make_Series(length + 1, sizeof(REBVAL), MKS_BLOCK);
 	SET_END(BLK_HEAD(series));
 	PG_Reb_Stats->Blocks++;
 	return series;
@@ -60,7 +60,7 @@
 	if (index > len) return Make_Block(0);
 
 	len -= index;
-	series = Make_Series(len + 1, sizeof(REBVAL), FALSE);
+	series = Make_Series(len + 1, sizeof(REBVAL), MKS_BLOCK);
 	COPY_BLK_PART(series, BLK_SKIP(block, index), len);
 
 	PG_Reb_Stats->Blocks++;
@@ -82,7 +82,7 @@
 	if (index > SERIES_TAIL(block)) return Make_Block(0);
 	if (index + len > SERIES_TAIL(block)) len = SERIES_TAIL(block) - index;
 
-	series = Make_Series(len + 1, sizeof(REBVAL), FALSE);
+	series = Make_Series(len + 1, sizeof(REBVAL), MKS_BLOCK);
 	COPY_BLK_PART(series, BLK_SKIP(block, index), len);
 
 	PG_Reb_Stats->Blocks++;
@@ -101,7 +101,7 @@
 {
 	REBSER *series;
 
-	series = Make_Series(length + 1, sizeof(REBVAL), FALSE);
+	series = Make_Series(length + 1, sizeof(REBVAL), MKS_BLOCK);
 	COPY_BLK_PART(series, blk, length);
 
 	PG_Reb_Stats->Blocks++;
@@ -197,7 +197,7 @@
 ***********************************************************************/
 {
 	REBCNT len = SERIES_TAIL(block);
-	REBSER *series = Make_Series(len + extra + 1, sizeof(REBVAL), FALSE);
+	REBSER *series = Make_Series(len + extra + 1, sizeof(REBVAL), MKS_BLOCK);
 	COPY_BLK_PART(series, BLK_HEAD(block), len);
 	PG_Reb_Stats->Blocks++;
 	return series;
@@ -270,7 +270,7 @@
 			len = VAL_INDEX(into);
 		}
 	} else {
-		series = Make_Series(len + 1, sizeof(REBVAL), FALSE);
+		series = Make_Series(len + 1, sizeof(REBVAL), MKS_BLOCK);
 		COPY_BLK_PART(series, blk, len);
 		len = 0;
 		type = REB_BLOCK;

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -814,7 +814,7 @@
 
 	len = VAL_LEN(value);
 	wide = SERIES_WIDE(src);
-	ser = Make_Series(len, wide, FALSE);
+	ser = Make_Series(len, wide, IS_BLOCK_SERIES(src) ? MKS_BLOCK : MKS_NONE);
 
 	memcpy(ser->data, src->data + (VAL_INDEX(value) * wide), len * wide);
 	ser->tail = len;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -145,16 +145,11 @@ static void Mark_Series_Only_Debug(REBSER *ser);
 **
 ***********************************************************************/
 {
+	assert(!IS_EXT_SERIES(series));
 	assert(IS_BLOCK_SERIES(series));
 
 	assert(!SERIES_GET_FLAG(series, SER_MARK));
 	SERIES_SET_FLAG(series, SER_MARK);
-
-	// "External" series are not marked or managed by the GC.
-	// !!! Should the REBSER be GC'd, but just their data pointers left
-	// alone and not freed?  What's the real goal? --@HF
-	if (IS_EXT_SERIES(series))
-		return;
 
 	// Add series to the end of the mark stack series and update terminator
 	if (SERIES_FULL(GC_Mark_Stack)) Extend_Series(GC_Mark_Stack, 8);

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -527,7 +527,7 @@ static void Process_Mark_Stack(void);
 				// even stack-relative contexts for functions.
 
 				REBVAL *first;
-				assert(SERIES_LEN(ser) > 0);
+				assert(SERIES_TAIL(ser) > 0);
 				first = BLK_HEAD(ser);
 
 				if (IS_FRAME(first)) {

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -192,7 +192,7 @@ static void Propagate_All_GC_Marks(void);
 #define MARK_BLOCK_DEEP(s) \
 	do { \
 		assert(!in_mark); \
-        QUEUE_MARK_BLOCK_DEEP(s); \
+		QUEUE_MARK_BLOCK_DEEP(s); \
 		Propagate_All_GC_Marks(); \
 	} while (0)
 
@@ -302,7 +302,7 @@ static void Propagate_All_GC_Marks(void);
 		QUEUE_MARK_BLOCK_DEEP(field->spec);
 
 		for (len = 0; len < field_fields->tail; len++) {
-            Queue_Mark_Field_Deep(
+			Queue_Mark_Field_Deep(
 				stu, cast(struct Struct_Field*, SERIES_SKIP(field_fields, len))
 			);
 		}
@@ -413,7 +413,7 @@ static void Propagate_All_GC_Marks(void);
 		}
 
 		if (ROUTINE_RVALUE(rot).spec)
-            Queue_Mark_Struct_Deep(&ROUTINE_RVALUE(rot));
+			Queue_Mark_Struct_Deep(&ROUTINE_RVALUE(rot));
 	}
 }
 
@@ -663,7 +663,7 @@ static void Propagate_All_GC_Marks(void);
 		case REB_ROUTINE:
 			QUEUE_MARK_BLOCK_DEEP(VAL_ROUTINE_SPEC(val));
 			QUEUE_MARK_BLOCK_DEEP(VAL_ROUTINE_ARGS(val));
-            Queue_Mark_Routine_Deep(&VAL_ROUTINE(val));
+			Queue_Mark_Routine_Deep(&VAL_ROUTINE(val));
 			break;
 
 		case REB_LIBRARY:
@@ -727,7 +727,7 @@ static void Propagate_All_GC_Marks(void);
 					continue;
 			}
 		}
-        Queue_Mark_Value_Deep(val);
+		Queue_Mark_Value_Deep(val);
 	}
 
 	assert(
@@ -1001,8 +1001,8 @@ static void Propagate_All_GC_Marks(void);
 	}
 
 	// Mark all root series:
-    MARK_BLOCK_DEEP(VAL_SERIES(ROOT_ROOT));
-    MARK_BLOCK_DEEP(Task_Series);
+	MARK_BLOCK_DEEP(VAL_SERIES(ROOT_ROOT));
+	MARK_BLOCK_DEEP(Task_Series);
 
 	// Mark all devices:
 	Mark_Devices_Deep();
@@ -1137,7 +1137,7 @@ static void Propagate_All_GC_Marks(void);
 	// nested structures don't cause the C stack to overflow.
 	GC_Mark_Stack = Make_Series(100, sizeof(REBSER *), MKS_NONE);
 	TERM_SERIES(GC_Mark_Stack);
-    KEEP_SERIES(GC_Mark_Stack, "gc mark stack");
+	KEEP_SERIES(GC_Mark_Stack, "gc mark stack");
 
 	GC_Series = Make_Series(60, sizeof(REBSER *), MKS_NONE);
 	KEEP_SERIES(GC_Series, "gc guarded");

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -130,7 +130,7 @@ static void Mark_Value_Deep_Core(REBVAL *val);
 
 static void Mark_Block_Deep_Core(REBSER *series);
 
-static void Mark_Series_Shallow_Debug(REBSER *ser);
+static void Mark_Series_Only_Debug(REBSER *ser);
 
 /***********************************************************************
 **
@@ -150,14 +150,9 @@ static void Mark_Series_Shallow_Debug(REBSER *ser);
 	assert(!SERIES_GET_FLAG(series, SER_MARK));
 	SERIES_SET_FLAG(series, SER_MARK);
 
-	// We assume "bare" series contain only "atoms" (like WORD! and INTEGER!)
-	// and have no series which would need to be marked.
-
-	// !!! Add debug build assert that verifies the series is really "bare".
-	if (IS_BARE_SERIES(series))
-		return;
-
-	// !!! "External" series are also not marked or managed by the GC.  (?)
+	// "External" series are not marked or managed by the GC.
+	// !!! Should the REBSER be GC'd, but just their data pointers left
+	// alone and not freed?  What's the real goal? --@HF
 	if (IS_EXT_SERIES(series))
 		return;
 
@@ -204,23 +199,30 @@ static void Process_Mark_Stack(void);
 	} while (0)
 
 #ifdef NDEBUG
-	#define MARK_SERIES_SHALLOW(s) SERIES_SET_FLAG((s), SER_MARK)
+	#define MARK_SERIES_ONLY(s) SERIES_SET_FLAG((s), SER_MARK)
 #else
-	#define MARK_SERIES_SHALLOW(s) Mark_Series_Shallow_Debug(s)
+	#define MARK_SERIES_ONLY(s) Mark_Series_Only_Debug(s)
 #endif
+
+// "Unword" blocks contain REBWRS-style words, which have type information
+// instead of a binding.  They shouldn't have any other types in them so we
+// don't need to mark deep...BUT doesn't hurt to check in debug builds!
+#define MARK_UNWORDS_BLOCK(s) \
+	do { \
+		ASSERT_UNWORDS_BLOCK(s); \
+		MARK_SERIES_ONLY(s); \
+	} while (0)
 
 
 #if !defined(NDEBUG)
 /***********************************************************************
 **
-*/	static void Mark_Series_Shallow_Debug(REBSER *ser)
+*/	static void Mark_Series_Only_Debug(REBSER *ser)
 /*
 **		Hook point for marking and tracing a single series mark.
 **
 ***********************************************************************/
 {
-	if (IS_BLOCK_SERIES(ser)) ASSERT_BLK(ser);
-
 	SERIES_SET_FLAG(ser, SER_MARK);
 }
 #endif
@@ -313,13 +315,12 @@ static void Process_Mark_Stack(void);
 	// The spec is the only ANY-BLOCK! in the struct
 	PUSH_MARK_BLOCK_DEEP(stu->spec);
 
-	MARK_SERIES_SHALLOW(stu->fields);
-	MARK_SERIES_SHALLOW(STRUCT_DATA_BIN(stu));
+	MARK_SERIES_ONLY(stu->fields);
+	MARK_SERIES_ONLY(STRUCT_DATA_BIN(stu));
 
-	assert(IS_BARE_SERIES(stu->data));
 	assert(!IS_EXT_SERIES(stu->data));
 	assert(SERIES_TAIL(stu->data) == 1);
-	MARK_SERIES_SHALLOW(stu->data);
+	MARK_SERIES_ONLY(stu->data);
 
 	series = stu->fields;
 	for (len = 0; len < series->tail; len++) {
@@ -341,9 +342,9 @@ static void Process_Mark_Stack(void);
 	PUSH_MARK_BLOCK_DEEP(ROUTINE_SPEC(rot));
 	ROUTINE_SET_FLAG(ROUTINE_INFO(rot), ROUTINE_MARK);
 
-	PUSH_MARK_BLOCK_DEEP(ROUTINE_FFI_ARG_TYPES(rot));
+	MARK_SERIES_ONLY(ROUTINE_FFI_ARG_TYPES(rot));
 	PUSH_MARK_BLOCK_DEEP(ROUTINE_FFI_ARG_STRUCTS(rot));
-	MARK_SERIES_SHALLOW(ROUTINE_EXTRA_MEM(rot));
+	MARK_SERIES_ONLY(ROUTINE_EXTRA_MEM(rot));
 
 	if (IS_CALLBACK_ROUTINE(ROUTINE_INFO(rot))) {
 		if (FUNC_BODY(&CALLBACK_FUNC(rot))) {
@@ -480,9 +481,10 @@ static void Process_Mark_Stack(void);
 		case REB_FRAME:
 			// Mark special word list. Contains no pointers because
 			// these are special word bindings (to typesets if used).
-			MARK_SERIES_SHALLOW(VAL_FRM_WORDS(val));
+			MARK_UNWORDS_BLOCK(VAL_FRM_WORDS(val));
 			if (VAL_FRM_SPEC(val))
 				PUSH_MARK_BLOCK_DEEP(VAL_FRM_SPEC(val));
+			// !!! See code below for ANY-WORD! which also deals with FRAME!
 			break;
 
 		case REB_PORT:
@@ -510,7 +512,7 @@ static void Process_Mark_Stack(void);
 		case REB_ACTION:
 		case REB_OP:
 			PUSH_MARK_BLOCK_DEEP(VAL_FUNC_SPEC(val));
-			MARK_SERIES_SHALLOW(VAL_FUNC_ARGS(val));
+			MARK_UNWORDS_BLOCK(VAL_FUNC_ARGS(val));
 			break;
 
 		case REB_WORD:	// (and also used for function STACK backtrace frame)
@@ -529,7 +531,21 @@ static void Process_Mark_Stack(void);
 				// bound words should keep their contexts from being GC'd...
 				// even stack-relative contexts for functions.
 
-				PUSH_MARK_BLOCK_DEEP(ser);
+				REBVAL *first;
+				assert(SERIES_LEN(ser) > 0);
+				first = BLK_HEAD(ser);
+
+				if (IS_FRAME(first)) {
+					// It's referring to an OBJECT!-style FRAME, where the
+					// first element is a FRAME! containing the word keys
+					// and the rest of the elements are the data values
+					PUSH_MARK_BLOCK_DEEP(ser);
+				}
+				else {
+					// It's referring to a FUNCTION!'s identifying series,
+					// which should just be a list of UNWORDs.
+					MARK_UNWORDS_BLOCK(ser);
+				}
 			}
 			else {
 			#ifndef NDEBUG
@@ -565,16 +581,16 @@ static void Process_Mark_Stack(void);
 		case REB_BITSET:
 			ser = VAL_SERIES(val);
 			assert(SERIES_WIDE(ser) <= sizeof(REBUNI));
-			MARK_SERIES_SHALLOW(ser);
+			MARK_SERIES_ONLY(ser);
 			break;
 
 		case REB_IMAGE:
 			//SERIES_SET_FLAG(VAL_SERIES_SIDE(val), SER_MARK); //????
-			MARK_SERIES_SHALLOW(VAL_SERIES(val));
+			MARK_SERIES_ONLY(VAL_SERIES(val));
 			break;
 
 		case REB_VECTOR:
-			MARK_SERIES_SHALLOW(VAL_SERIES(val));
+			MARK_SERIES_ONLY(VAL_SERIES(val));
 			break;
 
 		case REB_BLOCK:
@@ -584,13 +600,7 @@ static void Process_Mark_Stack(void);
 		case REB_GET_PATH:
 		case REB_LIT_PATH:
 			ser = VAL_SERIES(val);
-			assert(ser);
-			if (IS_BARE_SERIES(ser)) {
-				MARK_SERIES_SHALLOW(ser);
-				break;
-			}
-
-			assert(SERIES_WIDE(ser) == sizeof(REBVAL));
+			assert(IS_BLOCK_SERIES(ser) && SERIES_WIDE(ser) == sizeof(REBVAL));
 			assert(IS_END(BLK_SKIP(ser, SERIES_TAIL(ser))) || ser == DS_Series);
 
 			PUSH_MARK_BLOCK_DEEP(ser);
@@ -600,7 +610,7 @@ static void Process_Mark_Stack(void);
 			ser = VAL_SERIES(val);
 			PUSH_MARK_BLOCK_DEEP(ser);
 			if (ser->extra.series)
-				MARK_SERIES_SHALLOW(ser->extra.series);
+				MARK_SERIES_ONLY(ser->extra.series);
 			break;
 
 		case REB_CALLBACK:
@@ -1059,15 +1069,15 @@ static void Process_Mark_Stack(void);
 	Prior_Expand[0] = (REBSER*)1;
 
 	// Temporary series protected from GC. Holds series pointers.
-	GC_Protect = Make_Series(15, sizeof(REBSER *), FALSE);
+	GC_Protect = Make_Series(15, sizeof(REBSER *), MKS_NONE);
 	KEEP_SERIES(GC_Protect, "gc protected");
 
 	// The marking queue used in lieu of recursion to ensure that deeply
 	// nested structures don't cause the C stack to overflow.
-	GC_Mark_Stack = Make_Series(100, sizeof(REBSER *), FALSE);
+	GC_Mark_Stack = Make_Series(100, sizeof(REBSER *), MKS_NONE);
 	TERM_SERIES(GC_Mark_Stack);
 	KEEP_SERIES(GC_Mark_Stack, "gc mark queue");
 
-	GC_Series = Make_Series(60, sizeof(REBSER *), FALSE);
+	GC_Series = Make_Series(60, sizeof(REBSER *), MKS_NONE);
 	KEEP_SERIES(GC_Series, "gc guarded");
 }

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -126,30 +126,37 @@ REBVAL *N_watch(REBFRM *frame, REBVAL **inter_block)
 		// Print("Mark: %s %x", TYPE_NAME(val), val);
 #endif
 
-static void Mark_Value_Deep_Core(REBVAL *val);
+static void Queue_Mark_Value_Deep(REBVAL *val);
 
-static void Mark_Block_Deep_Core(REBSER *series);
+static void Push_Block_Marked_Deep(REBSER *series);
 
 static void Mark_Series_Only_Debug(REBSER *ser);
 
 /***********************************************************************
 **
-*/	static void Push_Mark_Block_Deep_Core(REBSER *series)
+*/	static void Push_Block_Marked_Deep(REBSER *series)
 /*
-**		Push the series into the deferred stack to be processed later
-**		with Process_Mark_Stack().  We go ahead and set this series mark
-**		because it's now "spoken for".  (Even though we haven't marked
-**		its actual dependencies yet, we want to prevent it from being
-**		wastefully stacked multiple times by another reference that
-**		would still see it as "unmarked".)
+**		Note: Call MARK_BLOCK_DEEP or QUEUE_MARK_BLOCK_DEEP instead!
+**
+**		Submits the block into the deferred stack to be processed later
+**		with Propagate_All_GC_Marks().  We have already set this series
+**		mark as it's now "spoken for".  (Though we haven't marked its
+**		dependencies yet, we want to prevent it from being wastefully
+**		submitted multiple times by another reference that would still
+**		see it as "unmarked".)
+**
+**		The data structure used for this processing is a stack and not
+**		a queue (for performance reasons).  But when you use 'queue'
+**		as a verb it has more leeway than as the CS noun, and can just
+**		mean "put into a list for later processing", hence macro names.
 **
 ***********************************************************************/
 {
 	assert(!IS_EXT_SERIES(series));
 	assert(IS_BLOCK_SERIES(series));
 
-	assert(!SERIES_GET_FLAG(series, SER_MARK));
-	SERIES_SET_FLAG(series, SER_MARK);
+    // set by calling macro (helps catch direct calls of this function)
+	assert(SERIES_GET_FLAG(series, SER_MARK));
 
 	// Add series to the end of the mark stack series and update terminator
 	if (SERIES_FULL(GC_Mark_Stack)) Extend_Series(GC_Mark_Stack, 8);
@@ -157,7 +164,7 @@ static void Mark_Series_Only_Debug(REBSER *ser);
 	cast(REBSER **, GC_Mark_Stack->data)[GC_Mark_Stack->tail] = NULL;
 }
 
-static void Process_Mark_Stack(void);
+static void Propagate_All_GC_Marks(void);
 
 #ifndef NDEBUG
 	static REBOOL in_mark = FALSE;
@@ -166,32 +173,32 @@ static void Process_Mark_Stack(void);
 // NOTE: The following macros uses S parameter multiple times, hence if S has
 // side effects this will run that side-effect multiply.
 
-// Non-Queued form for marking series.  Used for marking a *root set item*,
-// don't recurse from within Mark_Value/Mark_Gob/Mark_Block_Deep/etc.
-
-#define MARK_SERIES_DEEP(s) \
-	do { \
-		assert(!in_mark); \
-		if (!SERIES_GET_FLAG((s), SER_MARK)) { \
-			SERIES_SET_FLAG((s), SER_MARK); \
-			if (IS_BLOCK_SERIES(s)) { \
-				Mark_Block_Deep_Core(s); \
-				Process_Mark_Stack(); \
-			} \
-		} \
-	} while (0)
-
-
 // Deferred form for marking series that prevents potentially overflowing the
 // C execution stack.
 
-#define PUSH_MARK_BLOCK_DEEP(s) \
+#define QUEUE_MARK_BLOCK_DEEP(s) \
+    do { \
+        assert(IS_BLOCK_SERIES(s)); \
+        if (!SERIES_GET_FLAG((s), SER_MARK)) { \
+            SERIES_SET_FLAG((s), SER_MARK); \
+            Push_Block_Marked_Deep(s); \
+        } \
+    } while (0)
+
+
+// Non-Queued form for marking blocks.  Used for marking a *root set item*,
+// don't recurse from within Mark_Value/Mark_Gob/Mark_Block_Deep/etc.
+
+#define MARK_BLOCK_DEEP(s) \
 	do { \
-		assert(IS_BLOCK_SERIES(s)); \
-		if (!SERIES_GET_FLAG((s), SER_MARK)) { \
-			Push_Mark_Block_Deep_Core(s); \
-		} \
+		assert(!in_mark); \
+        QUEUE_MARK_BLOCK_DEEP(s); \
+		Propagate_All_GC_Marks(); \
 	} while (0)
+
+
+// Non-Deep form of mark, to be used on non-BLOCK! series or a block series
+// for which deep marking is not necessary (such as an UNWORDS block)
 
 #ifdef NDEBUG
 	#define MARK_SERIES_ONLY(s) SERIES_SET_FLAG((s), SER_MARK)
@@ -199,14 +206,22 @@ static void Process_Mark_Stack(void);
 	#define MARK_SERIES_ONLY(s) Mark_Series_Only_Debug(s)
 #endif
 
+
 // "Unword" blocks contain REBWRS-style words, which have type information
 // instead of a binding.  They shouldn't have any other types in them so we
 // don't need to mark deep...BUT doesn't hurt to check in debug builds!
+
 #define MARK_UNWORDS_BLOCK(s) \
 	do { \
 		ASSERT_UNWORDS_BLOCK(s); \
 		MARK_SERIES_ONLY(s); \
 	} while (0)
+
+
+// Assertion for making sure that all the deferred marks have been propagated
+
+#define ASSERT_NO_GC_MARKS_PENDING() \
+	assert(SERIES_TAIL(GC_Mark_Stack) == 0)
 
 
 #if !defined(NDEBUG)
@@ -225,8 +240,16 @@ static void Process_Mark_Stack(void);
 
 /***********************************************************************
 **
-*/	static void Mark_Gob(REBGOB *gob)
+*/	static void Queue_Mark_Gob_Deep(REBGOB *gob)
 /*
+**		'Queue' refers to the fact that after calling this routine,
+**		one will have to call Propagate_All_GC_Marks() to have the
+**		deep transitive closure be guaranteed fully marked.
+**
+**		Note: only referenced blocks are queued, the GOB structure
+**		itself is processed via recursion.  Deeply nested GOBs could
+**		in theory overflow the C stack.
+**
 ***********************************************************************/
 {
 	REBGOB **pane;
@@ -240,38 +263,46 @@ static void Process_Mark_Stack(void);
 		SERIES_SET_FLAG(GOB_PANE(gob), SER_MARK);
 		pane = GOB_HEAD(gob);
 		for (i = 0; i < GOB_TAIL(gob); i++, pane++)
-			Mark_Gob(*pane);
+			Queue_Mark_Gob_Deep(*pane);
 	}
 
-	if (GOB_PARENT(gob)) Mark_Gob(GOB_PARENT(gob));
+	if (GOB_PARENT(gob)) Queue_Mark_Gob_Deep(GOB_PARENT(gob));
 
 	if (GOB_CONTENT(gob)) {
 		if (GOB_TYPE(gob) >= GOBT_IMAGE && GOB_TYPE(gob) <= GOBT_STRING)
 			SERIES_SET_FLAG(GOB_CONTENT(gob), SER_MARK);
 		else if (GOB_TYPE(gob) >= GOBT_DRAW && GOB_TYPE(gob) <= GOBT_EFFECT)
-			PUSH_MARK_BLOCK_DEEP(GOB_CONTENT(gob));
+			QUEUE_MARK_BLOCK_DEEP(GOB_CONTENT(gob));
 	}
 
 	if (GOB_DATA(gob) && GOB_DTYPE(gob) && GOB_DTYPE(gob) != GOBD_INTEGER)
-		PUSH_MARK_BLOCK_DEEP(GOB_DATA(gob));
+		QUEUE_MARK_BLOCK_DEEP(GOB_DATA(gob));
 }
 
 
 /***********************************************************************
 **
-*/	static void Mark_Struct_Field(REBSTU *stu, struct Struct_Field *field)
+*/	static void Queue_Mark_Field_Deep(REBSTU *stu, struct Struct_Field *field)
 /*
+**		'Queue' refers to the fact that after calling this routine,
+**		one will have to call Propagate_All_GC_Marks() to have the
+**		deep transitive closure be guaranteed fully marked.
+**
+**		Note: only referenced blocks are queued, fields that are structs
+**		will be processed via recursion.  Deeply nested structs could
+**		in theory overflow the C stack.
+**
 ***********************************************************************/
 {
 	if (field->type == STRUCT_TYPE_STRUCT) {
 		unsigned int len = 0;
 		REBSER *field_fields = field->fields;
 
-		PUSH_MARK_BLOCK_DEEP(field_fields);
-		PUSH_MARK_BLOCK_DEEP(field->spec);
+		QUEUE_MARK_BLOCK_DEEP(field_fields);
+		QUEUE_MARK_BLOCK_DEEP(field->spec);
 
 		for (len = 0; len < field_fields->tail; len++) {
-			Mark_Struct_Field(
+            Queue_Mark_Field_Deep(
 				stu, cast(struct Struct_Field*, SERIES_SKIP(field_fields, len))
 			);
 		}
@@ -289,7 +320,7 @@ static void Process_Mark_Stack(void);
 			);
 
 			if (field->done)
-				Mark_Value_Deep_Core(data);
+				Queue_Mark_Value_Deep(data);
 		}
 	}
 	else {
@@ -300,15 +331,23 @@ static void Process_Mark_Stack(void);
 
 /***********************************************************************
 **
-*/	static void Mark_Struct(REBSTU *stu)
+*/	static void Queue_Mark_Struct_Deep(REBSTU *stu)
 /*
+**		'Queue' refers to the fact that after calling this routine,
+**		one will have to call Propagate_All_GC_Marks() to have the
+**		deep transitive closure be guaranteed fully marked.
+**
+**		Note: only referenced blocks are queued, the actual struct
+**		itself is processed via recursion.  Deeply nested structs could
+**		in theory overflow the C stack.
+**
 ***********************************************************************/
 {
 	unsigned int len = 0;
 	REBSER *series = NULL;
 
 	// The spec is the only ANY-BLOCK! in the struct
-	PUSH_MARK_BLOCK_DEEP(stu->spec);
+	QUEUE_MARK_BLOCK_DEEP(stu->spec);
 
 	MARK_SERIES_ONLY(stu->fields);
 	MARK_SERIES_ONLY(STRUCT_DATA_BIN(stu));
@@ -323,28 +362,36 @@ static void Process_Mark_Stack(void);
 			SERIES_SKIP(series, len)
 		);
 
-		Mark_Struct_Field(stu, field);
+		Queue_Mark_Field_Deep(stu, field);
 	}
 }
 
 
 /***********************************************************************
 **
-*/	static void Mark_Routine(REBROT *rot)
+*/	static void Queue_Mark_Routine_Deep(REBROT *rot)
 /*
+**		'Queue' refers to the fact that after calling this routine,
+**		one will have to call Propagate_All_GC_Marks() to have the
+**		deep transitive closure completely marked.
+**
+**		Note: only referenced blocks are queued, the routine's RValue
+**		is processed via recursion.  Deeply nested RValue structs could
+**		in theory overflow the C stack.
+**
 ***********************************************************************/
 {
-	PUSH_MARK_BLOCK_DEEP(ROUTINE_SPEC(rot));
+	QUEUE_MARK_BLOCK_DEEP(ROUTINE_SPEC(rot));
 	ROUTINE_SET_FLAG(ROUTINE_INFO(rot), ROUTINE_MARK);
 
 	MARK_SERIES_ONLY(ROUTINE_FFI_ARG_TYPES(rot));
-	PUSH_MARK_BLOCK_DEEP(ROUTINE_FFI_ARG_STRUCTS(rot));
+	QUEUE_MARK_BLOCK_DEEP(ROUTINE_FFI_ARG_STRUCTS(rot));
 	MARK_SERIES_ONLY(ROUTINE_EXTRA_MEM(rot));
 
 	if (IS_CALLBACK_ROUTINE(ROUTINE_INFO(rot))) {
 		if (FUNC_BODY(&CALLBACK_FUNC(rot))) {
-			PUSH_MARK_BLOCK_DEEP(FUNC_BODY(&CALLBACK_FUNC(rot)));
-			PUSH_MARK_BLOCK_DEEP(FUNC_SPEC(&CALLBACK_FUNC(rot)));
+			QUEUE_MARK_BLOCK_DEEP(FUNC_BODY(&CALLBACK_FUNC(rot)));
+			QUEUE_MARK_BLOCK_DEEP(FUNC_SPEC(&CALLBACK_FUNC(rot)));
 			SERIES_SET_FLAG(FUNC_ARGS(&CALLBACK_FUNC(rot)), SER_MARK);
 		}
 		else {
@@ -353,10 +400,10 @@ static void Process_Mark_Stack(void);
 	} else {
 		if (ROUTINE_GET_FLAG(ROUTINE_INFO(rot), ROUTINE_VARARGS)) {
 			if (ROUTINE_FIXED_ARGS(rot))
-				PUSH_MARK_BLOCK_DEEP(ROUTINE_FIXED_ARGS(rot));
+				QUEUE_MARK_BLOCK_DEEP(ROUTINE_FIXED_ARGS(rot));
 
 			if (ROUTINE_ALL_ARGS(rot))
-				PUSH_MARK_BLOCK_DEEP(ROUTINE_ALL_ARGS(rot));
+				QUEUE_MARK_BLOCK_DEEP(ROUTINE_ALL_ARGS(rot));
 		}
 
 		if (ROUTINE_LIB(rot))
@@ -366,15 +413,19 @@ static void Process_Mark_Stack(void);
 		}
 
 		if (ROUTINE_RVALUE(rot).spec)
-			Mark_Struct(&ROUTINE_RVALUE(rot));
+            Queue_Mark_Struct_Deep(&ROUTINE_RVALUE(rot));
 	}
 }
 
 
 /***********************************************************************
 **
-*/	static void Mark_Event(REBVAL *value)
+*/	static void Queue_Mark_Event_Deep(REBVAL *value)
 /*
+**		'Queue' refers to the fact that after calling this routine,
+**		one will have to call Propagate_All_GC_Marks() to have the
+**		deep transitive closure completely marked.
+**
 ***********************************************************************/
 {
 	REBREQ *req;
@@ -388,7 +439,7 @@ static void Process_Mark_Stack(void);
 		)
 	) {
 		// Comment says void* ->ser field of the REBEVT is a "port or object"
-		PUSH_MARK_BLOCK_DEEP(cast(REBSER*, VAL_EVENT_SER(value)));
+		QUEUE_MARK_BLOCK_DEEP(cast(REBSER*, VAL_EVENT_SER(value)));
 	}
 
 	if (IS_EVENT_MODEL(value, EVM_DEVICE)) {
@@ -401,7 +452,7 @@ static void Process_Mark_Stack(void);
 		while (req) {
 			// Comment says void* ->port is "link back to REBOL port object"
 			if (req->port)
-				PUSH_MARK_BLOCK_DEEP(cast(REBSER*, req->port));
+				QUEUE_MARK_BLOCK_DEEP(cast(REBSER*, req->port));
 			req = req->next;
 		}
 	}
@@ -410,12 +461,12 @@ static void Process_Mark_Stack(void);
 
 /***********************************************************************
 **
-*/ static void Mark_Devices(void)
+*/ static void Mark_Devices_Deep(void)
 /*
 **		Mark all devices. Search for pending requests.
 **
-**		This should be called at the top level, and not from inside a
-**		Process_Mark_Stack().
+**		This should be called at the top level, and as it is not
+**		'Queued' it guarantees that the marks have been propagated.
 **
 ***********************************************************************/
 {
@@ -430,14 +481,14 @@ static void Process_Mark_Stack(void);
 
 		for (req = dev->pending; req; req = req->next)
 			if (req->port)
-				MARK_SERIES_DEEP(cast(REBSER*, req->port));
+				MARK_BLOCK_DEEP(cast(REBSER*, req->port));
 	}
 }
 
 
 /***********************************************************************
 **
-*/	static void Mark_Value_Deep_Core(REBVAL *val)
+*/	static void Queue_Mark_Value_Deep(REBVAL *val)
 /*
 ***********************************************************************/
 {
@@ -452,7 +503,7 @@ static void Process_Mark_Stack(void);
 		case REB_DATATYPE:
 			// Type spec is allowed to be NULL.  See %typespec.r file
 			if (VAL_TYPE_SPEC(val))
-				PUSH_MARK_BLOCK_DEEP(VAL_TYPE_SPEC(val));
+				QUEUE_MARK_BLOCK_DEEP(VAL_TYPE_SPEC(val));
 			break;
 
 		case REB_ERROR:
@@ -467,7 +518,7 @@ static void Process_Mark_Stack(void);
 
 				// Panic(RP_THROW_IN_GC);
 			} else
-				PUSH_MARK_BLOCK_DEEP(VAL_ERR_OBJECT(val));
+				QUEUE_MARK_BLOCK_DEEP(VAL_ERR_OBJECT(val));
 			break;
 
 		case REB_TASK: // not yet implemented
@@ -478,7 +529,7 @@ static void Process_Mark_Stack(void);
 			// these are special word bindings (to typesets if used).
 			MARK_UNWORDS_BLOCK(VAL_FRM_WORDS(val));
 			if (VAL_FRM_SPEC(val))
-				PUSH_MARK_BLOCK_DEEP(VAL_FRM_SPEC(val));
+				QUEUE_MARK_BLOCK_DEEP(VAL_FRM_SPEC(val));
 			// !!! See code below for ANY-WORD! which also deals with FRAME!
 			break;
 
@@ -487,26 +538,26 @@ static void Process_Mark_Stack(void);
 			// Objects currently only have a FRAME, but that protects the
 			// keys wordlist via the FRAME! value in the first slot (which
 			// will be visited along with mapped values via this deep mark)
-			PUSH_MARK_BLOCK_DEEP(VAL_OBJ_FRAME(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_OBJ_FRAME(val));
 			break;
 
 		case REB_MODULE:
 			// A module is an object with an optional body (they currently
 			// do not use the body)
-			PUSH_MARK_BLOCK_DEEP(VAL_OBJ_FRAME(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_OBJ_FRAME(val));
 			if (VAL_MOD_BODY(val))
-				PUSH_MARK_BLOCK_DEEP(VAL_MOD_BODY(val));
+				QUEUE_MARK_BLOCK_DEEP(VAL_MOD_BODY(val));
 			break;
 
 		case REB_FUNCTION:
 		case REB_COMMAND:
 		case REB_CLOSURE:
 		case REB_REBCODE:
-			PUSH_MARK_BLOCK_DEEP(VAL_FUNC_BODY(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_FUNC_BODY(val));
 		case REB_NATIVE:
 		case REB_ACTION:
 		case REB_OP:
-			PUSH_MARK_BLOCK_DEEP(VAL_FUNC_SPEC(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_FUNC_SPEC(val));
 			MARK_UNWORDS_BLOCK(VAL_FUNC_ARGS(val));
 			break;
 
@@ -534,7 +585,7 @@ static void Process_Mark_Stack(void);
 					// It's referring to an OBJECT!-style FRAME, where the
 					// first element is a FRAME! containing the word keys
 					// and the rest of the elements are the data values
-					PUSH_MARK_BLOCK_DEEP(ser);
+					QUEUE_MARK_BLOCK_DEEP(ser);
 				}
 				else {
 					// It's referring to a FUNCTION!'s identifying series,
@@ -598,44 +649,45 @@ static void Process_Mark_Stack(void);
 			assert(IS_BLOCK_SERIES(ser) && SERIES_WIDE(ser) == sizeof(REBVAL));
 			assert(IS_END(BLK_SKIP(ser, SERIES_TAIL(ser))) || ser == DS_Series);
 
-			PUSH_MARK_BLOCK_DEEP(ser);
+			QUEUE_MARK_BLOCK_DEEP(ser);
 			break;
 
 		case REB_MAP:
 			ser = VAL_SERIES(val);
-			PUSH_MARK_BLOCK_DEEP(ser);
+			QUEUE_MARK_BLOCK_DEEP(ser);
 			if (ser->extra.series)
 				MARK_SERIES_ONLY(ser->extra.series);
 			break;
 
 		case REB_CALLBACK:
 		case REB_ROUTINE:
-			PUSH_MARK_BLOCK_DEEP(VAL_ROUTINE_SPEC(val));
-			PUSH_MARK_BLOCK_DEEP(VAL_ROUTINE_ARGS(val));
-			Mark_Routine(&VAL_ROUTINE(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_ROUTINE_SPEC(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_ROUTINE_ARGS(val));
+            Queue_Mark_Routine_Deep(&VAL_ROUTINE(val));
 			break;
 
 		case REB_LIBRARY:
 			MARK_LIB(VAL_LIB_HANDLE(val));
-			PUSH_MARK_BLOCK_DEEP(VAL_LIB_SPEC(val));
+			QUEUE_MARK_BLOCK_DEEP(VAL_LIB_SPEC(val));
 			break;
 
 		case REB_STRUCT:
-			Mark_Struct(&VAL_STRUCT(val));
+			Queue_Mark_Struct_Deep(&VAL_STRUCT(val));
 			break;
 
 		case REB_GOB:
-			Mark_Gob(VAL_GOB(val));
+			Queue_Mark_Gob_Deep(VAL_GOB(val));
 			break;
 
 		case REB_EVENT:
-			Mark_Event(val);
+			Queue_Mark_Event_Deep(val);
 			break;
 
 		default:
 			Panic_Core(RP_DATATYPE+1, VAL_TYPE(val));
 	}
 }
+
 
 /***********************************************************************
 **
@@ -675,7 +727,7 @@ static void Process_Mark_Stack(void);
 					continue;
 			}
 		}
-		Mark_Value_Deep_Core(val);
+        Queue_Mark_Value_Deep(val);
 	}
 
 	assert(
@@ -764,6 +816,7 @@ static void Process_Mark_Stack(void);
 	return count;
 }
 
+
 /***********************************************************************
 **
 */	ATTRIBUTE_NO_SANITIZE_ADDRESS static REBCNT Sweep_Libs(void)
@@ -799,6 +852,7 @@ static void Process_Mark_Stack(void);
 
 	return count;
 }
+
 
 /***********************************************************************
 **
@@ -839,7 +893,7 @@ static void Process_Mark_Stack(void);
 
 /***********************************************************************
 **
-*/	static void Process_Mark_Stack(void)
+*/	static void Propagate_All_GC_Marks(void)
 /*
 **		The Mark Stack is a series containing series pointers.  They
 **		have already had their SER_MARK set to prevent being added
@@ -851,6 +905,7 @@ static void Process_Mark_Stack(void);
 **
 ***********************************************************************/
 {
+	assert(!in_mark);
 	while (GC_Mark_Stack->tail != 0) {
 		// Data pointer may change in response to an expansion during
 		// Mark_Block_Deep_Core(), so must be refreshed on each loop.
@@ -865,7 +920,6 @@ static void Process_Mark_Stack(void);
 	}
 }
 
-#include <stdio.h>
 
 /***********************************************************************
 **
@@ -880,6 +934,8 @@ static void Process_Mark_Stack(void);
 	REBCNT count;
 
 	//Debug_Num("GC", GC_Disabled);
+
+	ASSERT_NO_GC_MARKS_PENDING();
 
 	// If disabled, exit now but set the pending flag.
 	if (GC_Disabled || !GC_Active) {
@@ -909,14 +965,20 @@ static void Process_Mark_Stack(void);
 	// Mark series stack (temp-saved series):
 	sp = (REBSER **)GC_Protect->data;
 	for (n = SERIES_TAIL(GC_Protect); n > 0; n--) {
-		MARK_SERIES_DEEP(*sp);
+        if (IS_BLOCK_SERIES(*sp))
+            MARK_BLOCK_DEEP(*sp);
+        else
+            MARK_SERIES_ONLY(*sp);
 		sp++; // can't increment inside macro arg, evaluated multiple times
 	}
 
 	// Mark all special series:
 	sp = (REBSER **)GC_Series->data;
 	for (n = SERIES_TAIL(GC_Series); n > 0; n--) {
-		MARK_SERIES_DEEP(*sp);
+        if (IS_BLOCK_SERIES(*sp))
+            MARK_BLOCK_DEEP(*sp);
+        else
+            MARK_SERIES_ONLY(*sp);
 		sp++; // can't increment inside macro arg, evaluated multiple times
 	}
 
@@ -931,16 +993,19 @@ static void Process_Mark_Stack(void);
 		REBSER *ser;
 		if ((ser = GC_Infants[n])) {
 			//Dump_Series(ser, "Safe Series");
-			MARK_SERIES_DEEP(ser);
+            if (IS_BLOCK_SERIES(ser))
+				MARK_BLOCK_DEEP(ser);
+            else
+                MARK_SERIES_ONLY(ser);
 		} else break;
 	}
 
 	// Mark all root series:
-	MARK_SERIES_DEEP(VAL_SERIES(ROOT_ROOT));
-	MARK_SERIES_DEEP(Task_Series);
+    MARK_BLOCK_DEEP(VAL_SERIES(ROOT_ROOT));
+    MARK_BLOCK_DEEP(Task_Series);
 
 	// Mark all devices:
-	Mark_Devices();
+	Mark_Devices_Deep();
 
 	count = Sweep_Routines(); // this needs to run before Sweep_Series(), because Routine has series with pointers, which can't be simply discarded by Sweep_Series
 
@@ -977,9 +1042,11 @@ static void Process_Mark_Stack(void);
 	GC_Disabled = 0;
 
 	if (Reb_Opts->watch_recycle) Debug_Fmt(cs_cast(BOOT_STR(RS_WATCH, 1)), count);
+
+	ASSERT_NO_GC_MARKS_PENDING();
+
 	return count;
 }
-
 
 
 /***********************************************************************
@@ -992,7 +1059,6 @@ static void Process_Mark_Stack(void);
 	((REBSER **)GC_Protect->data)[GC_Protect->tail++] = series;
 }
 
-#include <stdio.h>
 
 /***********************************************************************
 **
@@ -1071,7 +1137,7 @@ static void Process_Mark_Stack(void);
 	// nested structures don't cause the C stack to overflow.
 	GC_Mark_Stack = Make_Series(100, sizeof(REBSER *), MKS_NONE);
 	TERM_SERIES(GC_Mark_Stack);
-	KEEP_SERIES(GC_Mark_Stack, "gc mark queue");
+    KEEP_SERIES(GC_Mark_Stack, "gc mark stack");
 
 	GC_Series = Make_Series(60, sizeof(REBSER *), MKS_NONE);
 	KEEP_SERIES(GC_Series, "gc guarded");

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -604,9 +604,14 @@ clear_header:
 		if (Prior_Expand[n] == series) Prior_Expand[n] = 0;
 	}
 
-	if (!IS_EXT_SERIES(series)) {
+	if (!IS_EXT_SERIES(series))
 		Free_Series_Data(series, TRUE);
+	else {
+		// External series have their REBSER GC'd when Rebol doesn't need it,
+		// but the data pointer itself is not one that Rebol allocated
+		// !!! Should the external owner be told about the GC/free event?
 	}
+
 	series->info = 0; // includes width
 	//series->data = BAD_MEM_PTR;
 	//series->tail = 0xBAD2BAD2;

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -403,7 +403,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 /***********************************************************************
 **
-*/	REBSER *Make_Series(REBCNT length, REBCNT wide, REBOOL powerof2)
+*/	REBSER *Make_Series(REBCNT length, REBCNT wide, REBCNT flags)
 /*
 **		Make a series of a given length and width (unit size).
 **		Small series will be allocated from a REBOL pool.
@@ -435,7 +435,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 		length = Mem_Pools[pool_num].wide;
 		memset(node, 0, length);
 	} else {
-		if (powerof2) {
+		if (flags & MKS_POWER_OF_2) {
 				REBCNT len=1;
 			#ifdef NDEBUG
                 len = 2048;
@@ -485,6 +485,16 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	SERIES_REST(series) = length / wide; //FIXME: This is based on the assumption that length is multiple of wide
 	series->data = (REBYTE *)node;
 	series->info = wide; // also clears flags
+	if (flags & MKS_BLOCK) {
+		assert(wide == sizeof(REBVAL));
+		SERIES_SET_FLAG(series, SER_BLOCK);
+	}
+	else {
+		// Temporary sanity check of old invariant of IS_BLOCK_SERIES() until
+		// we are sure code is working.
+		assert(wide != sizeof(REBVAL));
+	}
+
 	LABEL_SERIES(series, "make");
 
 	if ((GC_Ballast -= length) <= 0) SET_SIGNAL(SIG_RECYCLE);

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -121,7 +121,14 @@
 			Trap(RE_PAST_END);
 		}
 
-		newser = Make_Series(new_size, wide, TRUE);
+		newser = Make_Series(
+			new_size,
+			wide,
+			IS_BLOCK_SERIES(series)
+				? (MKS_BLOCK | MKS_POWER_OF_2)
+				: MKS_POWER_OF_2
+		);
+
 		// If necessary, add series to the recently expanded list:
 		if (Prior_Expand[n] != series) {
 			n = (REBUPT)(Prior_Expand[0]) + 1;
@@ -260,7 +267,11 @@
 ***********************************************************************/
 {
 	REBCNT len = source->tail + 1;
-	REBSER *series = Make_Series(len, SERIES_WIDE(source), FALSE);
+	REBSER *series = Make_Series(
+		len,
+		SERIES_WIDE(source),
+		IS_BLOCK_SERIES(source) ? MKS_BLOCK : MKS_NONE
+	);
 
 	memcpy(series->data, source->data, len * SERIES_WIDE(source));
 	series->tail = source->tail;
@@ -276,7 +287,11 @@
 **
 ***********************************************************************/
 {
-	REBSER *series = Make_Series(length+1, SERIES_WIDE(source), FALSE);
+	REBSER *series = Make_Series(
+		length + 1,
+		SERIES_WIDE(source),
+		IS_BLOCK_SERIES(source) ? MKS_BLOCK : MKS_NONE
+	);
 
 	memcpy(series->data, source->data + index * SERIES_WIDE(source), (length+1) * SERIES_WIDE(source));
 	series->tail = length;
@@ -520,7 +535,11 @@
 	len = BYTE_SIZE(buf) ? ((REBYTE *)end) - BIN_HEAD(buf)
 		: ((REBUNI *)end) - UNI_HEAD(buf);
 
-	ser = Make_Series(len+1, SERIES_WIDE(buf), FALSE);
+	ser = Make_Series(
+		len + 1,
+		SERIES_WIDE(buf),
+		IS_BLOCK_SERIES(buf) ? MKS_BLOCK : MKS_NONE
+	);
 
 	memcpy(ser->data, buf->data, SERIES_WIDE(buf) * len);
 	ser->tail = len;

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -663,7 +663,7 @@ chk_neg:
 		REBSER * ser = NULL;
 		cmd = Val_Str_To_OS(arg);
 		argc = 1;
-		ser = Make_Series(argc + 1, sizeof(REBCHR*), FALSE);
+		ser = Make_Series(argc + 1, sizeof(REBCHR*), MKS_NONE);
 		argv = cast(const REBCHR**, SERIES_DATA(ser));
 		argv[0] = cmd;
 		argv[argc] = NULL;
@@ -674,7 +674,7 @@ chk_neg:
 		if (argc <= 0) {
 			Trap_DEAD_END(RE_TOO_SHORT);
 		}
-		ser = Make_Series(argc + 1, sizeof(REBCHR*), FALSE);
+		ser = Make_Series(argc + 1, sizeof(REBCHR*), MKS_NONE);
 		argv = cast(const REBCHR**, SERIES_DATA(ser));
 		for (i = 0; i < argc; i ++) {
 			REBVAL *param = VAL_BLK_SKIP(arg, i);
@@ -693,7 +693,7 @@ chk_neg:
 		REBSER * ser = NULL;
 		REBSER *path = Value_To_OS_Path(arg, FALSE);
 		argc = 1;
-		ser = Make_Series(argc + 1, sizeof(REBCHR*), FALSE);
+		ser = Make_Series(argc + 1, sizeof(REBCHR*), MKS_NONE);
 		argv = cast(const REBCHR**, SERIES_DATA(ser));
 		argv[0] = cast(REBCHR*, SERIES_DATA(path));
 		argv[argc] = NULL;

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -218,7 +218,7 @@ static struct digest {
 
 			if (digests[i].index == sym) {
 
-				digest = Make_Series(digests[i].len, 1, FALSE);
+				digest = Make_Series(digests[i].len, sizeof(char), MKS_NONE);
 				LABEL_SERIES(digest, "checksum digest");
 
 				if (D_REF(ARG_CHECKSUM_KEY)) {

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -276,7 +276,7 @@ static REBCNT *CRC_Table;
 	n = Get_Hash_Prime(len * 2); // best when 2X # of keys
 	if (!n) Trap_Num(RE_SIZE_LIMIT, len);
 
-	ser = Make_Series(n + 1, sizeof(REBCNT), FALSE);
+	ser = Make_Series(n + 1, sizeof(REBCNT), MKS_NONE);
 	LABEL_SERIES(ser, "make hash array");
 	Clear_Series(ser);
 	ser->tail = n;

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -40,7 +40,7 @@
 **
 ***********************************************************************/
 {
-	REBSER *series = Make_Series(length + 1, sizeof(REBYTE), FALSE);
+	REBSER *series = Make_Series(length + 1, sizeof(REBYTE), MKS_NONE);
 	LABEL_SERIES(series, "make binary");
 	BIN_DATA(series)[length] = 0;
 	return series;
@@ -56,7 +56,7 @@
 **
 ***********************************************************************/
 {
-	REBSER *series = Make_Series(length + 1, sizeof(REBUNI), FALSE);
+	REBSER *series = Make_Series(length + 1, sizeof(REBUNI), MKS_NONE);
 	LABEL_SERIES(series, "make unicode");
 	UNI_HEAD(series)[length] = 0;
 	return series;
@@ -286,7 +286,7 @@ cp_same:
 		if (n < length) wide = sizeof(REBUNI);
 	}
 
-	dst = Make_Series(length + 1, wide, FALSE);
+	dst = Make_Series(length + 1, wide, MKS_NONE);
 	Insert_String(dst, 0, src, index, length, TRUE);
 	SERIES_TAIL(dst) = length;
 	TERM_SERIES(dst);

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -892,7 +892,7 @@ is_none:
 #ifndef NDEBUG
 /***********************************************************************
 **
-*/	void Assert_Blk_Core(const REBSER *series)
+*/	void Assert_Blk_Core(const REBSER *series, REBOOL unwords)
 /*
 ***********************************************************************/
 {
@@ -912,6 +912,9 @@ is_none:
 			// Premature end
 			Panic_Series(series);
 		}
+
+		if (unwords && (!ANY_WORD(value) || !VAL_GET_OPT(value, OPTS_UNWORD)))
+			Panic_Series(series);
 	}
 
 	if (!IS_END(BLK_SKIP(series, SERIES_TAIL(series)))) {

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -203,7 +203,7 @@ const REBCNT Gob_Flag_Words[] = {
 
 	// Create or expand the pane series:
 	if (!GOB_PANE(gob)) {
-		GOB_PANE(gob) = Make_Series(count + 1, sizeof(REBGOB*), 0);
+		GOB_PANE(gob) = Make_Series(count + 1, sizeof(REBGOB*), MKS_NONE);
 		LABEL_SERIES(GOB_PANE(gob), "gob pane");
 		GOB_TAIL(gob) = count;
 		index = 0;

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -415,7 +415,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 		else return 0;
 	}
 
-	img = Make_Series(w * h + 1, sizeof(u32), FALSE);
+	img = Make_Series(w * h + 1, sizeof(u32), MKS_NONE);
 	LABEL_SERIES(img, "make image");
 	img->tail = w * h;
 	RESET_IMAGE(img->data, img->tail); //length in 'pixels'

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -725,9 +725,17 @@ static void ffi_to_rebol(REBRIN *rin,
 		if ((VAL_LEN(varargs) - n_fixed) % 2) {
 			Trap_Arg(varargs);
 		}
-		ser = Make_Series(n_fixed + (VAL_LEN(varargs) - n_fixed) / 2, sizeof(void *), FALSE);
+		ser = Make_Series(
+			n_fixed + (VAL_LEN(varargs) - n_fixed) / 2,
+			sizeof(void *),
+			MKS_NONE
+		);
 	} else if ((SERIES_TAIL(VAL_ROUTINE_FFI_ARG_TYPES(rot))) > 1) {
-		ser = Make_Series(SERIES_TAIL(VAL_ROUTINE_FFI_ARG_TYPES(rot)) - 1, sizeof(void *), FALSE);
+		ser = Make_Series(
+			SERIES_TAIL(VAL_ROUTINE_FFI_ARG_TYPES(rot)) - 1,
+			sizeof(void *),
+			MKS_NONE
+		);
 	}
 
 	/* save ser on stack such that it won't be GC'ed */
@@ -1004,7 +1012,8 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 #define N_ARGS 8
 
 	VAL_ROUTINE_SPEC(out) = Copy_Series(VAL_SERIES(data));
-	VAL_ROUTINE_FFI_ARG_TYPES(out) = Make_Series(N_ARGS, sizeof(ffi_type*), FALSE);
+	VAL_ROUTINE_FFI_ARG_TYPES(out) =
+		Make_Series(N_ARGS, sizeof(ffi_type*), MKS_NONE);
 	VAL_ROUTINE_ARGS(out) = Make_Block(N_ARGS);
 	Append_Value(VAL_ROUTINE_ARGS(out)); //first word should be 'self', but ignored here.
 	VAL_ROUTINE_FFI_ARG_STRUCTS(out) = Make_Block(N_ARGS);
@@ -1013,7 +1022,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 	VAL_ROUTINE_ABI(out) = FFI_DEFAULT_ABI;
 	VAL_ROUTINE_LIB(out) = NULL;
 
-	extra_mem = Make_Series(N_ARGS, sizeof(void*), FALSE);
+	extra_mem = Make_Series(N_ARGS, sizeof(void*), MKS_NONE);
 	VAL_ROUTINE_EXTRA_MEM(out) = extra_mem;
 
 	args = (ffi_type**)SERIES_DATA(VAL_ROUTINE_FFI_ARG_TYPES(out));

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -102,7 +102,9 @@ static REBOOL get_scalar(REBSTU *stu,
 				SET_TYPE(val, REB_STRUCT);
 				VAL_STRUCT_FIELDS(val) = field->fields;
 				VAL_STRUCT_SPEC(val) = field->spec;
-				VAL_STRUCT_DATA(val) = Make_Series(1, sizeof(struct Struct_Data), FALSE);
+				VAL_STRUCT_DATA(val) = Make_Series(
+					1, sizeof(struct Struct_Data), MKS_NONE
+				);
 				VAL_STRUCT_DATA_BIN(val) = STRUCT_DATA_BIN(stu);
 				VAL_STRUCT_OFFSET(val) = data - SERIES_DATA(VAL_STRUCT_DATA_BIN(val));
 				VAL_STRUCT_LEN(val) = field->size;
@@ -599,14 +601,10 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 	//RL_Print("%s\n", __func__);
 	REBINT max_fields = 16;
 
-	// If either of these conditions were true, then Rebol would
-	// interpret these series as being series of REBVAL.
+	VAL_STRUCT_FIELDS(out) = Make_Series(
+		max_fields, sizeof(struct Struct_Field), MKS_NONE
+	);
 
-	assert(sizeof(struct Struct_Field) != sizeof(REBVAL));
-	assert(sizeof(struct Struct_Data) != sizeof(REBVAL));
-
-	VAL_STRUCT_FIELDS(out) = Make_Series(max_fields, sizeof(struct Struct_Field), FALSE);
-	BARE_SERIES(VAL_STRUCT_FIELDS(out));
 	if (IS_BLOCK(data)) {
 		//Reduce_Block_No_Set(VAL_SERIES(data), 0, NULL);
 		//data = DS_POP;
@@ -621,12 +619,12 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 		REBCNT alignment = 0;
 
 		VAL_STRUCT_SPEC(out) = Copy_Series(VAL_SERIES(data));
-		VAL_STRUCT_DATA(out) = Make_Series(1, sizeof(struct Struct_Data), FALSE);
+		VAL_STRUCT_DATA(out) = Make_Series(
+			1, sizeof(struct Struct_Data), MKS_NONE
+		);
 		EXPAND_SERIES_TAIL(VAL_STRUCT_DATA(out), 1);
-		BARE_SERIES(VAL_STRUCT_DATA(out));
 
-		VAL_STRUCT_DATA_BIN(out) = Make_Series(max_fields << 2, 1, FALSE);
-		BARE_SERIES(VAL_STRUCT_DATA_BIN(out));
+		VAL_STRUCT_DATA_BIN(out) = Make_Series(max_fields << 2, 1, MKS_NONE);
 		VAL_STRUCT_OFFSET(out) = 0;
 
 		/* set type early such that GC will handle it correctly, i.e, not collect series in the struct */
@@ -876,7 +874,6 @@ failed:
 
 	/* writable field */
 	dst->data = Copy_Series(src->data);
-	BARE_SERIES(dst->data);
 	STRUCT_DATA_BIN(dst) = Copy_Series(STRUCT_DATA_BIN(src));
 }
 

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -319,7 +319,8 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 
 	len = size * dims;
 	if (len > 0x7fffffff) return 0;
-	ser = Make_Series(len+1, bits/8, TRUE); // !!! can width help extend the len?
+	// !!! can width help extend the len?
+	ser = Make_Series(len + 1, bits/8, MKS_NONE | MKS_POWER_OF_2);
 	LABEL_SERIES(ser, "make vector");
 	CLEAR(ser->data, len*bits/8);
 	ser->tail = len;  // !!! another way to do it?

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -164,6 +164,13 @@ enum Boot_Levels {
 	BOOT_LEVEL_FULL
 };
 
+// Modes allowed by Make_Series function:
+enum {
+	MKS_NONE		= 0,		// data is opaque (not delved into by the GC)
+	MKS_BLOCK		= 1 << 0,	// Contains REBVALs (seen by GC and Debug)
+	MKS_POWER_OF_2	= 1 << 1	// Round size up to a power of 2
+};
+
 // Modes allowed by Copy_Block function:
 enum {
 	COPY_SHALLOW = 0,

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -409,14 +409,14 @@ typedef struct Reb_Tuple {
 
 // Series Flags:
 enum {
-	SER_MARK = 1,		// Series was found during GC mark scan.
-	SER_KEEP = 1<<1,	// Series is permanent, do not GC it.
-	SER_LOCK = 1<<2,	// Series is locked, do not expand it
-	SER_EXT  = 1<<3,	// Series data is external (library), do not GC it.
-	SER_FREE = 1<<4,	// mark series as removed
-	SER_BARE = 1<<5,	// Series has no links to GC-able values
-	SER_PROT = 1<<6,	// Series is protected from modification
-	SER_MON  = 1<<7		// Monitoring
+	SER_MARK	= 1 << 0,	// was found during GC mark scan.
+	SER_KEEP	= 1 << 1,	// don't garbage collect even if unreferenced
+	SER_LOCK	= 1 << 2,	// size is locked (do not expand it)
+	SER_EXT		= 1 << 3,	// .data pointer is external, don't free() on GC
+	SER_FREE	= 1 << 4,	// rest of REBSER is uninitialized, can be reused
+	SER_BLOCK	= 1 << 5,	// is sizeof(REBVAL) wide and has valid values
+	SER_PROT	= 1 << 6,	// protected from modification
+	SER_MON		= 1 << 7	// !!! Monitoring (?)
 };
 
 #define SERIES_SET_FLAG(s, f) (SERIES_FLAGS(s) |= ((f) << 8))
@@ -429,8 +429,7 @@ enum {
 #define IS_EXT_SERIES(s)  SERIES_GET_FLAG(s, SER_EXT)
 #define LOCK_SERIES(s)    SERIES_SET_FLAG(s, SER_LOCK)
 #define IS_LOCK_SERIES(s) SERIES_GET_FLAG(s, SER_LOCK)
-#define BARE_SERIES(s)    SERIES_SET_FLAG(s, SER_BARE)
-#define IS_BARE_SERIES(s) SERIES_GET_FLAG(s, SER_BARE)
+#define IS_BLOCK_SERIES(s) SERIES_GET_FLAG((s), SER_BLOCK)
 #define PROTECT_SERIES(s) SERIES_SET_FLAG(s, SER_PROT)
 #define UNPROTECT_SERIES(s)  SERIES_CLR_FLAG(s, SER_PROT)
 #define IS_PROTECT_SERIES(s) SERIES_GET_FLAG(s, SER_PROT)
@@ -472,7 +471,6 @@ enum {
 #endif
 
 //#define LABEL_SERIES(s,l) s->label = (l)
-#define IS_BLOCK_SERIES(s) (SERIES_WIDE(s) == sizeof(REBVAL))
 
 // !!! Remove if not used after port:
 //#define	SERIES_SIDE(s)	 ((s)->link.side)
@@ -700,8 +698,10 @@ typedef struct Reb_Series_Ref
 
 #ifdef NDEBUG
 	#define ASSERT_BLK(s) cast(void, 0)
+	#define ASSERT_UNWORDS_BLOCK(s) cast(void, 0)
 #else
-	#define ASSERT_BLK(s) Assert_Blk_Core(s)
+	#define ASSERT_BLK(s) Assert_Blk_Core(s, FALSE)
+	#define ASSERT_UNWORDS_BLOCK(s) Assert_Blk_Core(s, TRUE)
 #endif
 
 


### PR DESCRIPTION
This attempts to kill several birds with one stone.  The original motivator
was that IS_BLOCK_SERIES would test a series to see if it contained
REBVALs by [seeing if its element width was 'sizeof(REBVAL)'](https://github.com/metaeducation/ren-c/blob/f7e0d396f8745ea4232a80dfb44efe3d25d5b9ba/src/include/sys-value.h#L524), as
opposed to having a [series flag](https://github.com/metaeducation/ren-c/blob/f7e0d396f8745ea4232a80dfb44efe3d25d5b9ba/src/include/sys-value.h#L459) for that purpose.  As series are used for
many other data types (pointers, REBYTE, REBUNI, etc) it always struck
me as sketchy because you might want to use it to make a series of
REBVAL-sized things that aren't REBVALs, and indeed the STRUCT!
implementation [wound up doing that](https://github.com/metaeducation/ren-c/blob/f7e0d396f8745ea4232a80dfb44efe3d25d5b9ba/src/core/t-struct.c#L602) (in 32-bit builds).

This called for a review of the somewhat-related SER_BARE flag, which
would prevent the garbage collector from descending into a series for
marking based on a guarantee that the series contained no composite
values.  This wasn't to say that it didn't contain REBVALs, in fact the
only original instance of these were for lists of REBWRS values (a.k.a.
"Unwords") in function word series and object frame keys.

The "take my word for it" property of SER_BARE was not as good as
having a debug check, and the "bareness" was already contextually
known to the GC based on the type it was marking.  This replaces that
flag with SER_BLOCK and [adds asserts regarding the "bareness"](https://github.com/metaeducation/ren-c/pull/31/files#diff-2d1074113db961d1231e62e0f00af616R207) into
the appropriate cases in the Mark_Value switch statement.

This also changes MARK_SERIES_SHALLOW to the better cueing name
of MARK_SERIES_ONLY (since it marks things that can't be considered to
have a possibility of being DEEP because they don't contain REBVALs in
the first place).  It then uses that flag for ROUTINE_FFI_ARG_TYPES
as [@ShixinZeng explained that these are not block series](https://github.com/metaeducation/ren-c/commit/a2d1c8a6b207e951db070264d2108deb2efe5845#commitcomment-12429888).