### PR TITLE
Make UNTIL arity-2, add LOOP-UNTIL & LOOP-WHILE

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -331,15 +331,26 @@ unless: native [
 	/only "Return block arg instead of evaluating it."
 ]
 
-until: native [
-	{Evaluates a block until it is TRUE. }
+loop-until: native [
+	{Evaluates a block until the result is TRUE?, and returns that result.}
 	block [block!]
 ]
 
+loop-while: native [
+	{Evaluates a block as long as it's not FALSE?. Returns last TRUE? result.}
+	block [block!]
+]
+
+until: native [
+	{Until a condition block evaluates to TRUE?, evaluates a body block.}
+	condition [block!]
+	body [block!]
+]
+
 while: native [
-	{While a condition block is TRUE, evaluates another block.}
-	cond-block [block!]
-	body-block [block!]
+	{While a condition block evaluates to TRUE?, evaluates a body block.}
+	condition [block!]
+	body [block!]
 ]
 
 ;-- Data Natives - nat_data.c

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -233,6 +233,12 @@ set 'r3-legacy* func [] [
 		; Not contentious, but trying to excise this ASAP
 		funct: (:function)
 
+		; Rebol2 and R3-Alpha had single-arity UNTIL, which was modified
+		; such that UNTIL has a separate condition block (like WHILE).  The
+		; arity-1 variant of UNTIL is LOOP-UNTIL, and LOOP-WHILE was added
+		;
+		until: :loop-until
+
 		; Add simple parse back in by delegating to split, and return a LOGIC!
 		parse: (function [
 			{Parses a string or block series according to grammar rules.}

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -377,7 +377,7 @@ check-data: func [port /local headers res data out chunk-size mk1 mk2 trailer st
 			;clear the port data only at the beginning of the request --Richard
 			unless port/data [port/data: make binary! length data]
 			out: port/data
-			until [
+			loop-until [
 				either parse data [
 					copy chunk-size some hex-digits thru crlfbin mk1: to end
 				] [


### PR DESCRIPTION
This transitions UNTIL to be arity-2, to be a natural pairing with the
WHILE construct.  (In the same spirit of IF vs. UNLESS).  The previous
version that is a condition only is then moved to LOOP-UNTIL, as a
way of saying what to do in the missing arity slot of the body.  Then
LOOP-WHILE is added to be the arity-1 WHILE complement of that.

Compatibility in `<r3-legacy>` is accomplished with:

    UNTIL: :LOOP-UNTIL

The word LOOP was chosen due to its generic sense.  ("What should
I be doing UNTIL that happens...or WHILE it is happening..." => "You
should loop.")  That's as opposed to having any specific relationship to
LOOP the construct's parameterization (now or under future redesign).

LOOP-WHILE has slightly more overhead than LOOP-UNTIL, because
it seeks to return the last TRUE? result (instead of being guaranteed to
return the FALSE or NONE value that caused the loop to break). Thus
LOOP-UNTIL remains the "most efficient" base looping construct.