### PR TITLE
Unicode insert fixes

### DIFF
--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -137,8 +137,15 @@
 	REBCNT tail  = SERIES_TAIL(dst_ser);
 	REBINT size;		// total to insert
 	REBOOL needs_free;
+	REBINT limit;
 
-	if (dups < 0) return (action == A_APPEND) ? 0 : dst_idx;
+	// For INSERT/PART and APPEND/PART
+	if (action != A_CHANGE && GET_FLAG(flags, AN_PART))
+		limit = dst_len; // should be non-negative
+	else
+		limit = -1;
+
+	if (limit == 0 || dups < 0) return (action == A_APPEND) ? 0 : dst_idx;
 	if (action == A_APPEND || dst_idx > tail) dst_idx = tail;
 
 	// If the src_val is not a string, then we need to create a string:
@@ -146,10 +153,12 @@
 		if (IS_INTEGER(src_val)) {
 			src_ser = Make_Series_Codepoint(Int8u(src_val));
 			needs_free = TRUE;
+			limit = -1;
 		}
 		else if (IS_BLOCK(src_val)) {
-			src_ser = Join_Binary(src_val); // NOTE: it's the shared FORM buffer!
+			src_ser = Join_Binary(src_val, limit); // NOTE: it's the shared FORM buffer!
 			needs_free = FALSE;
+			limit = -1;
 		}
 		else if (IS_CHAR(src_val)) {
 			// "UTF-8 was originally specified to allow codepoints with up to
@@ -159,8 +168,16 @@
 			src_ser = Make_Binary(6);
 			src_ser->tail = Encode_UTF8_Char(BIN_HEAD(src_ser), VAL_CHAR(src_val));
 			needs_free = TRUE;
+			limit = -1;
 		}
-		else if (!ANY_BINSTR(src_val))
+		else if (ANY_STR(src_val)) {
+			src_len = VAL_LEN(src_val);
+			if (limit >= 0 && src_len > limit) src_len = limit;
+			src_ser = Make_UTF8_From_Any_String(src_val, src_len, 0);
+			needs_free = TRUE;
+			limit = -1;
+		}
+		else if (!IS_BINARY(src_val))
 			raise Error_Invalid_Arg(src_val);
 	}
 	else if (IS_CHAR(src_val)) {
@@ -187,8 +204,7 @@
 		needs_free = FALSE;
 	}
 
-	// For INSERT or APPEND with /PART use the dst_len not src_len:
-	if (action != A_CHANGE && GET_FLAG(flags, AN_PART)) src_len = dst_len;
+	if (limit >= 0) src_len = limit;
 
 	// If Source == Destination we need to prevent possible conflicts.
 	// Clone the argument just to be safe.

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1195,8 +1195,6 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	REBUNI *up;
 	REBCNT n;
 
-	series->data = NULL;
-
 #if !defined(NDEBUG)
 	// We may be resizing a partially constructed series, or otherwise
 	// not want to preserve the previous contents
@@ -1205,6 +1203,8 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 #endif
 
 	assert(SERIES_WIDE(series) == 1);
+
+	series->data = NULL;
 
 	if (!Series_Data_Alloc(
 		series, tail_old + 1, cast(REBYTE, sizeof(REBUNI)), MKS_NONE

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -222,7 +222,7 @@ cp_same:
 			idx += n;
 			pos += n;
 			len -= n;
-			Widen_String(dst, FALSE);
+			Widen_String(dst, TRUE);
 			goto cp_same;
 		}
 		bp[n] = (REBYTE)up[n];
@@ -579,10 +579,12 @@ cp_same:
 
 /***********************************************************************
 **
-*/  REBSER *Join_Binary(const REBVAL *blk)
+*/  REBSER *Join_Binary(const REBVAL *blk, REBINT limit)
 /*
 **		Join a binary from component values for use in standard
 **		actions like make, insert, or append.
+**		limit: maximum number of values to process
+**		limit < 0 means no limit
 **
 **		WARNING: returns BUF_FORM, not a copy!
 **
@@ -594,9 +596,11 @@ cp_same:
 	REBCNT len;
 	void *bp;
 
+	if (limit < 0) limit = VAL_LEN(blk);
+
 	RESET_TAIL(series);
 
-	for (val = VAL_BLK_DATA(blk); NOT_END(val); val++) {
+	for (val = VAL_BLK_DATA(blk); limit > 0; val++, limit--) {
 		switch (VAL_TYPE(val)) {
 
 		case REB_INTEGER:

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -1159,11 +1159,12 @@ ConversionResult ConvertUTF8toUTF32 (
 	}
 	else {
 		REBOOL uni = !VAL_BYTE_SIZE(value);
-		REBCNT size = Length_As_UTF8(VAL_BIN_DATA(value), len, uni, ccr);
+		const void *data = uni ?
+			cast(const void*, VAL_UNI_DATA(value)) :
+			cast(const void*, VAL_BIN_DATA(value));
+		REBCNT size = Length_As_UTF8(data, len, uni, ccr);
 		series = Make_Binary(size + (GET_FLAG(opts, ENC_OPT_BOM) ? 3 : 0));
-		Encode_UTF8(
-			BIN_HEAD(series), size, VAL_BIN_DATA(value), &len, uni, ccr
-		);
+		Encode_UTF8(BIN_HEAD(series), size, data, &len, uni, ccr);
 	}
 
 	SERIES_TAIL(series) = len;

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -241,7 +241,7 @@ static REBSER *make_binary(REBVAL *arg, REBOOL make)
 
 	case REB_BLOCK:
 		// Join_Binary returns a shared buffer, so produce a copy:
-		ser = Copy_Sequence(Join_Binary(arg));
+		ser = Copy_Sequence(Join_Binary(arg, -1));
 		break;
 
 	// MAKE/TO BINARY! <tuple!>


### PR DESCRIPTION
Inserting Unicode into byte-strings doesn't seem to work at all.

    >> join "a" "^(100)"
    == ""

With my patch INSERT/PART and APPEND/PART count in bytes when the destination is binary!

    >> append/part #{61} "^(101)^(102)" 2
    == #{61C481}

What would be the correct behaviour?