### PR TITLE
Trigonometry shorthands introduced by Red

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -707,37 +707,37 @@ change-dir: native [
 
 cosine: native [
 	{Returns the trigonometric cosine.}
-	value [number!] {In degrees by default}
-	/radians {Value is specified in radians}
+	angle [number!] {In degrees by default}
+	/radians {Angle is specified in radians}
 ]
 
 sine: native [
 	{Returns the trigonometric sine.}
-	value [number!] {In degrees by default}
-	/radians {Value is specified in radians}
+	angle [number!] {In degrees by default}
+	/radians {Angle is specified in radians}
 ]
 
 tangent: native [
 	{Returns the trigonometric tangent.}
-	value [number!] {In degrees by default}
-	/radians {Value is specified in radians}
+	angle [number!] {In degrees by default}
+	/radians {Angle is specified in radians}
 ]
 
 arccosine: native [
 	{Returns the trigonometric arccosine (in degrees by default).}
-	value [number!]
+	cosine [number!]
 	/radians {Returns result in radians}
 ]
 
 arcsine: native [
 	{Returns the trigonometric arcsine (in degrees by default).}
-	value [number!]
+	sine [number!]
 	/radians {Returns result in radians}
 ]
 
 arctangent: native [
 	{Returns the trigonometric arctangent (in degrees by default).}
-	value [number!]
+	tangent [number!]
 	/radians {Returns result in radians}
 ]
 

--- a/src/mezz/mezz-colors.r
+++ b/src/mezz/mezz-colors.r
@@ -45,7 +45,10 @@ violet:		72.0.90
 brick:		178.34.34
 pink: 		255.164.200
 gold:		255.205.40
-tan:		222.184.135
+
+; `tan` is contentious with the radian-oriented shorthand for tangent
+;tan:		222.184.135
+
 beige:		255.228.196
 ivory:		255.255.240
 linen:		250.240.230

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -11,6 +11,53 @@ REBOL [
 	}
 ]
 
+; Shorthands for radian forms of trig functions, first introduced by Red.
+; http://www.red-lang.org/2014/08/043-floating-point-support.html
+
+cos: func [
+	{Returns the trigonometric cosine.}
+	angle [number!] {Angle in radians (use COSINE for degrees).}
+][
+	cosine/radians angle
+]
+
+sin: func [
+	{Returns the trigonometric sine.}
+	angle [number!] {Angle in radians (use SINE for degrees).}
+][
+	sine/radians angle
+]
+
+; !!! Note: Name is contentious with the color "tan" (in CSS and elsewhere)
+tan: func [
+	{Returns the trigonometric tangent.}
+	angle [number!] {Angle in radians (use TANGENT for degrees).}
+][
+	tangent/radians angle
+]
+
+acos: func [
+	{Calculate trigonometric arccosine (radians, use ARCCOSINE for degrees).}
+	cosine [number!]
+][
+	arccosine/radians cosine
+]
+
+asin: func [
+	{Calculate trigonometric arcsine (radians, use ARCSINE for degrees).}
+	sine [number!]
+][
+	arcsine/radians sine
+]
+
+atan: func [
+	{Calculate trigonometric arctangent (radians, use ARCTANGENT for degrees).}
+	tangent [number!]
+][
+	arctangent/radians tangent
+]
+
+
 mod: func [
 	"Compute a nonnegative remainder of A divided by B."
 	; In fact the function tries to find the remainder,


### PR DESCRIPTION
This PR contains the abbreviations for the trigonometry functions
as introduced by Red (updated from the post, e.g. it was initially
ARCTAN for the arctangent, but changed to ATAN)

http://www.red-lang.org/2014/08/043-floating-point-support.htm

Raising a question about whether to do this or not is that there
is contention between the color code for TAN and the abbreviated
form of TANGENT.  It's not clear which would be more deserving of
a "global" name, or if either colors or math functions should be put
under some more specific context.

In any case, this raises the question...and also updates some of
the help strings (as well as correcting mistakes from Red, which
at time of writing lists the ARC\* functions as taking an angle)
