### PR TITLE
Move eval from DO to EVAL, <r3-legacy> mode

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -135,9 +135,12 @@ Script: [
 
 	trap-with-expects:	[{must allow} :arg1 {as ERROR! to be TRAP handler}]
 
-	; Temporary error while DO MAKE ERROR! constructs are still outstanding
-	use-fail-for-error:	{Use FAIL (instead of THROW or DO) to trigger ERROR!}
-	limited-fail-input:	{FAIL requires complex expressions to be in a PAREN!}
+	; !!! Temporary errors while faulty constructs are still outstanding
+	; (more informative than just saying "function doesn't take that type")
+	use-eval-for-eval:  {Use EVAL (not DO) for inline evaluation of a value}
+	use-fail-for-error: {Use FAIL (instead of THROW or DO) to trigger ERROR!}
+
+	limited-fail-input: {FAIL requires complex expressions to be in a PAREN!}
 
 	invalid-arg:        [{invalid argument:} :arg1]
 	invalid-type:       [:arg1 {type is not allowed here}]

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -139,6 +139,7 @@ Script: [
 	; (more informative than just saying "function doesn't take that type")
 	use-eval-for-eval:  {Use EVAL (not DO) for inline evaluation of a value}
 	use-fail-for-error: {Use FAIL (instead of THROW or DO) to trigger ERROR!}
+	use-split-simple:   {Use SPLIT (instead of PARSE) for "simple" parsing}
 
 	limited-fail-input: {FAIL requires complex expressions to be in a PAREN!}
 

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -555,7 +555,10 @@ in: native [
 parse: native [
 	{Parses a string or block series according to grammar rules.}
 	input [series!] {Input series to parse}
-	rules [block!] {Rules to parse by}
+	;rules [block!] {Rules to parse by}
+	; !!! Does not actually handle STRING! and NONE!, used to give a more
+	; informative error message directing people to use SPLIT instead
+	rules [block! string! none!] {Rules to parse by}
 	/case {Uses case-sensitive comparison}
 	/all {(ignored refinement left for Rebol2 transitioning)}
 ]

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -118,18 +118,21 @@ continue: native [
 ;]
 
 do: native [
-	{Evaluates a block, file, URL, function, word, or any other value.}
-	value [any-type!] "Normally a file name, URL, or block"
+	{Evaluates a block of source code (directly or fetched according to type)}
+	;source [none! block! paren! string! binary! url! file! tag!]
+	; !!! Actually does not handle ERROR! or ANY-FUNCTION! but temporarily
+	; accepts them to trigger more informataive errors suggesting FAIL and EVAL
+	source [none! block! paren! string! binary! url! file! tag! error! any-function!]
 	/args "If value is a script, this will set its system/script/args"
 	arg   "Args passed to a script (normally a string)"
 	/next "Do next expression only, return it, update block variable"
 	var [word!] "Variable updated with new block position"
 ]
 
-;eval: native [
-;	{Evaluates a block, file, URL, function, word, or any other value.}
-;	value "Normally a file name, URL, or block"
-;]
+eval: native [
+	{(Special) Process received value *inline* as the evaluator loop would.}
+	value [any-type!] {BLOCK! passes-thru, FUNCTION! runs, SET-WORD! assigns...}
+]
 
 either: native [
 	{If TRUE condition return first arg, else second; evaluate blocks by default.}

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -141,6 +141,8 @@ options: context [  ; Options supplied to REBOL during startup
 
 	exit-functions-only: false
 	broken-case-semantics: false
+	do-runs-functions: false
+	do-raises-errors: false
 ]
 
 script: context [

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -128,14 +128,18 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	if (env_legacy != NULL && atoi(env_legacy) != 0) {
 		Debug_Str(
 			"**\n"
-			"** R3_LEGACY is TRUE in environment variable!\n"
+			"** R3_LEGACY is nonzero in environment variable!\n"
 			"** system/options relating to historical behaviors are heeded:\n"
 			"**\n"
-			"** system/options: [\n"
-			"**     (...)\n"
-			"**     exit-functions-only: false\n"
-			"**     broken-case-semantics: false\n"
-			"** ]\n"
+			"**     system/options: [\n"
+			"**         (...)\n"
+			"**         exit-functions-only: false\n"
+			"**         broken-case-semantics: false\n"
+			"**         do-runs-functions: false\n"
+			"**         do-raises-errors: false\n"
+			"**     ]\n"
+			"**\n"
+			"** Use `do <r3-legacy>` to enable more compatibility wrappers.\n"
 			"**\n"
 		);
 		PG_Legacy = TRUE;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1244,6 +1244,14 @@ bad_end:
 	REBOL_STATE state;
 	const REBVAL *error;
 
+	if (IS_NONE(rules) || IS_STRING(rules)) {
+		// !!! Temporary...more informative than having a simple "does not
+		// take type" response based on the spec not accepting string/none
+		raise Error_0(RE_USE_SPLIT_SIMPLE);
+	}
+
+	assert(IS_BLOCK(rules));
+
 	assert(IS_TRASH(D_OUT));
 
 	parse.series = VAL_SERIES(input);

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -85,6 +85,7 @@ typedef struct Reb_Series REBSER;
 enum {
 	OPT_VALUE_LINE = 0,	// Line break occurs before this value
 	OPT_VALUE_THROWN,	// Value is /NAME of a THROW (arg via THROWN_ARG)
+	OPT_VALUE_REEVALUATE, // Reevaluate result value
 	OPT_VALUE_MAX
 };
 
@@ -1171,7 +1172,6 @@ enum {
 	EXT_FUNC_INFIX = 0,		// called with "infix" protocol
 	EXT_FUNC_TRANSPARENT,	// no Definitionally Scoped return, ignores non-DS
 	EXT_FUNC_RETURN,		// function is a definitionally scoped return
-	EXT_FUNC_REDO,			// Reevaluate result value
 	EXT_FUNC_MAX
 };
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -45,6 +45,8 @@ use [word title] [
 
 decode-url: none ; set in sys init
 
+r3-legacy*: none ; set in %mezz-legacy.r
+
 ;-- Setup Codecs -------------------------------------------------------------
 
 for-each [codec handler] system/codecs [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -365,7 +365,7 @@ collect: func [
 	output [series!] "The buffer series (modified)"
 ][
 	unless output [output: make block! 16]
-	do func [keep] body func [value [any-type!] /only] [
+	eval func [keep] body func [value [any-type!] /only] [
 		output: apply :insert [output :value none none only]
 		:value
 	]

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -25,11 +25,8 @@ REBOL [
 ;-- can still work in older as well as newer Rebols.  Thus the detection
 ;-- has to be a bit "dynamic"
 
-unless value? 'length [length: :length? unset 'length?]
-unless value? 'index-of [index-of: :index? unset 'index?]
-unless value? 'offset-of [offset-of: :offset? unset 'offset?]
+do %r2r3-future.r
 
-unless value? 'for-each [for-each: :foreach every: :foreach unset 'foreach]
 
 ;-- !!! switch to use spaces when code is transitioned
 code-tab: (comment [rejoin [space space space space]] tab)

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -1,0 +1,68 @@
+REBOL [
+	Title: "Rebol2 and R3-Alpha Future Bridge to Ren/C"
+	Rights: {
+		Rebol is Copyright 1997-2015 REBOL Technologies
+		REBOL is a trademark of REBOL Technologies
+
+		Ren/C is Copyright 2015 MetaEducation
+	}
+	License: {
+		Licensed under the Apache License, Version 2.0
+		See: http://www.apache.org/licenses/LICENSE-2.0
+	}
+	Author: "@HostileFork"
+	Purpose: {
+		These routines can be run from a Rebol2 or R3-Alpha
+		to make them act more like Ren/C (which aims to
+		implement a finalized Rebol3 standard).
+
+		!!! Rebol2 support intended but not yet implemented.
+	}
+]
+
+unless value? 'length [length: :length? unset 'length?]
+unless value? 'index-of [index-of: :index? unset 'index?]
+unless value? 'offset-of [offset-of: :offset? unset 'offset?]
+unless value? 'type-of [type-of: :type? unset 'type?]
+
+unless value? 'for-each [
+	for-each: :foreach every: :foreach
+	;unset 'foreach ;-- tolerate it (for now, maybe indefinitely?)
+]
+
+; It is not possible to make a version of eval that does something other
+; than everything DO does in an older Rebol.  Which points to why exactly
+; it's important to have only one function like eval in existence.
+unless value? 'eval [
+    eval: :do
+]
+
+unless value? 'fail [
+	fail: func [
+		{Interrupts execution by reporting an error (a TRAP can intercept it).}
+		reason [error! string! block!] "ERROR! value, message string, or failure spec"
+	][
+		case [
+			error? reason [do error]
+			string? reason [do make error! reason]
+			block? reason [
+				for-each item reason [
+					unless any [
+						scalar? :item
+						string? :item
+						paren? :item
+						all [
+							word? :item
+							not any-function? get :item
+						]
+					][
+						do make error! (
+							"FAIL requires complex expressions to be in a PAREN!"
+						)
+					]
+				]
+				do make error! form reduce reason
+			]
+		]
+	]
+]


