### PR TITLE
Overhaul of binding routine names and parameters

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -440,12 +440,12 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	// Bind into lib or user spaces?
 	if (flags) {
 		// Top words will be added to lib:
-		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_SET);
-		Bind_Block(Lib_Context, BLK_HEAD(code), BIND_DEEP);
+		Bind_Array_Set_Forward_Shallow(BLK_HEAD(code), Lib_Context);
+		Bind_Array_Deep(BLK_HEAD(code), Lib_Context);
 	} else {
 		REBSER *user = VAL_OBJ_FRAME(Get_System(SYS_CONTEXTS, CTX_USER));
 		len = user->tail;
-		Bind_Block(user, BLK_HEAD(code), BIND_ALL | BIND_DEEP);
+		Bind_Array_All_Deep(BLK_HEAD(code), user);
 		SET_INTEGER(&vali, len);
 		Resolve_Context(user, Lib_Context, &vali, FALSE, 0);
 	}

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -397,7 +397,7 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 
 /***********************************************************************
 **
-*/	static REBINT Do_Args(struct Reb_Call *call, const REBVAL *path, REBSER *block, REBCNT index)
+*/	static REBINT Do_Args(struct Reb_Call *call, const REBVAL path[], REBSER *block, REBCNT index)
 /*
 **		Evaluate code block according to the function arg spec.
 **		Args are pushed onto the data stack in the same order
@@ -1553,7 +1553,7 @@ finished:
 
 /***********************************************************************
 **
-*/	void Do_Construct(REBVAL *value)
+*/	void Do_Construct(REBVAL value[])
 /*
 **		Do a block with minimal evaluation and no evaluation of
 **		functions. Used for things like script headers where security
@@ -1624,7 +1624,7 @@ finished:
 
 /***********************************************************************
 **
-*/	void Do_Min_Construct(REBVAL *value)
+*/	void Do_Min_Construct(REBVAL value[])
 /*
 **		Do no evaluation of the set values.
 **

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -510,7 +510,7 @@
 
 		// Bind and do an evaluation step (as with MAKE OBJECT! with A_MAKE
 		// code in REBTYPE(Object) and code in REBNATIVE(construct))
-		Bind_Block(err, VAL_BLK_DATA(arg), BIND_DEEP);
+		Bind_Array_Deep(VAL_BLK_DATA(arg), err);
 		if (DO_BLOCK_THROWS(&evaluated, VAL_SERIES(arg), 0)) {
 			ENABLE_GC;
 			*out = evaluated;
@@ -893,13 +893,13 @@
 
 	// Create error objects and error type objects:
 	*ROOT_ERROBJ = *Get_System(SYS_STANDARD, STD_ERROR);
-	errs = Construct_Object(0, VAL_BLK(errors), 0);
+	errs = Construct_Object(NULL, VAL_BLK_HEAD(errors), FALSE);
 
 	Val_Init_Object(Get_System(SYS_CATALOG, CAT_ERRORS), errs);
 
 	// Create objects for all error types:
 	for (val = BLK_SKIP(errs, 1); NOT_END(val); val++) {
-		errs = Construct_Object(0, VAL_BLK(val), 0);
+		errs = Construct_Object(NULL, VAL_BLK_HEAD(val), FALSE);
 		Val_Init_Object(val, errs);
 	}
 }
@@ -962,7 +962,7 @@
 	// Scan block of policies for the class: [file [allow read quit write]]
 	len = 0;	// file or url length
 	flags = 0;	// policy flags
-	for (policy = VAL_BLK(policy); NOT_END(policy); policy += 2) {
+	for (policy = VAL_BLK_HEAD(policy); NOT_END(policy); policy += 2) {
 
 		// Must be a policy tuple:
 		if (!IS_TUPLE(policy+1)) goto error;

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -73,7 +73,7 @@
 		value = Alloc_Tail_Blk(block);
 		VAL_SET(value, VAL_TYPE(word));
 		VAL_WORD_SYM(value) = VAL_BIND_SYM(word);
-		UNBIND(value);
+		UNBIND_WORD(value);
 	}
 
 	return block;
@@ -102,7 +102,7 @@
 		value = Alloc_Tail_Blk(block);
 		VAL_SET(value, VAL_TYPE(word));
 		VAL_WORD_SYM(value) = VAL_BIND_SYM(word);
-		UNBIND(value);
+		UNBIND_WORD(value);
 	}
 
 	return block;
@@ -129,7 +129,7 @@
 	*exts = 0;
 
 	blk = BLK_HEAD(block);
-	words = Collect_Frame(BIND_ALL | BIND_NO_DUP | BIND_NO_SELF, 0, blk);
+	words = Collect_Frame(NULL, blk, BIND_ALL | BIND_NO_DUP | BIND_NO_SELF);
 
 	// !!! needs more checks
 	for (; NOT_END(blk); blk++) {
@@ -155,7 +155,7 @@
 			}
 
 			// Turn block into typeset for parameter at current index
-			Make_Typeset(VAL_BLK(blk), BLK_SKIP(words, n), 0);
+			Make_Typeset(VAL_BLK_HEAD(blk), BLK_SKIP(words, n), 0);
 			break;
 
 		case REB_STRING:
@@ -233,7 +233,7 @@
 	if (
 		!IS_BLOCK(def)
 		|| (len = VAL_LEN(def)) < 2
-		|| !IS_BLOCK(spec = VAL_BLK(def))
+		|| !IS_BLOCK(spec = VAL_BLK_HEAD(def))
 	) return FALSE;
 
 	body = VAL_BLK_SKIP(def, 1);
@@ -267,7 +267,7 @@
 	REBVAL *spec;
 	REBVAL *body;
 
-	if (!args || ((spec = VAL_BLK(args)) && IS_END(spec))) {
+	if (!args || ((spec = VAL_BLK_HEAD(args)) && IS_END(spec))) {
 		body = 0;
 		if (IS_FUNCTION(value) || IS_CLOSURE(value))
 			VAL_FUNC_WORDS(value) = Copy_Block(VAL_FUNC_WORDS(value), 0);

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -383,6 +383,6 @@
 
 	SERIES_CLR_FLAG(series, SER_MARK);
 
-	for (val = VAL_BLK(val); NOT_END(val); val++)
+	for (val = VAL_BLK_HEAD(val); NOT_END(val); val++)
 		Unmark(val);
 }

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1423,7 +1423,7 @@ static REBSER *Scan_Full_Block(SCAN_STATE *scan_state, REBYTE mode_char);
 			value = BLK_TAIL(emitbuf);
 			emitbuf->tail++; // Protect the block from GC
 //			if (!Construct_Simple(value, block)) {
-			Bind_Block(Lib_Context, BLK_HEAD(block), BIND_ALL|BIND_DEEP);
+			Bind_Array_All_Deep(BLK_HEAD(block), Lib_Context);
 			//Bind_Global_Block(BLK_HEAD(block));
 			if (!Construct_Value(value, block)) {
 				if (IS_END(value)) Val_Init_Block(value, block);

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -267,7 +267,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 	if (rel)
 		Bind_Stack_Block(frame, blk); //!! needs deep
 	else
-		Bind_Block(frame, BLK_HEAD(blk), flags);
+		Bind_Array_Core(BLK_HEAD(blk), frame, flags);
 
 	return R_OUT;
 }
@@ -299,12 +299,10 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 {
 	REBVAL *word = D_ARG(1);
 
-	if (ANY_WORD(word)) {
-		UNBIND(word);
-	}
-	else {
-		Unbind_Block(VAL_BLK_DATA(word), NULL, D_REF(2));
-	}
+	if (ANY_WORD(word))
+		UNBIND_WORD(word);
+	else
+		Unbind_Array_Core(VAL_BLK_DATA(word), NULL, D_REF(2));
 
 	return R_ARG1;
 }
@@ -324,11 +322,9 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 {
 	REBSER *words;
 	REBCNT modes = 0;
-	REBVAL *prior = 0;
-	REBVAL *block;
+	REBVAL *values = VAL_BLK_DATA(D_ARG(1));
+	REBVAL *prior_values = NULL;
 	REBVAL *obj;
-
-	block = VAL_BLK_DATA(D_ARG(1));
 
 	if (D_REF(2)) modes |= BIND_DEEP;
 	if (!D_REF(3)) modes |= BIND_ALL;
@@ -337,13 +333,13 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 	if (D_REF(4)) {
 		obj = D_ARG(5);
 		if (ANY_OBJECT(obj))
-			prior = BLK_SKIP(VAL_OBJ_WORDS(obj), 1);
+			prior_values = BLK_SKIP(VAL_OBJ_WORDS(obj), 1);
 		else if (IS_BLOCK(obj))
-			prior = VAL_BLK_DATA(obj);
+			prior_values = VAL_BLK_DATA(obj);
 		// else stays 0
 	}
 
-	words = Collect_Block_Words(block, prior, modes);
+	words = Collect_Array_Words(values, prior_values, modes);
 	Val_Init_Block(D_OUT, words);
 	return R_OUT;
 }
@@ -424,7 +420,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 
 	// Special form: IN object block
 	if (IS_BLOCK(word) || IS_PAREN(word)) {
-		Bind_Block(frame, VAL_BLK(word), BIND_DEEP);
+		Bind_Array_Deep(VAL_BLK_HEAD(word), frame);
 		return R_ARG2;
 	}
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -79,7 +79,7 @@
 	SET_END(vals);
 
 	body = Clone_Block_Value(body_blk);
-	Bind_Block(frame, BLK_HEAD(body), BIND_DEEP);
+	Bind_Array_Deep(BLK_HEAD(body), frame);
 
 	*fram = frame;
 

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -125,7 +125,9 @@ REBREQ *req;		//!!! move this global
 	// Get queue block:
 	state = VAL_OBJ_VALUE(port, STD_PORT_STATE);
 	if (!IS_BLOCK(state)) return NULL;
-	for (value = VAL_BLK_TAIL(state) - 1; value >= VAL_BLK(state); -- value) {
+
+	value = VAL_BLK_TAIL(state) - 1;
+	for (; value >= VAL_BLK_HEAD(state); --value) {
 		if (VAL_EVENT_MODEL(value) == model) {
 			if (VAL_EVENT_TYPE(value) == type) {
 				return value;

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -69,7 +69,7 @@ static void No_Nones(REBVAL *arg) {
 
 	if (!ANY_BLOCK(data)) return FALSE;
 	if (type >= REB_PATH && type <= REB_LIT_PATH)
-		if (!ANY_WORD(VAL_BLK(data))) return FALSE;
+		if (!ANY_WORD(VAL_BLK_HEAD(data))) return FALSE;
 
 	*out = *data++;
 	VAL_SET(out, type);
@@ -545,7 +545,7 @@ static struct {
 	REBCNT n;
 	REBCNT k;
 	REBCNT idx = VAL_INDEX(value);
-	REBVAL *data = VAL_BLK(value);
+	REBVAL *data = VAL_BLK_HEAD(value);
 	REBVAL swap;
 
 	for (n = VAL_LEN(value); n > 1;) {

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -84,7 +84,7 @@
 		arg = Get_System(SYS_VIEW, VIEW_EVENT_TYPES);
 		if (IS_BLOCK(arg)) {
 			w = VAL_WORD_CANON(val);
-			for (n = 0, arg = VAL_BLK(arg); NOT_END(arg); arg++, n++) {
+			for (n = 0, arg = VAL_BLK_HEAD(arg); NOT_END(arg); arg++, n++) {
 				if (IS_WORD(arg) && VAL_WORD_CANON(arg) == w) {
 					VAL_EVENT_TYPE(value) = n;
 					return TRUE;
@@ -158,7 +158,7 @@
 	case SYM_FLAGS:
 		if (IS_BLOCK(val)) {
 			VAL_EVENT_FLAGS(value) &= ~(1<<EVF_DOUBLE | 1<<EVF_CONTROL | 1<<EVF_SHIFT);
-			for (val = VAL_BLK(val); NOT_END(val); val++)
+			for (val = VAL_BLK_HEAD(val); NOT_END(val); val++)
 				if (IS_WORD(val))
 					switch (VAL_WORD_CANON(val)) {
 						case SYM_CONTROL:
@@ -514,7 +514,7 @@ pick_it:
 				// exactly was supposed to have done.
 
 				if (!IS_BLOCK(BLK_HEAD(Windows) + VAL_EVENT_WIN(value))) return R_OUT;
-				wp = (REBWIN *)VAL_BLK(BLK_HEAD(Windows) + VAL_EVENT_WIN(value));
+				wp = cast(REBWIN *, VAL_BLK_HEAD(BLK_HEAD(Windows) + VAL_EVENT_WIN(value)));
 				*D_OUT = wp->masterFace;
 				return R_OUT;
 			}

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -133,7 +133,9 @@ static REBOOL Same_Func(REBVAL *val, REBVAL *arg)
 					D_OUT, Clone_Block(VAL_FUNC_BODY(value))
 				);
 				// See CC#2221 for why closure body copies have locals unbound
-				Unbind_Block(VAL_BLK(D_OUT), VAL_FUNC_WORDS(value), TRUE);
+				Unbind_Array_Core(
+					VAL_BLK_HEAD(D_OUT), VAL_FUNC_WORDS(value), TRUE
+				);
 				return R_OUT;
 
 			case REB_NATIVE:
@@ -145,7 +147,7 @@ static REBOOL Same_Func(REBVAL *val, REBVAL *arg)
 			break;
 		case OF_SPEC:
 			Val_Init_Block(value, Clone_Block(VAL_FUNC_SPEC(value)));
-			Unbind_Block(VAL_BLK(value), NULL, TRUE);
+			Unbind_Array_Deep(VAL_BLK_HEAD(value));
 			break;
 		case OF_TYPES:
 			Val_Init_Block(value, As_Typesets(VAL_FUNC_WORDS(value)));

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -466,7 +466,7 @@ const REBCNT Gob_Flag_Words[] = {
 			for (i = 0; Gob_Flag_Words[i]; i += 2)
 				CLR_FLAG(gob->flags, Gob_Flag_Words[i+1]);
 
-			for (val = VAL_BLK(val); NOT_END(val); val++)
+			for (val = VAL_BLK_HEAD(val); NOT_END(val); val++)
 				if (IS_WORD(val)) Set_Gob_Flag(gob, val);
 		}
 		break;

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -232,7 +232,7 @@ static REBSER *Trim_Object(REBSER *obj)
 ***********************************************************************/
 {
 	if (!IS_BLOCK(data)) return FALSE;
-	VAL_OBJ_FRAME(out) = Construct_Object(0, VAL_BLK_DATA(data), 0);
+	VAL_OBJ_FRAME(out) = Construct_Object(NULL, VAL_BLK_DATA(data), FALSE);
 	VAL_SET(out, type);
 	if (type == REB_ERROR) {
 		REBVAL result;
@@ -315,7 +315,7 @@ static REBSER *Trim_Object(REBSER *obj)
 				if (type == REB_OBJECT) {
 					obj = Make_Object(0, VAL_BLK_DATA(arg));
 					Val_Init_Object(D_OUT, obj); // GC save
-					Bind_Block(obj, VAL_BLK_DATA(arg), BIND_DEEP);
+					Bind_Array_Deep(VAL_BLK_DATA(arg), obj);
 
 					// GC-OK
 					if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(arg), 0))
@@ -337,8 +337,8 @@ static REBSER *Trim_Object(REBSER *obj)
 				// make task! [init]
 				if (type == REB_TASK) {
 					// Does it include a spec?
-					if (IS_BLOCK(VAL_BLK(arg))) {
-						arg = VAL_BLK(arg);
+					if (IS_BLOCK(VAL_BLK_HEAD(arg))) {
+						arg = VAL_BLK_HEAD(arg);
 						if (!IS_BLOCK(arg+1)) Trap_Make_DEAD_END(REB_TASK, value);
 						obj = Make_Module_Spec(arg);
 						VAL_MOD_BODY(value) = VAL_SERIES(arg+1);
@@ -396,7 +396,7 @@ static REBSER *Trim_Object(REBSER *obj)
 				obj = Make_Object(src_obj, VAL_BLK_DATA(arg));
 				Rebind_Frame(src_obj, obj);
 				Val_Init_Object(D_OUT, obj);
-				Bind_Block(obj, VAL_BLK_DATA(arg), BIND_DEEP);
+				Bind_Array_Deep(VAL_BLK_DATA(arg), obj);
 
 				// GC-OK
 				if (DO_BLOCK_THROWS(D_OUT, VAL_SERIES(arg), 0)) return R_OUT;
@@ -625,7 +625,7 @@ REBVAL *Get_Obj_Mods(REBFRM *frame, REBVAL **inter_block)
 		goto is_none;
 	}
 
-	Bind_Block(frm, BLK_HEAD(ser), FALSE);
+	Bind_Array_Shallow(BLK_HEAD(ser), frm);
 	VAL_SERIES(Temp_Blk_Value) = ser;
 	//ENABLE_GC;
 	return Temp_Blk_Value;

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1331,7 +1331,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 				switch (n) {
 					case SYM_SPEC:
 						Val_Init_Block(ret, Clone_Block(VAL_ROUTINE_SPEC(val)));
-						Unbind_Block(VAL_BLK(val), NULL, TRUE);
+						Unbind_Array_Deep(VAL_BLK_HEAD(val));
 						break;
 					case SYM_ADDR:
 						SET_INTEGER(ret, cast(REBUPT, VAL_ROUTINE_FUNCPTR(val)));
@@ -1378,7 +1378,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 				switch (n) {
 					case SYM_SPEC:
 						Val_Init_Block(ret, Clone_Block(VAL_ROUTINE_SPEC(val)));
-						Unbind_Block(VAL_BLK(val), NULL, TRUE);
+						Unbind_Array_Deep(VAL_BLK_HEAD(val));
 						break;
 					case SYM_ADDR:
 						SET_INTEGER(ret, (REBUPT)VAL_ROUTINE_DISPATCHER(val));

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1039,7 +1039,7 @@ static void init_fields(REBVAL *ret, REBVAL *spec)
 						break;
 					case SYM_SPEC:
 						Val_Init_Block(ret, Clone_Block(VAL_STRUCT_SPEC(val)));
-						Unbind_Block(VAL_BLK(val), NULL, TRUE);
+						Unbind_Array_Deep(VAL_BLK_HEAD(val));
 						break;
 					case SYM_ADDR:
 						SET_INTEGER(ret, (REBUPT)SERIES_SKIP(VAL_STRUCT_DATA_BIN(val), VAL_STRUCT_OFFSET(val)));

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -141,7 +141,7 @@
 {
 	if (!IS_BLOCK(data)) return FALSE;
 
-	if (!Make_Typeset(VAL_BLK(data), out, TRUE)) return FALSE;
+	if (!Make_Typeset(VAL_BLK_HEAD(data), out, TRUE)) return FALSE;
 	VAL_SET(out, REB_TYPESET);
 
 	return TRUE;

--- a/src/core/t-utype.c
+++ b/src/core/t-utype.c
@@ -67,7 +67,7 @@
 		// MAKE udef! [spec body]
 		if (IS_DATATYPE(value)) {
 			if (!IS_BLOCK(arg)) Trap_Arg_DEAD_END(arg);
-			spec = VAL_BLK(arg);
+			spec = VAL_BLK_HEAD(arg);
 			if (!IS_BLOCK(spec)) Trap_Arg_DEAD_END(arg);
 			body = VAL_BLK_SKIP(arg, 1);
 			if (!IS_BLOCK(body)) Trap_Arg_DEAD_END(arg);

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -322,7 +322,7 @@ no_result:
 
 	for (; index <= series->tail; index++) {
 
-		for (blk = VAL_BLK(block); NOT_END(blk); blk++) {
+		for (blk = VAL_BLK_HEAD(block); NOT_END(blk); blk++) {
 
 			item = blk;
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -835,7 +835,7 @@ struct Reb_Position
 #define BLK_RESET(b)	(b)->tail = 0, SET_END(BLK_HEAD(b))
 
 // Arg is a value:
-#define VAL_BLK(v)		BLK_HEAD(VAL_SERIES(v))
+#define VAL_BLK_HEAD(v)	BLK_HEAD(VAL_SERIES(v))
 #define VAL_BLK_DATA(v)	BLK_SKIP(VAL_SERIES(v), VAL_INDEX(v))
 #define VAL_BLK_SKIP(v,n)	BLK_SKIP(VAL_SERIES(v), (n))
 #define VAL_BLK_TAIL(v)	BLK_SKIP(VAL_SERIES(v), VAL_SERIES(v)->tail)
@@ -922,11 +922,11 @@ struct Reb_Word {
 #define HAS_FRAME(v)			VAL_WORD_FRAME(v)
 
 #ifdef NDEBUG
-	#define UNBIND(v) \
+	#define UNBIND_WORD(v) \
 		(VAL_WORD_FRAME(v)=NULL)
 #else
 	#define WORD_INDEX_UNBOUND MIN_I32
-	#define UNBIND(v) \
+	#define UNBIND_WORD(v) \
 		(VAL_WORD_FRAME(v)=NULL, VAL_WORD_INDEX(v)=WORD_INDEX_UNBOUND)
 #endif
 


### PR DESCRIPTION
In first trying to debug the binding routines, I was quickly confused by
the way the parameters were named and specified.  There would be
a routine with a name like "Bind_BlockXXX" that would take a REBVAL*
that was named block.  You would pass it a REB_BLOCK and it would
crash.  You would then see the code doing things like testing to see
if (IS_WORD(block)) and wonder what was going on.

After a while I realized that the routines were being passed pointers
to the head of a block's data series.  So the 'block' represented the
contents of the block...not a value holding the block series.

The strategy of attack I used to fix this was to give the routines a name
with the word "Array" in it, so "Bind_Array_X" instead of "Bind_Block_X".
That gives a pretty strong hint that even though you are passing a
REBVAL*, it better be the kind of pointer you can increment to get
another REBVAL.  (I considered "Bind_Values_X" but that could be
interpreted just to mean "bind the values in the subtree under the
singular REBVAL* I am passing.)

Secondly, instead of calling the parameter `REBVAL *block` I call it
`REBVAL value[]`.  For a function parameter, C compilers treat that
just like `REBVAL *value`...but it helps make a suggestion in the
prototype that it's an array.  By calling it "value" instead of "values"
it can be reused for iteration and speaking about one element at a
time...vs having a separate variable `value` that could be confused
with `values` and have the wrong one updated/used.

(Note: Where you see &value[0] used instead of passing just value,
that is not a mistake.  That is to indicate at the call site that it is not
a singular value, rather the first element of an array being passed.)

Spreading that decision through led to some changes, and as long
as I was changing things I did a little cleanup of parameter ordering
and some other trivial stuff that I think pushes it closer to being
understandable.  That included turning some helper implementation
functions static and giving them names suggesting they were not
meant to be APIs beyond the private implementation of the function.