### PR TITLE
Codebase-wide THROWN() audit, plus checks

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -172,7 +172,7 @@ static	BOOT_BLK *Boot_Block;
 	if (rebind > 1) Bind_Values_Deep(BLK_HEAD(block), Sys_Context);
 
 	if (Do_Block_Throws(&result, block, 0))
-		panic Error_0(RE_MISC);
+		panic Error_No_Catch_For_Throw(&result);
 
 	if (!IS_UNSET(&result))
 		panic Error_0(RE_MISC);
@@ -397,7 +397,7 @@ static	BOOT_BLK *Boot_Block;
 
 	if (Do_Block_Throws(&evaluated, VAL_SERIES(spec), 0)) {
 		*D_OUT = evaluated;
-		return R_OUT;
+		return R_OUT_IS_THROWN;
 	}
 
 	// On success, return the object (common case)
@@ -627,7 +627,7 @@ static	BOOT_BLK *Boot_Block;
 
 	// Evaluate the block (will eval FRAMEs within):
 	if (Do_Block_Throws(&result, VAL_SERIES(&Boot_Block->sysobj), 0))
-		panic Error_0(RE_MISC);
+		panic Error_No_Catch_For_Throw(&result);
 
 	// Expects UNSET! by convention
 	if (!IS_UNSET(&result))

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -380,7 +380,7 @@
 
 /***********************************************************************
 **
-*/	REBOOL Make_Error_Object_Throws(REBVAL *out, REBVAL *arg)
+*/	REBFLG Make_Error_Object_Throws(REBVAL *out, REBVAL *arg)
 /*
 **		Creates an error object from arg and puts it in value.
 **		The arg can be a string or an object body block.

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -351,8 +351,8 @@
 	}
 
 	if (Redo_Func_Throws(actor)) {
-		// No special handling needed, as we are just going to return
-		// the output value in D_OUT anyway.
+		// The throw name will be in D_OUT, with thrown value in task vars
+		return R_OUT_IS_THROWN;
 	}
 
 	return R_OUT;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -542,9 +542,6 @@ static void Propagate_All_GC_Marks(void);
 	// when an `if (Do_XXX_Throws())` branch was taken and when the throw
 	// should have been caught up the stack (before any more calls made).
 	//
-	// !!! Is it worth causing a panic on this in particular in the
-	// release build?  Odds are things will get more corrupt and crash.
-	//
 	assert(!THROWN(val));
 
 	switch (VAL_TYPE(val)) {

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -137,7 +137,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 			i = index;
 			index = Do_Next_May_Throw(D_OUT, block, index);
 
-			if (index == THROWN_FLAG) return R_OUT;
+			if (index == THROWN_FLAG) return R_OUT_IS_THROWN;
 
 			if (IS_CONDITIONAL_FALSE(D_OUT)) {
 				// !!! Only copies 3 values (and flaky), see CC#2231

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -630,6 +630,8 @@ skip_hidden: ;
 		return R_OUT;
 
 	case LOOP_EVERY:
+		if (threw) return R_OUT_IS_THROWN;
+
 		// Result is the cumulative TRUE? state of all the input (with any
 		// unsets taken out of the consideration).  The last TRUE? input
 		// if all valid and NONE! otherwise.  (Like ALL.)  If the loop

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -133,7 +133,7 @@ static struct digest {
 
 	while (index != END_FLAG) {
 		index = Do_Next_May_Throw(D_OUT, block, index);
-		if (index == THROWN_FLAG) return R_OUT;
+		if (index == THROWN_FLAG) return R_OUT_IS_THROWN;
 		Mold_Value(&mo, D_OUT, 0);
 	}
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -73,7 +73,7 @@
 		CONVERT_NAME_TO_THROWN(D_OUT, UNSET_VALUE);
 	}
 
-	return R_OUT;
+	return R_OUT_IS_THROWN;
 }
 
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -713,7 +713,15 @@ is_none:
 			if (pvs->setval && IS_PAIR(pvs->store)) {
 				REBVAL *sel = pvs->select;
 				pvs->value = pvs->store;
-				Next_Path(pvs); // sets value in pvs->store
+
+				if (Next_Path_Throws(pvs)) { // sets value in pvs->store
+
+					// !!! Gob and Struct do "sub-dispatch" which may throw
+					// No "PE_THREW" return, however.  (should there be?)
+
+					raise Error_No_Catch_For_Throw(pvs->store);
+				}
+
 				Set_GOB_Var(gob, sel, pvs->store); // write it back to gob
 			}
 			return PE_USE;

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -331,7 +331,7 @@ static REBSER *Trim_Object(REBSER *obj)
 
 					// GC-OK
 					if (Do_Block_Throws(D_OUT, VAL_SERIES(arg), 0))
-						return R_OUT;
+						return R_OUT_IS_THROWN;
 
 					break; // returns obj
 				}
@@ -367,7 +367,8 @@ static REBSER *Trim_Object(REBSER *obj)
 			if (type == REB_ERROR) {
 				// arg is block/string, returns value
 				if (Make_Error_Object_Throws(value, arg)) {
-					// going to return it anyway, no special handling needed
+					*D_OUT = *value;
+					return R_OUT_IS_THROWN;
 				}
 				type = 0;
 				break; // returns value
@@ -414,7 +415,8 @@ static REBSER *Trim_Object(REBSER *obj)
 				Bind_Values_Deep(VAL_BLK_DATA(arg), obj);
 
 				// GC-OK
-				if (Do_Block_Throws(D_OUT, VAL_SERIES(arg), 0)) return R_OUT;
+				if (Do_Block_Throws(D_OUT, VAL_SERIES(arg), 0))
+					return R_OUT_IS_THROWN;
 
 				break; // returns obj
 			}
@@ -435,7 +437,8 @@ static REBSER *Trim_Object(REBSER *obj)
 			if (type == REB_ERROR) {
 				// arg is block/string, returns value
 				if (Make_Error_Object_Throws(value, arg)) {
-					// going to return it anyway, no special handling needed
+					*D_OUT = *value;
+					return R_OUT_IS_THROWN;
 				}
 				type = 0; // type already set
 				break; // returns value

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1327,7 +1327,7 @@ bad_end:
 		}
 
 		// All other throws should just bubble up uncaught.
-		return R_OUT;
+		return R_OUT_IS_THROWN;
 	}
 
 	assert(IS_TRASH(D_OUT));


### PR DESCRIPTION
Rebol has two methods of interrupting control: errors and throws.
The error mechanism makes use of setjmp/longjmp and must be
explicitly caught by certain stack levels, but a thrown value can be
passed back as a return value from any call into the evaluator and
needs to have some kind of handling at each evaluator call site...
either to catch it, to bubble it up through the next return result, or
to raise an error on it.

Despite the importance of each call into the evaluator having
explicit handling for throws, there was a tendency in the original code
to often forget to handle it.  It has been an ongoing process to give
routines names (like XXX_Throws()) to signal that the caller must
be responsible for triaging a throw.

The elimination of the "parse longjmp hack" facilitated the addition of
more checks, and a further realization that the "thrown bit" could even
be moved off of values and fully as a property of the stack.  This goes
through each instance of throwing and vets it.  While many bugs where
potential throws/returns/quits have been found over time, this catches
many more.

A potentially temporary tool of having natives and actions return a flag
when they are throwing a value or passing it on would be able to
replace the idea of carrying thrown bits on values themselves.  This is
generally desirable, because putting a thrown bit on the value makes it
easy to get lost if not checked.  But other mechanisms may arise that
are less manual and still not costly, so it may be that this is not kept in
the long term.