### PR TITLE
QUIT via THROW, CATCH [] vs CATCH/ANY (CC#2247)

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -24,7 +24,6 @@ Throw: [
 	throw:              [{no catch for throw:} :arg1]
 	continue:           {no loop to continue}
 	halt:               [{halted by user or script}]
-	quit:               [{user script quit}]
 ]
 
 Note: [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -76,6 +76,7 @@ catch: native [
 	/name {Catches a named throw}
 	word [word! block!] {One or more names}
 	/quit {Special catch for QUIT native}
+	/any {Catch all throws except QUIT (can be used with /QUIT)}
 ]
 
 ;cause: native [
@@ -216,10 +217,11 @@ map-each: native [
 ;]
 
 quit: native [
-	{Stops evaluation and exits the interpreter.}
-	/return {Returns a value (to prior script or command shell)}
-	value {Note: use integers for command shell}
-	/now {Quit immediately}
+	{Stop evaluating and return control to command shell or calling script.}
+	/with {Yield a result (mapped to an integer if given to shell)}
+	value [any-type!] {See: http://en.wikipedia.org/wiki/Exit_status}
+	/return {(deprecated synonym for /WITH)}
+	return-value
 ]
 
 protect: native [

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -101,6 +101,10 @@ utc
 ; Used to recognize Rebol2 use of [catch] in function specs
 catch
 
+; Needed for processing of "special" THROW words that might exit interpreter
+exit
+quit
+
 ; Parse: - These words must not reserved above!!
 parse
 |	 ; must be first

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -447,7 +447,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		Resolve_Context(user, Lib_Context, &vali, FALSE, 0);
 	}
 
-	if (!DO_BLOCK(&out, code, 0)) {
+	if (DO_BLOCK_THROWS(&out, code, 0)) {
 		UNSAVE_SERIES(code);
 
 		if (

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -243,8 +243,7 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 	// object/(expr) case:
 	else if (IS_PAREN(path)) {
 
-		if (!DO_BLOCK(&temp, VAL_SERIES(path), 0)) {
-			// If temp is THROWN(), stop path evaluation
+		if (DO_BLOCK_THROWS(&temp, VAL_SERIES(path), 0)) {
 			*pvs->value = temp;
 			return;
 		}
@@ -928,7 +927,7 @@ do_at_index:
 		break;
 
 	case REB_PAREN:
-		if (!DO_BLOCK(out, VAL_SERIES(value), 0)) {
+		if (DO_BLOCK_THROWS(out, VAL_SERIES(value), 0)) {
 			index = THROWN_FLAG;
 			goto return_index;
 		}
@@ -1231,8 +1230,7 @@ finished:
 		if (IS_PAREN(value)) {
 			REBVAL evaluated;
 
-			if (!DO_BLOCK(&evaluated, VAL_SERIES(value), 0)) {
-				// throw, return, break, continue...
+			if (DO_BLOCK_THROWS(&evaluated, VAL_SERIES(value), 0)) {
 				*out = evaluated;
 				DS_DROP_TO(dsp_orig);
 				goto finished;

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -499,7 +499,7 @@
 		// Bind and do an evaluation step (as with MAKE OBJECT! with A_MAKE
 		// code in REBTYPE(Object) and code in REBNATIVE(construct))
 		Bind_Block(err, VAL_BLK_DATA(arg), BIND_DEEP);
-		if (!DO_BLOCK(&evaluated, VAL_SERIES(arg), 0)) {
+		if (DO_BLOCK_THROWS(&evaluated, VAL_SERIES(arg), 0)) {
 			ENABLE_GC;
 			*out = evaluated;
 			return FALSE;

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -576,7 +576,13 @@
 **
 ***********************************************************************/
 {
-	Do_Sys_Func(out, SYS_CTX_MAKE_MODULE_P, spec, 0);
+	if (!Do_Sys_Func(out, SYS_CTX_MAKE_MODULE_P, spec, 0)) {
+		// Gave back an unhandled RETURN, BREAK, CONTINUE, etc...
+		Do_Error(out);
+		DEAD_END_VOID;
+	}
+
+	// !!! Shouldn't this be testing for !IS_MODULE(out)?
 	if (IS_NONE(out)) Trap1(RE_INVALID_SPEC, spec);
 }
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -445,7 +445,7 @@
 
 	Eval_Functions++;
 
-	if (!DO_BLOCK(out, VAL_FUNC_BODY(func), 0)) {
+	if (DO_BLOCK_THROWS(out, VAL_FUNC_BODY(func), 0)) {
 		if (
 			VAL_ERR_NUM(out) == RE_RETURN
 			|| (VAL_ERR_NUM(out) == RE_THROW && VAL_ERR_SYM(out) == SYM_EXIT)
@@ -510,7 +510,7 @@
 	Rebind_Block(VAL_FUNC_WORDS(func), frame, BLK_HEAD(body), REBIND_TYPE);
 
 	SAVE_SERIES(body);
-	if (!DO_BLOCK(out, body, 0)) {
+	if (DO_BLOCK_THROWS(out, body, 0)) {
 		if (
 			VAL_ERR_NUM(out) == RE_RETURN
 			|| (VAL_ERR_NUM(out) == RE_THROW && VAL_ERR_SYM(out) == SYM_EXIT)

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -446,7 +446,10 @@
 	Eval_Functions++;
 
 	if (!DO_BLOCK(out, VAL_FUNC_BODY(func), 0)) {
-		if (VAL_ERR_NUM(out) == RE_RETURN || VAL_ERR_NUM(out) == RE_EXIT) {
+		if (
+			VAL_ERR_NUM(out) == RE_RETURN
+			|| (VAL_ERR_NUM(out) == RE_THROW && VAL_ERR_SYM(out) == SYM_EXIT)
+		) {
 			if (!VAL_GET_EXT(func, EXT_FUNC_TRANSPARENT))
 				TAKE_THROWN_ARG(out, out);
 		}
@@ -508,7 +511,10 @@
 
 	SAVE_SERIES(body);
 	if (!DO_BLOCK(out, body, 0)) {
-		if (VAL_ERR_NUM(out) == RE_RETURN || VAL_ERR_NUM(out) == RE_EXIT) {
+		if (
+			VAL_ERR_NUM(out) == RE_RETURN
+			|| (VAL_ERR_NUM(out) == RE_THROW && VAL_ERR_SYM(out) == SYM_EXIT)
+		) {
 			if (!VAL_GET_EXT(func, EXT_FUNC_TRANSPARENT))
 				TAKE_THROWN_ARG(out, out);
 		}

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -42,7 +42,13 @@
 **
 ***********************************************************************/
 {
-	Do_Sys_Func(out, SYS_CTX_MAKE_PORT_P, spec, 0);
+	if (!Do_Sys_Func(out, SYS_CTX_MAKE_PORT_P, spec, 0)) {
+		// Gave back an unhandled RETURN, BREAK, CONTINUE, etc...
+		Do_Error(out);
+		DEAD_END_VOID;
+	}
+
+	// !!! Shouldn't this be testing for !IS_PORT( ) ?
 	if (IS_NONE(out)) Trap1(RE_INVALID_SPEC, spec);
 }
 

--- a/src/core/c-task.c
+++ b/src/core/c-task.c
@@ -75,9 +75,10 @@
 	body = Clone_Block(VAL_MOD_BODY(task));
 	OS_TASK_READY(0);
 
-	// !!! Result is whether a THROWN() happened, and it would be
-	// important for TASK! if it were to be developed further
-	cast(void, DO_BLOCK(&ignored, body, 0));
+	if (DO_BLOCK_THROWS(&ignored, body, 0)) {
+		Do_Error(&ignored);
+		DEAD_END_VOID;
+	}
 
 	Debug_Str("End Task");
 }

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -238,7 +238,11 @@ x*/	REBRXT Do_Callback(REBSER *obj, u32 name, RXIARG *rxis, RXIARG *result)
 	}
 
 	// Evaluate the function:
-	Dispatch_Call(call);
+	if (!Dispatch_Call(call)) {
+		// !!! Needs better handling for THROWN() to safely "bubble up"
+		Do_Error(DSF_OUT(call));
+		DEAD_END;
+	}
 
 	// Return resulting value from output
 	*result = Value_To_RXI(&out);

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -578,8 +578,9 @@ typedef REBYTE *(INFO_FUNC)(REBINT opts, void *lib);
 					}
 				}
 				else if (IS_PAREN(val)) {
-					if (!DO_BLOCK(&save, VAL_SERIES(val), 0)) {
-						// !!! handle THROW, RETURN, BREAK...?
+					if (DO_BLOCK_THROWS(&save, VAL_SERIES(val), 0)) {
+						Do_Error(&save); // !!! Better answer?
+						DEAD_END_VOID;
 					}
 					val = &save;
 				}

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -639,7 +639,7 @@
 		return;
 	}
 
-	Throw(&error, NULL); // ENABLE_GC implied
+	Do_Error(&error); // ENABLE_GC implied
 	DEAD_END_VOID;
 }
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -329,7 +329,7 @@ enum {
 
 	if (error) return R_NONE;
 
-	if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
+	if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
 		// This means that D_OUT is a THROWN() value, but we have
 		// no special processing to apply.  Fall through and return it.
 	}
@@ -458,10 +458,9 @@ enum {
 				//     stuff: [print "This will be printed"]
 				//     case [true stuff]
 				//
-				if (!DO_BLOCK(
+				if (DO_BLOCK_THROWS(
 					D_OUT, VAL_SERIES(body_result), VAL_INDEX(body_result)
 				)) {
-					// D_OUT is a RETURN, BREAK, THROW...
 					return R_OUT;
 				}
 			}
@@ -519,7 +518,7 @@ enum {
 	// /ANY would override /NAME, so point out the potential confusion
 	if (catch_any && catch_named) Trap(RE_BAD_REFINES);
 
-	if (!DO_BLOCK(D_OUT, VAL_SERIES(block), VAL_INDEX(block))) {
+	if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(block), VAL_INDEX(block))) {
 		REBCNT sym = VAL_ERR_SYM(D_OUT);
 
 		if (
@@ -673,10 +672,9 @@ enum {
 			return R_OUT;
 		}
 
-		if (!DO_BLOCK(D_OUT, VAL_SERIES(value), 0)) {
-			// output is THROWN, RETURN, BREAK etc.
-			// no special handling though, just return it as we were going to
-		}
+		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(value), 0))
+			return R_OUT;
+
 		return R_OUT;
 
     case REB_NATIVE:
@@ -757,14 +755,13 @@ enum {
 	REBCNT argnum = IS_CONDITIONAL_FALSE(D_ARG(1)) ? 3 : 2;
 
 	if (IS_BLOCK(D_ARG(argnum)) && !D_REF(4) /* not using /ONLY */) {
-		if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(argnum)), 0)) {
-			// Value is RETURN, THROW, BREAK, etc...
-			// No special handling though, just return it as we were going to
-		}
+		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(argnum)), 0))
+			return R_OUT;
+
 		return R_OUT;
-	} else {
-		return argnum == 2 ? R_ARG2 : R_ARG3;
 	}
+
+	return argnum == 2 ? R_ARG2 : R_ARG3;
 }
 
 
@@ -804,10 +801,9 @@ enum {
 {
 	if (IS_CONDITIONAL_FALSE(D_ARG(1))) return R_NONE;
 	if (IS_BLOCK(D_ARG(2)) && !D_REF(3) /* not using /ONLY */) {
-		if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(2)), 0)) {
-			// Was a THROW, RETURN, BREAK, etc...
-			// No special handling, just return it like we were going to
-		}
+		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(2)), 0))
+			return R_OUT;
+
 		return R_OUT;
 	}
 	return R_ARG2;
@@ -914,17 +910,16 @@ enum {
 			found = TRUE;
 
 			// Evaluate code block, but if result is THROWN() then return it
-			if (!DO_BLOCK(D_OUT, VAL_SERIES(case_val), 0)) return R_OUT;
+			if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(case_val), 0)) return R_OUT;
 
 			if (!all) return R_OUT;
 		}
 	}
 
 	if (!found && IS_BLOCK(D_ARG(4))) {
-		if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(4)), 0)) {
-			// Value is THROW, RETURN, BREAK, etc...
-			// No special handling though, just return as we were going to
-		}
+		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(4)), 0))
+			return R_OUT;
+
 		return R_OUT;
 	}
 
@@ -957,11 +952,10 @@ enum {
 		if (except) {
 			if (IS_BLOCK(D_ARG(3))) {
 				// forget the result of the try (no way to pass to a block)
-				if (
-					!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(3)), VAL_INDEX(D_ARG(3)))
-				) {
-					// Was a THROW, RETURN, BREAK etc...
-					// No special handling, just return like we were going to
+				if (DO_BLOCK_THROWS(
+					D_OUT, VAL_SERIES(D_ARG(3)), VAL_INDEX(D_ARG(3))
+				)) {
+					return R_OUT;
 				}
 				return R_OUT;
 			}
@@ -992,8 +986,7 @@ enum {
 		return R_OUT;
 	}
 
-	if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
-		// Was a THROW, RETURN, BREAK, etc...
+	if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
 		// No special handling, just return like we were going to
 	}
 
@@ -1010,12 +1003,13 @@ enum {
 ***********************************************************************/
 {
 	if (IS_CONDITIONAL_TRUE(D_ARG(1))) return R_NONE;
+
 	if (IS_BLOCK(D_ARG(2)) && !D_REF(3) /* not using /ONLY */) {
-		if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(2)), 0)) {
-			// Was THROWN, RETURN, BREAK, etc...
-			// No special handling, just return it like we were going to
-		}
+		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(2)), 0))
+			return R_OUT;
+
 		return R_OUT;
 	}
