### PR TITLE
New CASE with switch for legacy behavior (CC#2245)

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -66,7 +66,8 @@ break: native [
 case: native [
 	{Evaluates each condition, and when true, evaluates what follows it.}
 	block [block!] {Block of cases (conditions followed by values)}
-	/all {Evaluate all cases (do not stop at first true case)}
+	/all {Evaluate all cases (do not stop at first TRUE? case)}
+	/only {Return block values instead of evaluating them.}
 ]
 
 catch: native [

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -140,6 +140,7 @@ options: context [  ; Options supplied to REBOL during startup
 	; Legacy Behaviors Options (enabled if R3_LEGACY=1 set in OS environment)
 
 	exit-functions-only: false
+	broken-case-semantics: false
 ]
 
 script: context [

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -134,6 +134,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 			"** system/options: [\n"
 			"**     (...)\n"
 			"**     exit-functions-only: false\n"
+			"**     broken-case-semantics: false\n"
 			"** ]\n"
 			"**\n"
 		);

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -34,7 +34,7 @@ clean-path: func [
 			]
 			file: append clear out file
 		]
-		file: append what-dir file
+		true [file: append what-dir file]
 	]
 
 	if all [dir not dir? file] [append file #"/"]


### PR DESCRIPTION
This reworks and elaborates on the implementation of CASE (with
comments).  Because it winds up being a fairly radical change, it has
a switch called `broken-case-semantics` that can be turned on in
debug builds when R3_LEGACY is set in the environment, which
should give it the behavior of an old Rebol2/Rebol3.

A main change is to address [CC#2245](http://curecode.org/rebol3/ticket.rsp?id=2245), where 'case [true add 1 2]'
and 'case [false add 1 2]' have differing interpretations of the structure
of the case.  In Rebol2 they return 3 and 2 respectively, while under
this implementation they return 3 and none.

A second change is the removal of a "feature" which was to tolerate
an odd number of condition/body pairings.  In Rebol2/Rebol3 this
would run the condition and then return TRUE or NONE.  This means
'case [1 > 2]' would be NONE and 'case [1 < 2]' would be TRUE.
While on the surface this seems to be just actively asking for bugs to
be harder to find, it was found to be used once as a way of being
lazy and not putting a "true" for the condition slot of a last default
item.  TRUE as condition of the default body in the case is a fine
idiom, is kind of cool, and doesn't open the door as wide to bugs.

Third is that the return value of the case is always the evaluated
value of the last TRUE? case that was run.  This means that:

    >> case/all [true [1 + 2] false [9]]
    == 3 ;-- would have been none in Rebol2 and old Rebol3