### PR TITLE
No execution possibility/suggestion for comment

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -89,8 +89,8 @@ catch: native [
 ;]
 
 comment: native [
-	{Ignores the argument value and returns nothing.}
-	value {A string, block, file, etc.}
+	{Ignores the argument value and returns nothing (no evaluations performed).}
+	:value [block! any-string! scalar!] {Literal value to be ignored.}
 ]
 
 compose: native [


### PR DESCRIPTION
Because comment did not get-quote its argument, it could wind
up being complicit in an evaluation.  That meant:

    >> comment probe {Hello}
    Hello

    >> comment (probe {Hello})
    Hello

    >> foo: does [probe {Hello}]
    >> comment foo
    Hello

This makes comment quote-like, and restricts it so that it does
not quote "active" types that would create confusion even if they
were being quoted (so no parens, any-words, paths...)

    >> comment (probe {Hello})
    ** Script error: comment does not allow paren! for its :value argument

    >> comment probe {Hello}
    ** Script error: comment does not allow word! for its :value argument

    >> foo: does [probe {Hello}]
    >> comment foo
    ** Script error: comment does not allow word! for its :value argument