### PR TITLE
Add "SAVE/UNSAVE_VALUE" (rename to GUARD...)

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -413,7 +413,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	}
 
 	code = Scan_Source(text, LEN_BYTES(text));
-	SAVE_SERIES(code);
+	PUSH_GUARD_SERIES(code);
 
 	// Bind into lib or user spaces?
 	if (flags) {
@@ -431,7 +431,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	}
 
 	if (Do_Block_Throws(&out, code, 0)) {
-		UNSAVE_SERIES(code);
+		DROP_GUARD_SERIES(code);
 
 		if (
 			IS_WORD(&out) &&
@@ -447,7 +447,7 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		raise Error_No_Catch_For_Throw(&out);
 	}
 
-	UNSAVE_SERIES(code);
+	DROP_GUARD_SERIES(code);
 
 	DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 
@@ -496,9 +496,9 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 	_close(f);
 #endif
 
-	SAVE_SERIES(text);
+	PUSH_GUARD_SERIES(text);
 	do_result = RL_Do_String(exit_status, text->data, flags, result);
-	UNSAVE_SERIES(text);
+	DROP_GUARD_SERIES(text);
 
 	Free_Series(text);
 	return do_result;

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -483,6 +483,9 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 	//
 	REBCNT manuals_tail = SERIES_TAIL(GC_Manuals);
 
+	REBCNT series_guard_tail = SERIES_TAIL(GC_Series_Guard);
+	REBCNT value_guard_tail = SERIES_TAIL(GC_Value_Guard);
+
 	const REBYTE *label_str = Get_Word_Name(DSF_LABEL(call));
 #endif
 
@@ -548,6 +551,9 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 	}
 
 	MANUALS_LEAK_CHECK(manuals_tail, cs_cast(label_str));
+
+	assert(series_guard_tail == SERIES_TAIL(GC_Series_Guard));
+	assert(value_guard_tail == SERIES_TAIL(GC_Value_Guard));
 #endif
 
 	SET_DSF(dsf_precall);
@@ -615,7 +621,11 @@ void Trace_Arg(REBINT num, const REBVAL *arg, const REBVAL *path)
 	// most notably it applies to the data stack--where output used to always
 	// be returned.
 	//
+#ifdef STRESS_CHECK_DO_OUT_POINTER
+	ASSERT_NOT_IN_SERIES_DATA(out);
+#else
 	assert(!IN_DATA_STACK(out));
+#endif
 
 	// Only need to check this once (C stack size would be the same each
 	// time this line is run if it were in a loop)

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -45,7 +45,8 @@
 	s->dsp = DSP;
 	s->dsf = DSF;
 
-	s->hold_tail = GC_Protect->tail;
+	s->series_guard_tail = GC_Series_Guard->tail;
+	s->value_guard_tail = GC_Value_Guard->tail;
 	s->gc_disable = GC_Disabled;
 
 	s->manuals_tail = SERIES_TAIL(GC_Manuals);
@@ -110,7 +111,8 @@
 		Free_Series(cast(REBSER**, GC_Manuals->data)[GC_Manuals->tail - 1]);
 	}
 
-	GC_Protect->tail = state->hold_tail;
+	GC_Series_Guard->tail = state->series_guard_tail;
+	GC_Value_Guard->tail = state->value_guard_tail;
 
 	GC_Disabled = state->gc_disable;
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -556,7 +556,7 @@
 	// execution.  (We could also protect it by stowing it in the call
 	// frame's copy of the closure value, which we might think of as its
 	// "archetype", but it may be valuable to keep that as-is.)
-	SAVE_SERIES(body);
+	PUSH_GUARD_SERIES(body);
 
 	if (Do_Block_Throws(out, body, 0)) {
 		if (
@@ -570,7 +570,7 @@
 
 	// References to parts of the closure's copied body may still be
 	// extant, but we no longer need to hold this reference on it
-	UNSAVE_SERIES(body);
+	DROP_GUARD_SERIES(body);
 }
 
 

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -178,8 +178,8 @@
 	nums[9] = 0;
 	nums[10] = GC_Ballast;
 	nums[11] = GC_Disabled;
-	nums[12] = SERIES_TAIL(GC_Protect);
-	nums[13] = 0; // Was GC_Last_Infant
+	nums[12] = SERIES_TAIL(GC_Series_Guard);
+	nums[13] = SERIES_TAIL(GC_Value_Guard);
 
 	for (n = 0; n < 14; n++) Debug_Fmt(cs_cast(BOOT_STR(RS_DUMP, n)), nums[n]);
 }

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -369,10 +369,14 @@ static REBREQ *Req_SIO;
 	} else if (ser == PG_Word_Table.hashes) {
 		// Dump hashes somehow?
 		Panic_Series(ser);
-	} else if (ser == GC_Protect) {
+	} else if (ser == GC_Series_Guard) {
 		// Dump protected series pointers somehow?
 		Panic_Series(ser);
-	} else
+	} else if (ser == GC_Value_Guard) {
+		// Dump protected value pointers somehow?
+		Panic_Series(ser);
+	}
+	else
 		Panic_Series(ser);
 
 	assert(GC_Disabled == 1);

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -671,6 +671,38 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 }
 
 
+#if !defined(NDEBUG)
+
+/***********************************************************************
+**
+*/	void Assert_Not_In_Series_Data_Debug(const void *pointer)
+/*
+***********************************************************************/
+{
+	REBSEG *seg;
+
+	for (seg = Mem_Pools[SERIES_POOL].segs; seg; seg = seg->next) {
+		REBSER *series = cast(REBSER *, seg + 1);
+		REBCNT n;
+		for (n = Mem_Pools[SERIES_POOL].units; n > 0; n--, series++) {
+			if (SERIES_FREED(series))
+				continue;
+
+			assert(
+				(pointer < cast(void *, series->data)) ||
+				(pointer >= cast(void *, (
+					series->data
+					- (SERIES_WIDE(series) * SERIES_BIAS(series))
+					+ Series_Allocated_Size(series)
+				)))
+			);
+		}
+	}
+}
+
+#endif
+
+
 /***********************************************************************
 **
 */	REBCNT Series_Allocated_Size(REBSER *series)

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -367,7 +367,7 @@ typedef enum {
 
 		out = Make_Array(VAL_LEN(data));
 		MANAGE_SERIES(out);
-		SAVE_SERIES(out);
+		PUSH_GUARD_SERIES(out);
 	}
 
 	// Get series info:
