### PR TITLE
Add CONTINUE/WITH, modify BREAK/WITH, cleanup

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -61,7 +61,7 @@ break: native [
 	{Breaks out of a loop, while, until, repeat, for-each, etc.}
 	/with {Forces the loop function to return a value}
 	value [any-value!]
-	/return {(deprecated synonym for /WITH)}
+	/return {(deprecated: mostly /WITH synonym, use THROW+CATCH if not)}
 	return-value [any-value!]
 ]
 
@@ -104,6 +104,8 @@ context: native [
 
 continue: native [
 	{Throws control back to top of loop.}
+	/with {Act as if loop body finished current evaluation with a value}
+	value [any-value!]
 ]
 
 ;dir?: native [

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -151,6 +151,7 @@ options: context [  ; Options supplied to REBOL during startup
 	no-switch-fallthrough: false
 	forever-64-bit-ints: false
 	print-forms-everything: false
+	break-with-overrides: false
 ]
 
 script: context [

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -763,10 +763,13 @@ was_caught:
 **
 ***********************************************************************/
 {
-	*D_OUT = *ROOT_CONTINUE_NATIVE;
-	CONVERT_NAME_TO_THROWN(D_OUT, UNSET_VALUE);
+	REBVAL *value = D_REF(1) ? D_ARG(2) : UNSET_VALUE;
 
-	return R_OUT;
+	*D_OUT = *ROOT_CONTINUE_NATIVE;
+
+	CONVERT_NAME_TO_THROWN(D_OUT, value);
+
+	return R_OUT_IS_THROWN;
 }
 
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1164,6 +1164,7 @@ struct Reb_Call;
 // this enumerated type containing its legal values).
 enum {
 	R_OUT = 0,
+	R_OUT_IS_THROWN = R_OUT, // can be synonym if per-value THROWN bit is kept
 	R_NONE,
 	R_UNSET,
 	R_TRUE,

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -224,6 +224,7 @@ set 'r3-legacy* func [] [
 	system/options/no-switch-fallthrough: true
 	system/options/forever-64-bit-ints: true
 	system/options/print-forms-everything: true
+	system/options/break-with-overrides: true
 
 	; False is already the default for this switch
 	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)


### PR DESCRIPTION
This commit adds a /WITH refinement to CONTINUE, such that it
will skip the rest of the loop body but still act like it had returned the
value it is passed:

    >> map-each x [1 2 3] [continue/with 4 "foo"]
    == [4 4 4]

This also reconciles the behavior of /WITH for BREAK in a similar
way, so that it will effectively make the body return that value for the
last iteration.  This leads to a concrete difference from /RETURN
which did not have the intention (and would not make sense to put
onto continue).

For more explanation and why /RETURN is not being kept around
(instead suggesting people use CATCH+THROW), see porting guide:

https://trello.com/c/cOgdiOAD

An `<r3-legacy>` switch is added for making /WITH act with the old
behavior of /RETURN, which is used as a synonym...however the
two behaviors cannot be left running concurrently.  Roughly speaking
this means that if there are any BREAK/WITHs inside of MAP-EACH
in the mezzanine then it would break legacy mode.  There aren't
any (yet) so that's not being treated as priority.

This also includes some reorganization and cleaning of the loop
constructs.  That was part of a global audit of THROWN() boundaries
that triggered the observation behind this change.