### PR TITLE
Command line handling revamp

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -38,7 +38,7 @@ catalog: context [
 	; Official list of system/options/flags that can appear.
 	; Must match host reb-args.h enum!
 	boot-flags: [
-		script args do import version debug secure
+		do import version debug secure
 		help vers quiet verbose
 		secure-min secure-max trace halt cgi boot-level no-window
 	]

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -976,7 +976,19 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	if (n >= SYM_BASE && n <= SYM_MODS)
 		PG_Boot_Level = n - SYM_BASE; // 0 - 3
 
-	Set_Option_String(rargs->args, OPTIONS_ARGS);
+	if (rargs->args) {
+		n = 0;
+		while (rargs->args[n++]);
+		// n == number_of_args + 1
+		val = Get_System(SYS_OPTIONS, OPTIONS_ARGS);
+		ser = Make_Block(n);
+		Set_Series(REB_BLOCK, val, ser);
+		SERIES_TAIL(ser) = n - 1;
+		for (n = 0; (data = rargs->args[n]); ++n)
+			Set_String(BLK_SKIP(ser, n), Copy_OS_Str(data, OS_STRLEN(data)));
+		BLK_TERM(ser);
+	}
+
 	Set_Option_String(rargs->debug, OPTIONS_DEBUG);
 	Set_Option_String(rargs->version, OPTIONS_VERSION);
 	Set_Option_String(rargs->import, OPTIONS_IMPORT);

--- a/src/include/reb-args.h
+++ b/src/include/reb-args.h
@@ -31,7 +31,7 @@
 typedef struct rebol_args {
 	REBCNT options;
 	REBCHR *script;
-	REBCHR *args;
+	REBCHR **args;
 	REBCHR *do_arg;
 	REBCHR *version;
 	REBCHR *debug;
@@ -47,8 +47,6 @@ typedef struct rebol_args {
 enum arg_opts {
 	ROF_EXT,
 
-	ROF_SCRIPT,
-	ROF_ARGS,
 	ROF_DO,
 	ROF_IMPORT,
 	ROF_VERSION,
@@ -75,13 +73,11 @@ enum arg_opts {
 #define RO_HELP        (1<<ROF_HELP)
 #define RO_IMPORT      (1<<ROF_IMPORT)
 #define RO_CGI         (1<<ROF_CGI)
-#define RO_ARGS        (1<<ROF_ARGS)
 #define RO_DO          (1<<ROF_DO)
 #define RO_DEBUG       (1<<ROF_DEBUG)
 #define RO_SECURE_MIN  (1<<ROF_SECURE_MIN)
 #define RO_SECURE_MAX  (1<<ROF_SECURE_MAX)
 #define RO_QUIET       (1<<ROF_QUIET)
-#define RO_SCRIPT      (1<<ROF_SCRIPT)
 #define RO_SECURE      (1<<ROF_SECURE)
 #define RO_TRACE       (1<<ROF_TRACE)
 #define RO_VERSION     (1<<ROF_VERSION)

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -332,11 +332,10 @@ usage: func [
 
 	Standard options:
 
-		--args data      Explicit arguments to script (quoted)
 		--do expr        Evaluate expression (quoted)
 		--help (-?)      Display this usage information
-		--script file    Explicit script filename
 		--version tuple  Script must be this version or greater
+		--               End of options
 
 	Special options:
 

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -110,7 +110,6 @@ finish-rl-start: func [
 	;-- Convert command line arg strings as needed:
 	script-args: args ; save for below
 	foreach [opt act] [
-		args    [if args [parse args ""]]
 		do-arg  block!
 		debug   block!
 		secure  word!


### PR DESCRIPTION
### Summary of Changes
* `--args` and `--script` options are replaced with `--` (end of options).
* Anything after the script filename is a script argument.
* All option values are required and may begin with hyphens.
* `system/script/args` is BLOCK! or NONE! for the script invoked from command line.
* The whole command line is disregarded if it has errors.

### Fixed Issues
#46 system/options/args is always #[none]
#48 command line errors are not fatal
[CC#1890](http://issue.cc/r3/1890) Script arguments containing whitespace or double quotes are garbled
[CC#2140](http://issue.cc/r3/2140) Failure when system/script/args > 1022 bytes
[CC#2227](http://issue.cc/r3/2227) Interpreter too eagerly consumes command-line arguments

### Compatibility
This patch changes semantics but tries to preserve features.
`r3 --args arg --script script.r` → `r3 --  script.r  arg`
`r3 --args arg` (why would you want args without a script?) → `r3 "" arg`
`system/script/args` (string!) → `reform system/script/args`

### Tests
There is no definitive set of tests for the new semantics. Would be good to have one.

### Future Steps
These can be done by changing few lines if desired:
* empty block when there are no arguments;
* mutually exclusive script and --do;
* disallow script arguments without a script.
