### PR TITLE
Kill parse longjmp hack, native THROW/NAMEs

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -19,16 +19,6 @@ Special: [
 	type: "special"		; Not really "errors"
 	null:				{invalid error code zero}
 	halt:               {halted by user or script}
-	exited:             {exit occurred}
-
-	; !!! Temporary: PARSE uses simulated error Trap to get out of arbitrary
-	; stacks when a paren! is THROWN() out of (e.g. parse {} [(return 0)]).
-	; This isn't sensible compared to just having a way to use ordinary
-	; C logic to return out of the stack.  There is overhead to cleaning up
-	; after the longjmp and cost to set up and drop a setjmp state on every
-	; parse (even those which will not need to use this hack).
-	;
-	parse-longjmp-hack:	{RE_PARSE_LONGJMP_HACK not in PARSE (impossible!)}
 ]
 
 Internal: [

--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -34,5 +34,15 @@ noname			; noname function word
 transparent-tag	; func w/o definitional return, ignores non-definitional ones
 infix-tag		; func is treated as "infix" (first parameter comes before it)
 
+;; Natives needed as values by the system for throw names (they use their
+;; own function values as names, to be agnostic about words)
+
+parse-native
+break-native
+continue-native
+quit-native
+return-native
+exit-native
+
 boot			; boot block defined in boot.r (GC'd after boot is done)
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -222,12 +222,14 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 
 	if (Do_Sys_Func_Throws(&out, SYS_CTX_FINISH_RL_START, 0)) {
 		if (
-			IS_WORD(&out) &&
-			(VAL_WORD_SYM(&out) == SYM_QUIT || VAL_WORD_SYM(&out) == SYM_EXIT)
+			IS_NATIVE(&out) && (
+				VAL_FUNC_CODE(&out) == VAL_FUNC_CODE(ROOT_QUIT_NATIVE)
+				|| VAL_FUNC_CODE(&out) == VAL_FUNC_CODE(ROOT_EXIT_NATIVE)
+			)
 		) {
 			int status;
 
-			TAKE_THROWN_ARG(&out, &out);
+			CATCH_THROWN(&out, &out);
 			status = Exit_Status_From_Value(&out);
 
 			DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
@@ -434,10 +436,12 @@ extern int Do_Callback(REBSER *obj, u32 name, RXIARG *args, RXIARG *result);
 		DROP_GUARD_SERIES(code);
 
 		if (
-			IS_WORD(&out) &&
-			(VAL_WORD_SYM(&out) == SYM_QUIT || VAL_WORD_SYM(&out) == SYM_EXIT)
+			IS_NATIVE(&out) && (
+				VAL_FUNC_CODE(&out) == VAL_FUNC_CODE(ROOT_QUIT_NATIVE)
+				|| VAL_FUNC_CODE(&out) == VAL_FUNC_CODE(ROOT_EXIT_NATIVE)
+			)
 		) {
-			TAKE_THROWN_ARG(&out, &out);
+			CATCH_THROWN(&out, &out);
 			DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 
 			*exit_status = Exit_Status_From_Value(&out);

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1050,6 +1050,8 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	Init_Mold(MIN_COMMON/4);
 	Init_Frame();
 	//Inspect_Series(0);
+
+	SET_TRASH_SAFE(TASK_THROWN_ARG);
 }
 
 

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -538,17 +538,14 @@ static void Propagate_All_GC_Marks(void);
 {
 	REBSER *ser = NULL;
 
-	if (THROWN(val)) {
-		// Running GC where it can get a chance to see a THROWN value
-		// is invalid because it is related to a temporary value saved
-		// with THROWN_ARG.  So if the GC sees the thrown, it is not
-		// seeing the THROWN_ARG.
-
-		// !!! It's not clear if this should crash or not.
-		// Aggressive Recycle() forces this to happen, review.
-
-		// panic Error_0(RE_THROW_IN_GC);
-	}
+	// If this happens, it means somehow Recycle() got called between
+	// when an `if (Do_XXX_Throws())` branch was taken and when the throw
+	// should have been caught up the stack (before any more calls made).
+	//
+	// !!! Is it worth causing a panic on this in particular in the
+	// release build?  Odds are things will get more corrupt and crash.
+	//
+	assert(!THROWN(val));
 
 	switch (VAL_TYPE(val)) {
 		case REB_UNSET:

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -49,13 +49,13 @@
 **	3: /return (deprecated)
 **	4: /return-value (deprecated)
 **
-**	While QUIT is implemented via a THROWN() value that bubbles up
-**	through the stack, it may not ultimately use the WORD! of QUIT
-**	as its /NAME when more specific values are allowed as names.
+**	QUIT is implemented via a THROWN() value that bubbles up through
+**	the stack.  It uses the value of its own native function as the
+**	name of the throw, like `throw/name value :quit`.
 **
 ***********************************************************************/
 {
-	Val_Init_Word_Unbound(D_OUT, REB_WORD, SYM_QUIT);
+	*D_OUT = *ROOT_QUIT_NATIVE;
 
 	if (D_REF(1)) {
 		CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(2));

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -113,11 +113,7 @@ enum {
 // A reason to favor the name as "the main part" is that having the name
 // value ready-at-hand allows easy testing of it to see if it needs
 // to be passed on.  That happens more often than using the arg, which
-// will occur exactly once (when it is caught).  Moreover, it is done
-// this way because historically Rebol used an ERROR! where the name
-// lived for this purpose.  The spot available in the error value only
-// afforded only 32 bits, which could only hold a symbol ID and hence
-// the name was presumed as corresponding to an unbound WORD!
+// will occur exactly once (when it is caught).
 
 #ifdef NDEBUG
 	#define CONVERT_NAME_TO_THROWN(name,arg) \
@@ -126,15 +122,17 @@ enum {
 			(*TASK_THROWN_ARG = *(arg)); \
 		} while (0)
 
-	#define TAKE_THROWN_ARG(arg,thrown) \
+	#define CATCH_THROWN(arg,thrown) \
 		do { \
-			assert(VAL_GET_OPT((thrown), OPT_VALUE_THROWN)); \
 			VAL_CLR_OPT((thrown), OPT_VALUE_THROWN); \
 			(*(arg) = *TASK_THROWN_ARG); \
 		} while (0)
 #else
-	#define CONVERT_NAME_TO_THROWN(n,a)		Convert_Name_To_Thrown_Debug(n, a)
-	#define TAKE_THROWN_ARG(a,t)			Take_Thrown_Arg_Debug(a, t)
+	#define CONVERT_NAME_TO_THROWN(n,a) \
+		Convert_Name_To_Thrown_Debug(n, a)
+
+	#define CATCH_THROWN(a,t) \
+		Catch_Thrown_Debug(a, t)
 #endif
 
 #define THROWN(v)			(VAL_GET_OPT((v), OPT_VALUE_THROWN))


### PR DESCRIPTION
Rebol uses C's precarious longjmp construct to implement error
handling, because it wants to (for instance) not have to add a check
after every memory allocation to determine if it failed...and then have
to gracefully find a way to move an error into its returning slot.

In PARSE's C implementation, it was using the error longjmp in a
hacky way in order to proxy out return results or throws from within an
embedded rule.  No error had actually occurred... it just was somewhat
deep into a stack and did not have a return result to indicate a throw
had happened.  Rather than adding the result, it pretended an error
occurred and "jumped the stack".

There are several reasons not to do this, including the unnecessary set
up and tear down of a setjmp/longjmp state on each parse call.  It also
creates a surprise on an error boundary that thinks an error means an
in-progress throw may be uncaught.  Yet erasing the thrown value for
parse on error would lose the very trick it was trying to do with raising
the error in the first place.

This resolves it by just removing the hack, and using a THROWN_FLAG
index (in the same way that the Do evaluator does) to bubble out from a
deep parse stack.  For its own RETURN keyword, it effectively throws to
itself using a throw identified w/name of the PARSE native function value.

Then this reinstates the assertions which were originally designed for
managing the side-value on the stack to carry the thrown argument.  It
also switches the names of the throw names for BREAK/CONTINUE/QUIT
and others to be the names of their natives.  This reopens the use of any
word for the user to throw and catch without worrying about stepping on
something the system is doing.