### PR TITLE
foreach => for-each/every, foreach as legacy

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -58,7 +58,7 @@ attempt: native [
 ]
 
 break: native [
-	{Breaks out of a loop, while, until, repeat, foreach, etc.}
+	{Breaks out of a loop, while, until, repeat, for-each, etc.}
 	/with {Forces the loop function to return a value}
 	value [any-type!]
 	/return {(deprecated synonym for /WITH)}
@@ -175,7 +175,7 @@ forever: native [
 	body [block!] {Block to evaluate each time}
 ]
 
-foreach: native [
+for-each: native [
 	{Evaluates a block for each value(s) in a series.}
 	'word [word! block!] {Word or block of words to set each time (local)}
 	data [series! any-object! map! none!] {The series to traverse}

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -320,7 +320,7 @@
 		// Recurse into sub-blocks:
 		if (ANY_EVAL_BLOCK(value) && (modes & BIND_DEEP))
 			Collect_Frame_Inner_Loop(binds, VAL_BLK_DATA(value), modes);
-		// In this mode (foreach native), do not allow non-words:
+		// In this mode (for-each native), do not allow non-words:
 		//else if (modes & BIND_GET) Trap_Arg_DEAD_END(value);
 	}
 	BLK_TERM(BUF_WORDS);

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -262,7 +262,7 @@
 */	static REB_R Loop_Each(struct Reb_Call *call_, REBINT mode)
 /*
 **		Supports these natives (modes):
-**			0: foreach
+**			0: for-each
 **			1: remove-each
 **			2: map
 **
@@ -431,7 +431,7 @@
 			}
 			else Trap_Arg_DEAD_END(words);
 		}
-		if (index == rindex) index++; //the word block has only set-words: foreach [a:] [1 2 3][]
+		if (index == rindex) index++; //the word block has only set-words: for-each [a:] [1 2 3][]
 
 		if (Do_Block_Throws(D_OUT, body, 0)) {
 			if ((err = Process_Loop_Throw(D_OUT)) >= 0) {
@@ -566,7 +566,7 @@ skip_hidden: ;
 
 /***********************************************************************
 **
-*/	REBNATIVE(foreach)
+*/	REBNATIVE(for_each)
 /*
 **		{Evaluates a block for each value(s) in a series.}
 **		'word [get-word! word! block!] {Word or block of words}

--- a/src/mezz/base-debug.r
+++ b/src/mezz/base-debug.r
@@ -38,7 +38,7 @@ probe: func [
 		]
 		block? :name [
 			out: make string! 50
-			foreach word name [
+			for-each word name [
 				either any [
 					word? :word
 					path? :word

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -28,7 +28,7 @@ title-of:
 	none
 
 use [word title] [
-	foreach name system/catalog/reflectors [
+	for-each name system/catalog/reflectors [
 		word: make word! ajoin [name "-of"]
 		word: bind/new word 'reflect
 		title: ajoin ["Returns a copy of the " name " of a " switch/default name [
@@ -47,7 +47,7 @@ decode-url: none ; set in sys init
 
 ;-- Setup Codecs -------------------------------------------------------------
 
-foreach [codec handler] system/codecs [
+for-each [codec handler] system/codecs [
 	if handle? handler [
 		; Change boot handle into object:
 		codec: set codec make object! [

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -112,11 +112,11 @@ make-dir: func [
 
 	; Create directories forward:
 	created: copy []
-	foreach dir dirs [
+	for-each dir dirs [
 		path: either empty? path [dir][path/:dir]
 		append path slash
 		if error? trap [make-dir path] [
-			foreach dir created [attempt [delete dir]]
+			for-each dir created [attempt [delete dir]]
 			cause-error 'access 'cannot-open path
 		]
 		insert created path
@@ -134,7 +134,7 @@ delete-dir: func [
 		dir: dirize dir
 		attempt [files: load dir]
 	] [
-		foreach file files [delete-dir dir/:file]
+		for-each file files [delete-dir dir/:file]
 	]
 	attempt [delete dir]
 ]

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -11,6 +11,9 @@ REBOL [
 	}
 ]
 
+; non-hyphenated "pretty" form of for-each (better than `foreach`)
+every: :for-each
+
 launch: func [
 	{Runs a script as a separate process; return immediately.}
 	script [file! string! none!] "The name of the script"

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -28,7 +28,7 @@ dp: delta-profile: func [
 	start: values-of stats/profile
 	do block
 	end: values-of stats/profile
-	foreach num start [
+	for-each num start [
 		change end end/1 - num
 		end: next end
 	]
@@ -43,7 +43,7 @@ speed?: function [
 	/times "Show time for each test"
 ][
 	result: copy []
-	foreach block [
+	for-each block [
 		[
 			loop 100'000 [
 				; measure more than just loop func

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -129,7 +129,7 @@ list-dir: func [
 	unless indent [indent: ""]
 	files: attempt [read %./]
 	if not files [print ["Not found:" :path] change-dir save-dir exit]
-	foreach file files [
+	for-each file files [
 		if any [
 			all [f dir? file]
 			all [d not dir? file]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -50,7 +50,7 @@ dump-obj: function [
 	out: copy []
 	wild: all [string? pat  find pat "*"]
 
-	foreach [word val] obj [
+	for-each [word val] obj [
 		type: type-of/word :val
 		str: either any [any-function? :type object? :type] [
 			reform [word mold spec-of :val words-of :val]
@@ -180,7 +180,7 @@ dump-obj: function [
 	][
 		item: form :word
 		either any-function? get :word [
-			foreach [a b] [ ; need a better method !
+			for-each [a b] [ ; need a better method !
 				"!" "-ex"
 				"?" "-q"
 				"*" "-mul"
@@ -282,7 +282,7 @@ dump-obj: function [
 	print-args: func [label list /extra /local str] [
 		if empty? list [exit]
 		print label
-		foreach arg list [
+		for-each arg list [
 			str: ajoin [tab arg/1]
 			if all [extra word? arg/1] [insert str tab]
 			if arg/2 [append append str " -- " arg/2]
@@ -389,7 +389,7 @@ what: func [
 
 	ctx: any [select system/modules :name lib]
 
-	foreach [word val] ctx [
+	for-each [word val] ctx [
 		if any-function? :val [
 			arg: either args [
 				arg: words-of :val
@@ -404,7 +404,7 @@ what: func [
 	]
 
 	vals: make string! size
-	foreach [word arg] sort/skip list 2 [
+	for-each [word arg] sort/skip list 2 [
 		append/dup clear vals #" " size
 		print [head change vals word any [arg ""]]
 	]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -46,6 +46,18 @@ offset?: :offset-of
 sign?: :sign-of
 
 
+; While `foreach` may have been comfortable for some as a word, its hard
+; not to see the word `reach` inside of it.  Once you recognize that it's
+; not a word and see it with fresh eyes, it looks bad...and also not part
+; of the family of other -each functions like `remove-each` and `map-each`.
+; The need for the hyphen for `for-each` isn't that bad, but the hyphen
+; does break the rhythm a little bit.  Choosing to let `each` stand alone
+; was deemed too ugly, so `every` was selected as a synonym of `for-each`.
+; But `foreach` is demoted to legacy / compatibility module
+
+foreach: :for-each
+
+
 ; The distinctions between Rebol's types is important to articulate.
 ; So using the term "BLOCK" generically to mean any composite
 ; series--as well as specificially the bracketed block type--is a

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -30,9 +30,9 @@ secure: function/with [
 
 	if policy = 'help [
 		print "You can set policies for:"
-		foreach [target pol] pol-obj [print ["  " target]]
+		for-each [target pol] pol-obj [print ["  " target]]
 		print "These can be set to:"
-		foreach [t d] [
+		for-each [t d] [
 			allow "no security"
 			ask   "ask user for permission"
 			throw "throw as an error"
@@ -48,13 +48,13 @@ secure: function/with [
 
 	if policy = 'query [
 		out: make block! 2 * length pol-obj
-		foreach [target pol] pol-obj [
+		for-each [target pol] pol-obj [
 			case [
 				; file 0.0.0 (policies)
 				tuple? pol [repend out [target word-policy pol]]
 				; file [allow read quit write]
 				block? pol [
-					foreach [item pol] pol [
+					for-each [item pol] pol [
 						if binary? item [item: to-string item] ; utf-8 decode
 						if string? item [item: to-rebol-file item]
 						repend out [item word-policy pol]
@@ -75,13 +75,13 @@ secure: function/with [
 	; Bulk-set all policies:
 	if word? policy [
 		n: make-policy 'all policy
-		foreach word words-of pol-obj [set word n]
+		for-each word words-of pol-obj [set word n]
 		set-policies pol-obj
 		exit
 	]
 
 	; Set each policy target separately:
-	foreach [target pol] policy [
+	for-each [target pol] policy [
 		assert/type [target [word! file! url!] pol [block! word! integer!]]
 		set-policy target make-policy target pol pol-obj
 	]
@@ -117,7 +117,7 @@ secure: function/with [
 		; Detailed case: [file [allow read throw write]]
 		flags: 0.0.0
 		assert-policy block? pol target pol
-		foreach [act perm] pol [
+		for-each [act perm] pol [
 			n: find acts act
 			assert-policy n target act
 			m: select [read 1.0.0 write 0.1.0 execute 0.0.1] perm
@@ -164,7 +164,7 @@ secure: function/with [
 		]
 		blk: make block! 4
 		n: 1
-		foreach act [read write execute] [
+		for-each act [read write execute] [
 			repend blk [pick acts 1 + pol/:n act]
 			++ n
 		]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -197,7 +197,7 @@ reword: func [
 		all [
 			map? values      ; Must be a map to use series keys with no dups
 			empty? char-end  ; If we have char-end, it gets appended to the keys
-			foreach [w v] values [
+			for-each [w v] values [
 				; Key types must match wtype and no unset values allowed
 				if any [unset? :v wtype <> type-of :w] [break/return false]
 				true
@@ -227,7 +227,7 @@ reword: func [
 			]
 		]
 		'else [  ; /only doesn't apply, just assign raw values
-			foreach [w v] values [  ; foreach can be used on all values types
+			for-each [w v] values [  ; for-each can be used on all values types
 				if any [set-word? :w lit-word? :w] [w: to word! :w]
 				lib/case [
 					wtype = type-of :w none
@@ -244,7 +244,7 @@ reword: func [
 	]
 	; Construct the reword rule
 	word: make block! 2 * length vals
-	foreach w vals [word: reduce/into [w '|] word]
+	for-each w vals [word: reduce/into [w '|] word]
 	word: head remove back word
 	; Convert keyword if the type doesn't match
 	cword: pick [(w: to wtype w)] wtype <> type-of source
@@ -384,7 +384,7 @@ format: function [
 
 	; Compute size of output (for better mem usage):
 	val: 0
-	foreach rule rules [
+	for-each rule rules [
 		if word? :rule [rule: get rule]
 		val: val + switch/default type-of/word :rule [
 			integer! [abs rule]
@@ -397,7 +397,7 @@ format: function [
 	insert/dup out p val
 
 	; Process each rule:
-	foreach rule rules [
+	for-each rule rules [
 		if word? :rule [rule: get rule]
 		switch type-of/word :rule [
 			integer! [

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -24,7 +24,7 @@ to-event:
 
 ; Auto-build the functions for the above TO-* words.
 use [word] [
-	foreach type system/catalog/datatypes [
+	for-each type system/catalog/datatypes [
 		; The list above determines what will be made here:
 		if in lib word: make word! head remove back tail ajoin ["to-" type] [
 			; Add doc line only if this build has autodocs:

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -138,7 +138,7 @@ make-http-request: func [
 		either file? target [next mold target] [target]
 		" HTTP/1.0" CRLF
 	]
-	foreach [word string] headers [
+	for-each [word string] headers [
 		repend result [mold word #" " string CRLF]
 	]
 	if content [

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -1056,10 +1056,10 @@ tls-awake: function [event [event!]] [
 			debug ["Read" length port/data "bytes proto-state:" tls-port/state/protocol-state]
 			complete?: tls-read-data tls-port/state port/data
 			application?: false
-			foreach proto tls-port/state/resp [
+			for-each proto tls-port/state/resp [
 				switch proto/type [
 					application [
-						foreach msg proto/messages [
+						for-each msg proto/messages [
 							if msg/type = 'app-data [
 								unless tls-port/data [tls-port/data: clear tls-port/state/port-data]
 								append tls-port/data msg/content
@@ -1069,7 +1069,7 @@ tls-awake: function [event [event!]] [
 						]
 					]
 					alert [
-						foreach msg proto/messages [
+						for-each msg proto/messages [
 							if msg/description = "Close notify" [
 								do-commands tls-port/state [close-notify]
 								insert system/ports/system make event! [type: 'read port: tls-port]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -201,7 +201,7 @@ export: func [
 	"Low level export of values (e.g. functions) to lib."
 	words [block!] "Block of words (already defined in local context)"
 ][
-	foreach word words [repend lib [word get word]]
+	for-each word words [repend lib [word get word]]
 ]
 
 assert-utf8: function [

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -57,7 +57,7 @@ encoding?: function [
 	"Returns the media codec name for given binary data. (identify)"
 	data [binary!]
 ][
-	foreach [name codec] system/codecs [
+	for-each [name codec] system/codecs [
 		if do-codec codec/entry 'identify data [
 			return name
 		]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -214,11 +214,11 @@ load-boot-exts: function [
 
 	ext-objs: []
 
-	foreach [spec caller] boot-exts [
+	for-each [spec caller] boot-exts [
 		append ext-objs load-extension/dispatch spec caller
 	]
 
-	foreach ext ext-objs [
+	for-each ext ext-objs [
 		case/all [
 			word? set [hdr: code:] load-header/only/required ext/lib-boot [
 				cause-error 'syntax hdr ext  ; word returned is error code
@@ -649,7 +649,7 @@ import: function [
 		word? module [
 			; Module (as word!) is not loaded already, so let's try to find it.
 			file: append to file! module system/options/default-suffix
-			foreach path system/options/module-paths [
+			for-each path system/options/module-paths [
 				if set [name: mod:] apply :load-module [
 					path/:file version ver check sum no-share no-lib /import /as module
 				] [break]
@@ -744,6 +744,6 @@ test: [
 		[1 2 3] = probe xload/header %test-emb.r
 	]
 ]
-foreach t test [print either do t ['ok] [join "FAILED:" mold t] print ""]
+for-each t test [print either do t ['ok] [join "FAILED:" mold t] print ""]
 halt
 ]

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -147,7 +147,7 @@ make-scheme: func [
 	; If actor is block build a non-contextual actor object:
 	if block? :def/actor [
 		actor: make object! (length def/actor) / 4
-		foreach [name func* args body] def/actor [ ; (maybe PARSE is better here)
+		for-each [name func* args body] def/actor [ ; (maybe PARSE is better here)
 			name: to word! name ; bug!!! (should not be necessary?)
 			repend actor [name func args body]
 		]

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -109,7 +109,7 @@ finish-rl-start: func [
 
 	;-- Convert command line arg strings as needed:
 	script-args: args ; save for below
-	foreach [opt act] [
+	for-each [opt act] [
 		do-arg  block!
 		debug   block!
 		secure  word!
@@ -134,7 +134,7 @@ finish-rl-start: func [
 		do bind-lib boot-mezz
 		boot-mezz: 'done
 
-		foreach [spec body] boot-prot [module spec body]
+		for-each [spec body] boot-prot [module spec body]
 		;do bind-lib boot-prot
 		;boot-prot: 'done
 

--- a/src/os/generic/iso3166.r
+++ b/src/os/generic/iso3166.r
@@ -33,7 +33,7 @@ binary-to-chex: func [
 ][
 	print ["bin: " mold bin]
 	ret: copy ""
-	foreach c bin [
+	for-each c bin [
 		append ret join "\x" skip to-hex to integer! to char! c 6
 	]
 	ret
@@ -44,7 +44,7 @@ capitalize: func [
 ][
 	ret: copy ""
 	words: parse n ""
-	foreach w words [
+	for-each w words [
 		case [
 			w = "OF" [
 				append ret "of "

--- a/src/os/generic/iso639.r
+++ b/src/os/generic/iso639.r
@@ -32,7 +32,7 @@ binary-to-chex: func [
 ][
 	print ["bin: " mold bin]
 	ret: copy ""
-	foreach c bin [
+	for-each c bin [
 		append ret join "\x" skip to-hex to integer! to char! c 6
 	]
 	ret

--- a/src/os/host-ext-test.c
+++ b/src/os/host-ext-test.c
@@ -70,7 +70,7 @@ char *RX_Spec =
 
 	"a: b: c: none\n"
 	"xtest: does [\n"
-		"foreach blk [\n"
+		"for-each blk [\n"
 			"[xarg0]\n"
 			"[xarg1 111]\n"
 			"[xarg1 1.1]\n"

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -25,10 +25,11 @@ REBOL [
 ;-- can still work in older as well as newer Rebols.  Thus the detection
 ;-- has to be a bit "dynamic"
 
-unless value? 'length [length: :length?]
-unless value? 'index-of [index-of: :index?]
-unless value? 'offset-of [offset-of: :offset?]
+unless value? 'length [length: :length? unset 'length?]
+unless value? 'index-of [index-of: :index? unset 'index?]
+unless value? 'offset-of [offset-of: :offset? unset 'offset?]
 
+unless value? 'for-each [for-each: :foreach every: :foreach unset 'foreach]
 
 ;-- !!! switch to use spaces when code is transitioned
 code-tab: (comment [rejoin [space space space space]] tab)
@@ -52,7 +53,7 @@ binary-to-c: func [
 		;-- grab hexes in groups of 8 bytes
 		hexed: enbase/base (copy/part data 8) 16
 		data: skip data 8
-		foreach [digit1 digit2] hexed [
+		for-each [digit1 digit2] hexed [
 			append out rejoin [{0x} digit1 digit2 {,} space]
 		]
 
@@ -76,7 +77,7 @@ binary-to-c: func [
 ; RETURN in it will return from the *caller*.  It will just wind up returning
 ; from *this loop wrapper* (in older Rebols) when the call is finished!
 ;
-foreach-record-NO-RETURN: func [
+for-each-record-NO-RETURN: func [
 	{Iterate a table with a header by creating an object for each row}
 	'record [word!] {Word to set each time to the row made into an object}
 	table [block!] {Table of values with header block as first element}
@@ -101,7 +102,7 @@ foreach-record-NO-RETURN: func [
 		]
 
 		spec: collect [
-			foreach column-name headings [
+			for-each column-name headings [
 				keep column-name
 				keep compose/only [quote (table/1)]
 				table: next table
@@ -131,7 +132,7 @@ find-record-unique: func [
 	]
 
 	result: none
-	foreach-record-NO-RETURN rec table [
+	for-each-record-NO-RETURN rec table [
 		unless value = select rec key [continue]
 
 		if result [

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -97,7 +97,7 @@ build: context [features: [help-strings]]
 
 up-word: func [w] [
 	w: uppercase form w
-	foreach [f t] [
+	for-each [f t] [
 		#"-" #"_"
 	][replace/all w f t]
 	w
@@ -109,7 +109,7 @@ emit: func [data] [repend out data]
 
 to-c-name: func [word] [
 	word: form word
-	foreach [f t] [
+	for-each [f t] [
 		"..." "ellipsis"
 		#"-" #"_"
 		#"." #"_"
@@ -193,7 +193,7 @@ emit {
 ^{
 }
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	emit-line/var "T_" type/class type/name
 ]
 emit-end
@@ -209,7 +209,7 @@ emit {
 ^{
 }
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	emit-line/var "PD_" switch/default type/path [
 		* [type/class]
 		- [0]
@@ -231,7 +231,7 @@ emit newline
 
 types-used: []
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	if all [
 		type/make = '*
 		word? type/class
@@ -259,7 +259,7 @@ emit {
 ^{
 }
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	either type/make = '* [
 		emit-line/var "MT_" type/class type/name
 	][
@@ -282,7 +282,7 @@ emit newline
 
 types-used: []
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	if all [
 		word? type/class
 		not find types-used type/class
@@ -308,7 +308,7 @@ emit {
 ^{
 }
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	emit-line/var "CT_" type/class type/name
 ]
 emit-end
@@ -335,7 +335,7 @@ write inc/tmp-comptypes.h out
 ;^{
 ;}
 ;
-;foreach-record-NO-RETURN type boot-types [
+;for-each-record-NO-RETURN type boot-types [
 ;	f: "Mold_"
 ;	switch/default type/mold [
 ;		* [t: type/class]
@@ -358,7 +358,7 @@ write inc/tmp-comptypes.h out
 ;***********************************************************************/
 ;^{
 ;}
-;foreach-record-NO-RETURN type boot-types [
+;for-each-record-NO-RETURN type boot-types [
 ;	f: "Mold_"
 ;	switch/default type/form [
 ;		*  [t: type/class]
@@ -398,7 +398,7 @@ emit [
 
 datatypes: []
 n: 0
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	append datatypes type/name
 	emit-line "REB_" type/name n
 	n: n + 1
@@ -416,7 +416,7 @@ emit {
 }
 
 new-types: []
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	append new-types to-word join type/name "!"
 	str: uppercase form type/name
 	replace/all str #"-" #"_"
@@ -436,8 +436,8 @@ emit {
 
 typeset-sets: []
 
-foreach-record-NO-RETURN type boot-types [
-	foreach ts compose [(type/typesets)] [
+for-each-record-NO-RETURN type boot-types [
+	for-each ts compose [(type/typesets)] [
 		spot: any [
 			select typeset-sets ts
 			first back insert tail typeset-sets reduce [ts copy []]
@@ -447,9 +447,9 @@ foreach-record-NO-RETURN type boot-types [
 ]
 remove/part typeset-sets 2 ; the - markers
 
-foreach [ts types] typeset-sets [
+for-each [ts types] typeset-sets [
 	emit ["#define TS_" up-word ts " ("]
-	foreach t types [
+	for-each t types [
 		emit ["((REBU64)1<<REB_" up-word t ")|"]
 	]
 	append remove back tail out ")^/"
@@ -469,7 +469,7 @@ rxt-record: [type offset size]
 ; Generate type table with necessary gaps
 rxt-types: []
 n: 0
-foreach :rxt-record ext-types [
+for-each :rxt-record ext-types [
 	if integer? offset [
 		insert/dup tail rxt-types 0 offset - n
 		n: offset
@@ -488,7 +488,7 @@ enum REBOL_Ext_Types
 }
 ]
 n: 0
-foreach :rxt-record ext-types [
+for-each :rxt-record ext-types [
 	either integer? offset [
 		emit-line "RXT_" rejoin [type " = " offset] n
 	][
@@ -519,7 +519,7 @@ extern const REBRXT Reb_To_RXT[REB_MAX];
 ^{
 }
 
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	either find ext-types type/name [
 		emit-line "RXT_" type/name type/name
 	][
@@ -538,7 +538,7 @@ emit {
 }
 
 n: 0
-foreach type rxt-types [
+for-each type rxt-types [
 	either word? type [emit-line "REB_" type n][
 		emit-line "" 0 n
 	]
@@ -556,7 +556,7 @@ emit {
 }
 
 n: 0
-foreach type rxt-types [
+for-each type rxt-types [
 	either all [
 		word? type
 		rec: find ext-types type
@@ -571,7 +571,7 @@ emit-end
 
 emit {
 #define RXT_ALLOWED_TYPES (}
-foreach type next rxt-types [
+for-each type next rxt-types [
 	if word? type [
 		emit replace join "((u64)" uppercase rejoin ["1<<REB_" type ") \^/"] #"-" #"_"
 		emit "|"
@@ -624,7 +624,7 @@ boot-strings: load %strings.r
 
 code: ""
 n: 0
-foreach str boot-strings [
+for-each str boot-strings [
 	either set-word? :str [
 		emit-line/define "#define RS_" to word! str n ;R3
 	][
@@ -653,7 +653,7 @@ emit {
 }
 
 n: 1
-foreach-record-NO-RETURN type boot-types [
+for-each-record-NO-RETURN type boot-types [
 	emit-line "SYM_" join type/name "_type" n
 	n: n + 1
 ]
@@ -662,7 +662,7 @@ boot-words: load %words.r
 
 replace boot-words '*port-modes* load %modes.r
 
-foreach word boot-words [
+for-each word boot-words [
 	emit-line "SYM_" word reform [n "-" word]
 	n: n + 1
 ]
@@ -684,7 +684,7 @@ emit {
 boot-actions: load %actions.r
 n: 1
 emit-line "A_" "type = 0" "Handled by interpreter"
-foreach word boot-actions [
+for-each word boot-actions [
 	if set-word? :word [
 		emit-line "A_" to word! :word n ;R3
 		n: n + 1
@@ -732,14 +732,14 @@ make-obj-defs: func [obj prefix depth /local f] [
 	uppercase prefix
 	emit ["enum " prefix "object {" newline]
 	emit-line prefix "SELF = 0" none
-	foreach field words-of obj [ ;R3
+	for-each field words-of obj [ ;R3
 		emit-line prefix field none
 	]
 	emit [tab uppercase join prefix "MAX^/"]
 	emit "};^/^/"
 
 	if depth > 1 [
-		foreach field words-of obj [ ;R3
+		for-each field words-of obj [ ;R3
 			f: join prefix [field #"_"]
 			replace/all f "-" "_"
 			all [
@@ -797,7 +797,7 @@ emit-head "Event Types" %reb-evtypes.h
 emit newline
 
 emit ["enum event_types {" newline]
-foreach field ob/view/event-types [
+for-each field ob/view/event-types [
 	emit-line "EVT_" field none
 ]
 emit [tab "EVT_MAX^/"]
@@ -805,7 +805,7 @@ emit "};^/^/"
 
 emit ["enum event_keys {" newline]
 emit-line "EVK_" "NONE" none
-foreach field ob/view/event-keys [
+for-each field ob/view/event-keys [
 	emit-line "EVK_" field none
 ]
 emit [tab "EVK_MAX^/"]
@@ -835,7 +835,7 @@ emit {
 }
 ; Generate ERROR object and append it to bootdefs.h:
 emit-line/code "REBVAL " 'self ";" ;R3
-foreach word words-of ob/standard/error [ ;R3
+for-each word words-of ob/standard/error [ ;R3
 	if word = 'near [word: 'nearest] ; prevents C problem
 	emit-line/code "REBVAL " word ";"
 ]
@@ -856,10 +856,10 @@ boot-errors: load %errors.r
 err-list: make block! 200
 errs: false
 
-foreach [cat msgs] boot-errors [
+for-each [cat msgs] boot-errors [
 	code: second msgs
 	new1: true
-	foreach [word val] skip msgs 4 [
+	for-each [word val] skip msgs 4 [
 		err: uppercase form to word! word ;R3
 		replace/all err "-" "_"
 		if find err-list err [print ["DUPLICATE Error Constant:" err] errs: true]
@@ -895,7 +895,7 @@ emit {
 enum port_modes ^{
 }
 
-foreach word data [
+for-each word data [
 	emit-enum word
 ]
 emit-end
@@ -913,9 +913,9 @@ mezz-files: load %../mezz/boot-files.r ; base lib, sys, mezz
 
 ;append boot-mezz+ none ?? why was this needed?
 
-foreach section [boot-base boot-sys boot-mezz] [
+for-each section [boot-base boot-sys boot-mezz] [
 	set section make block! 200
-	foreach file first mezz-files [
+	for-each file first mezz-files [
 		append get section load join %../mezz/ file
 	]
 	remove-tests get section
@@ -927,7 +927,7 @@ foreach section [boot-base boot-sys boot-mezz] [
 ]
 
 boot-protocols: make block! 20
-foreach file first mezz-files [
+for-each file first mezz-files [
 	m: load/all join %../mezz/ file ; not REBOL word
 	append/only append/only boot-protocols m/2 skip m 2
 ]
@@ -970,7 +970,7 @@ n: boot-sys
 
 nat-count: 0
 
-foreach val nats [
+for-each val nats [
 	if set-word? val [
 		emit-line/decl "REBNATIVE(" to word! val ");" ;R3
 		nat-count: nat-count + 1
@@ -981,7 +981,7 @@ print [nat-count "natives"]
 
 emit [newline {const REBFUN Native_Funcs[} nat-count {] = ^{
 }]
-foreach val nats [
+for-each val nats [
 	if set-word? val [
 		emit-line/code "N_" to word! val "," ;R3
 	]
@@ -994,7 +994,7 @@ emit newline
 ;where: find boot/script 'tests
 ;if where [
 ;	remove where
-;	foreach file sort load %../tests/ [
+;	for-each file sort load %../tests/ [
 ;		test: load join %../tests/ file
 ;		if test/1 <> 'skip-test [
 ;			where: insert where test
@@ -1005,7 +1005,7 @@ emit newline
 ;-- Build typespecs block (in same order as datatypes table):
 boot-typespecs: make block! 100
 specs: load %typespec.r
-foreach type datatypes [
+for-each type datatypes [
 	append/only boot-typespecs select specs type
 ]
 
@@ -1081,7 +1081,7 @@ typedef struct REBOL_Boot_Block ^{
 }
 ]
 
-foreach word sections [
+for-each word sections [
 	word: form word
 	remove/part word 5 ; boot_
 	emit-line/code "REBVAL " word ";"
@@ -1099,13 +1099,13 @@ typedef struct REBOL_Root_Context ^{
 }
 ]
 
-foreach word boot-root [
+for-each word boot-root [
 	emit-line/code "REBVAL " word ";"
 ]
 emit ["} ROOT_CTX;" lf lf]
 
 n: 0
-foreach word boot-root [
+for-each word boot-root [
 	emit-line/define "#define ROOT_" word join "(&Root_Context->" [lowercase replace/all form word #"-" #"_" ")"]
 	n: n + 1
 ]
@@ -1122,13 +1122,13 @@ typedef struct REBOL_Task_Context ^{
 }
 ]
 
-foreach word boot-task [
+for-each word boot-task [
 	emit-line/code "REBVAL " word ";"
 ]
 emit ["} TASK_CTX;" lf lf]
 
 n: 0
-foreach word boot-task [
+for-each word boot-task [
 	emit-line/define "#define TASK_" word join "(&Task_Context->" [lowercase replace/all form word #"-" #"_" ")"]
 	n: n + 1
 ]

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -13,6 +13,8 @@ REBOL [
 	Needs: 2.100.100
 ]
 
+do %common.r
+
 print "------ Building headers"
 
 r3: system/version > 2.100.0
@@ -133,7 +135,7 @@ files: sort read %./
 	wait 5
 ]
 
-foreach file files [
+for-each file files [
 	if all [
 		%.c = suffix? file
 		not find/match file "host-"
@@ -165,7 +167,7 @@ make-arg-enums: func [word] [
 	args: copy []
 	refs: copy []
 	; Gather arg words:
-	foreach w first def [
+	for-each w first def [
 		if any-word? w [
 			append args uw: uppercase replace/all form to word! w #"-" #"_" ; R3
 			if refinement? w [append refs uw  w: to word! w] ; R3
@@ -179,14 +181,14 @@ make-arg-enums: func [word] [
 	; Argument numbers:
 	emit ["enum act_" word "_arg {"]
 	emit [tab "ARG_" uword "_0,"]
-	foreach w args [emit [tab "ARG_" uword "_" w ","]]
+	for-each w args [emit [tab "ARG_" uword "_" w ","]]
 	emit [tab "ARG_" uword "_MAX"]
 	emit "};^/"
 
 	; Argument bitmask:
 	n: 0
 	emit ["enum act_" word "_mask {"]
-	foreach w args [
+	for-each w args [
 		emit [tab "AM_" uword "_" w " = 1 << " n ","]
 		n: n + 1
 	]
@@ -194,7 +196,7 @@ make-arg-enums: func [word] [
 	emit "};^/"
 
 	repend output ["#define ALL_" uword "_REFS ("]
-	foreach w refs [
+	for-each w refs [
 		repend output ["AM_" uword "_" w "|"]
 	]
 	remove back tail output
@@ -205,7 +207,7 @@ make-arg-enums: func [word] [
 
 acts: load %../boot/actions.r
 
-foreach word [
+for-each word [
 	copy
 	find
 	select
@@ -218,7 +220,7 @@ foreach word [
 
 acts: load %../boot/natives.r
 
-foreach word [
+for-each word [
 	checksum
 	request-file
 ] [make-arg-enums word]

--- a/src/tools/make-host-ext.r
+++ b/src/tools/make-host-ext.r
@@ -33,7 +33,7 @@ collect-files: func [
 ][
 	source: make block! 1000
 
-	foreach file files [
+	for-each file files [
 		data: load/all file
 		remove-each [a b] data [issue? a] ; commented sections
 		unless block? header: find data 'rebol [
@@ -103,14 +103,14 @@ emit-file: func [
 		insert exports exported-words
 	]
 
-	foreach word words [emit [tab "CMD_" prefix #"_" replace/all form-name word "'" "_LIT"  ",^/"]]
+	for-each word words [emit [tab "CMD_" prefix #"_" replace/all form-name word "'" "_LIT"  ",^/"]]
 	emit [tab "CMD_MAX" newline]
 	emit "};^/^/"
 
 	if src: select source to-set-word 'words [
 		emit ["enum " name "_words {^/"]
 		emit [tab "W_" prefix "_0,^/"]
-		foreach word src [emit [tab "W_" prefix #"_" form-name word ",^/"]]
+		for-each word src [emit [tab "W_" prefix #"_" form-name word ",^/"]]
 		emit [tab "W_MAX" newline]
 		emit "};^/^/"
 	]

--- a/src/tools/make-host-init.r
+++ b/src/tools/make-host-init.r
@@ -19,6 +19,8 @@ REBOL [
 	}
 ]
 
+do %common.r
+
 print "--- Make Host Init Code ---"
 ;print ["REBOL version:" system/version]
 
@@ -152,7 +154,7 @@ load-files: func [
 			system/product: (to lit-word! system/options/args/1)
 		]
 	]
-	foreach file file-list [
+	for-each file file-list [
 		print ["loading:" file]
 		file: load/header file
 		header: file/1

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -327,7 +327,7 @@ macro+: func [
 
 macro++: func ['name obj [object!] /local out] [
 	out: make string! 10
-	foreach n words-of obj [
+	for-each n words-of obj [
 		all [
 			obj/:n
 			flag? (n)
@@ -361,7 +361,7 @@ emit-obj-files: func [
 	/local cnt
 ][
 	cnt: 1
-	foreach file files [
+	for-each file files [
 		file: to-obj file
 		emit [%objs/ file " "]
 		if cnt // 4 = 0 [emit "\^/^-"]
@@ -378,7 +378,7 @@ emit-file-deps: func [
 	/dir path  ; from path
 	/local obj
 ][
-	foreach src files [
+	for-each src files [
 		obj: to-obj src
 		src: rejoin pick [["$R/" src]["$S/" path src]] not dir
 		emit [

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -153,7 +153,7 @@ typedef struct REBOL_Host_Lib ^{
 	REBDEV **devices;
 }
 
-foreach file files [
+for-each file files [
 	print ["scanning" file]
 	if all [
 		%.c = suffix? file

--- a/src/tools/make-zlib.r
+++ b/src/tools/make-zlib.r
@@ -133,6 +133,7 @@ make-warning-lines: func [name [file!] title [string!]] [
 	]
 ]
 
+do %common.r
 
 ;;
 ;; Generate %sys-zlib.h Aggregate Header File
@@ -140,7 +141,7 @@ make-warning-lines: func [name [file!] title [string!]] [
 
 header-lines: copy []
 
-foreach h-file [
+for-each h-file [
 	%zconf.h
 	%zutil.h
 	%zlib.h
@@ -181,7 +182,7 @@ append source-lines [
 	{#undef DO8 /* REBOL: see make-zlib.r */}
 ]
 
-foreach c-file [
+for-each c-file [
 	%adler32.c
 
 	%deflate.c

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -160,13 +160,13 @@ other-flags: context [
 ; A little bit of sanity-checking on the systems table
 use [rec unknown-flags] [
 	; !!! See notes about NO-RETURN in the loop wrapper definition.
-	foreach-record-NO-RETURN rec systems [
+	for-each-record-NO-RETURN rec systems [
 		assert [tuple? rec/id]
 		assert [(to-string rec/os-name) == (lowercase to-string rec/os-name)]
 		assert [(to-string rec/os-base) == (lowercase to-string rec/os-base)]
 		assert [not find (to-string rec/os-base) charset [#"-" #"_"]]
 		assert [block? rec/build-flags]
-		foreach flag rec/build-flags [assert [word? flag]]
+		for-each flag rec/build-flags [assert [word? flag]]
 
 		; Exclude should mutate (CC#2222), but this works either way
 		unknown-flags: exclude (unknown_flags: copy rec/build-flags) compose [


### PR DESCRIPTION
FOREACH was a bit of a black sheep as not using a hyphen
to separate the words, and represented a kind of slippery slope
that had been rejected by Rebol's philosophy (TYPE-OF and not
TYPEOF, for instance).  It also was in a family of other functions
that did have a hyphen, like remove-each and map-each.  It
also draws the eye toward the componet REACH..which once
it is seen sort of can't be unseen.

Debate centered on whether it was common enough to warrant
a non-hyphenated version, and just call it EACH.  That did not
seem to sit well, but the non-hyphenated synonym EVERY came
out as a possibility.  As there are other synonyms, it seems worth
a try.  So speculatively this adds that.

It also keeps FOREACH in the legacy mezzanines.