@@ -390,7 +390,7 @@ typedef enum {
 				SET_INTEGER(D_OUT, 0);
 			}
 			else if (mode == LOOP_MAP_EACH) {
-				UNSAVE_SERIES(out);
+				DROP_GUARD_SERIES(out);
 				Val_Init_Block(D_OUT, out);
 			}
 			return R_OUT;
@@ -587,7 +587,7 @@ skip_hidden: ;
 		return R_OUT;
 
 	case LOOP_MAP_EACH:
-		UNSAVE_SERIES(out);
+		DROP_GUARD_SERIES(out);
 		if (break_with) {
 			// If BREAK is given a /WITH parameter that is not an UNSET!, it
 			// is assumed that you want to override the accumulated mapped

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -326,7 +326,7 @@ static ffi_type* struct_to_ffi(const REBVAL *out, REBSER *fields, REBOOL make)
 	} else {
 		REBSER * ser= Make_Series(2, sizeof(ffi_type), MKS_NONE | MKS_LOCK);
 		stype = cast(ffi_type*, SERIES_DATA(ser));
-		SAVE_SERIES(ser);
+		PUSH_GUARD_SERIES(ser);
 	}
 
 	stype->size = stype->alignment = 0;
@@ -340,7 +340,7 @@ static ffi_type* struct_to_ffi(const REBVAL *out, REBSER *fields, REBOOL make)
 	} else {
 		REBSER * ser= Make_Series(2 + n_struct_fields(fields), sizeof(ffi_type *), MKS_NONE | MKS_LOCK);
 		stype->elements = cast(ffi_type**, SERIES_DATA(ser));
-		SAVE_SERIES(ser);
+		PUSH_GUARD_SERIES(ser);
 	}
 
 	for (i = 0; i < SERIES_TAIL(fields); i ++) {
@@ -724,7 +724,7 @@ static void ffi_to_rebol(REBRIN *rin,
 	 *	Instead of remembering how many times SAVE_SERIES has called, it's easier to
 	 *	just remember the initial pointer and restore it later.
 	**/
-	REBCNT GC_Protect_tail = GC_Protect->tail;
+	REBCNT series_guard_tail = GC_Series_Guard->tail;
 
 	if (VAL_ROUTINE_LIB(rot) != NULL) {
 		// lib is NULL when routine is constructed from address directly
@@ -839,7 +839,7 @@ static void ffi_to_rebol(REBRIN *rin,
 	if (ser) Free_Series(ser);
 
 	//restore the saved series stack pointer
-	GC_Protect->tail = GC_Protect_tail;
+	GC_Series_Guard->tail = series_guard_tail;
 }
 
 /***********************************************************************
@@ -868,27 +868,23 @@ static void process_type_block(const REBVAL *out, REBVAL *blk, REBCNT n, REBOOL 
 		REBVAL *t = VAL_BLK_DATA(blk);
 		if (IS_WORD(t) && VAL_WORD_CANON(t) == SYM_STRUCT_TYPE) {
 			/* followed by struct definition */
-			REBSER *ser;
-			REBVAL* tmp;
+			REBVAL tmp;
 
-			//lock the series to make BLK_HEAD permanent
-			ser = Make_Series(2, sizeof(REBVAL), MKS_ARRAY | MKS_LOCK);
-			SAVE_SERIES(ser);
-			tmp = BLK_HEAD(ser);
+			PUSH_GUARD_VALUE(&tmp);
 
 			++ t;
 			if (!IS_BLOCK(t) || VAL_LEN(blk) != 2)
 				raise Error_Invalid_Arg(blk);
 
-			if (!MT_Struct(tmp, t, REB_STRUCT))
+			if (!MT_Struct(&tmp, t, REB_STRUCT))
 				raise Error_Invalid_Arg(blk);
 
-			if (!rebol_type_to_ffi(out, tmp, n, make))
+			if (!rebol_type_to_ffi(out, &tmp, n, make))
 				raise Error_Invalid_Arg(blk);
 
-			UNSAVE_SERIES(ser);
-
-		} else {
+			DROP_GUARD_VALUE(&tmp);
+		}
+		else {
 			if (VAL_LEN(blk) != 1)
 				raise Error_Invalid_Arg(blk);
 
@@ -932,7 +928,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 	// so these lines (and the UNSAVE) can be deleted if that happens.
 	//
 	MANAGE_SERIES(ser);
-	SAVE_SERIES(ser);
+	PUSH_GUARD_SERIES(ser);
 
 	elem = Alloc_Tail_Array(ser);
 	SET_TYPE(elem, REB_FUNCTION);
@@ -1026,7 +1022,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 	}
 
 	// !!! Could be a Free_Series if not managed/saved to use with DO
-	UNSAVE_SERIES(ser);
+	DROP_GUARD_SERIES(ser);
 
 	DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 }

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -646,7 +646,7 @@ bad_target:
 
 	// Copy the value into its own block:
 	newparse.series = Make_Array(1);
-	SAVE_SERIES(newparse.series);
+	PUSH_GUARD_SERIES(newparse.series);
 	Append_Value(newparse.series, &value);
 	newparse.type = REB_BLOCK;
 	newparse.find_flags = parse->find_flags;
@@ -654,7 +654,7 @@ bad_target:
 	newparse.out = parse->out;
 
 	n = (Parse_Next_Block(&newparse, 0, item, 0) != NOT_FOUND) ? index : NOT_FOUND;
-	UNSAVE_SERIES(newparse.series);
+	DROP_GUARD_SERIES(newparse.series);
 	return n;
 }
 

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -86,7 +86,8 @@ TVAR REBPOL *Mem_Pools;		// Memory pool array
 TVAR REBINT GC_Disabled;	// GC disabled counter for critical sections.
 TVAR REBINT	GC_Ballast;		// Bytes allocated to force automatic GC
 TVAR REBOOL	GC_Active;		// TRUE when recycle is enabled (set by RECYCLE func)
