### PR TITLE
(via @meshpoint) Change Encode_UTF8 API

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1236,7 +1236,11 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **
 ***********************************************************************/
 {
-	return Length_As_UTF8(p, len, uni, ccr);
+	return Length_As_UTF8(
+		p,
+		len,
+		(uni ? FLAGIT(OPT_ENC_UNISRC) : 0) | (ccr ? FLAGIT(OPT_ENC_CRLF) : 0)
+	);
 }
 
 
@@ -1247,13 +1251,13 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **		Encode the unicode into UTF8 byte string.
 **
 **	Returns:
-**		Number of source chars used.
+**		Number of dst bytes used.
 **
 **	Arguments:
 **		dst - destination for encoded UTF8 bytes
 **		max - maximum size of the result in bytes
 **		src - source array of bytes or wide characters
-**		len - input is source length, updated to reflect dst bytes used
+**		len - input is source length, updated to reflect src chars used
 **		uni - true if src is in wide character format
 **		ccr - convert linefeed + carriage-return into just linefeed
 **
@@ -1267,7 +1271,13 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 **
 ***********************************************************************/
 {
-	return Encode_UTF8(dst, max, src, len, uni, ccr);
+	return Encode_UTF8(
+		dst,
+		max,
+		src,
+		len,
+		(uni ? FLAGIT(OPT_ENC_UNISRC) : 0) | (ccr ? FLAGIT(OPT_ENC_CRLF) : 0)
+	);
 }
 
 

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -61,23 +61,12 @@
 			len = req->actual;
 			if (GET_FLAG(req->flags, RRF_WIDE)) {
 				// convert to UTF8, so that it can be converted back to string!
-
-				REBCNT len_uni = len / sizeof(REBUNI); // correct length
-				REBCNT size = Length_As_UTF8(
-					cast(REBUNI*, req->common.data), len_uni, TRUE, FALSE
-				);
-				REBSER *ser = Make_Binary(size);
-
-				Encode_UTF8(
-					SERIES_DATA(ser),
-					size,
+				Val_Init_Binary(arg, Make_UTF8_Binary(
 					req->common.data,
-					&len_uni,
-					TRUE,
-					FALSE
-				);
-				SERIES_TAIL(ser) = len_uni;
-				Val_Init_Binary(arg, ser);
+					len / sizeof(REBUNI),
+					0,
+					FLAGIT(OPT_ENC_UNISRC)
+				));
 			}
 			else {
 				REBSER *ser = Make_Binary(len);
@@ -110,19 +99,13 @@
 
 		len = req->actual;
 		if (GET_FLAG(req->flags, RRF_WIDE)) {
-			REBCNT len_uni = len / sizeof(REBUNI); // correct length
-			REBCNT size = Length_As_UTF8(
-				cast(REBUNI*, req->common.data), len_uni, TRUE, FALSE
-			);
-			REBSER *ser = Make_Binary(size);
-
 			// convert to UTF8, so that it can be converted back to string!
-
-			Encode_UTF8(
-				SERIES_DATA(ser), size, req->common.data, &len_uni, TRUE, FALSE
-			);
-			SERIES_TAIL(ser) = len_uni;
-			Val_Init_Binary(arg, ser);
+			Val_Init_Binary(arg, Make_UTF8_Binary(
+				req->common.data,
+				len / sizeof(REBUNI),
+				0,
+				FLAGIT(OPT_ENC_UNISRC)
+			));
 		}
 		else {
 			REBSER *ser = Make_Binary(len);

--- a/src/core/s-file.c
+++ b/src/core/s-file.c
@@ -269,7 +269,6 @@
 	REBSER *ser; // will be unicode size
 #ifndef TO_WINDOWS
 	REBSER *bin;
-	REBCNT n;
 #endif
 
 	assert(ANY_BINSTR(val));
@@ -278,11 +277,9 @@
 
 #ifndef TO_WINDOWS
 	// Posix needs UTF8 conversion:
-	n = Length_As_UTF8(UNI_HEAD(ser), SERIES_TAIL(ser), TRUE, OS_CRLF);
-	bin = Make_Binary(n + FN_PAD);
-	Encode_UTF8(BIN_HEAD(bin), n+FN_PAD, UNI_HEAD(ser), &n, TRUE, OS_CRLF);
-	SERIES_TAIL(bin) = n;
-	TERM_SERIES(bin);
+	bin = Make_UTF8_Binary(
+		UNI_HEAD(ser), SERIES_LEN(ser), FN_PAD, FLAGIT(OPT_ENC_UNISRC)
+	);
 	Free_Series(ser);
 	ser = bin;
 #endif

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -608,6 +608,7 @@ cp_same:
 	REBVAL *val;
 	REBCNT tail = 0;
 	REBCNT len;
+	REBCNT bl;
 	void *bp;
 
 	if (limit < 0) limit = VAL_LEN(blk);
@@ -637,10 +638,17 @@ cp_same:
 		case REB_TAG:
 			len = VAL_LEN(val);
 			bp = VAL_BYTE_SIZE(val) ? VAL_BIN_DATA(val) : (REBYTE*)VAL_UNI_DATA(val);
-			len = Length_As_UTF8(bp, len, (REBOOL)!VAL_BYTE_SIZE(val), 0);
-			EXPAND_SERIES_TAIL(series, len);
-			Encode_UTF8(BIN_SKIP(series, tail), len, bp, &len, !VAL_BYTE_SIZE(val), 0);
-			series->tail = tail + len;
+			bl = Length_As_UTF8(
+				bp, len, VAL_BYTE_SIZE(val) ? 0 : FLAGIT(OPT_ENC_UNISRC)
+			);
+			EXPAND_SERIES_TAIL(series, bl);
+			series->tail = tail + Encode_UTF8(
+				BIN_SKIP(series, tail),
+				bl,
+				bp,
+				&len,
+				VAL_BYTE_SIZE(val) ? 0 : FLAGIT(OPT_ENC_UNISRC)
+			);
 			break;
 
 		case REB_CHAR:

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -975,7 +975,7 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
-*/	REBCNT Length_As_UTF8(const void *p, REBCNT len, REBOOL uni, REBOOL ccr)
+*/	REBCNT Length_As_UTF8(const void *p, REBCNT len, REBFLG opts)
 /*
 **		Returns how long the UTF8 encoded string would be.
 **
@@ -983,6 +983,8 @@ ConversionResult ConvertUTF8toUTF32 (
 {
 	REBCNT size = 0;
 	REBCNT c;
+	REBOOL uni = GET_FLAG(opts, OPT_ENC_UNISRC);
+	REBOOL ccr = GET_FLAG(opts, OPT_ENC_CRLF);
 	const REBYTE *bp = uni ? NULL : cast(const REBYTE *, p);
 	const REBUNI *up = uni ? cast(const REBUNI *, p) : NULL;
 
@@ -1042,14 +1044,14 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
-*/	REBCNT Encode_UTF8(REBYTE *dst, REBINT max, const void *src, REBCNT *len, REBFLG uni, REBFLG ccr)
+*/	REBCNT Encode_UTF8(REBYTE *dst, REBCNT max, const void *src, REBCNT *len, REBFLG opts)
 /*
 **		Encode the unicode into UTF8 byte string.
 **
-**		Source string can be byte or unichar sized (uni = TRUE);
+**		Source string can be byte or unichar sized (OPT_ENC_UNISRC);
 **		Max is the maximum size of the result (UTF8).
-**		Returns number of source chars used.
-**		Updates len for dst bytes used.
+**		Returns number of dst bytes used.
+**		Updates len for source chars used.
 **		Does not add a terminator.
 **
 ***********************************************************************/
@@ -1061,6 +1063,8 @@ ConversionResult ConvertUTF8toUTF32 (
 	const REBYTE *bp = cast(const REBYTE*, src);
 	const REBUNI *up = cast(const REBUNI*, src);
 	REBCNT cnt;
+	REBOOL uni = GET_FLAG(opts, OPT_ENC_UNISRC);
+	REBOOL ccr = GET_FLAG(opts, OPT_ENC_CRLF);
 
 	if (len) cnt = *len;
 	else cnt = uni ? Strlen_Uni(up) : LEN_BYTES(bp);
@@ -1071,7 +1075,7 @@ ConversionResult ConvertUTF8toUTF32 (
 #if defined(TO_WINDOWS)
 			if (ccr && c == LF) {
 				// If there's not room, don't try to output CRLF
-				if (2 > max) {up--; break;}
+				if (2 > max) {bp--; up--; break;}
 				*dst++ = CR;
 				max--;
 				c = LF;
@@ -1082,16 +1086,16 @@ ConversionResult ConvertUTF8toUTF32 (
 		}
 		else {
 			n = Encode_UTF8_Char(buf, c);
-			if (n > max) {up--; break;}
+			if (n > max) {bp--; up--; break;}
 			memcpy(dst, buf, n);
 			dst += n;
 			max -= n;
 		}
 	}
 
-	if (len) *len = dst - bs;
+	if (len) *len = uni ? up - cast(const REBUNI*, src) : bp - cast(const REBYTE*, src);
 
-	return uni ? up - cast(const REBUNI*, src) : bp - cast(const REBYTE*, src);
+	return dst - bs;
 }
 
 
@@ -1137,6 +1141,27 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
+*/	REBSER *Make_UTF8_Binary(const void *data, REBCNT len, REBCNT extra, REBFLG opts)
+/*
+**		Convert byte- or REBUNI-sized data to UTF8-encoded
+**		null-terminated series. Can reserve extra bytes of space.
+**		Resulting series must be either freed or handed to the GC.
+**
+***********************************************************************/
+{
+	REBCNT size = Length_As_UTF8(data, len, opts);
+	REBSER *series = Make_Binary(size + extra);
+	SERIES_TAIL(series) = Encode_UTF8(
+		BIN_HEAD(series), size, data, &len, opts
+	);
+	assert(SERIES_TAIL(series) == size);
+	STR_TERM(series);
+	return series;
+}
+
+
+/***********************************************************************
+**
 */	REBSER *Make_UTF8_From_Any_String(const REBVAL *value, REBCNT len, REBFLG opts)
 /*
 **		Do all the details to encode either a byte-sized or REBUNI
@@ -1145,32 +1170,25 @@ ConversionResult ConvertUTF8toUTF32 (
 **
 ***********************************************************************/
 {
-	REBSER *series;
-	REBFLG ccr = GET_FLAG(opts, ENC_OPT_CRLF);
-
 	assert(ANY_STR(value));
 
-	if (VAL_STR_IS_ASCII(value)) {
+	if (!GET_FLAG(opts, OPT_ENC_CRLF) && VAL_STR_IS_ASCII(value)) {
 		// We can copy a one-byte-per-character series if it doesn't contain
 		// codepoints like 128 - 255 (pure ASCII is valid UTF-8)
-
-		// !!! Does not pay attention to ENC_OPT_CRLF.  Should it?
-		series = Copy_Bytes(VAL_BIN_DATA(value), len);
+		return Copy_Bytes(VAL_BIN_DATA(value), len);
 	}
 	else {
-		REBOOL uni = !VAL_BYTE_SIZE(value);
-		const void *data = uni ?
-			cast(const void*, VAL_UNI_DATA(value)) :
-			cast(const void*, VAL_BIN_DATA(value));
-		REBCNT size = Length_As_UTF8(data, len, uni, ccr);
-		series = Make_Binary(size + (GET_FLAG(opts, ENC_OPT_BOM) ? 3 : 0));
-		Encode_UTF8(BIN_HEAD(series), size, data, &len, uni, ccr);
+		const void *data;
+		if (VAL_BYTE_SIZE(value)) {
+			CLR_FLAG(opts, OPT_ENC_UNISRC);
+			data = VAL_BIN_DATA(value);
+		}
+		else {
+			SET_FLAG(opts, OPT_ENC_UNISRC);
+			data = VAL_UNI_DATA(value);
+		}
+		return Make_UTF8_Binary(data, len, 0, opts);
 	}
-
-	SERIES_TAIL(series) = len;
-	STR_TERM(series);
-
-	return series;
 }
 
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -325,17 +325,18 @@ enum {
 
 // Encoding options:
 enum encoding_opts {
-	ENC_OPT_BIG,		// big endian (not little)
-	ENC_OPT_UTF8,		// UTF-8
-	ENC_OPT_UTF16,		// UTF-16
-	ENC_OPT_UTF32,		// UTF-32
-	ENC_OPT_BOM,		// byte order marker
-	ENC_OPT_CRLF,		// CR line termination
-	ENC_OPT_MAX
+	OPT_ENC_BIG,		// big endian (not little)
+	OPT_ENC_UTF8,		// UTF-8
+	OPT_ENC_UTF16,		// UTF-16
+	OPT_ENC_UTF32,		// UTF-32
+	OPT_ENC_BOM,		// byte order marker
+	OPT_ENC_CRLF,		// CR line termination
+	OPT_ENC_UNISRC,		// source is UCS2
+	OPT_ENC_MAX
 };
 
 #if OS_CRLF
-#define ENCF_OS_CRLF (1<<ENC_OPT_CRLF)
+#define ENCF_OS_CRLF (1<<OPT_ENC_CRLF)
 #else
 #define ENCF_OS_CRLF 0
 #endif

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -224,6 +224,7 @@ REBOOL Host_Start_Exiting(int *exit_status, int argc, REBCHR **argv) {
 	if (startup_rc >= 0 && (Main_Args.options & RO_DO) && Main_Args.do_arg) {
 		RXIARG result;
 		REBYTE *do_arg_utf8;
+		REBCNT len_uni;
 		REBCNT len_predicted;
 		REBCNT len_encoded;
 		int do_result;
@@ -232,18 +233,18 @@ REBOOL Host_Start_Exiting(int *exit_status, int argc, REBCHR **argv) {
 		// !!! Better helpers needed than this; Ren/C can call host's OS_ALLOC
 		// so this should be more seamless.
 	#ifdef TO_WINDOWS
+		len_uni = wcslen(Main_Args.do_arg);
 		len_predicted = RL_Length_As_UTF8(
-			Main_Args.do_arg, wcslen(Main_Args.do_arg), TRUE, TRUE
+			Main_Args.do_arg, len_uni, TRUE, FALSE
 		);
 		do_arg_utf8 = OS_ALLOC_ARRAY(REBYTE, len_predicted + 1);
-		len_encoded = len_predicted;
-		RL_Encode_UTF8(
+		len_encoded = RL_Encode_UTF8(
 			do_arg_utf8,
 			len_predicted + 1,
 			Main_Args.do_arg,
-			&len_encoded,
+			&len_uni,
 			TRUE,
-			TRUE
+			FALSE
 		);
 
 		// Sanity check; we shouldn't get a different answer.


### PR DESCRIPTION
The "len" argument of Encode_UTF8() was used as the source length on input and
as the result length on output. This caused some confusion in the calling code
about the meaning of a variable before and after the call. Now "len" is updated
to the amount of source used, and the result length is in the function return
value. The meaning of "len" argument and return value of RL_Encode_UTF8() is
changed accordingly. This change fixes bugs involving calls to Encode_UTF8().

Also, "uni" and "ccr" arguments of Encode_UTF8() and Length_As_UTF8() are
replaced with one "opts" argument. REBUNI* source is signalled by
"ENC_OPT_UNISRC" flag, and CRLF handling is signalled by "ENC_OPT_CRLF" flag.
Make_UTF8_Binary() helper function is added that calls Length_As_UTF8(),
Make_Binary(), Encode_UTF8().