### PR TITLE
Add basic line continuation handling to the console

### DIFF
--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -362,6 +362,7 @@ int main(int argc, char **argv_ansi)
 							inside_short_str = !inside_short_str;
 							break;
 						case '[':
+						case '(':
 							if (!inside_short_str && long_str_level == 0) {
 								cont_stack[cont_level++] = *utf8byte;
 								if (cont_level >= MAX_CONT_LEVEL) {
@@ -370,6 +371,7 @@ int main(int argc, char **argv_ansi)
 							}
 							break;
 						case ']':
+						case ')':
 							if (!inside_short_str && long_str_level == 0) {
 								if (cont_level > 0) {
 									cont_stack[--cont_level] = 0;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -113,17 +113,7 @@ void Host_Crash(const char *reason) {
 **  Posix args: as you would expect in C.
 **  Posix return: ditto.
 **
-
 */
-
-int tidy(REBYTE* error_str) {
-	Put_Str(error_str);
-	OS_Quit_Devices(0);
-#ifndef REB_CORE
-	OS_Destroy_Graphics();
-#endif
-
-}
 /***********************************************************************/
 
 // Using a main entry point for a console program (as opposed to WinMain)
@@ -372,7 +362,7 @@ int main(int argc, char **argv_ansi)
 							if (noshortstr && nolongstr) {
 								cont_cmd[cont_len++] = BOXON;
 								if (cont_len >= CONTMAX) {
-									tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
+									Host_Crash("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
 									return(1);
 								}
 								cont_str[0] = BOXON;
@@ -390,7 +380,7 @@ int main(int argc, char **argv_ansi)
 							if (noshortstr) {
 								cont_cmd[cont_len++] = BRACEON;
 								if (cont_len >= CONTMAX) {
-									tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
+									Host_Crash("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
 									return(2);
 								}
 								cont_str[0] = BRACEON;
@@ -440,7 +430,10 @@ int main(int argc, char **argv_ansi)
 		}
 	}
 #endif //!ENCAP
-	tidy(0);
+	OS_Quit_Devices(0);
+#ifndef REB_CORE
+	OS_Destroy_Graphics();
+#endif
 
 	// A QUIT does not exit this way, so the only valid return code is zero.
 	return 0;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -322,27 +322,26 @@ int main(int argc, char **argv_ansi)
 		RL_Do_String(cb_cast("quit"), 0, 0);
 	}
 
-	#define BOXON		   91
-	#define BOXOFF		   93
+	#define BOXON		91
+	#define BOXOFF		93
 	#define BRACEON		123
-	#define BRACEOFF	 125
-	#define QUOTE			 34
-	#define SEMICOL		   59
-	#define CONTMAX  80
+	#define BRACEOFF	125
+	#define QUOTE		34
+	#define SEMICOL		59
+	#define CONTMAX		80
 
-	REBYTE cont_str[] =  "    ";
+	REBYTE cont_str[] = "    ";
 	cont_str[0] = 0;
 	int cont_len = 0;
 
 	int buf_max = 32768;
-	REBYTE cont_cmd[CONTMAX]  = {0};
+	REBYTE cont_cmd[CONTMAX] = {0};
 	REBYTE cmd_buf[buf_max];
 	int buf_len = 0;
 	cmd_buf[buf_len] = 0;
 	int i;
 	BOOL noshortstr = TRUE;
 	BOOL nolongstr = TRUE;
-
 
 	// Console line input loop (just an example, can be improved):
 	if (
@@ -365,50 +364,50 @@ int main(int argc, char **argv_ansi)
 			}
 			if (line = Get_Str()) {
 				for (i = 0; line[i] != 0; i++) {
-					switch (line[i])  {
+					switch (line[i]) {
 						case QUOTE:
 							noshortstr = !noshortstr;
 							break;
 						case BOXON:
-							if (noshortstr &&  nolongstr)	{
+							if (noshortstr && nolongstr) {
 								cont_cmd[cont_len++] = BOXON;
 								if (cont_len >= CONTMAX) {
 									tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
 									return(1);
 								}
-								cont_str[0] = BOXON ;
+								cont_str[0] = BOXON;
 							}
 							break;
 						case BOXOFF:
-							if (noshortstr &&  nolongstr) {
-								if (cont_len >= 2)	{
-									cont_str[0] = cont_cmd[cont_len -2] ;
+							if (noshortstr && nolongstr) {
+								if (cont_len >= 2) {
+									cont_str[0] = cont_cmd[cont_len - 2];
 								}
 								cont_cmd[--cont_len] = 0;
 							}
 							break;
 						case BRACEON:
-							if (noshortstr )   {
+							if (noshortstr) {
 								cont_cmd[cont_len++] = BRACEON;
 								if (cont_len >= CONTMAX) {
 									tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
 									return(2);
 								}
-								cont_str[0] = BRACEON ;
+								cont_str[0] = BRACEON;
 								nolongstr = FALSE;
 							}
 							break;
 						case BRACEOFF:
-							if (noshortstr ) {
-								if (cont_len >= 2)	{
-									cont_str[0] = cont_cmd[cont_len -2] ;
+							if (noshortstr) {
+								if (cont_len >= 2) {
+									cont_str[0] = cont_cmd[cont_len - 2];
 								}
 								cont_cmd[--cont_len] = 0;
 								nolongstr = TRUE;
 							}
 							break;
 						case SEMICOL:
-							if (noshortstr && nolongstr)  {
+							if (noshortstr && nolongstr) {
 								line[i--] = 0;
 							}
 							break;
@@ -416,18 +415,18 @@ int main(int argc, char **argv_ansi)
 				}
 				noshortstr = TRUE;
 
-				if (buf_len + i > buf_max)	{
+				if (buf_len + i > buf_max) {
 					Put_Str("!!  ERROR!!max buffer len exceeded !!");
 					break;
 				}
-				strncpy(&cmd_buf[buf_len],line,  i);
+				strncpy(&cmd_buf[buf_len], line, i);
 				buf_len = buf_len + i;
 				cmd_buf[buf_len] = 0;
 
 				OS_FREE(line);
 
 				if (cont_len > 0) {
-						continue;
+					continue;
 				}
 
 				buf_len = 0;
@@ -437,7 +436,7 @@ int main(int argc, char **argv_ansi)
 				RL_Do_String(cmd_buf, 0, 0);
 				RL_Print_TOS(0, result_str);
 			}
-				else break ;// EOS
+			else break; // EOS
 		}
 	}
 #endif //!ENCAP

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -362,8 +362,7 @@ int main(int argc, char **argv_ansi)
 							if (noshortstr && nolongstr) {
 								cont_cmd[cont_len++] = BOXON;
 								if (cont_len >= CONTMAX) {
-									Host_Crash("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
-									return(1);
+									Host_Crash("Maximum console continuation level exceeded!");
 								}
 								cont_str[0] = BOXON;
 							}
@@ -380,8 +379,7 @@ int main(int argc, char **argv_ansi)
 							if (noshortstr) {
 								cont_cmd[cont_len++] = BRACEON;
 								if (cont_len >= CONTMAX) {
-									Host_Crash("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
-									return(2);
+									Host_Crash("Maximum console continuation level exceeded!");
 								}
 								cont_str[0] = BRACEON;
 								nolongstr = FALSE;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -316,7 +316,6 @@ int main(int argc, char **argv_ansi)
 	#define MAX_CONT_LEVEL 80
 
 	REBYTE cont_str[] = "    ";
-	cont_str[0] = 0;
 	int cont_level = 0;
 	REBYTE cont_stack[MAX_CONT_LEVEL] = {0};
 
@@ -339,10 +338,15 @@ int main(int argc, char **argv_ansi)
 	){
 		err_num = 0;  // reset error code (but should be able to set it below too!)
 		while (TRUE) {
-			if (cont_str[0]) {
+			if (cont_level > 0) {
+				int level;
+
+				cont_str[0] = cont_stack[cont_level - 1];
 				Put_Str(cont_str);
-				for (i = 1; i < cont_level; i++) {
-					Put_Str("    ");
+
+				cont_str[0] = ' ';
+				for (level = 1; level < cont_level; level++) {
+					Put_Str(cont_str);
 				}
 			} else {
 				Put_Str(prompt_str);
@@ -359,14 +363,10 @@ int main(int argc, char **argv_ansi)
 								if (cont_level >= MAX_CONT_LEVEL) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								cont_str[0] = line[i];
 							}
 							break;
 						case ']':
 							if (!inside_short_str && !inside_long_str) {
-								if (cont_level >= 2) {
-									cont_str[0] = cont_stack[cont_level - 2];
-								}
 								cont_stack[--cont_level] = 0;
 							}
 							break;
@@ -376,15 +376,11 @@ int main(int argc, char **argv_ansi)
 								if (cont_level >= MAX_CONT_LEVEL) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								cont_str[0] = line[i];
 								inside_long_str = TRUE;
 							}
 							break;
 						case '}':
 							if (!inside_short_str) {
-								if (cont_level >= 2) {
-									cont_str[0] = cont_stack[cont_level - 2];
-								}
 								cont_stack[--cont_level] = 0;
 								inside_long_str = FALSE;
 							}
@@ -413,7 +409,6 @@ int main(int argc, char **argv_ansi)
 				}
 
 				input_len = 0;
-				cont_str[0] = 0;
 				cont_level = 0;
 
 				RL_Do_String(input, 0, 0);

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -325,7 +325,7 @@ int main(int argc, char **argv_ansi)
 	input[input_len] = 0;
 	int i;
 	BOOL inside_short_str = FALSE;
-	BOOL inside_long_str = FALSE;
+	int long_str_level = 0;
 
 	// Console line input loop (just an example, can be improved):
 	if (
@@ -358,7 +358,7 @@ int main(int argc, char **argv_ansi)
 							inside_short_str = !inside_short_str;
 							break;
 						case '[':
-							if (!inside_short_str && !inside_long_str) {
+							if (!inside_short_str && long_str_level == 0) {
 								cont_stack[cont_level++] = line[i];
 								if (cont_level >= MAX_CONT_LEVEL) {
 									Host_Crash("Maximum console continuation level exceeded!");
@@ -366,7 +366,7 @@ int main(int argc, char **argv_ansi)
 							}
 							break;
 						case ']':
-							if (!inside_short_str && !inside_long_str) {
+							if (!inside_short_str && long_str_level == 0) {
 								if (cont_level > 0) {
 									cont_stack[--cont_level] = 0;
 								}
@@ -378,7 +378,7 @@ int main(int argc, char **argv_ansi)
 								if (cont_level >= MAX_CONT_LEVEL) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								inside_long_str = TRUE;
+								long_str_level++;
 							}
 							break;
 						case '}':
@@ -386,7 +386,9 @@ int main(int argc, char **argv_ansi)
 								if (cont_level > 0) {
 									cont_stack[--cont_level] = 0;
 								}
-								inside_long_str = FALSE;
+								if (long_str_level > 0) {
+									long_str_level--;
+								}
 							}
 							break;
 					}

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -271,9 +271,8 @@ REBINT Host_Start(int argc, char **argv) {
 
 
 void Host_Repl(REBINT startup_rc) {
-	// As defined, Put_Str takes non-const data
-	REBYTE prompt_str[] = ">> ";
-	REBYTE result_str[] = "== ";
+	const REBYTE prompt_str[] = ">> ";
+	const REBYTE result_str[] = "== ";
 
 	#define MAX_CONT_LEVEL 80
 	REBYTE cont_str[] = "    ";
@@ -312,7 +311,7 @@ void Host_Repl(REBINT startup_rc) {
 					Put_Str(cont_str);
 				}
 			} else {
-				Put_Str(prompt_str);
+				Put_Str(m_cast(REBYTE*, prompt_str));  // !!! Put_Str currently takes a non-const.
 			}
 			if ((line = Get_Str())) {
 				line_len = 0;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -312,13 +312,8 @@ int main(int argc, char **argv_ansi)
 		RL_Do_String(cb_cast("quit"), 0, 0);
 	}
 
-	#define LBRACKET	'['
-	#define RBRACKET	']'
-	#define LBRACE		'{'
-	#define RBRACE		'}'
-	#define	QUOTE		'"'
-	#define SEMICOL		';'
-	#define CONTMAX		80
+
+	#define CONTMAX 80
 
 	REBYTE cont_str[] = "    ";
 	cont_str[0] = 0;
@@ -355,19 +350,19 @@ int main(int argc, char **argv_ansi)
 			if (line = Get_Str()) {
 				for (i = 0; line[i] != 0; i++) {
 					switch (line[i]) {
-						case QUOTE:
+						case '"':
 							noshortstr = !noshortstr;
 							break;
-						case LBRACKET:
+						case '[':
 							if (noshortstr && nolongstr) {
-								cont_cmd[cont_len++] = LBRACKET;
+								cont_cmd[cont_len++] = line[i];
 								if (cont_len >= CONTMAX) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								cont_str[0] = LBRACKET;
+								cont_str[0] = line[i];
 							}
 							break;
-						case RBRACKET:
+						case ']':
 							if (noshortstr && nolongstr) {
 								if (cont_len >= 2) {
 									cont_str[0] = cont_cmd[cont_len - 2];
@@ -375,17 +370,17 @@ int main(int argc, char **argv_ansi)
 								cont_cmd[--cont_len] = 0;
 							}
 							break;
-						case LBRACE:
+						case '{':
 							if (noshortstr) {
-								cont_cmd[cont_len++] = LBRACE;
+								cont_cmd[cont_len++] = line[i];
 								if (cont_len >= CONTMAX) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								cont_str[0] = LBRACE;
+								cont_str[0] = line[i];
 								nolongstr = FALSE;
 							}
 							break;
-						case RBRACE:
+						case '}':
 							if (noshortstr) {
 								if (cont_len >= 2) {
 									cont_str[0] = cont_cmd[cont_len - 2];
@@ -394,7 +389,7 @@ int main(int argc, char **argv_ansi)
 								nolongstr = TRUE;
 							}
 							break;
-						case SEMICOL:
+						case ';':
 							if (noshortstr && nolongstr) {
 								line[i--] = 0;
 							}

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -312,12 +312,12 @@ int main(int argc, char **argv_ansi)
 		RL_Do_String(cb_cast("quit"), 0, 0);
 	}
 
-	#define BOXON		91
-	#define BOXOFF		93
-	#define BRACEON		123
-	#define BRACEOFF	125
-	#define QUOTE		34
-	#define SEMICOL		59
+	#define BOXON		'['
+	#define BOXOFF		']'
+	#define BRACEON		'{'
+	#define BRACEOFF	'}'
+	#define	QUOTE		'"'
+	#define SEMICOL		';'
 	#define CONTMAX		80
 
 	REBYTE cont_str[] = "    ";

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -312,10 +312,10 @@ int main(int argc, char **argv_ansi)
 		RL_Do_String(cb_cast("quit"), 0, 0);
 	}
 
-	#define BOXON		'['
-	#define BOXOFF		']'
-	#define BRACEON		'{'
-	#define BRACEOFF	'}'
+	#define LBRACKET	'['
+	#define RBRACKET	']'
+	#define LBRACE		'{'
+	#define RBRACE		'}'
 	#define	QUOTE		'"'
 	#define SEMICOL		';'
 	#define CONTMAX		80
@@ -358,16 +358,16 @@ int main(int argc, char **argv_ansi)
 						case QUOTE:
 							noshortstr = !noshortstr;
 							break;
-						case BOXON:
+						case LBRACKET:
 							if (noshortstr && nolongstr) {
-								cont_cmd[cont_len++] = BOXON;
+								cont_cmd[cont_len++] = LBRACKET;
 								if (cont_len >= CONTMAX) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								cont_str[0] = BOXON;
+								cont_str[0] = LBRACKET;
 							}
 							break;
-						case BOXOFF:
+						case RBRACKET:
 							if (noshortstr && nolongstr) {
 								if (cont_len >= 2) {
 									cont_str[0] = cont_cmd[cont_len - 2];
@@ -375,17 +375,17 @@ int main(int argc, char **argv_ansi)
 								cont_cmd[--cont_len] = 0;
 							}
 							break;
-						case BRACEON:
+						case LBRACE:
 							if (noshortstr) {
-								cont_cmd[cont_len++] = BRACEON;
+								cont_cmd[cont_len++] = LBRACE;
 								if (cont_len >= CONTMAX) {
 									Host_Crash("Maximum console continuation level exceeded!");
 								}
-								cont_str[0] = BRACEON;
+								cont_str[0] = LBRACE;
 								nolongstr = FALSE;
 							}
 							break;
-						case BRACEOFF:
+						case RBRACE:
 							if (noshortstr) {
 								if (cont_len >= 2) {
 									cont_str[0] = cont_cmd[cont_len - 2];

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -385,11 +385,6 @@ int main(int argc, char **argv_ansi)
 								inside_long_str = FALSE;
 							}
 							break;
-						case ';':
-							if (!inside_short_str && !inside_long_str) {
-								line[i--] = 0;
-							}
-							break;
 					}
 				}
 				inside_short_str = FALSE;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -117,10 +117,10 @@ void Host_Crash(const char *reason) {
 */
 
 int tidy(REBYTE* error_str) {
-    Put_Str(error_str);
-    OS_Quit_Devices(0);
+	Put_Str(error_str);
+	OS_Quit_Devices(0);
 #ifndef REB_CORE
-    OS_Destroy_Graphics();
+	OS_Destroy_Graphics();
 #endif
 
 }
@@ -321,127 +321,127 @@ int main(int argc, char **argv_ansi)
 
 		RL_Do_String(cb_cast("quit"), 0, 0);
 	}
-   
-    #define BOXON          91     
-    #define BOXOFF         93   
-    #define BRACEON     123   
-    #define BRACEOFF     125   
-    #define QUOTE            34   
-    #define SEMICOL        59
-    #define CONTMAX  80
-   
-    REBYTE cont_str[] =  "    ";
-    cont_str[0] = 0;
-    int cont_len = 0;
-   
-    int buf_max = 32768;
-    REBYTE cont_cmd[CONTMAX]  = {0};
-    REBYTE cmd_buf[buf_max];
-    int buf_len = 0;
-    cmd_buf[buf_len] = 0;
-    int i;
-    BOOL noshortstr = TRUE;
-    BOOL nolongstr = TRUE;
-   
-   
-    // Console line input loop (just an example, can be improved):
-    if (
-        !(Main_Args.options & RO_CGI)
-        && (
-            !Main_Args.script // no script was provided
-            || err_num < 0         // script halted or had error
-            || Main_Args.options & RO_HALT  // --halt option
-        )
-    ){
-        err_num = 0;  // reset error code (but should be able to set it below too!)
-        while (TRUE) {
-            if (cont_str[0]) {
-                Put_Str(cont_str);
-                for (i = 1; i < cont_len; i++) {
-                    Put_Str("    ");
-                }
-            } else {
-                Put_Str(prompt_str);
-            }
-            if (line = Get_Str()) {
-                for (i = 0; line[i] != 0; i++) {
-                    switch (line[i])  {
-                        case QUOTE:
-                            noshortstr = !noshortstr;
-                            break;
-                        case BOXON:
-                            if (noshortstr &&  nolongstr)   {
-                                cont_cmd[cont_len++] = BOXON;
-                                if (cont_len >= CONTMAX) {
-                                    tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
-                                    return(1);
-                                }
-                                cont_str[0] = BOXON ;
-                            }
-                            break;
-                        case BOXOFF:
-                            if (noshortstr &&  nolongstr) {
-                                if (cont_len >= 2)  {
-                                    cont_str[0] = cont_cmd[cont_len -2] ;
-                                }
-                                cont_cmd[--cont_len] = 0;
-                            }
-                            break;
-                        case BRACEON:
-                            if (noshortstr )   {   
-                                cont_cmd[cont_len++] = BRACEON;
-                                if (cont_len >= CONTMAX) {
-                                    tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
-                                    return(2);
-                                }
-                                cont_str[0] = BRACEON ;
-                                nolongstr = FALSE;
-                            }
-                            break;
-                        case BRACEOFF:
-                            if (noshortstr ) {
-                                if (cont_len >= 2)  {
-                                    cont_str[0] = cont_cmd[cont_len -2] ;
-                                }
-                                cont_cmd[--cont_len] = 0;
-                                nolongstr = TRUE;
-                            }
-                            break;
-                        case SEMICOL:
-                            if (noshortstr && nolongstr)  {
-                                line[i--] = 0;
-                            }
-                            break;
-                    }
-                }
-                noshortstr = TRUE;
 
-                if (buf_len + i > buf_max)  {
-                    Put_Str("!!  ERROR!!max buffer len exceeded !!");
-                    break;
-                }
-                strncpy(&cmd_buf[buf_len],line,  i);
-                buf_len = buf_len + i;
-                cmd_buf[buf_len] = 0;
-               
-                OS_FREE(line);
-               
-                if (cont_len > 0) {
-                        continue;
-                }
-               
-                buf_len = 0;
-                cont_str[0] = 0;
-                cont_len = 0;
-               
-                RL_Do_String(cmd_buf, 0, 0);
-                RL_Print_TOS(0, result_str);
-            }
-                else break ;// EOS
-        }    
-    }
+	#define BOXON		   91
+	#define BOXOFF		   93
+	#define BRACEON		123
+	#define BRACEOFF	 125
+	#define QUOTE			 34
+	#define SEMICOL		   59
+	#define CONTMAX  80
+
+	REBYTE cont_str[] =  "    ";
+	cont_str[0] = 0;
+	int cont_len = 0;
+
+	int buf_max = 32768;
+	REBYTE cont_cmd[CONTMAX]  = {0};
+	REBYTE cmd_buf[buf_max];
+	int buf_len = 0;
+	cmd_buf[buf_len] = 0;
+	int i;
+	BOOL noshortstr = TRUE;
+	BOOL nolongstr = TRUE;
+
+
+	// Console line input loop (just an example, can be improved):
+	if (
+		!(Main_Args.options & RO_CGI)
+		&& (
+			!Main_Args.script               // no script was provided
+			|| err_num < 0                  // script halted or had error
+			|| Main_Args.options & RO_HALT  // --halt option
+		)
+	){
+		err_num = 0;  // reset error code (but should be able to set it below too!)
+		while (TRUE) {
+			if (cont_str[0]) {
+				Put_Str(cont_str);
+				for (i = 1; i < cont_len; i++) {
+					Put_Str("    ");
+				}
+			} else {
+				Put_Str(prompt_str);
+			}
+			if (line = Get_Str()) {
+				for (i = 0; line[i] != 0; i++) {
+					switch (line[i])  {
+						case QUOTE:
+							noshortstr = !noshortstr;
+							break;
+						case BOXON:
+							if (noshortstr &&  nolongstr)	{
+								cont_cmd[cont_len++] = BOXON;
+								if (cont_len >= CONTMAX) {
+									tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
+									return(1);
+								}
+								cont_str[0] = BOXON ;
+							}
+							break;
+						case BOXOFF:
+							if (noshortstr &&  nolongstr) {
+								if (cont_len >= 2)	{
+									cont_str[0] = cont_cmd[cont_len -2] ;
+								}
+								cont_cmd[--cont_len] = 0;
+							}
+							break;
+						case BRACEON:
+							if (noshortstr )   {
+								cont_cmd[cont_len++] = BRACEON;
+								if (cont_len >= CONTMAX) {
+									tidy("!! ERROR!! max continuation 80 exceeded !!  \n exiting !! \n");
+									return(2);
+								}
+								cont_str[0] = BRACEON ;
+								nolongstr = FALSE;
+							}
+							break;
+						case BRACEOFF:
+							if (noshortstr ) {
+								if (cont_len >= 2)	{
+									cont_str[0] = cont_cmd[cont_len -2] ;
+								}
+								cont_cmd[--cont_len] = 0;
+								nolongstr = TRUE;
+							}
+							break;
+						case SEMICOL:
+							if (noshortstr && nolongstr)  {
+								line[i--] = 0;
+							}
+							break;
+					}
+				}
+				noshortstr = TRUE;
+
+				if (buf_len + i > buf_max)	{
+					Put_Str("!!  ERROR!!max buffer len exceeded !!");
+					break;
+				}
+				strncpy(&cmd_buf[buf_len],line,  i);
+				buf_len = buf_len + i;
+				cmd_buf[buf_len] = 0;
+
+				OS_FREE(line);
+
+				if (cont_len > 0) {
+						continue;
+				}
+
+				buf_len = 0;
+				cont_str[0] = 0;
+				cont_len = 0;
+
+				RL_Do_String(cmd_buf, 0, 0);
+				RL_Print_TOS(0, result_str);
+			}
+				else break ;// EOS
+		}
+	}
 #endif //!ENCAP
-    tidy(0);
+	tidy(0);
 
 	// A QUIT does not exit this way, so the only valid return code is zero.
 	return 0;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -367,7 +367,9 @@ int main(int argc, char **argv_ansi)
 							break;
 						case ']':
 							if (!inside_short_str && !inside_long_str) {
-								cont_stack[--cont_level] = 0;
+								if (cont_level > 0) {
+									cont_stack[--cont_level] = 0;
+								}
 							}
 							break;
 						case '{':
@@ -381,7 +383,9 @@ int main(int argc, char **argv_ansi)
 							break;
 						case '}':
 							if (!inside_short_str) {
-								cont_stack[--cont_level] = 0;
+								if (cont_level > 0) {
+									cont_stack[--cont_level] = 0;
+								}
 								inside_long_str = FALSE;
 							}
 							break;


### PR DESCRIPTION
This is an extended and fixed up version of a basic line continuation handling for the default console, based on the contribution of user sqlab on StackOverflow Chat/AltME.

Fixes include buffer underruns in the continuation stack (`>> ]]]]`) and handling handling of nested braces (`>> {{}[}`).

Extensions include the handling of parens (`(` and `)`), on-demand growing the buffer the input script is built up in, preservation of end-of-line comments (`>> 1  ; foo`).

Other cleanups include no new warnings when built with `gcc -std=gnu89 -Wall -Wwrite-strings -Wno-unused-variable -Wno-maybe-uninitialized -Wno-switch`, some adjustments to use pre-existing Ren/C facilities (such as `Host_Crash`), and a first factoring of `main` (which was getting long and intermixed) into its three primary parts.

__Known bugs/shortcomings, at the moment__:
- At least on my Linux, _pasting_ multi-line content into a console "eats" the last line (that is, the stuff after the last line separator). This seems to be a problem in the stdio handling, and not the console loop. Not yet investigated further.
- Caret-escaping: `>> "^"["`