### PR TITLE
RL_Map_Word did not provide length to Make_Word

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -861,7 +861,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **
 ***********************************************************************/
 {
-	return Make_Word(string, 0);
+	return Make_Word(string, LEN_BYTES(string));
 }
 
 


### PR DESCRIPTION
The same error is in a-lib2.c but it's unused anyway.