### PR TITLE
Add FAIL native for raising an error or error-spec

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -135,6 +135,10 @@ Script: [
 
 	trap-with-expects:	[{must allow} :arg1 {as ERROR! to be TRAP handler}]
 
+	; Temporary error while DO MAKE ERROR! constructs are still outstanding
+	use-fail-for-error:	{Use FAIL (instead of THROW or DO) to trigger ERROR!}
+	limited-fail-input:	{FAIL requires complex expressions to be in a PAREN!}
+
 	invalid-arg:        [{invalid argument:} :arg1]
 	invalid-type:       [:arg1 {type is not allowed here}]
 	invalid-op:         [{invalid operator:} :arg1]
@@ -170,8 +174,8 @@ Script: [
 
 	no-return:          {block did not return a value}
 	block-lines:        {expected block of lines}
-	no-catch:			[{no CATCH for THROW of} :arg1]
-	no-catch-named:		[{no CATCH for THROW of} :arg1 {with /NAME:} :arg2]
+	no-catch:			[{Missing CATCH for THROW of} :arg1]
+	no-catch-named:		[{Missing CATCH for THROW of} :arg1 {with /NAME:} :arg2]
 
 	locked-word:        [{protected variable - cannot modify:} :arg1]
 	protected:          {protected value or series - cannot modify}

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -83,11 +83,6 @@ catch: native [
 	handler [block! any-function!] {If FUNCTION!, spec matches [value name]}
 ]
 
-;cause: native [
-;	{Force error processing on an error value.}
-;	error [error!]
-;]
-
 comment: native [
 	{Ignores the argument value and returns nothing (no evaluations performed).}
 	:value [block! any-string! scalar!] {Literal value to be ignored.}
@@ -155,6 +150,11 @@ exit: native [
 	{Leave whatever enclosing Rebol state EXIT's block *actually* runs in.}
 	/with {Result for enclosing state (default is UNSET!)}
 	value [any-type!]
+]
+
+fail: native [
+	{Interrupts execution by reporting an error (a TRAP can intercept it).}
+	reason [error! string! block!] {ERROR! value, message string, or failure spec}
 ]
 
 find-script: native [

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -52,7 +52,7 @@ read-sync-awake: func [event [event!] /local error] [
 		error [
 			error: event/port/state/error
 			event/port/state/error: none
-			do error
+			fail error
 		]
 	] [
 		false

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -85,11 +85,11 @@ for-each-record-NO-RETURN: func [
 	/local headings result spec
 ] [
 	unless block? first table [
-		do make error! {Table of records does not start with a header block}
+		fail {Table of records does not start with a header block}
 	]
 	headings: map-each word first table [
 		unless word? word [
-			do make error! rejoin [{Heading} space word space {is not a word}]
+			fail [{Heading} word {is not a word}]
 		]
 		to-set-word word
 	]
@@ -98,7 +98,7 @@ for-each-record-NO-RETURN: func [
 
 	set/any quote result: while [not empty? table] [
 		if (length headings) > (length table) [
-			do make error! {Element count isn't even multiple of header count}
+			fail {Element count isn't even multiple of header count}
 		]
 
 		spec: collect [
@@ -126,9 +126,7 @@ find-record-unique: func [
 	/local rec result
 ] [
 	unless find first table key [
-		do make error! rejoin [
-			key space {not found in table headers} space first table
-		]
+		fail [key {not found in table headers:} (first table)]
 	]
 
 	result: none
@@ -136,9 +134,7 @@ find-record-unique: func [
 		unless value = select rec key [continue]
 
 		if result [
-			do make error! rejoin [
-				{More than one table record matches} space key {=} value
-			]
+			fail [{More than one table record matches} key {=} value]
 		]
 
 		result: rec

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -657,7 +657,7 @@ for-each [cat msgs] boot-errors [
 					either get-word? item [{ %v }] [item]
 				]
 			]
-			true [do make error! {Non-STRING! non-BLOCK! as %errors.r value}]
+			true [fail {Non-STRING! non-BLOCK! as %errors.r value}]
 		]
 		append code null
 	]
@@ -904,7 +904,7 @@ for-each [cat msgs] boot-errors [
 	emit newline
 ]
 
-if errs [do make error! "Invalid errors.r input"]
+if errs [fail "Invalid errors.r input"]
 
 emit-end
 

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -85,7 +85,7 @@ func-header: [
 				newline
 				http://stackoverflow.com/questions/693788/c-void-arguments
 			]
-			do make error! "C++ no-arg prototype used instead of C style"
+			fail "C++ no-arg prototype used instead of C style"
 		]
 
 		append-spec spec

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -279,7 +279,7 @@ append plat-id config/id/3
 
 ; Collect OS-specific host files:
 unless os-specific-objs: select file-base to word! join "os-" config/os-base [
-	do make error! rejoin [
+	fail rejoin [
 		"make-make.r requires os-specific obj list in file-base.r" newline
 		"none was provided for os-" config/os-base
 	]

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -33,7 +33,7 @@ change-dir %../os/
 
 ; Collect OS-specific host files:
 unless os-specific-objs: select file-base to word! join "os-" config/os-base [
-	do make error! rejoin [
+	fail rejoin [
 		"make-os-ext.r requires os-specific obj list in file-base.r"
 		space "none was provided for os-" config/os-base
 	]

--- a/src/tools/make-zlib.r
+++ b/src/tools/make-zlib.r
@@ -77,7 +77,7 @@ disable-user-includes: func [
 
 	; If we inline a header, it should happen once and only once for each
 	unless empty? headers [
-		throw make error! rejoin [{Not all headers inlined by make-zlib:} space mold headers]  
+		fail [{Not all headers inlined by make-zlib:} (mold headers)]
 	]
 ]
 

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -188,7 +188,7 @@ config-system: func [
 ][
 	; Don't override a literal version tuple with a guess
 	if all [guess version] [
-		do make error! "config-system called with both /version and /guess"
+		fail "config-system called with both /version and /guess"
 	]
 
 	id: any [
@@ -202,7 +202,7 @@ config-system: func [
 			probe hint
 			hint: load hint
 			unless tuple? hint [
-				do make error! rejoin [
+				fail [
 					"Expected platform id (tuple like 0.3.1), not:" hint
 				]
 			]
@@ -214,8 +214,8 @@ config-system: func [
 	]
 
 	unless result: find-record-unique systems 'id id [
-		do make error! rejoin [
-			{No table entry for} space version space {found in systems.r}
+		fail [
+			{No table entry for} version {found in systems.r}
 		]
 	]
 


### PR DESCRIPTION
The FAIL native takes the place of DO'ing an error to raise it, and
is also able to take a STRING! or a BLOCK!.  The string is sent to
MAKE ERROR! directly, while blocks are processed in a new kind of
"error creation dialect".  The dialect evaluates a WORD! as long as
it does not evaluate to a function, and also will evaluate parens:

     fail ["Problem with foo:" foo "occurred at" (1 + 2)]

...this would behave equivalently to what has been written as:

    do make error! form reduce [
        "problem with foo:" foo "occurred at" (1 + 2)
    ]

Limiting types is to faciliate the dialect becoming more expressive.
It may use SET-WORD!, TAG!, and other choices to cue the fields
and formatting template structure for the error object being returned
to TRAP.  Hence those types are available for future expansion.  In
the meantime, the PAREN!'s general-purpose-escape will allow
for any substitution that FORM REDUCE might otherwise achieve.

It removes a commented out prior placeholder for a FAIL-like native
that was named "CAUSE".  That word may make sense when paired
directly with something like a variable named `error`...but as a
convenience routine that might be used with (for instance) a string it
doesn't communicate that an error has occurred and that execution
will be interrupted.  (RAISE was rejected for similar reasons.)

This is planned as the replacement for DO's handling of errors.  So
calling DO on an ERROR! will now still raise an error, but not the one
you asked for...rather an error directing the user to the use of FAIL.

Similarly, THROW directs users who try and pass errors to use FAIL
(as it would be a common misconception for people from other
languages to think that THROW is what you are supposed to use).
While a refinement was considered to allow throwing errors, the
rarity of the operation and the existence of workarounds (e.g. putting
the error in a block) makes it seem better to leave it.  Should throwing
an ERROR! turn out to be actually common, this can be reconsidered
and a refinement named.