### PR TITLE
/WITH for CATCH w/handler, TRY => TRAP (+ legacy)

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -57,6 +57,8 @@ Script: [
 	expect-type:        [:arg1 :arg2 {field must be of type} :arg3]
 	cannot-use:         [{cannot use} :arg1 {on} :arg2 {value}]
 
+	trap-with-expects:	[{must allow} :arg1 {as ERROR! to be TRAP handler}]
+
 	invalid-arg:        [{invalid argument:} :arg1]
 	invalid-type:       [:arg1 {type is not allowed here}]
 	invalid-op:         [{invalid operator:} :arg1]

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -79,6 +79,8 @@ catch: native [
 	name-list [block! word! any-function! object!] {Names to catch (single name if not block)}
 	/quit {Special catch for QUIT native}
 	/any {Catch all throws except QUIT (can be used with /QUIT)}
+	/with {Handle thrown case with code}
+	handler [block! any-function!] {If FUNCTION!, spec matches [value name]}
 ]
 
 ;cause: native [
@@ -304,11 +306,11 @@ trace: native [
 ;	/stack {Show stack index}
 ]
 
-try: native [
-	{Tries to DO a block and returns its value or an error.}
+trap: native [
+	{Tries to DO a block, trapping error as return value (if one is raised).}
 	block [block!]
-	/except "On exception, evaluate this code block"
-	code [block! any-function!]
+	/with "Handle error case with code"
+	handler [block! any-function!] {If FUNCTION!, spec allows [error [error!]]}
 ]
 
 unless: native [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -68,3 +68,25 @@ sign?: :sign-of
 ;why?
 ;info?
 ;exists?
+
+
+; In word-space, TRY is very close to ATTEMPT, in having ambiguity about what
+; is done with the error if one happens.  It also has historical baggage with
+; TRY/CATCH constructs. TRAP does not have that, and better parallels CATCH
+; by communicating you seek to "trap errors in this code (with this handler)"
+; Here trapping the error suggests you "caught it in a trap" and it is
+; in the trap (and hence in your possession) to examine.  /WITH is not only
+; shorter than /EXCEPT but it makes much more sense.
+;
+; !!! This may free up TRY for more interesting uses, such as a much shorter
+; word to use for ATTEMPT.
+;
+try: func [
+	<transparent>
+	{Tries to DO a block and returns its value or an error.}
+	block [block!]
+	/except "On exception, evaluate this code block"
+	code [block! any-function!]
+] [
+	either except [trap/with block code] [trap block]
+]


### PR DESCRIPTION
This adds the missing ability of CATCH to supply a handler, via the
/WITH refinement.  It is modeled after how TRY worked, which was
to take a BLOCK! or an ANY-FUNCTION! and be willing to take a
function that can process its args -or- one of reduced arity.  The arg
order in CATCH's case is thrown arg first, and then the throw name.

It also renames the TRY native to TRAP, because it's basically just
better in every way...but leaves TRY around for compatibility.  What
makes it better is that it doesn't have the TRY/CATCH baggage
where people will think you use it to catch throws, but also that as
a word it's less ambiguous on the fact that it evaluates to the error.
("TRAP" is more parallel to "CATCH" in that it's an action where
you expect to have a thing in your hand that was caught/trapped.)
TRY may be a better and shorter fit for ATTEMPT where you try
something and then if it didn't work out you just have NONE!

While I was at it I made it so that giving a function expecting more
args than the handler could provide would be an error (accounting
for refinements as not being required arguments).  I also added a
more explicit message about trap needing you to pass it a function
that takes an ERROR!, but mostly just because there was a
comment saying it might need a better message.  (As I made that
note I could have just deleted it, but I figured it wouldn't hurt to
have a more specific error.)