### PR TITLE
Word-valued refinement variables, APPLY lockdown

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -132,8 +132,7 @@ Script: [
 	expect-val:         [{expected} :arg1 {not} :arg2]
 	expect-type:        [:arg1 :arg2 {field must be of type} :arg3]
 	cannot-use:         [{cannot use} :arg1 {on} :arg2 {value}]
-
-	trap-with-expects:	[{must allow} :arg1 {as ERROR! to be TRAP handler}]
+	apply-too-many:		{Too many values in processed argument block of APPLY.}
 
 	; !!! Temporary errors while faulty constructs are still outstanding
 	; (more informative than just saying "function doesn't take that type")

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -147,6 +147,7 @@ options: context [  ; Options supplied to REBOL during startup
 	do-raises-errors: false
 	datatype-word-strict: false
 	group-not-paren: false ;; bias the default to PAREN! vs GROUP! (for now...)
+	refinements-true: false
 ]
 
 script: context [

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -174,10 +174,22 @@
 			break;
 
 		case REB_REFINEMENT:
-			// Refinement only allows logic! and none! for its datatype:
 			n++;
 			value = BLK_SKIP(words, n);
-			VAL_TYPESET(value) = (TYPESET(REB_LOGIC) | TYPESET(REB_NONE));
+
+		#if !defined(NDEBUG)
+			// Because Mezzanine functions are written to depend on the idea
+			// that when they get a refinement it will be a WORD! and not a
+			// LOGIC!, we have to capture the desire to get LOGIC! vs WORD!
+			// at function creation time...not dispatch time.  We encode the
+			// bit in the refinement's typeset that it accepts.
+			if (LEGACY(OPTIONS_REFINEMENTS_TRUE)) {
+				VAL_TYPESET(value) = (TYPESET(REB_LOGIC) | TYPESET(REB_NONE));
+				break;
+			}
+		#endif
+			// Refinements can nominally be only WORD! or NONE!
+			VAL_TYPESET(value) = (TYPESET(REB_WORD) | TYPESET(REB_NONE));
 			break;
 
 		case REB_TAG:

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -69,7 +69,9 @@ use: func [
 	vars [block! word!] {Local word(s) to the block}
 	body [block!] {Block to evaluate}
 ][
-	apply make closure! reduce [compose [<transparent> (vars)] copy/deep body] []
+	apply make closure! reduce [
+		compose [<transparent> /local (vars)] copy/deep body
+	] []
 ]
 
 object: func [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -196,6 +196,7 @@ set 'r3-legacy* func [] [
 	system/options/broken-case-semantics: true
 	system/options/exit-functions-only: true
 	system/options/datatype-word-strict: true
+	system/options/refinements-true: true
 
 	; False is already the default for this switch
 	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)
@@ -228,11 +229,19 @@ set 'r3-legacy* func [] [
 				]
 
 				true [
+					; !!! We could write this as:
+					;
+					;     lib/parse/:case input rules
+					;
+					; However, system/options/refinements-true has been set.
+					; We could move the set to after the function is defined,
+					; but probably best since this is "mixed up" code to use
+					; the pattern that works either way.
+					;
 					true? apply :lib/parse [input rules case]
 				]
 			]
 		])
-
 	]
 
 	return none

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -68,7 +68,7 @@ remold: func [
 	/all  {Mold in serialized format}
 	/flat {No indentation}
 ][
-	apply :mold [reduce :value only all flat]
+	mold/:only/:all/:flat reduce :value
 ]
 
 charset: func [
@@ -366,6 +366,16 @@ collect: func [
 ][
 	unless output [output: make block! 16]
 	eval func [<transparent> keep] body func [value [any-type!] /only] [
+		; In the default operation, this could now be written as:
+		;
+		;     output: insert/:only :value
+		;
+		; However, even though the system/options/refinements-true operation
+		; is captured at function definition time to work how the function
+		; expected, this is creating new functions *dynamically*.  As long as
+		; the option exists, we must use APPLY in case the compatibility
+		; mode is on and ONLY is #[true] (instead of the WORD! ONLY)
+		;
 		output: apply :insert [output :value none none only]
 		:value
 	]

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -228,7 +228,7 @@ update-proto-state: func [
 	either any [
 		none? ctx/protocol-state
 		all [
-			next-state: apply :get-next-proto-state [ctx write-state]
+			next-state: get-next-proto-state/:write-state ctx
 			find next-state new-state
 		]
 	] [


### PR DESCRIPTION
This changes it so that when a refinement is used in a function,
the value of that refinement is not #[true] but rather an unbound
WORD! which has the same symbol as the refinement itself.
If the refinement is unused, it is NONE! as before.  A legacy
mode for switching back to using TRUE is provided, but the
property will only apply to functions which were created since
the mode was turned on.

This is part (but not all) of a plan for making chaining smoother.
Another small part of this plan is included which lets you use
NONE! and GET-WORD! in refinement dispatch.  So you can
write `x: 'only` and `append/:x [a b c] [d e]` => `[a b c [d e]]`.
This is just a start, but work will be needed on path dispatch
to allow for parentheses, and just generally fixing mechanisms
so that things like `apo: :append/only` can work for capturing
refined functions into new functions.

Getting this to work required digging into APPLY, which had
two parallel codepaths with varying degrees of weakness.  It
seemed time to unify them and get the implementations to
do better checking, which allowed them to (for instance)
properly type-check the handler functions used by TRAP and
CATCH.  The mechanics were made more strict overall, so
that invoking a function through APPLY has to follow the
same basic rules as calling functions from the evaluator (e.g.
you can't set a refinement argument to true and then give
one of its arguments without the other).

Token APPLYs were switched to use the new chaining form,
but really being able to use it will require the ability for
passing NONE! to a refinement argument to "un-ask" for that
refinement (even though it was used in the invocation).