### PR TITLE
TO-INTEGER/UNSIGNED and conversion fixes

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -581,6 +581,15 @@ to-hex: native [
 	len [integer!]
 ]
 
+to-integer: native [
+	{Synonym of TO INTEGER! when used without refinements, adds /UNSIGNED.}
+	value [
+		integer! decimal! percent! money! char! time!
+		issue! binary! any-string!
+	]
+	/unsigned {For BINARY! interpret as unsigned, otherwise error if signed.}
+]
+
 type-of: native [
 	{Returns the datatype of a value.}
 	value [any-value!]

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1515,7 +1515,8 @@ static REBSER *Scan_Full_Block(SCAN_STATE *scan_state, REBYTE mode_char);
 
 		case TOKEN_INTEGER:		// or start of DATE
 			if (*ep != '/' || mode_char == '/') {
-				if (0 == Scan_Integer(bp, len, value))
+				VAL_SET(value, REB_INTEGER);
+				if (!Scan_Integer(&VAL_INT64(value), bp, len))
 					goto syntax_error;
 			}
 			else {				// A / and not in block
@@ -1530,7 +1531,8 @@ static REBSER *Scan_Full_Block(SCAN_STATE *scan_state, REBYTE mode_char);
 		case TOKEN_DECIMAL:
 		case TOKEN_PERCENT:
 			// Do not allow 1.2/abc:
-			if (*ep == '/' || !Scan_Decimal(bp, len, value, 0))
+			VAL_SET(value, REB_DECIMAL);
+			if (*ep == '/' || !Scan_Decimal(&VAL_DECIMAL(value), bp, len, 0))
 				goto syntax_error;
 			if (bp[len-1] == '%') {
 				VAL_SET(value, REB_PERCENT);
@@ -1546,7 +1548,9 @@ static REBSER *Scan_Full_Block(SCAN_STATE *scan_state, REBYTE mode_char);
 
 		case TOKEN_TIME:
 			if (bp[len-1] == ':' && mode_char == '/') {	// could be path/10: set
-				if (!Scan_Integer(bp, len-1, value)) goto syntax_error;
+				VAL_SET(value, REB_INTEGER);
+				if (!Scan_Integer(&VAL_INT64(value), bp, len - 1))
+					goto syntax_error;
 				scan_state->end--;	// put ':' back on end but not beginning
 				break;
 			}

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -64,7 +64,7 @@
 
 /*********************************************************************
 **
-*/	REBYTE *Qualify_String(REBVAL *val, REBINT max_len, REBCNT *length, REBINT opts)
+*/	REBYTE *Qualify_String(const REBVAL *val, REBINT max_len, REBCNT *length, REBINT opts)
 /*
 **	Prequalifies a string before using it with a function that
 **	expects it to be 8-bits.

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -367,7 +367,11 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 				REBYTE *bp;
 				REBCNT len;
 				bp = Qualify_String(val, 24, &len, FALSE);
-				if (Scan_Decimal(bp, len, D_OUT, type != REB_PERCENT)) {
+
+				VAL_SET(D_OUT, REB_DECIMAL);
+				if (Scan_Decimal(
+					&VAL_DECIMAL(D_OUT), bp, len, type != REB_PERCENT
+				)) {
 					d1 = VAL_DECIMAL(D_OUT);
 					if (type == REB_PERCENT) break;
 					goto setDec;
@@ -386,7 +390,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 				REBYTE *bp;
 				REBCNT len;
 				bp = Qualify_String(val, MAX_HEX_LEN, &len, FALSE);
-				if (Scan_Hex(bp, &VAL_INT64(D_OUT), len, len) == 0)
+				if (Scan_Hex(&VAL_INT64(D_OUT), bp, len, len) == 0)
 					raise Error_Bad_Make(REB_DECIMAL, val);
 				d1 = VAL_DECIMAL(D_OUT);
 				break;

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -46,6 +46,232 @@
 
 /***********************************************************************
 **
+*/	void Value_To_Int64(REBI64 *out, const REBVAL *value, REBOOL no_sign)
+/*
+**	Interpret `value` as a 64-bit integer and return it in `out`.
+**
+**	If `no_sign` is TRUE then use that to inform an ambiguous conversion
+**	(e.g. TO-INTEGER/UNSIGNED #{FF} is 255 instead of -1).  However, it
+**	won't contradict the sign of unambiguous source.  So the string "-1"
+**	will raise an error if you try to convert it unsigned.  (For this,
+**	use `abs to-integer "-1"` and not `to-integer/unsigned "-1"`.)
+**
+**	Because Rebol's INTEGER! uses a signed REBI64 and not an unsigned
+**	REBU64, a request for unsigned interpretation is limited to using
+**	63 of those bits.  A range error will be thrown otherwise.
+**
+**	If a type is added or removed, update REBNATIVE(to_integer)'s spec
+**
+***********************************************************************/
+{
+	// !!! Code extracted from REBTYPE(Integer)'s A_MAKE and A_TO cases
+	// Use SWITCH instead of IF chain? (was written w/ANY_STR test)
+
+	if (IS_INTEGER(value)) {
+		*out = VAL_INT64(value);
+		goto check_sign;
+	}
+	if (IS_DECIMAL(value) || IS_PERCENT(value)) {
+		if (VAL_DECIMAL(value) < MIN_D64 || VAL_DECIMAL(value) >= MAX_D64)
+			raise Error_0(RE_OVERFLOW);
+
+		*out = cast(REBI64, VAL_DECIMAL(value));
+		goto check_sign;
+	}
+	else if (IS_MONEY(value)) {
+		*out = deci_to_int(VAL_MONEY_AMOUNT(value));
+		goto check_sign;
+	}
+	else if (IS_BINARY(value)) { // must be before ANY_STR() test...
+
+		// Rebol3 creates 8-byte big endian for signed 64-bit integers.
+		// Rebol2 created 4-byte big endian for signed 32-bit integers.
+		//
+		// Values originating in file formats from other systems vary widely.
+		// Note that in C the default interpretation of single bytes in most
+		// implementations of a `char` is signed.
+		//
+		// We assume big-Endian for decoding (clients can REVERSE if they
+		// want little-Endian).  Also by default assume that any missing
+		// sign-extended to 64-bits based on the most significant byte
+		//
+		//     #{01020304} => #{0000000001020304}
+		//     #{DECAFBAD} => #{FFFFFFFFDECAFBAD}
+		//
+		// To override this interpretation and always generate an unsigned
+		// result, pass in `no_sign`.  (Used by TO-INTEGER/UNSIGNED)
+		//
+		// If under these rules a number cannot be represented within the
+		// numeric range of the system's INTEGER!, it will error.  This
+		// attempts to "future-proof" for other integer sizes and as an
+		// interface could support BigNums in the future.
+
+		REBYTE *bp = VAL_BIN_DATA(value);
+		REBCNT n = VAL_LEN(value);
+		REBOOL negative;
+		REBINT fill;
+
+	#if !defined(NDEBUG)
+		// This is what R3-Alpha did.
+		if (LEGACY(OPTIONS_FOREVER_64_BIT_INTS)) {
+			*out = 0;
+			if (n > sizeof(REBI64)) n = sizeof(REBI64);
+			for (; n; n--, bp++)
+				*out = (*out << 8) | *bp;
+
+			// There was no TO-INTEGER/UNSIGNED in R3-Alpha, so even if
+			// running in compatibility mode we can check the sign if used.
+			goto check_sign;
+		}
+	#endif
+
+		if (n == 0) {
+			// !!! Should #{} empty binary be 0 or error?  (Historically, 0)
+			*out = 0;
+			return;
+		}
+
+		// default signedness interpretation to high-bit of first byte, but
+		// override if the function was called with `no_sign`
+		negative = no_sign ? FALSE : *bp >= 0x80;
+
+		// Consume any leading 0x00 bytes (or 0xFF if negative)
+		while (n != 0 && *bp == (negative ? 0xFF : 0x00)) {
+			bp++; n--;
+		}
+
+		// If we were consuming 0xFFs and passed to a byte that didn't have
+		// its high bit set, we overstepped our bounds!  Go back one.
+		if (negative && n > 0 && *bp < 0x80) {
+			bp--; n++;
+		}
+
+		// All 0x00 bytes must mean 0 (or all 0xFF means -1 if negative)
+		if (n == 0) {
+			if (negative) {
+				assert(!no_sign);
+				*out = -1;
+			} else
+				*out = 0;
+			return;
+		}
+
+		// Not using BigNums (yet) so max representation is 8 bytes after
+		// leading 0x00 or 0xFF stripped away
+		if (n > 8)
+			raise Error_1(RE_OUT_OF_RANGE, value);
+
+		// Pad out to make sure any missing upper bytes match sign
+		for (fill = n; fill < 8; fill++)
+			*out = (*out << 8) | (negative ? 0xFF : 0x00);
+
+		// Use binary data bytes to fill in the up-to-8 lower bytes
+		while (n != 0) {
+			*out = (*out << 8) | *bp;
+			bp++;
+			n--;
+		}
+
+		if (no_sign && *out < 0) {
+			// bits may become signed via shift due to 63-bit limit
+			raise Error_1(RE_OUT_OF_RANGE, value);
+		}
+
+		return;
+	}
+	else if (IS_ISSUE(value)) {
+		// Like converting a binary, except uses a string of codepoints
+		// from the word name conversion.  Does not allow for signed
+		// interpretations, e.g. #FFFF => 65535, not -1.  Unsigned makes
+		// more sense as these would be hexes likely typed in by users,
+		// who rarely do 2s-complement math in their head.
+
+		const REBYTE *bp = Get_Word_Name(value);
+		REBCNT len = LEN_BYTES(bp);
+
+		if (len > MAX_HEX_LEN) {
+			// Lacks BINARY!'s accommodation of leading 00s or FFs
+			raise Error_1(RE_OUT_OF_RANGE, value);
+		}
+
+		if (!Scan_Hex(out, bp, len, len))
+			raise Error_Bad_Make(REB_INTEGER, value);
+
+		// !!! Unlike binary, always assumes unsigned (should it?).  Yet still
+		// might run afoul of 64-bit range limit.
+		if (*out < 0)
+			raise Error_1(RE_OUT_OF_RANGE, value);
+
+		return;
+	}
+	else if (ANY_STR(value)) {
+		REBYTE *bp;
+		REBCNT len;
+		REBDEC dec;
+		bp = Qualify_String(value, VAL_LEN(value), &len, FALSE);
+		if (
+			memchr(bp, '.', len)
+			|| memchr(bp, 'e', len)
+			|| memchr(bp, 'E', len)
+		) {
+			if (Scan_Decimal(&dec, bp, len, TRUE)) {
+				if (dec < MAX_I64 && dec >= MIN_I64) {
+					*out = cast(REBI64, dec);
+					goto check_sign;
+				}
+
+				raise Error_0(RE_OVERFLOW);
+			}
+		}
+		if (Scan_Integer(out, bp, len))
+			goto check_sign;
+
+		raise Error_Bad_Make(REB_INTEGER, value);
+	}
+	else if (IS_LOGIC(value)) {
+		// Rebol's choice is that no integer is uniquely representative of
+		// "falsehood" condition, e.g. `if 0 [print "this prints"]`.  So to
+		// say TO FALSE is 0 would be disingenuous.
+
+		raise Error_Bad_Make(REB_INTEGER, value);
+	}
+	else if (IS_CHAR(value)) {
+		*out = VAL_CHAR(value);
+		assert(*out >= 0);
+		return;
+	}
+	else if (IS_TIME(value)) {
+		*out = SECS_IN(VAL_TIME(value));
+		assert(*out >= 0);
+		return;
+	}
+	else
+		raise Error_Bad_Make(REB_INTEGER, value);
+
+check_sign:
+	if (no_sign && *out < 0)
+		raise Error_0(RE_POSITIVE);
+}
+
+
+/***********************************************************************
+**
+*/	REBNATIVE(to_integer)
+/*
+***********************************************************************/
+{
+	REBVAL * const value = D_ARG(1);
+	REBOOL no_sign = D_REF(2);
+
+	VAL_SET(D_OUT, REB_INTEGER);
+	Value_To_Int64(&VAL_INT64(D_OUT), value, no_sign);
+
+	return R_OUT;
+}
+
+
+/***********************************************************************
+**
 */	REBTYPE(Integer)
 /*
 ***********************************************************************/
@@ -163,7 +389,10 @@
 		break;
 
 	case A_EVENQ: num = ~num;
-	case A_ODDQ: DECIDE(num & 1);
+	case A_ODDQ:
+		if (num & 1)
+			return R_TRUE;
+		return R_FALSE;
 
 	case A_ROUND:
 		val2 = D_ARG(3);
@@ -204,125 +433,31 @@
 	case A_MAKE:
 	case A_TO:
 		val = D_ARG(2);
-		if (IS_DECIMAL(val) || IS_PERCENT(val)) {
-			if (VAL_DECIMAL(val) < MIN_D64 || VAL_DECIMAL(val) >= MAX_D64)
-				raise Error_0(RE_OVERFLOW);
-			num = (REBI64)VAL_DECIMAL(val);
+		VAL_SET(D_OUT, REB_INTEGER);
+
+		if (action == A_MAKE && IS_LOGIC(val)) {
+			// !!! Due to Rebol's policies on conditional truth and falsehood,
+			// it refuses to say TO FALSE is 0.  MAKE has shades of meaning
+			// that are more "dialected", e.g. MAKE BLOCK! 10 creates a block
+			// with capacity 10 and not literally `[10]` (or a block with ten
+			// NONE! values in it).  Under that liberal umbrella it decides
+			// that it will make an integer 0 out of FALSE due to it having
+			// fewer seeming "rules" than TO would.
+
+			VAL_INT64(D_OUT) = VAL_LOGIC(val) ? 1 : 0;
+
+			// !!! The same principle could suggest MAKE is not bound by
+			// the "reversibility" requirement and hence could interpret
+			// binaries unsigned by default.  Before getting things any
+			// weirder should probably leave it as is.
 		}
-		else if (IS_INTEGER(val))
-			num = VAL_INT64(val);
-		else if (IS_MONEY(val))
-			num = deci_to_int(VAL_MONEY_AMOUNT(val));
-		else if (IS_ISSUE(val)) {
-			const REBYTE *bp = Get_Word_Name(val);
-			REBCNT len;
-			len = LEN_BYTES(bp);
-			n = MIN(MAX_HEX_LEN, len);
-			if (Scan_Hex(bp, &num, n, n) == 0) goto is_bad;
+		else {
+			// use signed logic by default (use TO-INTEGER/UNSIGNED to force
+			// unsigned interpretation or error if that doesn't make sense)
+
+			Value_To_Int64(&VAL_INT64(D_OUT), val, FALSE);
 		}
-		else if (IS_BINARY(val)) { // must be before STRING!
-			REBYTE *bp = VAL_BIN_DATA(val);
-			REBOOL negative;
-			REBINT fill;
-
-			n = VAL_LEN(val);
-
-		#if !defined(NDEBUG)
-			if (LEGACY(OPTIONS_FOREVER_64_BIT_INTS)) {
-				num = 0;
-				if (n > sizeof(REBI64)) n = sizeof(REBI64);
-				for (; n; n--, bp++)
-					num = (num << 8) | *bp;
-				break;
-			}
-		#endif
-
-			// Rebol3 creates 8-byte big endian for signed 64-bit integers.
-			// Rebol2 created 4-byte big endian for signed 32-bit integers,
-			// Several variations exist embedded in file formats.
-			//
-			// Assume big-Endian for decoding (clients can REVERSE if they
-			// want little-Endian).  Also assume that any missing bytes are
-			// sign-extended to 64-bits based on the most significant byte.
-			//
-			//     #{01020304} => #{0000000001020304}
-			//     #{DECAFBAD} => #{FFFFFFFFDECAFBAD}
-			//
-			// If under these rules a number cannot be represented in the
-			// numeric format of the system, it will error.  This attempts
-			// to "future-proof" for other integer sizes and accommodates
-			// more flexible decoding options (prepend 0xFF for always
-			// negative, prepend 0x00 for always positive, leave as-is for
-			// signed interpretation).
-
-			if (n == 0) {
-				num = 0; // !!! Should #{} empty binary be 0 or error?
-				break;
-			}
-
-			negative = *bp >= 0x80; // would result be negative?
-
-			// Consume any leading 0xFF or 0x00 bytes
-			while (n != 0 && (*bp == 0xFF || *bp == 0x00)) {
-				bp++; n--;
-			}
-			if (n == 0) {
-				if (negative)
-					num = -1; // it was all 0xFF bytes, must mean -1
-				else
-					num = 0; // it was all 0x00 bytes, must mean 0
-				break;
-			}
-
-			// Not using BigNums (yet) so max representation is 8 bytes
-			if (n > 8)
-				raise Error_1(RE_OUT_OF_RANGE, val);
-
-			// Pad out to make sure any missing upper bytes match sign
-			for (fill = n; fill < 8; fill++)
-				num = (num << 8) | (negative ? 0xFF : 0x00);
-
-			// Use binary data bytes to fill in the up-to-8 lower bytes
-			while (n != 0) {
-				num = (num << 8) | *bp;
-				bp++;
-				n--;
-			}
-		}
-		else if (ANY_STR(val)) {
-			REBYTE *bp;
-			REBCNT len;
-			bp = Qualify_String(val, VAL_LEN(val), &len, FALSE);
-			if (memchr(bp, '.', len)
-			   	|| memchr(bp, 'e', len)
-			   	|| memchr(bp, 'E', len)) {
-				if (Scan_Decimal(bp, len, D_OUT, TRUE)) {
-					double v = VAL_DECIMAL(D_OUT);
-					if (v < MAX_D64 && v >= MIN_D64) {
-						num = (REBI64)v;
-					}
-					else
-						raise Error_0(RE_OVERFLOW);
-					break;
-				}
-			}
-			if (Scan_Integer(bp, len, D_OUT))
-				return R_OUT;
-			goto is_bad;
-		}
-		else if (IS_LOGIC(val)) {
-			// No integer is uniquely representative of true, so TO conversions reject
-			// integer-to-logic conversions.  MAKE is more liberal and constructs true
-			// to 1 and false to 0.
-			if (action != A_MAKE) goto is_bad;
-			num = VAL_LOGIC(val) ? 1 : 0;
-		}
-		else if (IS_CHAR(val))
-			num = VAL_CHAR(val);
-		// else if (IS_NONE(val)) num = 0;
-		else if (IS_TIME (val)) num = SECS_IN(VAL_TIME(val));
-		else goto is_bad;
-		break;
+		return R_OUT;
 
 	default:
 		raise Error_Illegal_Action(REB_INTEGER, action);
@@ -330,13 +465,4 @@
 
 	SET_INTEGER(D_OUT, num);
 	return R_OUT;
-
-is_bad:
-	raise Error_Bad_Make(REB_INTEGER, val);
-
-is_false:
-	return R_FALSE;
-
-is_true:
-	return R_TRUE;
 }

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -11,9 +11,17 @@ REBOL [
 	}
 ]
 
-; These must be listed now, because there is no longer a global context for mezz functions:
-; Are we sure we really want all these?? -Carl A108
-to-logic: to-integer: to-decimal: to-percent: to-money: to-char: to-pair:
+; !!! Carl wrote "Are we sure we really want all these?" as a comment here.
+; Discussion of eliminating the TO-XXX functions in favor of TO XXX! resolved
+; to say that many people prefer them...and that they also may serve a point
+; by showing a list of legal conversion types in the help.  They also could
+; have refinements giving slightly different abilities than the default
+; unrefined TO XXX! behavior would give.
+
+; These must be listed explicitly in order for the words to be collected
+; as legal "globals" for the mezzanine context (otherwise SET would fail)
+
+to-logic: to-decimal: to-percent: to-money: to-char: to-pair:
 to-tuple: to-time: to-date: to-binary: to-string: to-file: to-email: to-url: to-tag:
 to-bitset: to-image: to-vector: to-block: to-paren:
 to-path: to-set-path: to-get-path: to-lit-path: to-map: to-datatype: to-typeset:
@@ -25,10 +33,18 @@ to-event:
 ; Auto-build the functions for the above TO-* words.
 use [word] [
 	for-each type system/catalog/datatypes [
-		; The list above determines what will be made here:
-		if in lib word: make word! head remove back tail ajoin ["to-" type] [
+		word: make word! head remove back tail ajoin ["to-" type]
+
+		; The list above determines what will be made here, but we must not
+		; overwrite any NATIVE! implementations.  (e.g. TO-INTEGER is a
+		; native with a refinement for interpreting as unsigned.)
+
+		if all [
+			word: in lib word
+			none? get word
+		][
 			; Add doc line only if this build has autodocs:
-			set in lib :word func either string? first spec-of :make [
+			set word func either string? first spec-of :make [
 				reduce [reform ["Converts to" form type "value."] 'value]
 			][
 				[value]


### PR DESCRIPTION
This factors out the functionality of INTEGER!'s TO conversion into
a service function, and then adds a parameter to that function for
enforcing interpretation to be unsigned.  Then it creates a NATIVE!
version of TO-INTEGER! which provides an /UNSIGNED refinement
to use the new ability.

It also fixes a bug in the TO INTEGER! implementation for numbers
(introduced in fea5921).  The problem would occur when leading 0xFF
bytes were followed by a byte without the high bit set.  This would
lead to positive interpretations of those numbers.

Several other adjustments were made to correct edge cases or add
informative errors for surprising results.  As a by-product of writing the
routine for general purposes, it can generate a REBI64 directly into a
value cell or into a REBI64 without a value cell.