### PR TITLE
Default IF, WHILE, EVERY to unsets, x: () legal

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -121,10 +121,10 @@ continue: native [
 
 do: native [
 	{Evaluates a block of source code (directly or fetched according to type)}
-	;source [none! block! paren! string! binary! url! file! tag!]
+	;source [unset! none! block! paren! string! binary! url! file! tag!]
 	; !!! Actually does not handle ERROR! or ANY-FUNCTION! but temporarily
 	; accepts them to trigger more informataive errors suggesting FAIL and EVAL
-	source [none! block! paren! string! binary! url! file! tag! error! any-function!]
+	source [unset! none! block! paren! string! binary! url! file! tag! error! any-function!]
 	/args "If value is a script, this will set its system/script/args"
 	arg   "Args passed to a script (normally a string)"
 	/next "Do next expression only, return it, update block variable"

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -152,6 +152,8 @@ options: context [  ; Options supplied to REBOL during startup
 	forever-64-bit-ints: false
 	print-forms-everything: false
 	break-with-overrides: false
+	none-instead-of-unsets: false
+	cant-unset-set-words: false
 ]
 
 script: context [

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -236,6 +236,19 @@ struct Reb_Datatype {
 #define	SET_NONE(v)		VAL_SET(v, REB_NONE)
 #define NONE_VALUE		ROOT_NONE_VAL
 
+// In legacy mode we still support the old convention that an IF that does
+// not take its branch or a WHILE loop that never runs its body return a NONE!
+// value instead of an UNSET!.  To track the locations where this decision is
+// made more easily, SET_UNSET_UNLESS_LEGACY_NONE() is used.
+//
+#ifdef NDEBUG
+	#define	SET_UNSET_UNLESS_LEGACY_NONE(v) \
+		SET_UNSET(v)
+#else
+	#define SET_UNSET_UNLESS_LEGACY_NONE(v) \
+		(LEGACY(OPTIONS_NONE_INSTEAD_OF_UNSETS) ? SET_NONE(v) : SET_UNSET(v))
+#endif
+
 #define EMPTY_BLOCK		ROOT_EMPTY_BLOCK
 #define EMPTY_SERIES	VAL_SERIES(ROOT_EMPTY_BLOCK)
 

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -155,7 +155,9 @@ file-type?: func [
 	"Return the identifying word for a specific file type (or NONE)."
 	file [file! url!]
 ][
-	if file: find find system/options/file-types suffix? file word! [first file]
+	relax if file: find find system/options/file-types suffix? file word! [
+		first file
+	]
 ]
 
 split-path: func [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -234,6 +234,8 @@ set 'r3-legacy* func [] [
 	system/options/forever-64-bit-ints: true
 	system/options/print-forms-everything: true
 	system/options/break-with-overrides: true
+	system/options/none-instead-of-unsets: true
+	system/options/cant-unset-set-words: true
 
 	; False is already the default for this switch
 	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -115,7 +115,7 @@ math: function/with [
 		:pre-uop :post-uop :prim-val
 	]
 
-	res: if parse expr expression [expr-val]
+	res: either parse expr expression [expr-val] [none]
 
 	set [
 		expr-val expr-op term-val term-op power-val unary-val

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -575,7 +575,7 @@ load-module: function [
 				ver0 > modver [ ; and it's newer, use it instead
 					mod: none  set [hdr code] mod0
 					modver: ver0  modsum: sum0
-					ext: if object? code [code] ; delayed extension
+					ext: all [(object? code) code] ; delayed extension
 					override?: not delay  ; stays delayed if /delay
 				]
 			]

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -112,7 +112,7 @@ finish-rl-start: func [
 		do-arg  block!
 		debug   block!
 		secure  word!
-		import  [if import [to-rebol-file import]]
+		import  [relax if import [to-rebol-file import]]
 		version tuple!
 	][
 		set opt attempt either block? act [act][

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -84,7 +84,7 @@ load-until-blank: function [
 
 	rebol-value: parsing-at x [
 		res: any [attempt [load-next x] []]
-		if not empty? res [second res]
+		either empty? res [none] [second res]
 	]
 
 	terminator: [opt wsp newline opt wsp newline]
@@ -94,9 +94,11 @@ load-until-blank: function [
 		opt wsp opt [1 2 newline] position: to end
 	]
 
-	if parse text rule [
+	either parse text rule [
 		values: load copy/part text position
 		reduce [values position]
+	][
+		none
 	]
 ]
 
@@ -154,17 +156,21 @@ proto-parser: context [
 		doubleslashed-lines: [copy lines some ["//" thru newline]]
 
 		is-format2015-intro: parsing-at position [
-			if all [
+			either all [
 				lines: attempt [decode-lines lines {//} { }]
 				data: load-until-blank lines
 				data: attempt [
-					if set-word? first data/1 [
+					either set-word? first data/1 [
 						notes.post: data/2
 						data/1
+					][
+						none
 					]
 				]
 			] [
 				position ; Success.
+			][
+				none
 			]
 		]
 


### PR DESCRIPTION
**WARNING** this change can cause subtle bugs in previous
patterns of the form:

    all [1 (if 1 > 2 [3]) 4]

While ALL always considered unsets a method for "opting out" of
the vote and not causing a test to fail, failing IF's NONE *would*
cause a test to fail.  New patterns of thinking a condition failing means
a 'void' or absence of data instead of a chainable "falsity" is a cool
interpretation--and worth the change systemically.  However, such
code will need to be ported to something more like:

    all [1 all [(1 > 2) 3] 4]

Or even more elegantly flattened to:

    all [1 (1 > 2) 3 4]

The option to switch to EITHER with NONE also exists, or to
experiment with the new RELAX native.

`<r3-legacy>` has the added switches:

    none-instead-of-unsets: false
    cant-unset-set-words: false