### PR TITLE
Fix out-of-context word in Reword function.

### DIFF
--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -160,7 +160,7 @@ reword: func [
 	char [char! any-string! binary! block! none!] {Default "$"}
 	/into "Insert into a buffer instead (returns position after insert)"
 	output [any-string! binary!] "The buffer series (modified)"
-	/local char-end vals word wtype cword out fout rule a b w v
+	/local char-end vals word wtype cword out fout rule a b w v c
 ][
 	assert/type [local none!]  ; Prevent locals injection
 	unless into [output: make source length? source]


### PR DESCRIPTION
REWORD would die with the error: `** Script error: c: word is not bound to a context`, this request adds `'c` to the list of locals.