### PR TITLE
Expand possible /NAME types for THROW

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -16,13 +16,8 @@ REBOL [
 
 Throw: [
 	code: 0
-	type: "throw error"
+	type: "non-error"
 	null:				{invalid error code zero}
-	break:              {no loop to break}
-	return:             {return not in function}
-	exit:				{no context to handle EXIT (impossible!)}
-	throw:              [{no catch for throw:} :arg1]
-	continue:           {no loop to continue}
 	halt:               [{halted by user or script}]
 ]
 
@@ -97,7 +92,8 @@ Script: [
 
 	no-return:          {block did not return a value}
 	block-lines:        {expected block of lines}
-	throw-usage:        {invalid use of a thrown error value}
+	no-catch:			[{no CATCH for THROW of} :arg1]
+	no-catch-named:		[{no CATCH for THROW of} :arg1 {with /NAME:} :arg2]
 
 	locked-word:        [{protected variable - cannot modify:} :arg1]
 	protected:          {protected value or series - cannot modify}

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -59,8 +59,10 @@ attempt: native [
 
 break: native [
 	{Breaks out of a loop, while, until, repeat, foreach, etc.}
-	/return {Forces the loop function to return a value}
+	/with {Forces the loop function to return a value}
 	value [any-type!]
+	/return {(deprecated synonym for /WITH)}
+	return-value [any-type!]
 ]
 
 case: native [
@@ -74,7 +76,7 @@ catch: native [
 	{Catches a throw from a block and returns its value.}
 	block [block!] {Block to evaluate}
 	/name {Catches a named throw}
-	word [word! block!] {One or more names}
+	name-list [block! word! any-function! object!] {Names to catch (single name if not block)}
 	/quit {Special catch for QUIT native}
 	/any {Catch all throws except QUIT (can be used with /QUIT)}
 ]
@@ -291,7 +293,7 @@ throw: native [
 	{Throws control back to a previous catch.}
 	value [any-type!] {Value returned from catch}
 	/name {Throws to a named catch}
-	word [word!]
+	name-value [word! any-function! object!]
 ]
 
 trace: native [

--- a/src/boot/task.r
+++ b/src/boot/task.r
@@ -21,6 +21,7 @@ ballast			; current memory ballast (used for GC)
 max-ballast		; ballast reset value
 thrown-arg		; for holding an error argument during throw back
 stack-error		; special stack overlow error object
+halt-error		; special halt error object
 this-context	; current context
 buf-emit		; temporary emit output block
 buf-words		; temporary word cache

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -101,9 +101,13 @@ utc
 ; Used to recognize Rebol2 use of [catch] in function specs
 catch
 
-; Needed for processing of "special" THROW words that might exit interpreter
+; Needed for processing of THROW's /NAME words used by system
+; NOTE: may become something more specific than WORD!
 exit
 quit
+;break ;-- covered by parse below
+;return ;-- covered by parse below
+continue
 
 ; Parse: - These words must not reserved above!!
 parse

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -241,10 +241,13 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 
 	if (!Do_Sys_Func(&out, SYS_CTX_FINISH_RL_START, 0)) {
 		if (
-			VAL_ERR_NUM(&out) == RE_THROW &&
-			(VAL_ERR_SYM(&out) == SYM_QUIT || VAL_ERR_SYM(error) == SYM_EXIT)
+			IS_WORD(&out) &&
+			(VAL_WORD_SYM(&out) == SYM_QUIT || VAL_WORD_SYM(error) == SYM_EXIT)
 		) {
-			int status = VAL_ERR_STATUS(&out);
+			int status;
+
+			TAKE_THROWN_ARG(&out, &out);
+			status = Exit_Status_From_Value(&out);
 
 			DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 
@@ -451,10 +454,13 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		UNSAVE_SERIES(code);
 
 		if (
-			VAL_ERR_NUM(&out) == RE_THROW &&
-			(VAL_ERR_SYM(&out) == SYM_QUIT || VAL_ERR_SYM(&out) == SYM_EXIT)
+			IS_WORD(&out) &&
+			(VAL_WORD_SYM(&out) == SYM_QUIT || VAL_WORD_SYM(&out) == SYM_EXIT)
 		) {
-			int status = VAL_ERR_STATUS(&out);
+			int status;
+
+			TAKE_THROWN_ARG(&out, &out);
+			status = Exit_Status_From_Value(&out);
 
 			DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 
@@ -463,7 +469,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 			DEAD_END;
 		}
 
-		Do_Error(&out);
+		Trap_Thrown(&out);
 		DEAD_END;
 	}
 

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -735,6 +735,7 @@ do_at_index:
 	if (--Eval_Count <= 0 || Eval_Signals) Do_Signals();
 
 	value = BLK_SKIP(block, index);
+	assert(!THROWN(value));
 
 	if (Trace_Flags) Trace_Line(block, index, value);
 

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -578,7 +578,7 @@
 {
 	if (!Do_Sys_Func(out, SYS_CTX_MAKE_MODULE_P, spec, 0)) {
 		// Gave back an unhandled RETURN, BREAK, CONTINUE, etc...
-		Do_Error(out);
+		Trap_Thrown(out);
 		DEAD_END_VOID;
 	}
 
@@ -1161,6 +1161,7 @@
 		// (Including looking up 'append' in the user context.)
 
 		if (index > 0) {
+			REBVAL *value;
 			if (
 				writable &&
 				VAL_GET_EXT(FRM_WORDS(context) + index, EXT_WORD_LOCK)
@@ -1172,7 +1173,9 @@
 				return NULL;
 			}
 
-			return FRM_VALUES(context) + index;
+			value = FRM_VALUES(context) + index;
+			assert(!THROWN(value));
+			return value;
 		}
 
 		// NEGATIVE INDEX: Word is stack-relative bound to a function with
@@ -1190,6 +1193,8 @@
 			// the stack, so check for no DSF first...
 			while (call) {
 				if (context == VAL_FUNC_WORDS(DSF_FUNC(call))) {
+					REBVAL *value;
+
 					assert(!IS_CLOSURE(DSF_FUNC(call)));
 					assert(!call->pending);
 
@@ -1207,7 +1212,9 @@
 						return NULL;
 					}
 
-					return DSF_ARG(call, -index);
+					value = DSF_ARG(call, -index);
+					assert(!THROWN(value));
+					return value;
 				}
 
 				call = PRIOR_DSF(call);
@@ -1261,6 +1268,8 @@
 
 		if (index > 0) {
 			*out = *(FRM_VALUES(context) + index);
+			assert(!IS_TRASH(out));
+			assert(!THROWN(out));
 			return;
 		}
 
@@ -1272,6 +1281,7 @@
 					assert(!call->pending);
 					*out = *DSF_ARG(call, -index);
 					assert(!IS_TRASH(out));
+					assert(!THROWN(out));
 					return;
 				}
 				call = PRIOR_DSF(call);

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -447,8 +447,8 @@
 
 	if (DO_BLOCK_THROWS(out, VAL_FUNC_BODY(func), 0)) {
 		if (
-			VAL_ERR_NUM(out) == RE_RETURN
-			|| (VAL_ERR_NUM(out) == RE_THROW && VAL_ERR_SYM(out) == SYM_EXIT)
+			IS_WORD(out) &&
+			(VAL_WORD_SYM(out) == SYM_RETURN || VAL_WORD_SYM(out) == SYM_EXIT)
 		) {
 			if (!VAL_GET_EXT(func, EXT_FUNC_TRANSPARENT))
 				TAKE_THROWN_ARG(out, out);
@@ -512,8 +512,8 @@
 	SAVE_SERIES(body);
 	if (DO_BLOCK_THROWS(out, body, 0)) {
 		if (
-			VAL_ERR_NUM(out) == RE_RETURN
-			|| (VAL_ERR_NUM(out) == RE_THROW && VAL_ERR_SYM(out) == SYM_EXIT)
+			IS_WORD(out) &&
+			(VAL_WORD_SYM(out) == SYM_RETURN || VAL_WORD_SYM(out) == SYM_EXIT)
 		) {
 			if (!VAL_GET_EXT(func, EXT_FUNC_TRANSPARENT))
 				TAKE_THROWN_ARG(out, out);

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -44,7 +44,7 @@
 {
 	if (!Do_Sys_Func(out, SYS_CTX_MAKE_PORT_P, spec, 0)) {
 		// Gave back an unhandled RETURN, BREAK, CONTINUE, etc...
-		Do_Error(out);
+		Trap_Thrown(out);
 		DEAD_END_VOID;
 	}
 

--- a/src/core/c-task.c
+++ b/src/core/c-task.c
@@ -76,7 +76,7 @@
 	OS_TASK_READY(0);
 
 	if (DO_BLOCK_THROWS(&ignored, body, 0)) {
-		Do_Error(&ignored);
+		Trap_Thrown(&ignored);
 		DEAD_END_VOID;
 	}
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -240,7 +240,7 @@ x*/	REBRXT Do_Callback(REBSER *obj, u32 name, RXIARG *rxis, RXIARG *result)
 	// Evaluate the function:
 	if (!Dispatch_Call(call)) {
 		// !!! Needs better handling for THROWN() to safely "bubble up"
-		Do_Error(DSF_OUT(call));
+		Trap_Thrown(DSF_OUT(call));
 		DEAD_END;
 	}
 
@@ -579,7 +579,7 @@ typedef REBYTE *(INFO_FUNC)(REBINT opts, void *lib);
 				}
 				else if (IS_PAREN(val)) {
 					if (DO_BLOCK_THROWS(&save, VAL_SERIES(val), 0)) {
-						Do_Error(&save); // !!! Better answer?
+						Trap_Thrown(&save); // !!! Better answer?
 						DEAD_END_VOID;
 					}
 					val = &save;

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -603,7 +603,7 @@
 
 	//DISABLE_GC;
 
-	assert(errnum >= RE_THROW_MAX);
+	assert(errnum != 0);
 
 	ss->errors++;
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -108,7 +108,9 @@
 	for (; (ii > 0) ? si <= ei : si >= ei; si += ii) {
 		VAL_INDEX(var) = si;
 
-		if (DO_BLOCK_THROWS(out, body, 0) && Check_Error(out) >= 0) break;
+		if (DO_BLOCK_THROWS(out, body, 0)) {
+			if (Process_Loop_Throw(out) >= 0) break;
+		}
 
 		if (VAL_TYPE(var) != type) Trap1(RE_INVALID_TYPE, var);
 		si = VAL_INDEX(var);
@@ -129,7 +131,9 @@
 	while ((incr > 0) ? start <= end : start >= end) {
 		VAL_INT64(var) = start;
 
-		if (DO_BLOCK_THROWS(out, body, 0) && Check_Error(out) >= 0) break;
+		if (DO_BLOCK_THROWS(out, body, 0)) {
+			if (Process_Loop_Throw(out) >= 0) break;
+		}
 
 		if (!IS_INTEGER(var)) Trap_Type(var);
 		start = VAL_INT64(var);
@@ -170,7 +174,9 @@
 	for (; (i > 0.0) ? s <= e : s >= e; s += i) {
 		VAL_DECIMAL(var) = s;
 
-		if (DO_BLOCK_THROWS(out, body, 0) && Check_Error(out) >= 0) break;
+		if (DO_BLOCK_THROWS(out, body, 0)) {
+			if (Process_Loop_Throw(out) >= 0) break;
+		}
 
 		if (!IS_DECIMAL(var)) Trap_Type(var);
 		s = VAL_DECIMAL(var);
@@ -230,7 +236,7 @@
 			}
 
 			if (DO_BLOCK_THROWS(D_OUT, body, bodi)) {
-				if (Check_Error(D_OUT) >= 0) {
+				if (Process_Loop_Throw(D_OUT) >= 0) {
 					break;
 				}
 			}
@@ -419,7 +425,7 @@
 		if (index == rindex) index++; //the word block has only set-words: foreach [a:] [1 2 3][]
 
 		if (DO_BLOCK_THROWS(D_OUT, body, 0)) {
-			if ((err = Check_Error(D_OUT)) >= 0) {
+			if ((err = Process_Loop_Throw(D_OUT)) >= 0) {
 				index = rindex;
 				break;
 			}
@@ -539,7 +545,7 @@ skip_hidden: ;
 {
 	do {
 		if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(D_ARG(1)), 0)) {
-			if (Check_Error(D_OUT) >= 0) return R_OUT;
+			if (Process_Loop_Throw(D_OUT) >= 0) return R_OUT;
 		}
 	} while (TRUE);
 
@@ -605,7 +611,7 @@ skip_hidden: ;
 
 	for (; count > 0; count--) {
 		if (DO_BLOCK_THROWS(D_OUT, block, index)) {
-			if (Check_Error(D_OUT) >= 0) break;
+			if (Process_Loop_Throw(D_OUT) >= 0) break;
 		}
 	}
 	return R_OUT;
@@ -662,7 +668,7 @@ skip_hidden: ;
 	do {
 utop:
 		if (DO_BLOCK_THROWS(D_OUT, b1, i1)) {
-			if (Check_Error(D_OUT) >= 0) break;
+			if (Process_Loop_Throw(D_OUT) >= 0) break;
 			goto utop;
 		}
 
@@ -695,10 +701,9 @@ utop:
 
 	do {
 		if (DO_BLOCK_THROWS(&temp, b1, i1) || IS_UNSET(&temp)) {
-			if (Check_Error(&temp) >= 0) {
-				// Check_Error modifies its argument such that temp will be
+			if (Process_Loop_Throw(&temp) >= 0) {
+				// Process_Loop_Throw modifies its argument so temp will be
 				// UNSET! (or the arg to BREAK/WITH) if a BREAK happened.
-				// (It will also complain if temp was an UNSET!.)
 				*D_OUT = temp;
 				return R_OUT;
 			}
@@ -711,8 +716,8 @@ utop:
 		// decided to run the body...
 
 		if (DO_BLOCK_THROWS(D_OUT, b2, i2)) {
-			// !!! Check_Error may modify its argument
-			if (Check_Error(D_OUT) >= 0) return R_OUT;
+			// !!! Process_Loop_Throw may modify its argument
+			if (Process_Loop_Throw(D_OUT) >= 0) return R_OUT;
 		}
 	} while (TRUE);
 }

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -56,15 +56,13 @@
 **
 ***********************************************************************/
 {
-	VAL_SET(D_OUT, REB_ERROR);
-	VAL_ERR_NUM(D_OUT) = RE_THROW;
-	VAL_ERR_SYM(D_OUT) = SYM_QUIT;
+	Init_Word_Unbound(D_OUT, REB_WORD, SYM_QUIT);
 
 	if (D_REF(1)) {
-		ADD_THROWN_ARG(D_OUT, D_ARG(2));
+		CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(2));
 	}
 	else if (D_REF(3)) {
-		ADD_THROWN_ARG(D_OUT, D_ARG(4));
+		CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(4));
 	}
 	else {
 		// Chosen to do it this way because returning to a calling script it
@@ -73,7 +71,7 @@
 
 		// (UNSET! will be translated to 0 if it gets caught for the shell)
 
-		ADD_THROWN_ARG(D_OUT, UNSET_VALUE);
+		CONVERT_NAME_TO_THROWN(D_OUT, UNSET_VALUE);
 	}
 
 	return R_OUT;

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -923,16 +923,8 @@ static void Mold_Error(const REBVAL *value, REB_MOLD *mold, REBFLG molded)
 		return;
 	}
 
-	if (VAL_ERR_NUM(value) < RE_THROW_MAX) {
-		// Though we generally do not make error objects for THROWN() errors,
-		// we do make one here for the purposes of molding.
-		frame = Make_Error(VAL_ERR_NUM(value), value, 0, 0);
-		err = ERR_VALUES(frame);
-	}
-	else {
-		frame = VAL_ERR_OBJECT(value);
-		err = VAL_ERR_VALUES(value);
-	}
+	frame = VAL_ERR_OBJECT(value);
+	err = VAL_ERR_VALUES(value);
 
 	// Form: ** <type> Error:
 	Emit(mold, "** WB", &err->type, RS_ERRS+0);
@@ -998,6 +990,14 @@ static void Mold_Error(const REBVAL *value, REB_MOLD *mold, REBFLG molded)
 
 	assert(SERIES_WIDE(mold->series) == sizeof(REBUNI));
 	assert(ser);
+
+	if (THROWN(value)) {
+		// !!! You do not want to see THROWN values leak into user awareness,
+		// as they are an implementation detail.  So unless this is debug
+		// output, it should be an assert.  Thus REB_MOLD probably needs a
+		// "for debug output purposes" switch.
+		Emit(mold, "S", "!!! THROWN() -> ");
+	}
 
 	// Special handling of string series: {
 	if (ANY_STR(value) && !IS_TAG(value)) {

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -518,7 +518,6 @@ static REBSER *Trim_Object(REBSER *obj)
 		if (action < 3) action |= 4;  // add SELF to list
 reflect:
 #endif
-		if (THROWN(value)) Trap_DEAD_END(RE_THROW_USAGE);
 		Set_Block(value, Make_Object_Block(VAL_OBJ_FRAME(value), action));
 		break;
 

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -936,7 +936,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 	if (DO_BLOCK_THROWS(&safe, ser, 0)) {
 		// !!! Does not check for thrown cases...what should this
 		// do in case of THROW, BREAK, QUIT?
-		Do_Error(&safe);
+		Trap_Thrown(&safe);
 		DEAD_END_VOID;
 	}
 

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -568,7 +568,7 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 		if (DO_BLOCK_THROWS(&ret, VAL_SERIES(val), 0)) {
 			// !!! Does not check for thrown cases...what should this
 			// do in case of THROW, BREAK, QUIT?
-			Do_Error(&ret);
+			Trap_Thrown(&ret);
 			DEAD_END;
 		}
 

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -190,7 +190,7 @@ static const char *Dia_Fmt = "DELECT - cmd: %s length: %d missed: %d total: %d";
 		if (DO_BLOCK_THROWS(&safe, VAL_SERIES(value), 0)) {
 			// !!! Does not check for thrown cases...what should this
 			// do in case of THROW, BREAK, QUIT?
-			Do_Error(&safe);
+			Trap_Thrown(&safe);
 			DEAD_END;
 		}
 		DS_PUSH(&safe);


### PR DESCRIPTION
Expand possible /NAME types for THROW

This is a change which unhinges the THROW and CATCH mechanics
from the implementation details of ERROR!. Keeping them separate
is good for continuing the stamping out of confusion which these
types have experienced, which helps make sure that throws don't get
dropped on the floor. But additionally the switch of THROWN() to an
options bit (that can be applied to any value) permits the /NAME of a
throw to be derived from the full spectrum of the rest of the value.

The prior limitation of name specification to a 32-bit slot inside of an
ERROR! value meant that a named throw could only have the
interpretation of that as a word symbol ID. So only unbound words
could be used as /NAMEs. This change will *mechanically* permit
any name, but currently it limits to NONE!, WORD!, ANY-FUNCTION!
and OBJECT!. It also does the equality test via EQUAL? and hence
it will ignore the binding of words in a CATCH/NAME comparison.

    >> catch/name [throw/name 1020 :append] :append
    == 1020

For control-flow mechanics like BREAK, CONTINUE, and QUIT this
currently uses WORD!, but can be tuned to other choices as they
are chosen to be fit. This commit also adds /WITH as the preferred
way to specify an argument to BREAK.