### PR TITLE
Ren c ffi

### DIFF
--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -517,5 +517,4 @@
 		DSF_ARG(DSF, 1), SERIES_TAIL(VAL_FUNC_WORDS(routine)) - 1
 	);
 	Call_Routine(routine, args, DSF_OUT(DSF));
-	Free_Series(args);
 }

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -595,6 +595,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	// PRESERVE flag only makes sense for Remake_Series, where there is
 	// previous data to be kept.
 	assert(!(flags & MKS_PRESERVE));
+	assert(wide != 0 && length != 0);
 
 	if ((cast(REBU64, length) * wide) > MAX_I32) Trap(RE_NO_MEMORY);
 

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -624,6 +624,8 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 		// REBSER header allocation is done
 
 		SERIES_SET_FLAG(series, SER_EXTERNAL);
+		series->info |= wide & 0xFF;
+		series->rest = length;
 	}
 	else {
 		// Allocate the actual data blob that holds the series elements

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -619,6 +619,8 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	series->info = 0; // start with all flags clear...
 	series->data = NULL;
 
+	if (flags & MKS_LOCK) SERIES_SET_FLAG(series, SER_LOCK);
+
 	if (flags & MKS_EXTERNAL) {
 		// External series will poke in their own data pointer after the
 		// REBSER header allocation is done
@@ -891,6 +893,9 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 	// SER_EXTERNAL manages its own memory and shouldn't call Remake
 	assert(!(flags & MKS_EXTERNAL));
+
+	// SER_LOCK has unexpandable data and shouldn't call Remake
+	assert(!(flags & MKS_LOCK));
 
 	// We only let you preserve if the data is the same width as original
 #if !defined(NDEBUG)

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -170,7 +170,8 @@ enum {
 	MKS_BLOCK		= 1 << 0,	// Contains REBVALs (seen by GC and Debug)
 	MKS_POWER_OF_2	= 1 << 1,	// Round size up to a power of 2
 	MKS_EXTERNAL	= 1 << 2,	// Uses external pointer--don't alloc data
-	MKS_PRESERVE	= 1 << 3	// "Remake" only (save what data possible)
+	MKS_PRESERVE	= 1 << 3,	// "Remake" only (save what data possible)
+	MKS_LOCK		= 1 << 4	// series is unexpandable
 };
 
 // Modes allowed by Copy_Block function:


### PR DESCRIPTION
This series makes gtk-demo.r runnable again.

MKS_LOCK flag might not be necessary, as it can be set after being created. But it's convenient, and it conceptually makes sense to lock down the series while it's being created.