### PR TITLE
Differentiate 4-byte/8-byte binary-to-int process

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -150,6 +150,7 @@ options: context [  ; Options supplied to REBOL during startup
 	refinements-true: false
 	no-switch-evals: false
 	no-switch-fallthrough: false
+	forever-64-bit-ints: false
 ]
 
 script: context [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -223,6 +223,7 @@ set 'r3-legacy* func [] [
 	system/options/refinements-true: true
 	system/options/no-switch-evals: true
 	system/options/no-switch-fallthrough: true
+	system/options/forever-64-bit-ints: true
 
 	; False is already the default for this switch
 	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)


### PR DESCRIPTION
This was motivated by discovery that Rebol3's CRC32 hash values
are returned as signed quantities.  When reading a 32-bit CRC out
of the zip container as bytes, using TO-INTEGER on it would extend
it to a 64-bit quantity which was never signed...leading to a difference
of comparison.

Using logic based on a previous futureproofing proposal from...
someone, this does not interpret to-integer #{FFFFFFFF} in Ren/C as
#{00000000FFFFFFFF} but rather #{FFFFFFFFFFFFFFF}.  It will
effectively extend the bytes to the left to make a 64-bit number based
on the high bit of the most significant big-endian byte of the input.
If a 4-byte number coming from Rebol2's TO-BINARY of an integer is
read then it will be compatible, and if an 8-byte number coming from
Rebol3's TO-BINARY of an integer is read then that will be compatible
also.  As an added benefit, one can force the interpretation of a number
as positive by prepending a #{00} to the binary prior to conversion, or
force a negative interpretation by prepending a #{FF}.

This does not change the TO-BINARY behavior, leaving it as always
producing a 64-bit binary from integers.  However, it does change the
truncation rule for long numbers to an error.  Hence a long byte stream
cannot have its head converted implicitly.

With this and the zip changes, unzip.reb works with correct external
CRC calculations via an unmodified zlib.

A legacy switch for conditional code related to this and other bit-size
futureproofing #ifdefs was added and enabled in <r3-legacy>