### PR TITLE
ANY- prefix for SERIES!, NUMBER!, SCALAR!

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -21,38 +21,38 @@ REBOL [
 
 add: action [
 	{Returns the addition of two values.}
-	value1 [scalar! date!]
+	value1 [any-scalar! date!]
 	value2
 ]
 
 subtract: action [
 	{Returns the second value subtracted from the first.}
-	value1 [scalar! date!]
-	value2 [scalar! date!]
+	value1 [any-scalar! date!]
+	value2 [any-scalar! date!]
 ]
 
 multiply: action [
 	{Returns the first value multiplied by the second.}
-	value1 [scalar!]
-	value2 [scalar!]
+	value1 [any-scalar!]
+	value2 [any-scalar!]
 ]
 
 divide: action [
 	{Returns the first value divided by the second.}
-	value1 [scalar!]
-	value2 [scalar!]
+	value1 [any-scalar!]
+	value2 [any-scalar!]
 ]
 
 remainder: action [
 	{Returns the remainder of first value divided by second.}
-	value1 [scalar!]
-	value2 [scalar!]
+	value1 [any-scalar!]
+	value2 [any-scalar!]
 ]
 
 power: action [
 	{Returns the first number raised to the second number.}
-	number [number!]
-	exponent [number!]
+	number [any-number!]
+	exponent [any-number!]
 ]
 
 and~: action [
@@ -77,7 +77,7 @@ xor~: action [
 
 negate: action [
 	{Changes the sign of a number.}
-	number [number! pair! money! time! bitset!]
+	number [any-number! pair! money! time! bitset!]
 ]
 
 complement: action [
@@ -87,14 +87,14 @@ complement: action [
 
 absolute: action [
 	{Returns the absolute value.}
-	value [number! pair! money! time!]
+	value [any-number! pair! money! time!]
 ]
 
 round: action [
 	{Rounds a numeric value; halves round up (away from zero) by default.}
-	value [number! pair! money! time!] "The value to round"
+	value [any-number! pair! money! time!] "The value to round"
 	/to "Return the nearest multiple of the scale parameter"
-	scale [number! money! time!] "Must be a non-zero value"
+	scale [any-number! money! time!] "Must be a non-zero value"
 	/even      "Halves round toward even results"
 	/down      "Round toward zero, ignoring discarded digits. (truncate)"
 	/half-down "Halves round toward zero"
@@ -113,79 +113,79 @@ random: action [
 
 odd?: action [
 	{Returns TRUE if the number is odd.}
-	number [number! char! date! money! time! pair!]
+	number [any-number! char! date! money! time! pair!]
 ]
 
 even?: action [
 	{Returns TRUE if the number is even.}
-	number [number! char! date! money! time! pair!]
+	number [any-number! char! date! money! time! pair!]
 ]
 
 ;-- Series Navigation
 
 head: action [
 	{Returns the series at its beginning.}
-	series [series! gob! port!]
+	series [any-series! gob! port!]
 ]
 
 tail: action [
 	{Returns the series just past its end.}
-	series [series! gob! port!]
+	series [any-series! gob! port!]
 ]
 
 head?: action [
 	{Returns TRUE if a series is at its beginning.}
-	series [series! gob! port!]
+	series [any-series! gob! port!]
 ]
 
 tail?: action [
 	{Returns TRUE if series is at or past its end; or empty for other types.}
-	series [series! object! gob! port! bitset! map! none!]
+	series [any-series! object! gob! port! bitset! map! none!]
 ]
 
 past?: action [
 	{Returns TRUE if series is past its end.}
-	series [series! gob! port!]
+	series [any-series! gob! port!]
 ]
 
 next: action [
 	{Returns the series at its next position.}
-	series [series! gob! port!]
+	series [any-series! gob! port!]
 ]
 
 back: action [
 	{Returns the series at its previous position.}
-	series [series! gob! port!]
+	series [any-series! gob! port!]
 ]
 
 skip: action [
 	{Returns the series forward or backward from the current position.}
-	series [series! gob! port!]
-	offset [number! logic! pair!]
+	series [any-series! gob! port!]
+	offset [any-number! logic! pair!]
 ]
 
 at: action [
 	{Returns the series at the specified index.}
-	series [series! gob! port!]
-	index [number! logic! pair!]
+	series [any-series! gob! port!]
+	index [any-number! logic! pair!]
 ]
 
 index-of: action [
 	{Returns the current position (index) of the series.}
-	series [series! gob! port! none!]
+	series [any-series! gob! port! none!]
 	/xy {Returns index as an XY pair offset}
 ]
 
 length: action [
 	{Returns the length (from the current position for series.)}
-	series [series! port! map! tuple! bitset! object! gob! struct! any-word! none!]
+	series [any-series! port! map! tuple! bitset! object! gob! struct! any-word! none!]
 ]
 
 ;-- Series Extraction
 
 pick: action [
 	{Returns the value at the specified position.}
-	aggregate [series! map! gob! pair! date! time! tuple! bitset! port!]
+	aggregate [any-series! map! gob! pair! date! time! tuple! bitset! port!]
 	index {Index offset, symbol, or other value to use as index}
 ]
 
@@ -193,10 +193,10 @@ pick: action [
 
 find: action [
 	{Searches for a value; for series returns where found, else none.}
-	series [series! gob! port! bitset! typeset! object! none!]
+	series [any-series! gob! port! bitset! typeset! object! none!]
 	value [any-type!]
 	/part {Limits the search to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/only {Treats a series value as only a single value}
 	/case {Characters are case-sensitive}
 	/any  {Enables the * and ? wildcards}
@@ -212,10 +212,10 @@ find: action [
 
 select: action [
 	{Searches for a value; returns the value that follows, else none.}
-	series [series! port! map! object! none!]
+	series [any-series! port! map! object! none!]
 	value [any-type!]
 	/part {Limits the search to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/only {Treats a series value as only a single value}
 	/case {Characters are case-sensitive}
 	/any  {Enables the * and ? wildcards}
@@ -251,9 +251,9 @@ to: action [
 
 copy: action [
 	{Copies a series, object, or other value.}
-	value [series! port! map! object! bitset! any-function!] {At position}
+	value [any-series! port! map! object! bitset! any-function!] {At position}
 	/part {Limits to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/deep {Also copies series values within the block}
 	/types {What datatypes to copy}
 	kinds [typeset! datatype!]
@@ -261,68 +261,68 @@ copy: action [
 
 take: action [
 	{Removes and returns one or more elements.}
-	series [series! port! gob! none!] {At position (modified)}
+	series [any-series! port! gob! none!] {At position (modified)}
 	/part {Specifies a length or end position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/deep {Also copies series values within the block}
 	/last {Take it from the tail end}
 ]
 
 insert: action [
 	{Inserts element(s); for series, returns just past the insert.}
-	series [series! port! map! gob! object! bitset! port!] {At position (modified)}
+	series [any-series! port! map! gob! object! bitset! port!] {At position (modified)}
 	value [any-type!] {The value to insert}
 	/part {Limits to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/only {Only insert a block as a single value (not the contents of the block)}
 	/dup {Duplicates the insert a specified number of times}
-	count [number! pair!]
+	count [any-number! pair!]
 ]
 
 append: action [
 	{Inserts element(s) at tail; for series, returns head.}
-	series [series! port! map! gob! object! bitset!] {Any position (modified)}
+	series [any-series! port! map! gob! object! bitset!] {Any position (modified)}
 	value [any-type!] {The value to insert}
 	/part {Limits to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/only {Only insert a block as a single value (not the contents of the block)}
 	/dup {Duplicates the insert a specified number of times}
-	count [number! pair!]
+	count [any-number! pair!]
 ]
 
 remove: action [
 	{Removes element(s); returns same position.}
-	series [series! gob! port! bitset! none!] {At position (modified)}
+	series [any-series! gob! port! bitset! none!] {At position (modified)}
 	/part {Removes multiple elements or to a given position}
-	limit [number! series! pair! char!]
+	limit [any-number! any-series! pair! char!]
 ]
 
 change: action [
 	{Replaces element(s); returns just past the change.}
-	series [series! gob! port! struct!]{At position (modified)}
+	series [any-series! gob! port! struct!]{At position (modified)}
 	value [any-type!] {The new value}
 	/part {Limits the amount to change to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/only {Only change a block as a single value (not the contents of the block)}
 	/dup {Duplicates the change a specified number of times}
-	count [number! pair!]
+	count [any-number! pair!]
 ]
 
 poke: action [
 	{Replaces an element at a given position.}
-	series [series! port! map! gob! bitset!] {(modified)}
+	series [any-series! port! map! gob! bitset!] {(modified)}
 	index {Index offset, symbol, or other value to use as index}
 	value [any-type!] {The new value (returned)}
 ]
 
 clear: action [
 	{Removes elements from current position to tail; returns at new tail.}
-	series [series! port! map! gob! bitset! none!] {At position (modified)}
+	series [any-series! port! map! gob! bitset! none!] {At position (modified)}
 ]
 
 trim: action [
 	{Removes spaces from strings or nones from blocks or objects.}
-	series [series! object! error! module!] {Series (modified) or object (made)}
+	series [any-series! object! error! module!] {Series (modified) or object (made)}
 	/head {Removes only from the head}
 	/tail {Removes only from the tail}
 	/auto {Auto indents lines relative to first line}
@@ -333,27 +333,27 @@ trim: action [
 
 swap: action [
 	{Swaps elements between two series or the same series.}
-	series1 [series! gob!] {At position (modified)}
-	series2 [series! gob!] {At position (modified)}
+	series1 [any-series! gob!] {At position (modified)}
+	series2 [any-series! gob!] {At position (modified)}
 ]
 
 reverse: action [
 	{Reverses the order of elements; returns at same position.}
-	series [series! gob! tuple! pair!] {At position (modified)}
+	series [any-series! gob! tuple! pair!] {At position (modified)}
 	/part {Limits to a given length or position}
-	limit [number! series!]
+	limit [any-number! any-series!]
 ]
 
 sort: action [
 	{Sorts a series; default sort order is ascending.}
-	series [series!] {At position (modified)}
+	series [any-series!] {At position (modified)}
 	/case {Case sensitive sort}
 	/skip {Treat the series as records of fixed size}
 	size [integer!] {Size of each record}
 	/compare  {Comparator offset, block or function}
 	comparator [integer! block! any-function!]
 	/part {Sort only part of a series}
-	limit [number! series!] {Length of series to sort}
+	limit [any-number! any-series!] {Length of series to sort}
 	/all {Compare all fields}
 	/reverse {Reverse sort order}
 ]
@@ -390,13 +390,13 @@ read: action [
 	{Read from a file, URL, or other port.}
 	source [port! file! url! block!]
 	/part {Partial read a given number of units (source relative)}
-		limit [number!]
+		limit [any-number!]
 	/seek {Read from a specific position (source relative)}
-		index [number!]
+		index [any-number!]
 	/string {Convert UTF and line terminators to standard text string}
 	/lines {Convert to block of strings (implies /string)}
 ;	/as {Convert to string using a specified encoding}
-;		encoding [none! number!] {UTF number (0 8 16 -16)}
+;		encoding [none! any-number!] {UTF number (0 8 16 -16)}
 ]
 
 write: action [
@@ -404,15 +404,15 @@ write: action [
 	destination [port! file! url! block!]
 	data [binary! string! block!] {Data to write (non-binary converts to UTF-8)}
 	/part {Partial write a given number of units}
-		limit [number!]
+		limit [any-number!]
 	/seek {Write at a specific position}
-		index [number!]
+		index [any-number!]
 	/append {Write data at end of file}
 	/allow {Specifies protection attributes}
 		access [block!]
 	/lines {Write each value in a block as a separate line}
 ;	/as {Convert string to a specified encoding}
-;		encoding [none! number!] {UTF number (0 8 16 -16)}
+;		encoding [none! any-number!] {UTF number (0 8 16 -16)}
 ]
 
 open?: action [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -85,7 +85,7 @@ catch: native [
 
 comment: native [
 	{Ignores the argument value and returns nothing (no evaluations performed).}
-	:value [block! any-string! scalar!] {Literal value to be ignored.}
+	:value [block! any-string! any-scalar!] {Literal value to be ignored.}
 ]
 
 compose: native [
@@ -145,7 +145,7 @@ either: native [
 every: native [
 	{Returns last TRUE? value if evaluating a block over a series is all TRUE?}
 	'word [word! block!] {Word or block of words to set each time (local)}
-	data [series! any-object! map! none!] {The series to traverse}
+	data [any-series! any-object! map! none!] {The series to traverse}
 	body [block!] {Block to evaluate each time}
 ]
 
@@ -168,9 +168,9 @@ find-script: native [
 for: native [
 	{Evaluate a block over a range of values. (See also: REPEAT)}
 	'word [word!] "Variable to hold current value"
-	start [series! number!] "Starting value"
-	end   [series! number!] "Ending value"
-	bump  [number!] "Amount to skip each time"
+	start [any-series! any-number!] "Starting value"
+	end   [any-series! any-number!] "Ending value"
+	bump  [any-number!] "Amount to skip each time"
 	body  [block!] "Block to evaluate"
 ]
 
@@ -188,7 +188,7 @@ forever: native [
 for-each: native [
 	{Evaluates a block for each value(s) in a series.}
 	'word [word! block!] {Word or block of words to set each time (local)}
-	data [series! any-object! map! none!] {The series to traverse}
+	data [any-series! any-object! map! none!] {The series to traverse}
 	body [block!] {Block to evaluate each time}
 ]
 
@@ -213,7 +213,7 @@ if: native [
 
 loop: native [
 	{Evaluates a block a specified number of times.}
-	count [number!] {Number of repetitions}
+	count [any-number!] {Number of repetitions}
 	block [block!] {Block to evaluate}
 ]
 
@@ -240,7 +240,7 @@ quit: native [
 
 protect: native [
 	"Protect a series or a variable from being modified."
-	value [word! series! bitset! map! object! module!]
+	value [word! any-series! bitset! map! object! module!]
 	/deep "Protect all sub-series/objects as well"
 	/words  "Process list as words (and path words)"
 	/values "Process list of values (implied GET)"
@@ -249,7 +249,7 @@ protect: native [
 
 unprotect: native [
 	"Unprotect a series or a variable (it can again be modified)."
-	value [word! series! bitset! map! object! module!]
+	value [word! any-series! bitset! map! object! module!]
 	/deep "Protect all sub-series as well"
 	/words "Block is a list of words"
 	/values "Process list of values (implied GET)"
@@ -277,14 +277,14 @@ reduce: native [
 repeat: native [
 	{Evaluates a block a number of times or over a series.}
 	'word [word!] {Word to set each time}
-	value [number! series! none!] {Maximum number or series to traverse}
+	value [any-number! any-series! none!] {Maximum number or series to traverse}
 	body [block!] {Block to evaluate each time}
 ]
 
 remove-each: native [
 	{Removes values for each block that returns true; returns removal count.}
 	'word [word! block!] {Word or block of words to set each time (local)}
-	data [series!] {The series to traverse (modified)}
+	data [any-series!] {The series to traverse (modified)}
 	body [block!] {Block to evaluate (return TRUE to remove)}
 ]
 
@@ -526,14 +526,14 @@ lowercase: native [
 	"Converts string of characters to lowercase."
 	string [any-string! char!] {(modified if series)}
 	/part {Limits to a given length or position}
-	limit [number! any-string!]
+	limit [any-number! any-string!]
 ]
 
 uppercase: native [
 	"Converts string of characters to uppercase."
 	string [any-string! char!] {(modified if series)}
 	/part {Limits to a given length or position}
-	limit [number! any-string!]
+	limit [any-number! any-string!]
 ]
 
 dehex: native [
@@ -555,7 +555,7 @@ in: native [
 
 parse: native [
 	{Parses a string or block series according to grammar rules.}
-	input [series!] {Input series to parse}
+	input [any-series!] {Input series to parse}
 	;rules [block!] {Rules to parse by}
 	; !!! Does not actually handle STRING! and NONE!, used to give a more
 	; informative error message directing people to use SPLIT instead
@@ -685,7 +685,7 @@ now: native [
 
 wait: native [
 	{Waits for a duration, port, or both.}
-	value [number! time! port! block! none!]
+	value [any-number! time! port! block! none!]
 	/all {Returns all in a block}
 	/only {only check for ports given in the block to this function}
 ]
@@ -707,63 +707,63 @@ change-dir: native [
 
 cosine: native [
 	{Returns the trigonometric cosine.}
-	value [number!] {In degrees by default}
+	value [any-number!] {In degrees by default}
 	/radians {Value is specified in radians}
 ]
 
 sine: native [
 	{Returns the trigonometric sine.}
-	value [number!] {In degrees by default}
+	value [any-number!] {In degrees by default}
 	/radians {Value is specified in radians}
 ]
 
 tangent: native [
 	{Returns the trigonometric tangent.}
-	value [number!] {In degrees by default}
+	value [any-number!] {In degrees by default}
 	/radians {Value is specified in radians}
 ]
 
 arccosine: native [
 	{Returns the trigonometric arccosine (in degrees by default).}
-	value [number!]
+	value [any-number!]
 	/radians {Returns result in radians}
 ]
 
 arcsine: native [
 	{Returns the trigonometric arcsine (in degrees by default).}
-	value [number!]
+	value [any-number!]
 	/radians {Returns result in radians}
 ]
 
 arctangent: native [
 	{Returns the trigonometric arctangent (in degrees by default).}
-	value [number!]
+	value [any-number!]
 	/radians {Returns result in radians}
 ]
 
 exp: native [
 	{Raises E (the base of natural logarithm) to the power specified}
-	power [number!]
+	power [any-number!]
 ]
 
 log-10: native [
 	{Returns the base-10 logarithm.}
-	value [number!]
+	value [any-number!]
 ]
 
 log-2: native [
 	{Return the base-2 logarithm.}
-	value [number!]
+	value [any-number!]
 ]
 
 log-e: native [
 	{Returns the natural (base-E) logarithm of the given value}
-	value [number!]
+	value [any-number!]
 ]
 
 square-root: native [
 	{Returns the square root of a number.}
-	value [number!]
+	value [any-number!]
 ]
 
 shift: native [
@@ -947,7 +947,7 @@ do-commands: native [
 
 ds: native ["Temporary stack debug"]
 dump: native ["Temporary debug dump" v]
-check: native ["Temporary series debug check" val [series!]]
+check: native ["Temporary series debug check" val [any-series!]]
 
 do-callback: native [
 	"Internal function to process callback events."
@@ -958,7 +958,7 @@ do-callback: native [
 limit-usage: native [
 	"Set a usage limit only once (used for SECURE)."
 	field [word!] "eval (count) or memory (bytes)"
-	limit [number!]
+	limit [any-number!]
 ]
 
 selfless?: native [
@@ -980,8 +980,8 @@ map-gob-offset: native [
 
 as-pair: native [
 	"Combine X and Y values into a pair."
-	x [number!]
-	y [number!]
+	x [any-number!]
+	y [any-number!]
 ]
 
 ;read-file: native [f [file!]]
@@ -1050,24 +1050,24 @@ lesser-or-equal?: native [
 
 minimum: native [
 	{Returns the lesser of the two values.}
-	value1 [scalar! date! series!]
-	value2 [scalar! date! series!]
+	value1 [any-scalar! date! any-series!]
+	value2 [any-scalar! date! any-series!]
 ]
 
 maximum: native [ ; Note: Some datatypes expect all binary ops to be <= this
 	{Returns the greater of the two values.}
-	value1 [scalar! date! series!]
-	value2 [scalar! date! series!]
+	value1 [any-scalar! date! any-series!]
+	value2 [any-scalar! date! any-series!]
 ]
 
 negative?: native [
 	{Returns TRUE if the number is negative.}
-	number [number! money! time! pair!]
+	number [any-number! money! time! pair!]
 ]
 
 positive?: native [
 	{Returns TRUE if the value is positive.}
-	number [number! money! time! pair!]
+	number [any-number! money! time! pair!]
 ]
 
 zero?: native [

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -19,9 +19,9 @@ any-type! ;-- signals beginning of typesets (SYM_ANY_TYPEX hardcoded reference)
 any-word!
 any-path!
 any-function!
-number!
-scalar!
-series!
+any-number!
+any-scalar!
+any-series!
 any-string!
 any-object!
 any-array! ;-- replacement for any-block! that doesn't conflate with "block"

--- a/src/core/f-round.c
+++ b/src/core/f-round.c
@@ -47,9 +47,9 @@ enum {
 **
 */  REBCNT Get_Round_Flags(struct Reb_Call *call_)
 /*
-**		1 n [number! money! time!] "The value to round"
+**		1 n [any-number! money! time!] "The value to round"
 **		2 /to "Return the nearest multiple of the scale parameter"
-**		3	scale [number! money! time!] "Must be a non-zero value"
+**		3	scale [any-number! money! time!] "Must be a non-zero value"
 **		4 /even      "Halves round toward even results"
 **		5 /down      "Round toward zero, ignoring discarded digits. (truncate)"
 **		6 /half-down "Halves round toward zero"

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -692,7 +692,7 @@ skip_hidden: ;
 /*
 **		{Evaluates a block for each value(s) in a series.}
 **		'word [get-word! word! block!] {Word or block of words}
-**		data [series!] {The series to traverse}
+**		data [any-series!] {The series to traverse}
 **		body [block!] {Block to evaluate each time}
 **
 ***********************************************************************/
@@ -706,7 +706,7 @@ skip_hidden: ;
 */	REBNATIVE(remove_each)
 /*
 **		'word [get-word! word! block!] {Word or block of words}
-**		data [series!] {The series to traverse}
+**		data [any-series!] {The series to traverse}
 **		body [block!] {Block to evaluate each time}
 **
 ***********************************************************************/
@@ -720,7 +720,7 @@ skip_hidden: ;
 */	REBNATIVE(map_each)
 /*
 **		'word [get-word! word! block!] {Word or block of words}
-**		data [series!] {The series to traverse}
+**		data [any-series!] {The series to traverse}
 **		body [block!] {Block to evaluate each time}
 **
 ***********************************************************************/
@@ -734,7 +734,7 @@ skip_hidden: ;
 */	REBNATIVE(every)
 /*
 **		'word [get-word! word! block!] {Word or block of words}
-**		data [series!] {The series to traverse}
+**		data [any-series!] {The series to traverse}
 **		body [block!] {Block to evaluate each time}
 **
 ***********************************************************************/

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -229,8 +229,8 @@ enum {
 /*
 **	Set functions use this arg pattern:
 **
-**		set1 [ series! bitset! date! ] "first set"
-**		set2 [ series! bitset! date! ] "second set"
+**		set1 [ any-series! bitset! date! ] "first set"
+**		set2 [ any-series! bitset! date! ] "second set"
 **		/case "case sensitive"
 **		/skip "treat the series as records of fixed size"
 **		size [integer!]

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -388,14 +388,14 @@ static struct {
 **
 */	static void Sort_Block(REBVAL *block, REBFLG ccase, REBVAL *skipv, REBVAL *compv, REBVAL *part, REBFLG all, REBFLG rev)
 /*
-**		series [series!]
+**		series [any-series!]
 **		/case {Case sensitive sort}
 **		/skip {Treat the series as records of fixed size}
 **		size [integer!] {Size of each record}
 **		/compare  {Comparator offset, block or function}
 **		comparator [integer! block! function!]
 **		/part {Sort only part of a series}
-**		limit [number! series!] {Length of series to sort}
+**		limit [any-number! any-series!] {Length of series to sort}
 **		/all {Compare all fields}
 **		/reverse {Reverse sort order}
 **

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -690,7 +690,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 **		 1 image
 **		 2 value [any-type!]
 **		 3 /part {Limits the search to a given length or position.}
-**		 4 range [number! series! port!]
+**		 4 range [any-number! any-series! port!]
 **		 5 /only {ignore alpha value.}
 **		 6 /case - ignored
 **		 7 /any  - ignored

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -509,14 +509,29 @@ typedef u16 REBUNI;
 **
 ***********************************************************************/
 
-#if (defined(__clang__) || defined (__GNUC__))
+#if defined(__GNUC__) && (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 5)
+
 	#define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
 	#define ATTRIBUTE_NO_RETURN __attribute__ ((noreturn))
 	#define DEAD_END __builtin_unreachable()
+
+#elif defined(__clang__)
+
+	#define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+	#define ATTRIBUTE_NO_RETURN __attribute__ ((noreturn))
+
+	#if __has_builtin(__builtin_unreachable)
+		#define DEAD_END __builtin_unreachable()
+	#else
+		#define DEAD_END
+	#endif
+
 #else
+
 	#define ATTRIBUTE_NO_SANITIZE_ADDRESS
 	#define ATTRIBUTE_NO_RETURN
 	#define DEAD_END
+
 #endif
 
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -86,11 +86,11 @@ internal!: make typeset! [
 
 immediate!: make typeset! [
 	; Does not include internal datatypes
-	none! logic! scalar! date! any-word! datatype! typeset! event!
+	none! logic! any-scalar! date! any-word! datatype! typeset! event!
 ]
 
 system/options/result-types: make typeset! [
-	immediate! series! bitset! image! object! map! gob!
+	immediate! any-series! bitset! image! object! map! gob!
 ]
 
 ;-- Create "To-Datatype" conversion functions early in bootstrap:
@@ -120,20 +120,20 @@ any-object?: func [
 	value [any-type!]
 ][find any-object! type-of :value]
 
-number?: func [
+any-number?: func [
 	"Return TRUE if value is a number (integer or decimal)."
 	value [any-type!]
-][find number! type-of :value]
+][find any-number! type-of :value]
 
-series?: func [
+any-series?: func [
 	"Return TRUE if value is any type of series."
 	value [any-type!]
-][find series! type-of :value]
+][find any-series! type-of :value]
 
-scalar?: func [
+any-scalar?: func [
 	"Return TRUE if value is any type of scalar."
 	value [any-type!]
-][find scalar! type-of :value]
+][find any-scalar! type-of :value]
 
 any-array?: func [
 	"Return TRUE if value is a series containing all the same type."

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -103,11 +103,11 @@ tenth: func [
 
 last: func [
 	{Returns the last value of a series.}
-	value [series! tuple! gob!]
+	value [any-series! tuple! gob!]
 	/local len
 ] [
 	case [
-		series? value [pick back tail value 1]
+		any-series? value [pick back tail value 1]
 		tuple? value [pick value length value]
 		gob? value [
 			; The C code effectively used 'pick value t' with:
@@ -134,13 +134,13 @@ last: func [
 
 repend: func [
 	"Appends a reduced value to a series and returns the series head."
-	series [series! port! map! gob! object! bitset!] {Series at point to insert (modified)}
+	series [any-series! port! map! gob! object! bitset!] {Series at point to insert (modified)}
 	value {The value to insert}
 	/part {Limits to a given length or position}
-	limit [number! series! pair!]
+	limit [any-number! any-series! pair!]
 	/only {Inserts a series as a series}
 	/dup {Duplicates the insert a specified number of times}
-	count [number! pair!]
+	count [any-number! pair!]
 ][
 	apply :append [series reduce :value part limit only dup count]
 ]
@@ -150,7 +150,7 @@ join: func [
 	value "Base value"
 	rest "Value or block of values"
 ][
-	value: either series? :value [copy value] [form :value]
+	value: either any-series? :value [copy value] [form :value]
 	repend value :rest
 ]
 

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -79,7 +79,7 @@ input: function [
 
 ask: func [
 	"Ask the user for input."
-	question [series!] "Prompt to user"
+	question [any-series!] "Prompt to user"
 	/hide "mask input with *"
 ][
 	prin question
@@ -88,7 +88,7 @@ ask: func [
 
 confirm: func [
 	"Confirms a user choice."
-	question [series!] "Prompt to user"
+	question [any-series!] "Prompt to user"
 	/with choices [string! block!]
 	/local response
 ][

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -134,6 +134,23 @@ any-block!: :any-array!
 any-block?: :any-array?
 
 
+; By having typesets prefixed with ANY-*, it helps cement the realization
+; on the user's part that they are not dealing with a concrete type...so
+; even though this is in the function prototype, they will not get back
+; that answer from TYPE-OF, nor could they pass it to MAKE or TO.  Because
+; typsets cannot be returned in that way, they're easier than most things
+; to make synonyms for the old ANY-less variations.
+
+number!: :any-number!
+number?: :any-number?
+
+scalar!: :any-scalar!
+scalar?: :any-scalar?
+
+series!: :any-series!
+series?: :any-series?
+
+
 ; !!! These have not been renamed yet, because of questions over what they
 ; actually return.  CONTEXT-OF was a candidate, however the current behavior
 ; of just returning TRUE from BIND? when the word is linked to a function
@@ -219,7 +236,7 @@ set 'r3-legacy* func [] [
 		; Add simple parse back in by delegating to split, and return a LOGIC!
 		parse: (function [
 			{Parses a string or block series according to grammar rules.}
-			input [series!] "Input series to parse"
+			input [any-series!] "Input series to parse"
 			rules [block! string! none!] "Rules (string! is <r3-legacy>, use SPLIT)"
 			/case "Uses case-sensitive comparison"
 			/all "Ignored refinement for <r3-legacy>"

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -17,8 +17,8 @@ mod: func [
 	; that is "almost non-negative"
 	; Example: 0.15 - 0.05 - 0.1 // 0.1 is negative,
 	; but it is "almost" zero, i.e. "almost non-negative"
-	a [number! money! time!]
-	b [number! money! time!] "Must be nonzero."
+	a [any-number! money! time!]
+	b [any-number! money! time!] "Must be nonzero."
 	/local r
 ] [
 	; Compute the smallest non-negative remainder
@@ -32,12 +32,12 @@ mod: func [
 
 modulo: func [
 	{Wrapper for MOD that handles errors like REMAINDER. Negligible values (compared to A and B) are rounded to zero.}
-	a [number! money! time!]
-	b [number! money! time!] "Absolute value will be used"
+	a [any-number! money! time!]
+	b [any-number! money! time!] "Absolute value will be used"
 	/local r
 ] [
 	; Coerce B to a type compatible with A
-	any [number? a  b: make a b]
+	any [any-number? a  b: make a b]
 	; Get the "accurate" MOD value
 	r: mod a abs b
 	; If the MOD result is "near zero", w.r.t. A and B,
@@ -48,7 +48,7 @@ modulo: func [
 
 sign-of: func [
 	"Returns sign of number as 1, 0, or -1 (to use as multiplier)."
-	number [number! money! time!]
+	number [any-number! money! time!]
 ][
 	case [
 		positive? number [1]
@@ -59,7 +59,7 @@ sign-of: func [
 
 minimum-of: func [
 	{Finds the smallest value in a series}
-	series [series!] {Series to search}
+	series [any-series!] {Series to search}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]
 	/local spot
@@ -75,7 +75,7 @@ minimum-of: func [
 
 maximum-of: func [
 	{Finds the largest value in a series}
-	series [series!] {Series to search}
+	series [any-series!] {Series to search}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]
 	/local spot
@@ -167,7 +167,7 @@ math: function/with [
 
 	; WARNING: uses recursion for parens.
 	primary: [
-		set prim-val [number! | word!]
+		set prim-val [any-number! | word!]
 		| set prim-val paren! (prim-val: translate to-block :prim-val)
 	]
 ]

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -104,7 +104,7 @@ secure: function/with [
 	][
 		; Special cases: [eval 100000]
 		if find [eval memory] target [
-			assert-policy number? pol target pol
+			assert-policy any-number? pol target pol
 			limit-usage target pol ; pol is a number here
 			return 3.3.3 ; always quit
 		]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -13,15 +13,15 @@ REBOL [
 
 empty?: func [
 	{Returns TRUE if empty or NONE, or for series if index is at or beyond its tail.}
-	series [series! object! gob! port! bitset! map! none!]
+	series [any-series! object! gob! port! bitset! map! none!]
 ][
 	tail? series
 ]
 
 offset-of: func [
 	"Returns the offset between two series positions."
-	series1 [series!]
-	series2 [series!]
+	series1 [any-series!]
+	series2 [any-series!]
 ][
 	subtract index-of series2 index-of series1
 ]
@@ -35,7 +35,7 @@ found?: func [
 
 last?: single?: func [
 	"Returns TRUE if the series length is 1."
-	series [series! port! map! tuple! bitset! object! gob! any-word!]
+	series [any-series! port! map! tuple! bitset! object! gob! any-word!]
 ][
 	1 = length series
 ]
@@ -56,7 +56,7 @@ rejoin: func [
 	;/with "separator"
 ][
 	if empty? block: reduce block [return block]
-	append either series? first block [copy first block][
+	append either any-series? first block [copy first block][
 		form first block
 	] next block
 ]
@@ -108,7 +108,7 @@ array: func [
 		block? rest [
 			loop size [block: insert/only block array/initial rest :value]
 		]
-		series? :value [
+		any-series? :value [
 			loop size [block: insert/only block copy/deep value]
 		]
 		any-function? :value [ ; So value can be a thunk :)
@@ -123,7 +123,7 @@ array: func [
 
 replace: func [
 	"Replaces a search value with the replace value within the target series."
-	target  [series!] "Series to replace within (modified)"
+	target  [any-series!] "Series to replace within (modified)"
 	search  "Value to be replaced (converted if necessary)"
 	replace "Value to replace with (called each time if a function)"
 	/all "Replace all occurrences"  ;!!! Note ALL is redefined in here!
@@ -282,7 +282,7 @@ reword: func [
 
 move: func [
 	"Move a value or span of values in a series."
-	source [series!] "Source series (modified)"
+	source [any-series!] "Source series (modified)"
 	offset [integer!] "Offset to move by, or index to move to"
 	/part "Move part of a series"
 	limit [integer!] "The length of the part to move"
@@ -304,14 +304,14 @@ move: func [
 
 extract: func [
 	"Extracts a value from a series at regular intervals."
-	series [series!]
+	series [any-series!]
 	width [integer!] "Size of each entry (the skip)"
 	/index "Extract from an offset position"
-	pos "The position(s)" [number! logic! block!]
+	pos "The position(s)" [any-number! logic! block!]
 	/default "Use a default value instead of none"
 	value "The value to use (will be called each time if a function)"
 	/into "Insert into a buffer instead (returns position after insert)"
-	output [series!] "The buffer series (modified)"
+	output [any-series!] "The buffer series (modified)"
 	/local len val
 ][  ; Default value is "" for any-string! output
 	if zero? width [return any [output make series 0]]  ; To avoid an infinite loop
@@ -322,7 +322,7 @@ extract: func [
 	]
 	unless index [pos: 1]
 	either block? pos [
-		unless parse pos [some [number! | logic!]] [cause-error 'Script 'invalid-arg reduce [pos]]
+		unless parse pos [some [any-number! | logic!]] [cause-error 'Script 'invalid-arg reduce [pos]]
 		unless output [output: make series len * length pos]
 		if all [not default any-string? output] [value: copy ""]
 		forskip series width [forall pos [
@@ -342,7 +342,7 @@ extract: func [
 
 alter: func [
 	"Append value if not found, else remove it; returns true if added."
-	series [series! port! bitset!] {(modified)}
+	series [any-series! port! bitset!] {(modified)}
 	value
 	/case "Case-sensitive comparison"
 ][
@@ -362,7 +362,7 @@ collect: func [
 	"Evaluates a block, storing values via KEEP function, and returns block of collected values."
 	body [block!] "Block to evaluate"
 	/into "Insert into a buffer instead (returns position after insert)"
-	output [series!] "The buffer series (modified)"
+	output [any-series!] "The buffer series (modified)"
 ][
 	unless output [output: make block! 16]
 	eval func [<transparent> keep] body func [value [any-type!] /only] [
@@ -446,7 +446,7 @@ printf: func [
 
 split: func [
 	"Split a series into pieces; fixed or variable size, fixed number, or at delimiters"
-	series	[series!] "The series to split"
+	series	[any-series!] "The series to split"
 	dlm		[block! integer! char! bitset! any-string!] "Split size, delimiter(s), or rule(s)."
 	/into	"If dlm is an integer, split into n pieces, rather than pieces of length n."
 	/local size piece-size count mk1 mk2 res fill-val add-fill-val
@@ -534,7 +534,7 @@ find-all: function [
 	value
 	body [block!] "Evaluated for each occurrence"
 ][
-	assert [series? orig: get series]
+	assert [any-series? orig: get series]
 	while [any [set series find get series :value (set series orig false)]] [
 		do body
 		++ (series)

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -48,7 +48,7 @@ unless value? 'fail [
 			block? reason [
 				for-each item reason [
 					unless any [
-						scalar? :item
+						any-scalar? :item
 						string? :item
 						paren? :item
 						all [


### PR DESCRIPTION
When ARRAY was picked to be the general category word for BLOCK,
PATH, and GROUP...it opened up the ability to make the typeset and
type check either have an ANY- on them or not.  (It did not have that
opportunity when BLOCK was already taken for a category member.)

That opportunity landed on the side of thinking the ANY- was a good
cue for those reading the code.  It helps educate new users to realize
they are not dealing with a concrete type.  It also sort of "self-checks"
because one would not think to write MAKE ANY-ARRAY! because
that comes off as obviously nonsensical, whereas one might have a
harder time immediately processing why MAKE ARRAY! gave an
error after several ARRAY? tests seemed to work just fine, in the
context of a routine with several usable ARRAY! parameters.

This drew scrutiny on the three type sets without ANY- prefixes on
them: NUMBER!, SERIES!, and SCALAR!.  After seeming universal
consensus that ARRAY! should have the ANY-, putting it on those
typesets makes sense for the same reasons.  It's also not that
disruptive in terms of compatibility as typeset aliases work nearly as
well as typesets, since there's no TO-WORD conversion for them.

(The actual word used by the system has one advantage, that MAKE
TYPESET! will accept that word unbound...but if bound, the word
will be looked up to the type or typeset it references.  I know this
is there because I looked, but I don't know if anyone uses it.  Adding
that particular compatibility switch can be done on-demand if so.)

Commit also (slightly) tidies how typesets are made during boot.