### PR TITLE
Initialize encryption context that was left NULL

### DIFF
--- a/src/codecs/rsa/rsa.h
+++ b/src/codecs/rsa/rsa.h
@@ -35,6 +35,19 @@
 extern "C" {
 #endif
 
+#ifdef TO_WINDOWS
+	#include <windows.h>
+	#include <wincrypt.h>
+
+	extern HCRYPTPROV gCryptProv; // encryption provider handle
+#else
+	#include <fcntl.h>
+	#include <unistd.h>
+
+	extern int rng_fd; // file descriptor for random number generator
+#endif
+
+
 /*
  * RSA Options
  */


### PR DESCRIPTION
In order to generate random numbers for the https protocol, the
"core extension" uses /dev/random on linux/posix, but on Windows
uses the platform's CryptGenRandom() API.  However, the first
parameter to CryptGenRandom() is an HCRYPTPROV ("encryption
provider") that was never initialized.

Since the uninitialized variable was global, it defaulted to 0...and it
seems that in some cases Windows is tolerant of this.  However,
linking the same code into another runtime environment (other
DLLs loaded and services used) showed it crashing.  Calling the
initializer for the encryption provider remedied the problem.

Because this code lives in the "core extension", it does not have
an include file strategy laid out for how it would use ordinary
Rebol functions.  Rather than create those dependencies at this
time, this commit does a light reorganization and adds error
checking and asserts.

Debug builds will fail early at the initialization failure time, while
release builds will crash only when the random generator is
called after an initialization failure.