-TVAR REBSER	*GC_Protect;	// A stack of protected series (removed by pop)
+TVAR REBSER *GC_Series_Guard; // A stack of protected series (removed by pop)
+TVAR REBSER *GC_Value_Guard; // A stack of protected series (removed by pop)
 PVAR REBSER	*GC_Mark_Stack; // Series pending to mark their reachables as live
 TVAR REBFLG GC_Stay_Dirty;  // Do not free memory, fill it with 0xBB
 TVAR REBSER **Prior_Expand;	// Track prior series expansions (acceleration)

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -95,7 +95,8 @@ typedef struct Rebol_State {
 
 	REBINT dsp;
 	struct Reb_Call *dsf;
-	REBCNT hold_tail;	// Tail for GC_Protect
+	REBCNT series_guard_tail;
+	REBCNT value_guard_tail;
 	REBVAL error;
 	REBINT gc_disable;      // Count of GC_Disables at time of Push
 
@@ -195,6 +196,8 @@ typedef struct Rebol_State {
 
 #define DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(s) \
 	do { \
+		assert(GC_Series_Guard->tail == (s)->series_guard_tail); \
+		assert(GC_Value_Guard->tail == (s)->value_guard_tail); \
 		assert(GC_Disabled == (s)->gc_disable); \
 		assert(IS_TRASH(&(s)->error)); \
 		MANUALS_LEAK_CHECK((s)->manuals_tail, "drop trap"); \


### PR DESCRIPTION
In order to protect a series from being garbage collected in a way that was
efficient and safe for recursively protecting and unprotecting the same
series, the SAVE_SERIES and UNSAVE_SERIES macros existed.  They
used a stack to efficiently save and release the pointers, as well as to
check in the debug build to make sure the last saved series was the next
to be unsaved.

No parallel way of saving a value existed, perhaps because most values
live in series.  (You don't want to hold onto pointers to them because the
series can have their data arrays moved during reallocation.)  However, if
a value is known to live in stable memory it could use the same technique
to keep any series it references protected from GC (as long as it is, actually
stable).

Because no mechanism existed, it was necessary to put even a single value
into a locked series and then save *that* series.  This implements a light
solution just like SAVE_SERIES for SAVE_VALUE.  Additionally, it provides
a debug check to make sure that the saved value does not live inside of
series memory (which is too costly to run in general cases, but good to do
for peace of mind...and applicable to other routines that do not want to be
holding onto potentially unstable memory cells).

This also renames the macros from SAVE_XXX / UNSAVE_XXX to
PUSH_GUARD_XXX / DROP_GUARD_XXX.  This helps emphasize the
stacklike nature at the callsite, and "guarding" is a less ambiguous word for
what is being done to the series than "saving" (which might suggest some
kind of serialization).