### PR TITLE
Add AND? OR? XOR? NOT? operations

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -748,11 +748,6 @@ log-e: native [
 	value [number!]
 ]
 
-not: native [
-	{Returns the logic complement.}
-	value {(Only FALSE and NONE return TRUE)}
-]
-
 square-root: native [
 	{Returns the square root of a number.}
 	value [number!]
@@ -764,6 +759,37 @@ shift: native [
 	bits [integer!] "Positive for left shift, negative for right shift"
 	/logical "Logical shift (sign bit ignored)"
 ]
+
+
+;-- Conditional logic
+
+and?: native [
+	;-- TBD: define infix form later as AND (rename bitwise AND to AND*)
+	{Returns true if both values are conditionally true (no "short-circuit")}
+	value1
+	value2
+]
+
+not?: native [
+	;-- defined later as synonym NOT
+	{Returns the logic complement.}
+	value {(Only FALSE and NONE return TRUE)}
+]
+
+or?: native [
+	;-- TBD: define infix form later as OR (rename bitwise OR to OR+)
+	{Returns true if either value is conditionally true (no "short-circuit")}
+	value1
+	value2
+]
+
+xor?: native [
+	;-- TBD: define infix form later as XOR (rename bitwise XOR to XOR-)
+	{Returns true if only one of the two values is conditionally true.}
+	value1
+	value2
+]
+
 
 ;-- New, hackish stuff:
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -442,11 +442,51 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 
 /***********************************************************************
 **
-*/	REBNATIVE(not)
+*/	REBNATIVE(andq)
+/*
+***********************************************************************/
+{
+	if (IS_CONDITIONAL_TRUE(D_ARG(1)) && IS_CONDITIONAL_TRUE(D_ARG(2)))
+		return R_TRUE;
+	else
+		return R_FALSE;
+}
+
+
+/***********************************************************************
+**
+*/	REBNATIVE(notq)
 /*
 ***********************************************************************/
 {
 	return IS_CONDITIONAL_FALSE(D_ARG(1)) ? R_TRUE : R_FALSE;
+}
+
+
+/***********************************************************************
+**
+*/	REBNATIVE(orq)
+/*
+***********************************************************************/
+{
+	if (IS_CONDITIONAL_TRUE(D_ARG(1)) || IS_CONDITIONAL_TRUE(D_ARG(2)))
+		return R_TRUE;
+	else
+		return R_FALSE;
+}
+
+
+/***********************************************************************
+**
+*/	REBNATIVE(xorq)
+/*
+***********************************************************************/
+{
+	// Note: no boolean ^^ in C; normalize to booleans and check unequal
+	if (!IS_CONDITIONAL_TRUE(D_ARG(1)) != !IS_CONDITIONAL_TRUE(D_ARG(2)))
+		return R_TRUE;
+	else
+		return R_FALSE;
 }
 
 

--- a/src/mezz/base-constants.r
+++ b/src/mezz/base-constants.r
@@ -49,7 +49,8 @@ crlf:      "^M^J"
 
 ;-- Function synonyms:
 q: :quit
-!: :not
+not: :not?
+!: :not?
 min: :minimum
 max: :maximum
 abs: :absolute


### PR DESCRIPTION
This is a step toward CC#1879 moving AND, OR, and XOR to be
conditional, by providing the conditional forms of the operations
in prefix form. The baseline version of NOT was renamed to NOT?
o fit in with the group, and then aliased to NOT (since it has no
infix form).