### PR TITLE
Unsets "no vote" for ALL and ANY, won't return them

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -30,12 +30,12 @@ also: native [
 ]
 
 all: native [
-	{Shortcut AND. Evaluates and returns at the first FALSE or NONE.}
+	{Shortcut AND. Returns NONE vs. TRUE (or last evaluation if it was TRUE?)}
 	block [block!] {Block of expressions}
 ]
 
 any: native [
-	{Shortcut OR. Evaluates and returns the first value that is not FALSE or NONE.}
+	{Shortcut OR, ignores unsets. Returns the first TRUE? result, or NONE.}
 	block [block!] {Block of expressions}
 ]
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -823,11 +823,13 @@ struct Reb_Position
 // Conditional truth and falsehood allows an interpretation where a NONE! is
 // a FALSE value.  These macros (like many others in the codebase) capture
 // their parameters multiple times, so multiple evaluations can happen!
+//
+// Unsets are neither conditionally true nor conditionally false.
 
 #define IS_CONDITIONAL_FALSE(v) \
 	(IS_NONE(v) || (IS_LOGIC(v) && !VAL_LOGIC(v)))
 #define IS_CONDITIONAL_TRUE(v) \
-	!IS_CONDITIONAL_FALSE(v)
+	(!IS_UNSET(v) && !IS_CONDITIONAL_FALSE(v))
 
 
 /***********************************************************************


### PR DESCRIPTION
This change makes ANY and ALL safer to use generically in places
that expect to use the value, such as IF ANY ... or UNLESS ALL ...
Summary on the porting guide:

https://trello.com/c/wyXCkx67/