### PR TITLE
Don't zero fill memory allocations by default

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1129,6 +1129,7 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	PG_Mem_Limit = 0;
 	PG_Reb_Stats = ALLOC(REB_STATS);
 	Reb_Opts = ALLOC(REB_OPTS);
+	CLEAR(Reb_Opts, sizeof(REB_OPTS));
 	Saved_State = NULL;
 
 	// Thread locals:

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -565,6 +565,7 @@ SCHEME_ACTIONS *Scheme_Actions;	// Initial Global (not threaded)
 ***********************************************************************/
 {
 	Scheme_Actions = ALLOC_ARRAY(SCHEME_ACTIONS, MAX_SCHEMES);
+	CLEAR(Scheme_Actions, MAX_SCHEMES * sizeof(SCHEME_ACTIONS));
 
 	Init_Console_Scheme();
 	Init_File_Scheme();

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -419,6 +419,7 @@ make_sym:
 
 		// The word (symbol) table itself:
 		PG_Word_Table.series = Make_Array(WORD_TABLE_SIZE);
+		Clear_Series(PG_Word_Table.series);
 		SET_NONE(BLK_HEAD(PG_Word_Table.series)); // Put a NONE at head.
 		KEEP_SERIES(PG_Word_Table.series, "word table"); // words are never GC'd
 		PG_Word_Table.series->tail = 1;  // prevent the zero case


### PR DESCRIPTION
Rebol's wrapper for memory allocation internally is called
Make_Mem.  I've gone in and commented about why it's done
the way it is (or why I think it is, anyway).  One thing it would do
was that it would zero memory by default.

This takes that off, which brings two benefits.  One benefit is
not paying for the initialization if those zeros are just going to be
overwritten anyway.  The other more important benefit is that
it means address sanitizer and valgrind can tell you when you
are accessing uninitialized parts of an allocation...because once
it sees you've written a zero it assumes the memory is "valid".

One area where memory still has to be cleared in the current
implementation is a "Node" allocation from a series pool, when
it first creates a reusable node (but not on each reused allocation).
Added comments to explain what's going on and what directions
might be taken with it, but for now leaving it to work how it does.