### PR TITLE
#2219 UNSET of an unbound word gives an error

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -114,7 +114,7 @@ Script: [
 	type: "script error"
 	no-value:           [:arg1 {has no value}]
 	need-value:         [:arg1 {needs a value}]
-	not-defined:        [:arg1 {word is not bound to a context}]
+	not-bound:          [:arg1 {word is not bound to a context}]
 	no-relative:        [:arg1 {word is bound relative to context not on stack}]
 	not-in-context:     [:arg1 {is not in the specified context}]
 

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -599,7 +599,7 @@ type-of: native [
 
 unset: native [
 	{Unsets the value of a word (in its current context.)}
-	word [word! block!] {Word or block of words}
+	word [any-word! block!] {Word or block of words}
 ]
 
 utf?: native [

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1307,7 +1307,7 @@
 		return NULL; // is this a case where we should *always* trap?
 	}
 
-	if (trap) raise Error_1(RE_NOT_DEFINED, word);
+	if (trap) raise Error_1(RE_NOT_BOUND, word);
 	return NULL;
 }
 
@@ -1382,7 +1382,7 @@
 		return;
 	}
 
-	raise Error_1(RE_NOT_DEFINED, word);
+	raise Error_1(RE_NOT_BOUND, word);
 }
 
 
@@ -1400,7 +1400,7 @@
 
 	assert(!THROWN(value));
 
-	if (!HAS_FRAME(word)) raise Error_1(RE_NOT_DEFINED, word);
+	if (!HAS_FRAME(word)) raise Error_1(RE_NOT_BOUND, word);
 
 	assert(VAL_WORD_FRAME(word));
 //  Print("Set %s to %s [frame: %x idx: %d]", Get_Word_Name(word), Get_Type_Name(value), VAL_WORD_FRAME(word), VAL_WORD_INDEX(word));
@@ -1426,7 +1426,7 @@
 	call = DSF;
 	while (VAL_WORD_FRAME(word) != VAL_WORD_FRAME(DSF_LABEL(call))) {
 		call = PRIOR_DSF(call);
-		if (!call) raise Error_1(RE_NOT_DEFINED, word); // change error !!!
+		if (!call) raise Error_1(RE_NO_RELATIVE, word);
 	}
 
 	assert(

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -528,7 +528,7 @@ err:
 	if (ANY_WORD(val)) {
 		if (VAL_WORD_INDEX(val) < 0) return R_TRUE;
 		frm = VAL_WORD_FRAME(val);
-		if (!frm) raise Error_1(RE_NOT_DEFINED, val);
+		if (!frm) raise Error_1(RE_NOT_BOUND, val);
 	}
 	else frm = VAL_OBJ_FRAME(D_ARG(1));
 


### PR DESCRIPTION
Previously `unset unbind 'foo` would silently return an unset instead
of notifying you.  It was silent about other errors as well, e.g. you could
write unset [1 2 3] and not alert you.  You could also not unset other word
types (you can with SET if they are bound).

This adds in the missing errors and allows you to unset other word types.
It also renames the "unbound" error message constant to being not-bound
instead of the vaguer "not-defined"