### PR TITLE
Tighten/clarify UTF8 char decoding interfaces

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -102,6 +102,8 @@ Internal: [
 	bad-evaltype:		{invalid datatype for evaluation}
 	hash-overflow:		{Hash ran out of space}
 	no-print-ptr:		{print is missing string pointer}
+
+	codepoint-too-high:	[{codepoint} :arg1 {too large for current interpreter}]
 ]
 
 Syntax: [

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -157,17 +157,19 @@ static REBCNT *CRC_Table;
 **
 ***********************************************************************/
 {
-	REBINT m, n;
+	REBUNI m, n;
 	REBINT hash;
-	REBCNT ulen;
 
 	hash = (REBINT)len + (REBINT)((REBYTE)LO_CASE(*str));
 
-	ulen = (REBCNT)len; // so the & operation later isn't for the wrong type
-
-	for (; ulen > 0; str++, ulen--) {
+	for (; len > 0; str++, len--) {
 		n = *str;
-		if (n > 127 && (m = Decode_UTF8_Char(&str, &ulen))) n = m; // mods str, ulen
+		if (n >= 0x80) {
+			str = Back_Scan_UTF8_Char(&m, str, &len);
+			assert(str); // UTF8 should have already been verified good
+
+			n = m;
+		}
 		if (n < UNICODE_CASES) n = LO_CASE(n);
 		n = (REBYTE)((hash >> CRCSHIFTS) ^ (REBYTE)n); // drop upper 8 bits
 		hash = MASK_CRC(hash << 8) ^ (REBINT)CRC_Table[n];

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -267,15 +267,21 @@
 **
 ***********************************************************************/
 {
-	REBINT c1, c2;
+	REBUNI c1, c2;
 	REBCNT l1 = LEN_BYTES(s1);
 	REBINT result = 0;
 
 	for (; l1 > 0 && l2 > 0; s1++, s2++, l1--, l2--) {
-		c1 = (REBYTE)*s1;
-		c2 = (REBYTE)*s2;
-		if (c1 > 127) c1 = Decode_UTF8_Char(&s1, &l1); //!!! can return 0 on error!
-		if (c2 > 127) c2 = Decode_UTF8_Char(&s2, &l2);
+		c1 = *s1;
+		c2 = *s2;
+		if (c1 > 127) {
+			s1 = Back_Scan_UTF8_Char(&c1, s1, &l1);
+			assert(s1); // UTF8 should have already been verified good
+		}
+		if (c2 > 127) {
+			s2 = Back_Scan_UTF8_Char(&c1, s2, &l2);
+			assert(s2); // UTF8 should have already been verified good
+		}
 		if (c1 != c2) {
 			if (c1 >= UNICODE_CASES || c2 >= UNICODE_CASES ||
 				LO_CASE(c1) != LO_CASE(c2)) {

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -58,7 +58,7 @@
 /*
 ***********************************************************************/
 {
-	REBINT	chr = VAL_CHAR(D_ARG(1));
+	REBUNI chr = VAL_CHAR(D_ARG(1));
 	REBINT	arg;
 	REBVAL	*val;
 
@@ -134,9 +134,19 @@
 			arg = VAL_LEN(val);
 			if (arg == 0) goto bad_make;
 			if (*bp > 0x80) {
-				if (!Legal_UTF8_Char(bp, arg)) goto bad_make;
-				chr = Decode_UTF8_Char(&bp, 0); // zero on error
-				if (!chr) goto bad_make;
+				// !!! This test is presumably redundant - temporarily left
+				// in as a check to see if its presence here detected
+				// anything differently that Scan_UTF8_Char wouldn't.
+				REBOOL redundant_legal = Legal_UTF8_Char(bp, arg);
+
+				if (!Back_Scan_UTF8_Char(&chr, bp, NULL)) {
+					assert(!redundant_legal);
+					goto bad_make;
+				}
+				if (!redundant_legal) {
+					assert(FALSE);
+					goto bad_make;
+				}
 			}
 			else
 				chr = *bp;


### PR DESCRIPTION
This is a rescue of some tinkering from before Ren/C in a mostly
irrelevant clone.  It seemed to be clarifying enough to be worth going
ahead and trying to merge in before throwing that repository away.

The interface of Decode_UTF8_Char and its callers was complex
and obscured the need to handle certain invalid return results.  Some
places did not check the result and shouldn't have to.  This makes it
more standardized by matching the Scan_XXX routines more
closely.  It also adds documentation for the behavior.

A special error is also added to help distinguish invalid UTF8 data
from one with a codepoint simply too high for the Rebol implementation
to currently handle.

A likely redundant check is moved for now to assert that the redundant
check matches the result if the check is not run.