### PR TITLE
Print BINARY! as raw bytes to console, skip NONE!

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -151,6 +151,7 @@ options: context [  ; Options supplied to REBOL during startup
 	no-switch-evals: false
 	no-switch-fallthrough: false
 	forever-64-bit-ints: false
+	print-forms-everything: false
 ]
 
 script: context [

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -77,7 +77,7 @@ static REBREQ *Req_SIO;
 
 /***********************************************************************
 **
-*/	static void Print_OS_Line(void)
+*/	void Print_OS_Line(void)
 /*
 **		Print a new line.
 **
@@ -98,7 +98,7 @@ static REBREQ *Req_SIO;
 
 /***********************************************************************
 **
-*/	static void Prin_OS_String(const void *p, REBCNT len, REBOOL uni)
+*/	void Prin_OS_String(const void *p, REBCNT len, REBOOL uni)
 /*
 **		Print a string, but no line terminator or space.
 **

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -224,6 +224,7 @@ set 'r3-legacy* func [] [
 	system/options/no-switch-evals: true
 	system/options/no-switch-fallthrough: true
 	system/options/forever-64-bit-ints: true
+	system/options/print-forms-everything: true
 
 	; False is already the default for this switch
 	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)


### PR DESCRIPTION
An issue discovered regarding Rebol's limitations of interacting in a
web CGI environment is that it has no way to do full 8-bit transport to
the console.  Unlike WRITE, PRINT of a binary would not send the
raw bytes to the device but rather do an effective PROBE of the data.

The general idea that a PRINT of a value is a general-purpose way
of inspecting any arbitrary Rebol type is already undermined by its
longstanding behavior with BLOCK!.  Hence, in order to make it
possible to access things like terminal escape codes and other needs
it makes more sense to treat printing of a binary in a way that gives
full raw access to the device.

(This does not change the behavior of BINARY! inside of a block that
is passed to PRINT, which is currently the domain of FORM.)

This adds another behavior which has been sought after and requested,
which is that NONE! and UNSET! omit any print whatsoever.  This
makes it possible for a function call to "opt out" of a print.