### PR TITLE
Skip stack-relative lookups in forming call frames

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1192,11 +1192,13 @@
 			// Get_Var could theoretically be called with no evaluation on
 			// the stack, so check for no DSF first...
 			while (call) {
-				if (context == VAL_FUNC_WORDS(DSF_FUNC(call))) {
+				if (
+					call->args_ready
+					&& context == VAL_FUNC_WORDS(DSF_FUNC(call))
+				) {
 					REBVAL *value;
 
 					assert(!IS_CLOSURE(DSF_FUNC(call)));
-					assert(!call->pending);
 
 					if (
 						writable &&
@@ -1276,9 +1278,11 @@
 		if (index < 0) {
 			struct Reb_Call *call = DSF;
 			while (call) {
-				if (context == VAL_FUNC_WORDS(DSF_FUNC(call))) {
+				if (
+					call->args_ready
+					&& context == VAL_FUNC_WORDS(DSF_FUNC(call))
+				) {
 					assert(!IS_CLOSURE(DSF_FUNC(call)));
-					assert(!call->pending);
 					*out = *DSF_ARG(call, -index);
 					assert(!IS_TRASH(out));
 					assert(!THROWN(out));

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -221,9 +221,7 @@
 	call->prior = CS_Top;
 	CS_Top = call;
 
-#if !defined(NDEBUG)
-	call->pending = TRUE;
-#endif
+	call->args_ready = FALSE;
 
 	call->out = out;
 


### PR DESCRIPTION
I knew it was possible to leak out a word from a stack relative
frame lookup and then try to look it up in a forming frame, but I
figured any code that did so would be broken and so an assert
would be good to notify people of that.  What I missed was that
the mechanics of the previous code was such that forming
frames...though positionally deeper in the stack than the frames
which would sneakily look into them...were still not considered
as candidates for stack-relative lookup.

Which is a long way of saying Rebol3 already gave an error on
cases like this, when I thought it was letting it slip:

    leaker: func [/eval e /gimme g] [
        either gimme [return [g]] [reduce e]
    ]

    leaker/eval reduce leaker/gimme 10

So my assert really should have been an error, and now it is.
I'll note that it's picks up an improved error, as before it was:

** Script error: g word is not bound to a context

But now it is:

** Script error: g word is bound relative to context not on stack