### PR TITLE
ERROR => same struct as OBJECT/PORT/MODULE

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -105,19 +105,6 @@ static	BOOT_BLK *Boot_Block;
 		if (sizeof(REBGOB) != 64) panic Error_0(RE_BAD_SIZE);
 	}
 	if (sizeof(REBDAT) != 4) panic Error_0(RE_BAD_SIZE);
-
-	// !!! C standard doesn't support 'offsetof(struct S, s_member.submember)'
-	// so we're stuck using addition here.
-
-	if (
-		offsetof(struct Reb_Error, data)
-		+ offsetof(union Reb_Error_Data, frame)
-		!= offsetof(struct Reb_Object, frame)
-	) {
-		// When errors are exposed to the user then they must have a frame
-		// and act like objects (they're dispatched through REBTYPE(Object))
-		panic Error_0(RE_MISC);
-	}
 }
 
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -374,7 +374,6 @@
 	ENSURE_FRAME_MANAGED(err_frame);
 
 	VAL_SET(out, REB_ERROR);
-	VAL_ERR_NUM(out) = VAL_INT32(&ERR_VALUES(err_frame)->code);
 	VAL_ERR_OBJECT(out) = err_frame;
 
 	ASSERT_ERROR(out);
@@ -400,7 +399,7 @@
 	// Create a new error object from another object, including any non-standard fields:
 	if (IS_ERROR(arg) || IS_OBJECT(arg)) {
 		err = Merge_Frames(VAL_OBJ_FRAME(ROOT_ERROBJ),
-			IS_ERROR(arg) ? VAL_OBJ_FRAME(arg) : VAL_ERR_OBJECT(arg));
+			IS_ERROR(arg) ? VAL_ERR_OBJECT(arg) : VAL_OBJ_FRAME(arg));
 		error = ERR_VALUES(err);
 
 		if (!Find_Error_Info(error, &code)) code = RE_INVALID_ERROR;

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -275,7 +275,7 @@ chkDecimal:
 		return Compare_Word(s,t,is_case);
 
 	case REB_ERROR:
-		return VAL_ERR_NUM(s) - VAL_ERR_NUM(s);
+		return VAL_ERR_NUM(s) - VAL_ERR_NUM(t);
 
 	case REB_OBJECT:
 	case REB_MODULE:


### PR DESCRIPTION
At one point in time, ERROR! objects did double duty as the value
type for THROWN() values generated for function returns and
similar.  The error then contained a number identifying the throw
and a possible argument.

With the desire to allow a "full value's worth" of value to /NAME a
throw, the THROWN() convention was changed to a header bit that
could be set on any value type.  This meant all errors were changed
to have "object frames" and be ordinary objects which could be
handed to the user (with two exceptions: halt and a parse hack).

This commit started as comment maintenance but then shifted to
merging ERROR! in to be in the same form as PORT!, MODULE!,
and OBJECT! which share a common REBVAL structure.  (This
is similar to how series values like BLOCK! and STRING! and
PAREN! and BINARY! share the same structure.)