### PR DESCRIPTION
This adds the special EVAL primitive, which will handle a value inline
however the evaluator would:

    >> eval (quote x:) 10
    >> print x
    10

    >> eval :add 10 20
    == 30

What makes it special is that it is not a function that could be written
in user code, because it has an arity dictated by its argument...and
user functions have to be fixed arity.

Previously DO was the only operation that exposed the evaluator in
this special way, but it only worked with functions.  EVAL pulls that
out of DO (making it a normal function) and gives the behavior for
all data types, which localizes the specialness.

With DO more limited, it creates another divergence from R3-Alpha,
so this commit carries a tool in it with a new behavior for how DO
handles tags.  You can say `DO <r3-legacy>` and get legacy behaviors
back...such as making DO accept more types again, or putting back
simple parse, etc.  Older Rebols will treat this as a no-op because
DO of a tag didn't do anything, which makes it a good method.

The one thing that can't be put back--however--is for the wrapped
DO function to behave like EVAL.  This is because the operation is
special...and since you cannot write a function that acts like EVAL
does, you cannot write a wrapper for it either.  So basically, any DO
calls on functions *must* be changed to EVAL.

DO of a tag long-term is conceived as a way to invoke a named
module picked out of some directory service.  This commit adds a
few hardcoded items as a starter set (though not all of them are in
working order to be loaded from URL by Ren/C yet, it's a call to
action to make it so...)