### PR TITLE
Let DATATYPE! compare as corresponding WORD!

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -145,6 +145,7 @@ options: context [  ; Options supplied to REBOL during startup
 	broken-case-semantics: false
 	do-runs-functions: false
 	do-raises-errors: false
+	datatype-word-strict: false
 ]
 
 script: context [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -172,6 +172,7 @@ set 'r3-legacy* func [] [
 	system/options/do-raises-errors: true
 	system/options/broken-case-semantics: true
 	system/options/exit-functions-only: true
+	system/options/datatype-word-strict: true
 
 	append system/contexts/user compose [
 


### PR DESCRIPTION
This updates the routine that implements the EQUAL? function to
do a coercion of datatypes into a WORD!.  (This coercion is not
applied in STRICT-EQUAL?)

    >> (type? 3) = 'integer!
    == true

    >> (type? 3) == 'integer!
    == false

Because SWITCH does not use the same function to test cases,
you can't apply this there yet...(until that change is also committed)

Also makes it clearer that Compare_Modify_Values is boolean.