### PR TITLE
Possibly fixes #1422 (event queue overflow)

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -446,12 +446,12 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 		Recycle();
 	}
 
-#ifdef NOT_USED_INVESTIGATE
-	if (GET_FLAG(sigs, SIG_EVENT_PORT)) {  // !!! Why not used?
+	// Was #ifdef'd out in R3-Alpha open source code. Enabled due to #1422
+	if (GET_FLAG(sigs, SIG_EVENT_PORT)) {
+		REBINT result = Awake_System(NULL, FALSE); // !!! just event port?
 		CLR_SIGNAL(SIG_EVENT_PORT);
-		Awake_Event_Port();
+		cast(void, result); // !!! Should the result be acted on?
 	}
-#endif
 
 	// Escape only allowed after MEZZ boot (no handlers):
 	if (GET_FLAG(sigs, SIG_ESCAPE) && PG_Boot_Phase >= BOOT_MEZZ) {


### PR DESCRIPTION
Event list expansion was added by Atronix to deal with bug #1422.
Original expansion set EVENT_LIMIT to 0xFFFF REB_EVENT values (64k).
This was much larger than the hard limit of 128 set by original
open-source Rebol.  But adding `SET_SIGNAL(SIG_EVENT_PORT)` in
`Append_Event()` corrected the bug and allowed the limit to be
lowered.  Still the chunking/expansion mechanic is retained.