### PR TITLE
CHANGE-DIR to URL, relative paths for DO of URL

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -699,8 +699,8 @@ wake-up: native [
 what-dir: native ["Returns the current directory path."]
 
 change-dir: native [
-	"Changes the current directory path."
-	path [file!]
+	"Changes the current path (where scripts with relative paths will be run)."
+	path [file! url!]
 ]
 
 ;-- Math Natives - nat_math.c

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -117,6 +117,8 @@ options: context [  ; Options supplied to REBOL during startup
 	path:           ; Where script was started or the startup dir
 		none
 
+	current-path:	; Current URL! or FILE! path to use for relative lookups
+
 	flags:          ; Boot flag bits (see system/catalog/boot-flags)
 	script:         ; Filename of script to evaluate
 	args:           ; Command line arguments passed to script

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -118,6 +118,11 @@ list-dir: func [
 	/local files save-dir info
 ][
 	save-dir: what-dir
+
+	unless file? save-dir [
+		fail ["No directory listing protocol registered for" save-dir]
+	]
+
 	switch type-of/word :path [
 		unset! [] ; Stay here
 		file! [change-dir path]


### PR DESCRIPTION
This adds support for the ability to change-dir to a URL.  It does not
add support for listing the contents of URL!s...and there is no
common convention for HTML directory listings.  However there may
be something to put in port schemes for SFTP and others (even
HTTP could get plugins for scraping out data for GitHub directory lists,
or auto-generated pages by apache for servers with that enabled).

The motive for this was in particular to facilitate a DO of a URL, in
which that source has relative paths via file to `do %something.reb`.
By letting the DO of the URL put Rebol "into that path", then when
a FILE! is run it will be relative to that URL.  This way, if you have
files organized on web server paths to match the scheme you
would have them locally, it will still work.