+
 	return R_ARG2;
 }

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -108,7 +108,7 @@
 	for (; (ii > 0) ? si <= ei : si >= ei; si += ii) {
 		VAL_INDEX(var) = si;
 
-		if (!DO_BLOCK(out, body, 0) && Check_Error(out) >= 0) break;
+		if (DO_BLOCK_THROWS(out, body, 0) && Check_Error(out) >= 0) break;
 
 		if (VAL_TYPE(var) != type) Trap1(RE_INVALID_TYPE, var);
 		si = VAL_INDEX(var);
@@ -129,7 +129,7 @@
 	while ((incr > 0) ? start <= end : start >= end) {
 		VAL_INT64(var) = start;
 
-		if (!DO_BLOCK(out, body, 0) && Check_Error(out) >= 0) break;
+		if (DO_BLOCK_THROWS(out, body, 0) && Check_Error(out) >= 0) break;
 
 		if (!IS_INTEGER(var)) Trap_Type(var);
 		start = VAL_INT64(var);
@@ -170,7 +170,7 @@
 	for (; (i > 0.0) ? s <= e : s >= e; s += i) {
 		VAL_DECIMAL(var) = s;
 
-		if (!DO_BLOCK(out, body, 0) && Check_Error(out) >= 0) break;
+		if (DO_BLOCK_THROWS(out, body, 0) && Check_Error(out) >= 0) break;
 
 		if (!IS_DECIMAL(var)) Trap_Type(var);
 		s = VAL_DECIMAL(var);
@@ -229,7 +229,7 @@
 				VAL_INDEX(var) = idx;
 			}
 
-			if (!DO_BLOCK(D_OUT, body, bodi)) {	// Break, throw, continue, error.
+			if (DO_BLOCK_THROWS(D_OUT, body, bodi)) {
 				if (Check_Error(D_OUT) >= 0) {
 					break;
 				}
@@ -418,7 +418,7 @@
 		}
 		if (index == rindex) index++; //the word block has only set-words: foreach [a:] [1 2 3][]
 
-		if (!DO_BLOCK(D_OUT, body, 0)) {
+		if (DO_BLOCK_THROWS(D_OUT, body, 0)) {
 			if ((err = Check_Error(D_OUT)) >= 0) {
 				index = rindex;
 				break;
@@ -538,7 +538,7 @@ skip_hidden: ;
 ***********************************************************************/
 {
 	do {
-		if (!DO_BLOCK(D_OUT, VAL_SERIES(D_ARG(1)), 0)) {
+		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(1)), 0)) {
 			if (Check_Error(D_OUT) >= 0) return R_OUT;
 		}
 	} while (TRUE);
@@ -604,7 +604,7 @@ skip_hidden: ;
 	SET_NONE(D_OUT); // Default result to NONE if the loop does not run
 
 	for (; count > 0; count--) {
-		if (!DO_BLOCK(D_OUT, block, index)) {
+		if (DO_BLOCK_THROWS(D_OUT, block, index)) {
 			if (Check_Error(D_OUT) >= 0) break;
 		}
 	}
@@ -661,7 +661,7 @@ skip_hidden: ;
 
 	do {
 utop:
-		if (!DO_BLOCK(D_OUT, b1, i1)) {
+		if (DO_BLOCK_THROWS(D_OUT, b1, i1)) {
 			if (Check_Error(D_OUT) >= 0) break;
 			goto utop;
 		}
@@ -694,12 +694,11 @@ utop:
 	SET_NONE(D_OUT);
 
 	do {
-		if (!DO_BLOCK(&temp, b1, i1) || IS_UNSET(&temp)) {
-			// Unset, break, throw, error.
+		if (DO_BLOCK_THROWS(&temp, b1, i1) || IS_UNSET(&temp)) {
 			if (Check_Error(&temp) >= 0) {
-				// Check_Error modifies its argument such that TOS will be
+				// Check_Error modifies its argument such that temp will be
 				// UNSET! (or the arg to BREAK/WITH) if a BREAK happened.
-				// (It will also complain if DS_TOP was an UNSET!.)
+				// (It will also complain if temp was an UNSET!.)
 				*D_OUT = temp;
 				return R_OUT;
 			}
@@ -711,8 +710,7 @@ utop:
 		// Not interested in the value of the condition loop once we've
 		// decided to run the body...
 
-		if (!DO_BLOCK(D_OUT, b2, i2)) {
-			// Break, throw, continue, error.
+		if (DO_BLOCK_THROWS(D_OUT, b2, i2)) {
 			// !!! Check_Error may modify its argument
 			if (Check_Error(D_OUT) >= 0) return R_OUT;
 		}

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -318,7 +318,8 @@ static REBSER *Trim_Object(REBSER *obj)
 					Bind_Block(obj, VAL_BLK_DATA(arg), BIND_DEEP);
 
 					// GC-OK
-					if (!DO_BLOCK(D_OUT, VAL_SERIES(arg), 0)) return R_OUT;
+					if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(arg), 0))
+						return R_OUT;
 
 					break; // returns obj
 				}
@@ -398,7 +399,7 @@ static REBSER *Trim_Object(REBSER *obj)
 				Bind_Block(obj, VAL_BLK_DATA(arg), BIND_DEEP);
 
 				// GC-OK
-				if (!DO_BLOCK(D_OUT, VAL_SERIES(arg), 0)) return R_OUT;
+				if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(arg), 0)) return R_OUT;
 
 				break; // returns obj
 			}

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -933,10 +933,11 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 		}
 	}
 
-	if (!DO_BLOCK(&safe, ser, 0)) {
-		// There was a RETURN, THROW, BREAK etc. during evaluation
-		// !!! What should actually happen here?
-		Trap(RE_MISC);
+	if (DO_BLOCK_THROWS(&safe, ser, 0)) {
+		// !!! Does not check for thrown cases...what should this
+		// do in case of THROW, BREAK, QUIT?
+		Do_Error(&safe);
+		DEAD_END_VOID;
 	}
 
 	elem = &safe;

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -565,10 +565,11 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 	if (IS_BLOCK(val)) {// make struct! [a: [int32 [2]] [0 0]]
 		REBVAL ret;
 
-		if (!DO_BLOCK(&ret, VAL_SERIES(val), 0)) {
+		if (DO_BLOCK_THROWS(&ret, VAL_SERIES(val), 0)) {
 			// !!! Does not check for thrown cases...what should this
-			// do in case of THROW, BREAK, RETURN?  Currently it would
-			// say it expected an integer and not allow the throw.
+			// do in case of THROW, BREAK, QUIT?
+			Do_Error(&ret);
+			DEAD_END;
 		}
 
 		if (!IS_INTEGER(&ret)) {

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -187,11 +187,11 @@ static const char *Dia_Fmt = "DELECT - cmd: %s length: %d missed: %d total: %d";
 		break;
 
 	case REB_PAREN:
-		if (!DO_BLOCK(&safe, VAL_SERIES(value), 0)) {
-			// Value is a THROW, RETURN, BREAK, etc...
-			// !!! Odds are we shouldn't push this on the stack and continue,
-			// but it's not clear what was intended here.
-			Panic(RP_MISC);
+		if (DO_BLOCK_THROWS(&safe, VAL_SERIES(value), 0)) {
+			// !!! Does not check for thrown cases...what should this
+			// do in case of THROW, BREAK, QUIT?
+			Do_Error(&safe);
+			DEAD_END;
 		}
 		DS_PUSH(&safe);
 		value = DS_TOP;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -208,7 +208,7 @@ void Print_Parse_Index(REBCNT type, const REBVAL *rules, REBSER *series, REBCNT 
 	// Do an expression:
 	case REB_PAREN:
 		// might GC
-		if (!DO_BLOCK(&save, VAL_SERIES(item), 0)) {
+		if (DO_BLOCK_THROWS(&save, VAL_SERIES(item), 0)) {
 			*parse->out = save;
 			Trap(RE_PARSE_LONGJMP_HACK); // !!! should return gracefully!
 			DEAD_END;
@@ -281,7 +281,7 @@ void Print_Parse_Index(REBCNT type, const REBVAL *rules, REBSER *series, REBCNT 
 	// Do an expression:
 	case REB_PAREN:
 		// might GC
-		if (!DO_BLOCK(&save, VAL_SERIES(item), 0)) {
+		if (DO_BLOCK_THROWS(&save, VAL_SERIES(item), 0)) {
 			*parse->out = save;
 			Trap(RE_PARSE_LONGJMP_HACK); // !!! should return gracefully!
 			DEAD_END;
@@ -340,7 +340,7 @@ no_result:
 						if (IS_END(item)) goto bad_target;
 						if (IS_PAREN(item)) {
 							// might GC
-							if (!DO_BLOCK(&save, VAL_SERIES(item), 0)) {
+							if (DO_BLOCK_THROWS(&save, VAL_SERIES(item), 0)) {
 								*parse->out = save;
 								Trap(RE_PARSE_LONGJMP_HACK);
 								DEAD_END;
@@ -443,7 +443,7 @@ next:		// Check for | (required if not end)
 found:
 	if (IS_PAREN(blk + 1)) {
 		REBVAL evaluated;
-		if (!DO_BLOCK(&evaluated, VAL_SERIES(blk + 1), 0)) {
+		if (DO_BLOCK_THROWS(&evaluated, VAL_SERIES(blk + 1), 0)) {
 			*parse->out = evaluated;
 			Trap(RE_PARSE_LONGJMP_HACK); // !!! should return gracefully!
 			DEAD_END;
@@ -455,7 +455,7 @@ found:
 found1:
 	if (IS_PAREN(blk + 1)) {
 		REBVAL evaluated;
-		if (!DO_BLOCK(&evaluated, VAL_SERIES(blk + 1), 0)) {
+		if (DO_BLOCK_THROWS(&evaluated, VAL_SERIES(blk + 1), 0)) {
 			*parse->out = save;
 			Trap(RE_PARSE_LONGJMP_HACK); // !!! should return gracefully!
 			DEAD_END;
@@ -603,7 +603,7 @@ bad_target:
 			if (IS_END(item)) Trap1_DEAD_END(RE_PARSE_END, item-2);
 			if (IS_PAREN(item)) {
 				// might GC
-				if (!DO_BLOCK(&save, VAL_SERIES(item), 0)) {
+				if (DO_BLOCK_THROWS(&save, VAL_SERIES(item), 0)) {
 					*parse->out = save;
 					Trap(RE_PARSE_LONGJMP_HACK);
 					DEAD_END;
@@ -788,7 +788,9 @@ bad_target:
 
 					case SYM_RETURN:
 						if (IS_PAREN(rules)) {
-							if (!DO_BLOCK(parse->out, VAL_SERIES(rules), 0)) {
+							if (DO_BLOCK_THROWS(
+								parse->out, VAL_SERIES(rules), 0
+							)) {
 								// If the paren evaluation result gives a
 								// THROW, BREAK, CONTINUE, etc then we'll
 								// return that (but we were returning anyway,
@@ -822,7 +824,7 @@ bad_target:
 						if (!IS_PAREN(item)) Trap1_DEAD_END(RE_PARSE_RULE, item);
 
 						// might GC
-						if (!DO_BLOCK(&save, VAL_SERIES(item), 0)) {
+						if (DO_BLOCK_THROWS(&save, VAL_SERIES(item), 0)) {
 							*parse->out = save;
 							Trap(RE_PARSE_LONGJMP_HACK);
 							DEAD_END;
@@ -930,7 +932,7 @@ bad_target:
 			REBVAL evaluated;
 
 			// might GC
-			if (!DO_BLOCK(&evaluated, VAL_SERIES(item), 0)) {
+			if (DO_BLOCK_THROWS(&evaluated, VAL_SERIES(item), 0)) {
 				*parse->out = evaluated;
 				Trap(RE_PARSE_LONGJMP_HACK); // !!! should return gracefully!
 				DEAD_END;
@@ -1000,7 +1002,7 @@ bad_target:
 					rulen = 1;
 					if (IS_PAREN(rules)) {
 						// might GC
-						if (!DO_BLOCK(&save, VAL_SERIES(rules), 0)) {
+						if (DO_BLOCK_THROWS(&save, VAL_SERIES(rules), 0)) {
 							*parse->out = save;
 							Trap(RE_PARSE_LONGJMP_HACK);
 							DEAD_END;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1265,7 +1265,7 @@ bad_end:
 	assert(IS_TRASH(D_OUT));
 	parse.out = D_OUT;
 
-	PUSH_CATCH(&error, &state);
+	PUSH_TRAP(&error, &state);
 
 // The first time through the following code 'error' will be NULL, but...
 // Trap()s can longjmp here, so 'error' won't be NULL *if* that happens!
@@ -1299,8 +1299,7 @@ bad_end:
 		}
 
 		// All other errors we don't interfere with, and just re-trap
-		Throw(error, NULL);
-		DEAD_END;
+		Do_Error(error);
 	}
 
 	index = Parse_Rules_Loop(&parse, VAL_INDEX(input), VAL_BLK_DATA(rules), 0);
@@ -1311,7 +1310,7 @@ bad_end:
 	// parse->out value here (instead of in RE_PARSE_LONGJMP_HACK handling).
 	assert(IS_TRASH(D_OUT));
 
-	DROP_CATCH_SAME_STACKLEVEL_AS_PUSH(&state);
+	DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 
 	// Parse can fail if the match rule state can't process pending input
 	if (index == NOT_FOUND)


### PR DESCRIPTION
(Note: Should fix #41)

In the commit description for 2db2935d92 I explained how THROW
had two cases where the longjmp mechanic was used to pass a
value up the stack, instead of "bubbling up" through stacks that did
not have to explicitly initiate a setjmp state or recover from a longjmp
in order to receive the values.  The first was when PARSE needed to
"prematurely" end the parse process (through something other than a
match failure).  The second was when a QUIT was issued.

This takes away the requirement for CATCH to do a setjmp setup by
making QUIT a named throw.  Propagating that decision through
led to finding some more "swallowing" cases where THROWN values
were being ignored and not handled in any way, such as if there were
a THROW out of a MAKE of a PORT! or MODULE!.

There is a behavioral change to CATCH needed for this, which is that
it does not catch a named throw if you do not use /NAME.  Without it
this can't work.  Because some clients (notably test code) need a way
of actually intercepting any THROW, an /ALL refinement was added.
Expanding the range of values that can be used as a /NAME may
change what is used for QUIT to not be a WORD!.