### PR TITLE
Permit DO to raise errors again

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -138,7 +138,7 @@ Script: [
 	; !!! Temporary errors while faulty constructs are still outstanding
 	; (more informative than just saying "function doesn't take that type")
 	use-eval-for-eval:  {Use EVAL (not DO) for inline evaluation of a value}
-	use-fail-for-error: {Use FAIL (instead of THROW or DO) to trigger ERROR!}
+	use-fail-for-error: [{Use FAIL (not THROW or DO) to raise} :arg1]
 	use-split-simple:   {Use SPLIT (instead of PARSE) for "simple" parsing}
 
 	limited-fail-input: {FAIL requires complex expressions to be in a PAREN!}

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -144,7 +144,6 @@ options: context [  ; Options supplied to REBOL during startup
 	exit-functions-only: false
 	broken-case-semantics: false
 	do-runs-functions: false
-	do-raises-errors: false
 	datatype-word-strict: false
 	group-not-paren: false ;; bias the default to PAREN! vs GROUP! (for now...)
 	refinements-true: false

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -677,11 +677,11 @@ was_caught:
 		// trying to use it to trigger errors, because if THROW just didn't
 		// take errors in the spec it wouldn't guide what *to* use.
 		//
-		raise Error_0(RE_USE_FAIL_FOR_ERROR);
+		raise Error_1(RE_USE_FAIL_FOR_ERROR, value);
 
 		// Note: Caller can put the ERROR! in a block or use some other
 		// such trick if it wants to actually throw an error.
-		// (Better than complicating throw with /error-is-intentional!)
+		// (Better than complicating via THROW/ERROR-IS-INTENTIONAL!)
 	}
 
 	if (named) {
@@ -846,13 +846,13 @@ was_caught:
 		return R_OUT;
 
 	case REB_ERROR:
-	#if !defined(NDEBUG)
-		if (LEGACY(OPTIONS_DO_RAISES_ERRORS))
-			raise Error_Is(value);
-	#endif
-		// This path will no longer raise the error you asked for, though it
-		// will still raise *an* error directing you to use FAIL.)
-		raise Error_0(RE_USE_FAIL_FOR_ERROR);
+		// FAIL is the preferred operation for triggering errors, as it has
+		// a natural behavior for blocks passed to construct readable messages
+		// and "FAIL X" more clearly communicates a failure than "DO X"
+		// does.  However DO of an ERROR! would have to raise an error
+		// anyway, so it might as well raise the one it is given.
+		//
+		raise Error_Is(value);
 
 	case REB_TASK:
 		Do_Task(value);

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -216,7 +216,6 @@ set 'r3-legacy* func [] [
 	; at different times on a case-by-case basis.
 	;
 	system/options/do-runs-functions: true
-	system/options/do-raises-errors: true
 	system/options/broken-case-semantics: true
 	system/options/exit-functions-only: true
 	system/options/datatype-word-strict: true


### PR DESCRIPTION
When FAIL was conceived, it seemed that letting DO raise errors was
encouraging of unclear practices.  (DO X doesn't look like a failure or
exception triggering mechanism if you don't know that X is an error, and
it's not that great of a way of saying it even if it's clear that it is an error.)
So DO of an ERROR! was turned into a different error than the one you
asked for...instructing you to use FAIL instead.

This was creating a bit of a bump, and likely an unnecessary one.  If DO
of an ERROR! is just going to give you an error anyway, it might as well
give the error you asked for.

However, THROW not allowing you to pass it an ERROR! is important and
being kept.  If THROW is used instead of FAIL (or DO) then it will confuse
matters with TRAP, making it seem surprising that a thrown error could
not be trapped.  The message for trying to THROW an error helps to
reinforce that you shouldn't use DO by mentioning not to use either THROW
or DO (even though DO will now continue to work).

Making the ergonomics a little easier, THROW of an ERROR! now puts the
error as the argument to the "do not throw error!"...so you can read what it
was *and* get an error, while still getting the advice.