### PR TITLE
Free extant manual series during Trap()

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -471,7 +471,7 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 	// newly allocated series should either be (a) freed or (b) delegated
 	// to management by the GC...else they'd represent a leak
 	//
-	REBSER *manuals = GC_Manuals;
+	REBCNT manuals_tail = SERIES_TAIL(GC_Manuals);
 
 	const REBYTE *label_str = Get_Word_Name(DSF_LABEL(call));
 #endif
@@ -537,7 +537,7 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 		Panic(RP_MISC);
 	}
 
-	MANUALS_LEAK_CHECK(manuals, cs_cast(label_str));
+	MANUALS_LEAK_CHECK(manuals_tail, cs_cast(label_str));
 #endif
 
 	SET_DSF(dsf_precall);

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -519,10 +519,8 @@
 		DSF_NUM_ARGS(DSF)
 	);
 	assert(VAL_FUNC_NUM_PARAMS(routine) == DSF_NUM_ARGS(DSF));
-	MANAGE_SERIES(args);
-	SAVE_SERIES(args);
 
 	Call_Routine(routine, args, DSF_OUT(DSF));
 
-	UNSAVE_SERIES(args);
+	Free_Series(args);
 }

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -235,9 +235,6 @@
 	}
 	else {
 		series = Copy_Values_Len_Shallow(BLK_SKIP(block, index), tail - index);
-
-		// Hand to the GC to manage *before* the recursion, in case it fails
-		// from being too deep.  This way the GC cleans it up during trap.
 		MANAGE_SERIES(series);
 
 		if (types != 0)

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -92,19 +92,10 @@ PVAR REBSER	*GC_Mark_Stack; // Series pending to mark their reachables as live
 TVAR REBFLG GC_Stay_Dirty;  // Do not free memory, fill it with 0xBB
 TVAR REBSER **Prior_Expand;	// Track prior series expansions (acceleration)
 
-#if !defined(NDEBUG)
-	// In the debug build, the REBSERs can be linked as a doubly linked
-	// list so that we can keep track of the series that are manually
-	// memory managed.  That is to say: all the series that have been
-	// allocated with Make_Series() but have not been handed to the
-	// garbage collector via MANAGE_SERIES().
-	//
-	// These manually-managed series must either be freed with Free_Series()
-	// or handed over to the GC at certain synchronized points, else they
-	// would represent a memory leak in the release build.
-
-	TVAR REBSER *GC_Manuals;	// Manually memory managed (not by GC)
-#endif
+// These manually-managed series must either be freed with Free_Series()
+// or handed over to the GC at certain synchronized points, else they
+// would represent a memory leak in the release build.
+TVAR REBSER *GC_Manuals;	// Manually memory managed (not by GC)
 
 TVAR REBUPT Stack_Limit;	// Limit address for CPU stack.
 

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -84,9 +84,7 @@ typedef struct Rebol_State {
 	REBVAL error;
 	REBINT gc_disable;      // Count of GC_Disables at time of Push
 
-#if !defined(NDEBUG)
-	REBSER *manuals;	// Where GC_Manuals was when state started
-#endif
+	REBCNT manuals_tail;	// Where GC_Manuals was when state started
 
 #ifdef HAS_POSIX_SIGNAL
 	sigjmp_buf cpu_state;
@@ -184,6 +182,6 @@ typedef struct Rebol_State {
 	do { \
 		assert(GC_Disabled == (s)->gc_disable); \
 		assert(IS_TRASH(&(s)->error)); \
-		MANUALS_LEAK_CHECK((s)->manuals, "drop trap"); \
+		MANUALS_LEAK_CHECK((s)->manuals_tail, "drop trap"); \
 		Saved_State = (s)->last_state; \
 	} while (0)

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -465,14 +465,6 @@ typedef struct Reb_Tuple {
 #if !defined(NDEBUG)
 	REBINT *guard; // intentionally alloc'd and freed for use by Panic_Series
 #endif
-
-// These links are used to make a list in the debug build to track the series
-// which have not been handed over to MANAGE_SERIES(), and thus can represent
-// a leak in the release build.  (See GC_Manuals declaration for details.)
-#if !defined(NDEBUG)
-	struct Reb_Series *next;
-	struct Reb_Series *prev;
-#endif
 };
 
 #define SERIES_TAIL(s)	 ((s)->tail)


### PR DESCRIPTION
This was a question early on, as to whether it should be the
responsibility of code using series to find a way to free the
manual series they'd allocated if an error was going to be
trapped... or if it should be handled automatically.  Handling it
automatically meant that some extra tracking would have to be
in the release build--while not handling it meant the tracking
would only be in the debug build for alerts.

The rationale for not doing it automatically was that in C code,
you cannot do a longjmp in the middle of arbitrary code and not
expect to leak resources.  There is no stack unwinding and no
destructors...so if an error traps while you've got a file open,
then you have a leaked file handle on your hands.  Given that
no general mechanism was in existence, it seemed to suggest
vigilance on the part of coders to make sure they didn't do a
Trap unless they were sure it was safe.  That made it cheaper
to mark a series managed, since there was no tracking list.

However, the nail in the coffin for this was out-of-memory errors
and C stack overflows.  These can occur in routines and at times
over which there isn't as much control...and getting the control
would involve putting in checks at every allocation or copy.  So
automatic handling would have to be added.

In order to make the cost acceptable, the linked-list approach
(which cost two extra pointers per series in the debug build)
had to be replaced.  The new code uses a list of series pointers
representing the extant manuals.  This list is pushed at the back,
and when removals are done it searches from back to front.
Most of the time the manual series is going to be the last one
allocated, but if it isn't then it will go find it and then swap the
positions of whatever is last into that slot and drop the tail.

Doing automatic freeing of extant manual series will not be
able to magically solve all the exception handling needs.  If a
resource that needs to be cleaned up isn't a Rebol series,
one will need to do a PUSH_TRAP and have handling code.
That way you can respond to out of memory errors or a stack
overflow resulting from things like copying recursive blocks.
But this at least takes care of the common need and makes
it easier whether you push a trap or not.