### PR TITLE
ANY-TYPE! => ANY-VALUE!

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -194,7 +194,7 @@ pick: action [
 find: action [
 	{Searches for a value; for series returns where found, else none.}
 	series [any-series! gob! port! bitset! typeset! object! none!]
-	value [any-type!]
+	value [any-value!]
 	/part {Limits the search to a given length or position}
 	limit [any-number! any-series! pair!]
 	/only {Treats a series value as only a single value}
@@ -213,7 +213,7 @@ find: action [
 select: action [
 	{Searches for a value; returns the value that follows, else none.}
 	series [any-series! port! map! object! none!]
-	value [any-type!]
+	value [any-value!]
 	/part {Limits the search to a given length or position}
 	limit [any-number! any-series! pair!]
 	/only {Treats a series value as only a single value}
@@ -231,7 +231,7 @@ select: action [
 
 reflect: action [
 	{Returns specific details about a datatype.}
-	value [any-type!]
+	value [any-value!]
 	field [word!] "Such as: spec, body, words, values, title"
 ]
 
@@ -239,14 +239,14 @@ reflect: action [
 
 make: action [
 	{Constructs or allocates the specified datatype.}
-	type [any-type!] {The datatype or an example value}
-	spec [any-type!] {Attributes or size of the new value (modified)}
+	type [any-value!] {The datatype or an example value}
+	spec [any-value!] {Attributes or size of the new value (modified)}
 ]
 
 to: action [
 	{Converts to a specified datatype.}
-	type [any-type!] {The datatype or example value}
-	spec [any-type!] {The attributes of the new value}
+	type [any-value!] {The datatype or example value}
+	spec [any-value!] {The attributes of the new value}
 ]
 
 copy: action [
@@ -271,7 +271,7 @@ take: action [
 insert: action [
 	{Inserts element(s); for series, returns just past the insert.}
 	series [any-series! port! map! gob! object! bitset! port!] {At position (modified)}
-	value [any-type!] {The value to insert}
+	value [any-value!] {The value to insert}
 	/part {Limits to a given length or position}
 	limit [any-number! any-series! pair!]
 	/only {Only insert a block as a single value (not the contents of the block)}
@@ -282,7 +282,7 @@ insert: action [
 append: action [
 	{Inserts element(s) at tail; for series, returns head.}
 	series [any-series! port! map! gob! object! bitset!] {Any position (modified)}
-	value [any-type!] {The value to insert}
+	value [any-value!] {The value to insert}
 	/part {Limits to a given length or position}
 	limit [any-number! any-series! pair!]
 	/only {Only insert a block as a single value (not the contents of the block)}
@@ -300,7 +300,7 @@ remove: action [
 change: action [
 	{Replaces element(s); returns just past the change.}
 	series [any-series! gob! port! struct!]{At position (modified)}
-	value [any-type!] {The new value}
+	value [any-value!] {The new value}
 	/part {Limits the amount to change to a given length or position}
 	limit [any-number! any-series! pair!]
 	/only {Only change a block as a single value (not the contents of the block)}
@@ -312,7 +312,7 @@ poke: action [
 	{Replaces an element at a given position.}
 	series [any-series! port! map! gob! bitset!] {(modified)}
 	index {Index offset, symbol, or other value to use as index}
-	value [any-type!] {The new value (returned)}
+	value [any-value!] {The new value (returned)}
 ]
 
 clear: action [

--- a/src/boot/booters.r
+++ b/src/boot/booters.r
@@ -16,7 +16,7 @@ REBOL [
 ]
 
 ; Special block used as spec to the datatype test functions (e.g. time?):
-["Returns TRUE if it is this type." value [any-type!] 0]
+["Returns TRUE if it is this type." value [any-value!] 0]
 
 ; The native function must be defined first. This is a
 ; special boot function created manually within the C code.

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -25,8 +25,8 @@ ajoin: native [
 
 also: native [
 	{Returns the first value, but also evaluates the second.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 all: native [
@@ -60,9 +60,9 @@ attempt: native [
 break: native [
 	{Breaks out of a loop, while, until, repeat, for-each, etc.}
 	/with {Forces the loop function to return a value}
-	value [any-type!]
+	value [any-value!]
 	/return {(deprecated synonym for /WITH)}
-	return-value [any-type!]
+	return-value [any-value!]
 ]
 
 case: native [
@@ -114,7 +114,7 @@ continue: native [
 
 ;disarm: native [
 ;	{(Deprecated - not needed) Converts error to an object. Other types not modified.}
-;	error [any-type!]
+;	error [any-value!]
 ;]
 
 do: native [
@@ -131,14 +131,14 @@ do: native [
 
 eval: native [
 	{(Special) Process received value *inline* as the evaluator loop would.}
-	value [any-type!] {BLOCK! passes-thru, FUNCTION! runs, SET-WORD! assigns...}
+	value [any-value!] {BLOCK! passes-thru, FUNCTION! runs, SET-WORD! assigns...}
 ]
 
 either: native [
 	{If TRUE condition return first arg, else second; evaluate blocks by default.}
 	condition
-	true-branch [any-type!]
-	false-branch [any-type!]
+	true-branch [any-value!]
+	false-branch [any-value!]
 	/only "Suppress evaluation of block args."
 ]
 
@@ -152,7 +152,7 @@ every: native [
 exit: native [
 	{Leave whatever enclosing Rebol state EXIT's block *actually* runs in.}
 	/with {Result for enclosing state (default is UNSET!)}
-	value [any-type!]
+	value [any-value!]
 ]
 
 fail: native [
@@ -207,7 +207,7 @@ halt: native [
 if: native [
 	{If TRUE condition, return arg; evaluate blocks by default.}
 	condition
-	true-branch [any-type!]
+	true-branch [any-value!]
 	/only "Return block arg instead of evaluating it."
 ]
 
@@ -233,7 +233,7 @@ map-each: native [
 quit: native [
 	{Stop evaluating and return control to command shell or calling script.}
 	/with {Yield a result (mapped to an integer if given to shell)}
-	value [any-type!] {See: http://en.wikipedia.org/wiki/Exit_status}
+	value [any-value!] {See: http://en.wikipedia.org/wiki/Exit_status}
 	/return {(deprecated synonym for /WITH)}
 	return-value
 ]
@@ -290,7 +290,7 @@ remove-each: native [
 
 return: native [
 	{Returns a value from a function.}
-	value [any-type!]
+	value [any-value!]
 ]
 
 switch: native [
@@ -304,7 +304,7 @@ switch: native [
 
 throw: native [
 	{Throws control back to a previous catch.}
-	value [any-type!] {Value returned from catch}
+	value [any-value!] {Value returned from catch}
 	/name {Throws to a named catch}
 	name-value [word! any-function! object!]
 ]
@@ -327,7 +327,7 @@ trap: native [
 unless: native [
 	{If FALSE condition, return arg; evaluate blocks by default.}
 	condition
-	false-branch [any-type!]
+	false-branch [any-value!]
 	/only "Return block arg instead of evaluating it."
 ]
 
@@ -567,7 +567,7 @@ parse: native [
 set: native [
 	{Sets a word, path, block of words, or object to specified value(s).}
 	word [any-word! any-path! block! object!] {Word, block of words, path, or object to be set (modified)}
-	value [any-type!] {Value or block of values}
+	value [any-value!] {Value or block of values}
 	/any {Allows setting words to any value, including unset}
 	/pad {For objects, if block is too short, remaining words are set to NONE}
 ]
@@ -581,7 +581,7 @@ to-hex: native [
 
 type-of: native [
 	{Returns the datatype of a value.}
-	value [any-type!]
+	value [any-value!]
 ]
 
 unset: native [
@@ -610,17 +610,17 @@ value?: native [
 
 print: native [
 	{Outputs a value followed by a line break.}
-	value [any-type!] {The value to print}
+	value [any-value!] {The value to print}
 ]
 
 prin: native [
 	{Outputs a value with no line break.}
-	value [any-type!]
+	value [any-value!]
 ]
 
 mold: native [
 	{Converts a value to a REBOL-readable string.}
-	value [any-type!] {The value to mold}
+	value [any-value!] {The value to mold}
 	/only {For a block value, mold only its contents, no outer []}
 	/all  {Use construction syntax}
 	/flat {No indentation}
@@ -628,7 +628,7 @@ mold: native [
 
 form: native [
 	{Converts a value to a human-readable string.}
-	value [any-type!] {The value to form}
+	value [any-value!] {The value to form}
 ]
 
 new-line: native [
@@ -988,44 +988,44 @@ as-pair: native [
 
 equal?: native [
 	{Returns TRUE if the values are equal.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 not-equal?: native [
 	{Returns TRUE if the values are not equal.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 equiv?: native [
 	{Returns TRUE if the values are equivalent.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 not-equiv?: native [
 	{Returns TRUE if the values are not equivalent.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 strict-equal?: native [
 	{Returns TRUE if the values are strictly equal.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 strict-not-equal?: native [
 	{Returns TRUE if the values are not strictly equal.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 same?: native [
 	{Returns TRUE if the values are identical.}
-	value1 [any-type!]
-	value2 [any-type!]
+	value1 [any-value!]
+	value2 [any-value!]
 ]
 
 greater?: native [ ; Note: some datatypes expect >, <, >=, <= to be in this order.

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -15,7 +15,7 @@ REBOL [
 	}
 ]
 
-any-type! ;-- signals beginning of typesets (SYM_ANY_TYPEX hardcoded reference)
+any-value! ;-- signal start of typesets (SYM_ANY_VALUEX hardcoded reference)
 any-word!
 any-path!
 any-function!

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -514,7 +514,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 */	REBNATIVE(set)
 /*
 **		word [any-word! block! object!] {Word or words to set}
-**		value [any-type!] {Value or block of values}
+**		value [any-value!] {Value or block of values}
 **		/any {Allows setting words to any value.}
 **		/pad {For objects, if block is too short, remaining words are set to NONE.}
 **

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -688,7 +688,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 **	Finds a value in a series and returns the series at the start of it.
 **
 **		 1 image
-**		 2 value [any-type!]
+**		 2 value [any-value!]
 **		 3 /part {Limits the search to a given length or position.}
 **		 4 range [any-number! any-series! port!]
 **		 5 /only {ignore alpha value.}

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -50,7 +50,7 @@ const struct {
 	REBCNT sym;
 	REBU64 bits;
 } Typesets[] = {
-	{SYM_ANY_TYPEX, (cast(REBU64, 1) << REB_MAX) - 2}, // do not include END!
+	{SYM_ANY_VALUEX, (cast(REBU64, 1) << REB_MAX) - 2}, // do not include END!
 	{SYM_ANY_WORDX, TS_WORD},
 	{SYM_ANY_PATHX, TS_PATH},
 	{SYM_ANY_FUNCTIONX, TS_FUNCTION},
@@ -157,8 +157,8 @@ const struct {
 				TYPE_SET(value, KIND_FROM_SYM(sym));
 				continue;
 			} // Special typeset symbols:
-			else if (sym >= SYM_ANY_TYPEX && sym < SYM_DATATYPES)
-				val = BLK_SKIP(types, sym - SYM_ANY_TYPEX);
+			else if (sym >= SYM_ANY_VALUEX && sym < SYM_DATATYPES)
+				val = BLK_SKIP(types, sym - SYM_ANY_VALUEX);
 		}
 		if (!val) val = block;
 		if (IS_DATATYPE(val)) {

--- a/src/mezz/base-debug.r
+++ b/src/mezz/base-debug.r
@@ -18,7 +18,7 @@ REBOL [
 
 probe: func [
 	{Debug print a molded value and returns that same value.}
-	value [any-type!]
+	value [any-value!]
 ][
 	print mold :value
 	:value

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -97,57 +97,57 @@ system/options/result-types: make typeset! [
 
 any-string?: func [
 	"Return TRUE if value is any type of string."
-	value [any-type!]
+	value [any-value!]
 ][find any-string! type-of :value]
 
 any-function?: func [
 	"Return TRUE if value is any type of function."
-	value [any-type!]
+	value [any-value!]
 ][find any-function! type-of :value]
 
 any-word?: func [
 	"Return TRUE if value is any type of word."
-	value [any-type!]
+	value [any-value!]
 ][find any-word! type-of :value]
 
 any-path?: func [
 	"Return TRUE if value is any type of path."
-	value [any-type!]
+	value [any-value!]
 ][find any-path! type-of :value]
 
 any-object?: func [
 	"Return TRUE if value is any type of object."
-	value [any-type!]
+	value [any-value!]
 ][find any-object! type-of :value]
 
 any-number?: func [
 	"Return TRUE if value is a number (integer or decimal)."
-	value [any-type!]
+	value [any-value!]
 ][find any-number! type-of :value]
 
 any-series?: func [
 	"Return TRUE if value is any type of series."
-	value [any-type!]
+	value [any-value!]
 ][find any-series! type-of :value]
 
 any-scalar?: func [
 	"Return TRUE if value is any type of scalar."
-	value [any-type!]
+	value [any-value!]
 ][find any-scalar! type-of :value]
 
 any-array?: func [
 	"Return TRUE if value is a series containing all the same type."
-	value [any-type!]
+	value [any-value!]
 ][find any-array! type-of :value]
 
 true?: func [
 	"Returns true if an expression can be used as true."
-	val ; Note: No [any-type!] - we want unset! to fail.
+	val ; Note: No [any-value!] - we want unset! to fail.
 ] [not not :val]
 
 quote: func [
 	"Returns the value passed to it without evaluation."
-	:value [any-type!]
+	:value [any-value!]
 ] [
 	:value
 ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -93,7 +93,7 @@ dump-obj: function [
 
 ?: help: func [
 	"Prints information about words and values."
-	'word [any-type!]
+	'word [any-value!]
 	/doc "Open web browser to related documentation."
 	/local value args item type-name types tmp print-args
 ][

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -48,7 +48,7 @@ REBOL [
 
 op?: func [
 	"Returns TRUE if the argument is an ANY-FUNCTION? and INFIX?"
-	value [any-type!]
+	value [any-value!]
 ][
 	either any-function? :value [:infix? :value] false
 ]
@@ -66,7 +66,7 @@ op?: func [
 ;
 type?: function [
 	"Returns the datatype of a value <r3-legacy>."
-	value [any-type!]
+	value [any-value!]
 	/word "No longer in TYPE-OF, as WORD! and DATATYPE! can be EQUAL?"
 ][
 	either word [
@@ -150,6 +150,13 @@ scalar?: :any-scalar?
 series!: :any-series!
 series?: :any-series?
 
+; ANY-TYPE! had an ambiguity in it, which was that with DATATYPE! around
+; (possibly being renamed to TYPE! but maybe not) it sounded as if it might
+; mean ANY-DATATYPE!--which is more narrow than what it meant to say which
+; is "really, any legal Rebol value, type or otherwise".  So ANY-VALUE! is
+; the better word for that.  Added for backwards compatibility.
+;
+any-type!: :any-value!
 
 ; !!! These have not been renamed yet, because of questions over what they
 ; actually return.  CONTEXT-OF was a candidate, however the current behavior

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -365,7 +365,7 @@ collect: func [
 	output [any-series!] "The buffer series (modified)"
 ][
 	unless output [output: make block! 16]
-	eval func [<transparent> keep] body func [value [any-type!] /only] [
+	eval func [<transparent> keep] body func [value [any-value!] /only] [
 		; In the default operation, this could now be written as:
 		;
 		;     output: insert/:only :value

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -1112,7 +1112,7 @@ sys/make-scheme [
 			return port
 		]
 
-		write: func [port [port!] value [any-type!]] [
+		write: func [port [port!] value [any-value!]] [
 			if find [encrypted-handshake application] port/state/protocol-state [
 				do-commands/no-wait port/state compose [
 					application (value)

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -38,9 +38,13 @@ unless value? 'for-each [
 ; *all* typesets now are ANY-XXX to help distinguish them from concrete types
 ; https://trello.com/c/d0Nw87kp
 ;
-unless value? 'any-scalar? [any-scalar?: :scalar?]
-unless value? 'any-series? [any-series?: :series?]
-unless value? 'any-number? [any-number?: :number?]
+unless value? 'any-scalar? [any-scalar?: :scalar? any-scalar!: scalar!]
+unless value? 'any-series? [any-series?: :series? any-series!: series!]
+unless value? 'any-number? [any-number?: :number? any-number!: number!]
+unless value? 'any-value? [
+	any-value?: func [item [any-type!]] [not unset? :item]
+	any-value!: any-type!
+]
 
 ; It is not possible to make a version of eval that does something other
 ; than everything DO does in an older Rebol.  Which points to why exactly


### PR DESCRIPTION
There is an ambiguity inherent when types themselves are values
in the language, and you say "ANY-TYPE".  The problem is that may
suggest something more narrow than what has been meant, which
historically is that ANY-TYPE meant "any legal Rebol value" (and that
included UNSET!, when UNSET! was a legal Rebol value, which it is
now planned to not be).

Renaming it to ANY-VALUE! clears up the problem, so you don't think
it suggests it could be "any type", e.g. STRING! or INTEGER! etc.

ANY-TYPE! added to legacy for backward compatibilty.