### PR TITLE
Legacy switches available in all debug builds

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -139,7 +139,7 @@ options: context [  ; Options supplied to REBOL during startup
 	file-types: []
 	result-types: none
 
-	; Legacy Behaviors Options (enabled if R3_LEGACY=1 set in OS environment)
+	; Legacy Behaviors Options (paid attention to only by debug builds)
 
 	exit-functions-only: false
 	broken-case-semantics: false

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -123,29 +123,6 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 
 	Init_Core(rargs);
 
-#if !defined(NDEBUG)
-	env_legacy = getenv("R3_LEGACY");
-	if (env_legacy != NULL && atoi(env_legacy) != 0) {
-		Debug_Str(
-			"**\n"
-			"** R3_LEGACY is nonzero in environment variable!\n"
-			"** system/options relating to historical behaviors are heeded:\n"
-			"**\n"
-			"**     system/options: [\n"
-			"**         (...)\n"
-			"**         exit-functions-only: false\n"
-			"**         broken-case-semantics: false\n"
-			"**         do-runs-functions: false\n"
-			"**         do-raises-errors: false\n"
-			"**     ]\n"
-			"**\n"
-			"** Use `do <r3-legacy>` to enable more compatibility wrappers.\n"
-			"**\n"
-		);
-		PG_Legacy = TRUE;
-	}
-#endif
-
 	GC_Active = TRUE; // Turn on GC
 	if (rargs->options & RO_TRACE) {
 		Trace_Level = 9999;

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1142,7 +1142,6 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 
 #ifndef NDEBUG
 	PG_Always_Malloc = FALSE;
-	PG_Legacy = FALSE;
 #endif
 
 	// Globals

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -431,6 +431,7 @@ enum {
 		// Until such time as DO guarantees such things aren't legal,
 		// CASE must evaluate block literals too.
 
+	#if !defined(NDEBUG)
 		if (
 			LEGACY(OPTIONS_BROKEN_CASE_SEMANTICS)
 			&& IS_CONDITIONAL_FALSE(condition_result)
@@ -444,6 +445,7 @@ enum {
 			SET_NONE(D_OUT);
 			continue;
 		}
+	#endif
 
 		index = Do_Next_May_Throw(body_result, block, index);
 
@@ -453,10 +455,12 @@ enum {
 		}
 
 		if (index == END_FLAG) {
+		#if !defined(NDEBUG)
 			if (LEGACY(OPTIONS_BROKEN_CASE_SEMANTICS)) {
 				// case [first [a b c]] => true ;-- in Rebol2
 				return R_TRUE;
 			}
+		#endif
 
 			// case [first [a b c]] => **error**
 			raise Error_0(RE_PAST_END);
@@ -484,12 +488,14 @@ enum {
 				*D_OUT = *body_result;
 			}
 
+		#if !defined(NDEBUG)
 			if (LEGACY(OPTIONS_BROKEN_CASE_SEMANTICS)) {
 				if (IS_UNSET(D_OUT)) {
 					// case [true [] false [1 + 2]] => true ;-- in Rebol2
 					SET_TRUE(D_OUT);
 				}
 			}
+		#endif
 
 			// One match is enough to return the result now, unless /ALL
 			if (!all) return R_OUT;
@@ -943,10 +949,14 @@ was_caught:
 **
 ***********************************************************************/
 {
+#if !defined(NDEBUG)
 	if (LEGACY(OPTIONS_EXIT_FUNCTIONS_ONLY))
 		Val_Init_Word_Unbound(D_OUT, REB_WORD, SYM_RETURN);
 	else
 		Val_Init_Word_Unbound(D_OUT, REB_WORD, SYM_EXIT);
+#else
+	Val_Init_Word_Unbound(D_OUT, REB_WORD, SYM_EXIT);
+#endif
 
 	CONVERT_NAME_TO_THROWN(D_OUT, D_REF(1) ? D_ARG(2) : UNSET_VALUE);
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -845,26 +845,25 @@ enum Reb_Fail_Prep {
 **
 **	Legacy Modes Checking
 **
-**		Ren/C wants to try out new things that will (or likely will) make
-**		it into the official release.  But it also wants transitioning
-**		feasible from Rebol2 and Rebol3-alpha, and without paying
+**		Ren/C wants to try out new things that will likely be included
+**		it the official Rebol3 release.  But it also wants transitioning
+**		to be feasible from Rebol2 and R3-Alpha, without paying that
 **		much to check for "old" modes if they're not being used.  So
 **		system/options contains flags used for enabling specific
 **		features relied upon by old code.
 **
 **		In order to keep these easements from adding to the measured
-**		performance cost in the system, they are only supported in
-**		debug builds.  Also, none of them are checked by default...
-**		you must have run the executable with an environment variable
-**		set as R3_LEGACY=1, which sets PG_Legacy so the check is done.
+**		performance cost in the system (and to keep them from being
+**		used for anything besides porting), they are only supported in
+**		debug builds.
 **
 ***********************************************************************/
 
-#ifdef NDEBUG
-	#define LEGACY(option) FALSE
-#else
-	#define LEGACY(option) \
-		(PG_Legacy && IS_CONDITIONAL_TRUE(Get_System(SYS_OPTIONS, (option))))
+#if !defined(NDEBUG)
+	#define LEGACY(option) ( \
+		(PG_Boot_Phase >= BOOT_ERRORS) \
+		&& IS_CONDITIONAL_TRUE(Get_System(SYS_OPTIONS, (option))) \
+	)
 #endif
 
 

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -60,7 +60,6 @@ PVAR REB_OPTS *Reb_Opts;
 
 #ifndef NDEBUG
 	PVAR REBOOL PG_Always_Malloc;	// For memory-related troubleshooting
-	PVAR REBOOL PG_Legacy;			// Need to check for old operation modes
 #endif
 
 // A REB_END value, which comes in handy if you ever need the address of

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -14,8 +14,9 @@ REBOL [
 	Description: {
 		These definitions turn the clock backward for Rebol code that was
 		written prior to Ren/C, e.g. binaries available on rebolsource.net
-		or R3-Alpha binaries from rebol.com.  (See also the OS environment
-		setting R3_LEGACY=1).
+		or R3-Alpha binaries from rebol.com.  Some flags which are set
+		which affect the behavior of natives and the evaluator ARE ONLY
+		ENABLED IN DEBUG BUILDS OF REN/C...so be aware of that.
 
 		Some "legacy" definitions (like `foreach` as synonym of `for-each`)
 		are kept by default for now, possibly indefinitely.  For other
@@ -163,9 +164,9 @@ try: func [
 ;
 set 'r3-legacy* func [] [
 
-	; NOTE: these flags only work if R3_LEGACY is set to "1" in the
-	; environment and you are using a debug build equipped to support
-	; them.  A better availability test for the functionality is needed
+	; NOTE: these flags only work in debug builds.  A better availability
+	; test for the functionality is needed, as these flags may be expired
+	; at different times on a case-by-case basis.
 	;
 	system/options/do-runs-functions: true
 	system/options/do-raises-errors: true


### PR DESCRIPTION
The evolving story for how to continue running code in Ren/C
which has not been updated (either partially-or-fully) is that DO of
`<r3-legacy>` will turn back the clock and morph the behavior to act
more like an R3-Alpha.  This requires some shim code written as
Rebol functions working along with some conditional behavior in
the C code.

The idea originally was that these switches should be hidden and
very hard to get...controlled through an environment variable so
you wouldn't accidentally be running them.  But as the idea
emerged that they'd only be in debug builds, that seems like
enough of a disincentive to depend upon it without making it any
more difficult than that.