### PR TITLE
Differentiate EVERY return result, loop constants

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -144,6 +144,13 @@ either: native [
 	/only "Suppress evaluation of block args."
 ]
 
+every: native [
+	{Returns last TRUE? value if evaluating a block over a series is all TRUE?}
+	'word [word! block!] {Word or block of words to set each time (local)}
+	data [series! any-object! map! none!] {The series to traverse}
+	body [block!] {Block to evaluate each time}
+]
+
 exit: native [
 	{Leave whatever enclosing Rebol state EXIT's block *actually* runs in.}
 	/with {Result for enclosing state (default is UNSET!)}

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -11,9 +11,6 @@ REBOL [
 	}
 ]
 
-; non-hyphenated "pretty" form of for-each (better than `foreach`)
-every: :for-each
-
 launch: func [
 	{Runs a script as a separate process; return immediately.}
 	script [file! string! none!] "The name of the script"

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -52,8 +52,9 @@ sign?: :sign-of
 ; of the family of other -each functions like `remove-each` and `map-each`.
 ; The need for the hyphen for `for-each` isn't that bad, but the hyphen
 ; does break the rhythm a little bit.  Choosing to let `each` stand alone
-; was deemed too ugly, so `every` was selected as a synonym of `for-each`.
-; But `foreach` is demoted to legacy / compatibility module
+; was deemed too ugly, so `every` was selected as a near-synonym of
+; `for-each` (with a different return result).  But `foreach` is demoted
+; to legacy / compatibility module
 
 foreach: :for-each
 


### PR DESCRIPTION
The name EVERY is used in underscore.js for a routine that
will test a condition for every item in a series.  Although the
idea was to use EVERY as a synonym for FOR-EACH, it
seems that having a cumulative return result that's more like
ALL MAP-EACH is more useful and fitting for the name EVERY.

This adds a starter implementation for EVERY, but note that it
is subject to a quirky behavior regarding UNSET! which is to
treat it as if it were conditionally true.  That is the case for ALL
right now as well.  Both should be resolved, but that is a
separate issue.

There were also some odd numeric constants used in the
loop code, and this goes ahead and turns those into an
enumeration.