### PR TITLE
SWITCH uses EQUAL?+STRICT-EQUAL?, more...

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -299,6 +299,7 @@ switch: native [
 	cases [block!] "Block of cases to check"
 	/default case "Default case if no others found"
 	/all "Evaluate all matches (not just first one)"
+	/strict "Use STRICT-EQUAL? when comparing cases instead of EQUAL?"
 ]
 
 throw: native [

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -148,6 +148,8 @@ options: context [  ; Options supplied to REBOL during startup
 	datatype-word-strict: false
 	group-not-paren: false ;; bias the default to PAREN! vs GROUP! (for now...)
 	refinements-true: false
+	no-switch-evals: false
+	no-switch-fallthrough: false
 ]
 
 script: context [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -197,6 +197,8 @@ set 'r3-legacy* func [] [
 	system/options/exit-functions-only: true
 	system/options/datatype-word-strict: true
 	system/options/refinements-true: true
+	system/options/no-switch-evals: true
+	system/options/no-switch-fallthrough: true
 
 	; False is already the default for this switch
 	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)


### PR DESCRIPTION
After adding functionality to make datatypes compare EQUAL? to
the word for their type symbol, this drew attention to the fact that
switch was not using EQUAL? or STRICT-EQUAL? comparison.  It
also did not have a /CASE refinement.  This started as a rewrite of
switch to handle those issues, adding /STRICT.

So long as switch was being updated in terms of its comparison,
the code was easy enough to put a couple of other differences in
These behaviors can be disabled with legacy switches, and permit
the evaluation of GET-WORD!, GET-PATH!, and PAREN!.

Another setting controls the ability to have the switch value "fall out"
the bottom if there is no block to catch it.  This can be an alternate
way to express a default.  (Previously such cases would just be a
No-Op and return NONE! as the result, which was not very useful.)