### PR TITLE
Eliminate Guard_Series and Loose_Series

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1129,6 +1129,7 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	PG_Mem_Limit = 0;
 	PG_Reb_Stats = ALLOC(REB_STATS);
 	Reb_Opts = ALLOC(REB_OPTS);
+	CLEAR(Reb_Opts, sizeof(REB_OPTS));
 	Saved_State = NULL;
 
 	// Thread locals:

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -565,6 +565,7 @@ SCHEME_ACTIONS *Scheme_Actions;	// Initial Global (not threaded)
 ***********************************************************************/
 {
 	Scheme_Actions = ALLOC_ARRAY(SCHEME_ACTIONS, MAX_SCHEMES);
+	CLEAR(Scheme_Actions, MAX_SCHEMES * sizeof(SCHEME_ACTIONS));
 
 	Init_Console_Scheme();
 	Init_File_Scheme();

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -101,7 +101,6 @@
 	if (!IS_BINARY(state)) {
 		REBSER *data = Make_Binary(size);
 		REBREQ *req = (REBREQ*)STR_HEAD(data);
-		Guard_Series(data); // GC safe if no other references
 		req->clen = size;
 		CLEAR(STR_HEAD(data), size);
 		//data->tail = size; // makes it easier for ACCEPT to clone the port

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -419,6 +419,7 @@ make_sym:
 
 		// The word (symbol) table itself:
 		PG_Word_Table.series = Make_Array(WORD_TABLE_SIZE);
+		Clear_Series(PG_Word_Table.series);
 		SET_NONE(BLK_HEAD(PG_Word_Table.series)); // Put a NONE at head.
 		KEEP_SERIES(PG_Word_Table.series, "word table"); // words are never GC'd
 		PG_Word_Table.series->tail = 1;  // prevent the zero case

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1046,16 +1046,6 @@ static void Propagate_All_GC_Marks(void);
 		sp++; // can't increment inside macro arg, evaluated multiple times
 	}
 
-	// Mark all special series:
-	sp = (REBSER **)GC_Series->data;
-	for (n = SERIES_TAIL(GC_Series); n > 0; n--) {
-        if (Is_Array_Series(*sp))
-            MARK_BLOCK_DEEP(*sp);
-        else
-            MARK_SERIES_ONLY(*sp);
-		sp++; // can't increment inside macro arg, evaluated multiple times
-	}
-
 	// Mark all root series:
 	MARK_BLOCK_DEEP(VAL_SERIES(ROOT_ROOT));
 	MARK_BLOCK_DEEP(Task_Series);
@@ -1131,42 +1121,6 @@ static void Propagate_All_GC_Marks(void);
 
 /***********************************************************************
 **
-*/	void Guard_Series(REBSER *series)
-/*
-**		A list of protected series, managed by specific removal.
-**
-***********************************************************************/
-{
-	LABEL_SERIES(series, "guarded");
-	if (SERIES_FULL(GC_Series)) Extend_Series(GC_Series, 8);
-	((REBSER **)GC_Series->data)[GC_Series->tail++] = series;
-}
-
-
-/***********************************************************************
-**
-*/	void Loose_Series(REBSER *series)
-/*
-**		Remove a series from the protected list.
-**
-***********************************************************************/
-{
-	REBSER **sp;
-	REBCNT n;
-
-	LABEL_SERIES(series, "unguarded");
-	sp = (REBSER **)GC_Series->data;
-	for (n = 0; n < SERIES_TAIL(GC_Series); n++) {
-		if (sp[n] == series) {
-			Remove_Series(GC_Series, n, 1);
-			break;
-		}
-	}
-}
-
-
-/***********************************************************************
-**
 */	void Init_GC(void)
 /*
 **		Initialize garbage collector.
@@ -1189,7 +1143,4 @@ static void Propagate_All_GC_Marks(void);
 	GC_Mark_Stack = Make_Series(100, sizeof(REBSER *), MKS_NONE);
 	TERM_SERIES(GC_Mark_Stack);
 	KEEP_SERIES(GC_Mark_Stack, "gc mark stack");
-
-	GC_Series = Make_Series(60, sizeof(REBSER *), MKS_NONE);
-	KEEP_SERIES(GC_Series, "gc guarded");
 }

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -89,7 +89,6 @@ TVAR REBINT	GC_Ballast;		// Bytes allocated to force automatic GC
 TVAR REBOOL	GC_Active;		// TRUE when recycle is enabled (set by RECYCLE func)
 TVAR REBSER	*GC_Protect;	// A stack of protected series (removed by pop)
 PVAR REBSER	*GC_Mark_Stack; // Series pending to mark their reachables as live
-TVAR REBSER	*GC_Series;		// An array of protected series (removed by address)
 TVAR REBFLG GC_Stay_Dirty;  // Do not free memory, fill it with 0xBB
 TVAR REBSER **Prior_Expand;	// Track prior series expansions (acceleration)
 


### PR DESCRIPTION
Because it's necessary to protect series from garbage collection
when you know they aren't reachable from the root set, there
is Save_Series and Unsave_Series.  These routines are for
temporarily keeping a series alive, and use an efficient stack
approach for pushing and popping the protections.  If an error
is trapped in the middle of a state, then after the longjmp any
protections in the stack will be released.

Guard_Series and Loose_Series were similar, except without
a stack requirement...so you could just guard any series for an
unlimited amount of time.  This made the removals in
Loose_Series less efficient, because it would have to search
a list to find the series to release.  It also meant that there was
now a way to mark a series as being live persistently with no
reference from the root set...and leak.

In fact the one call to Guard_Series was from port code that
would wind up leaking a REBREQ-sized series on every
allocation...because it never called Loose_Series.  It does not
appear to have been necessary because the REBREQ it is
storing refers to the port...so as long as it is reachable by the
set already covered by the GC (which it should be).

It may be necessary to have some more ways to protect things
from the GC, but a carte-blanche like Guard_Series to request
a "forever" protection with no checking isn't a good shape to
encourage.  So I'm removing it as it seems that it did not create
problems for the REBREQs, but we will have to see if that is the
case for everyone's code.