### PR TITLE
FUNC + CLOS => native, non-head spec/body, cleanups

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -83,6 +83,12 @@ catch: native [
 	handler [block! any-function!] {If FUNCTION!, spec matches [value name]}
 ]
 
+clos: native [
+	{Defines a closure function.}
+	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
+	body [block!] {The body block of the function}
+]
+
 comment: native [
 	{Ignores the argument value and returns nothing (no evaluations performed).}
 	:value [block! any-string! any-scalar!] {Literal value to be ignored.}
@@ -200,6 +206,12 @@ forskip: native [
 	size [integer! decimal!] "Number of positions to skip each time"
 	body [block!] "Block to evaluate each time"
 	/local orig result
+]
+
+func: native [
+	{Defines a user function with given spec and body.}
+	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
+	body [block!] {The body block of the function}
 ]
 
 halt: native [

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1682,7 +1682,7 @@ return_index:
 		// empty block just to provide something in the slot
 		// !!! Could use more sophisticated backtracing in general
 
-		block = EMPTY_SERIES;
+		block = EMPTY_ARRAY;
 		index = 0;
 	}
 

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -87,7 +87,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Bitset(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Bitset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -70,16 +70,16 @@ static void No_Nones(REBVAL *arg) {
 
 /***********************************************************************
 **
-*/	REBFLG MT_Array(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Array(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 **	"Make Type" dispatcher for the following subtypes:
 **
-**		MT_Block(REBVAL *out, REBVAL *data, REBCNT type)
-**		MT_Paren(REBVAL *out, REBVAL *data, REBCNT type)
-**		MT_Path(REBVAL *out, REBVAL *data, REBCNT type)
-**		MT_Set_Path(REBVAL *out, REBVAL *data, REBCNT type)
-**		MT_Get_Path(REBVAL *out, REBVAL *data, REBCNT type)
-**		MT_Lit_Path(REBVAL *out, REBVAL *data, REBCNT type)
+**		MT_Block
+**		MT_Paren
+**		MT_Path
+**		MT_Set_Path
+**		MT_Get_Path
+**		MT_Lit_Path
 **
 ***********************************************************************/
 {

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -43,15 +43,16 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Datatype(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Datatype(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {
+	REBCNT sym;
 	if (!IS_WORD(data)) return FALSE;
-	type = VAL_WORD_CANON(data);
-	if (type > REB_MAX) return FALSE;
+	sym = VAL_WORD_CANON(data);
+	if (sym > REB_MAX) return FALSE;
 	VAL_SET(out, REB_DATATYPE);
-	VAL_TYPE_KIND(out) = cast(enum Reb_Kind, type - 1);
+	VAL_TYPE_KIND(out) = KIND_FROM_SYM(sym);
 	VAL_TYPE_SPEC(out) = 0;
 	return TRUE;
 }

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -414,7 +414,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Date(REBVAL *val, REBVAL *arg, REBCNT type)
+*/	REBFLG MT_Date(REBVAL *val, REBVAL *arg, enum Reb_Kind type)
 /*
 **		Given a block of values, construct a date datatype.
 **

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -113,7 +113,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 
 /***********************************************************************
 **
-*/  REBFLG MT_Decimal(REBVAL *out, REBVAL *data, REBCNT type)
+*/  REBFLG MT_Decimal(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -351,7 +351,7 @@ is_none:
 
 /***********************************************************************
 **
-*/	REBFLG MT_Event(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Event(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -679,7 +679,7 @@ is_none:
 
 /***********************************************************************
 **
-*/	REBFLG MT_Gob(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Gob(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -55,7 +55,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Image(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Image(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -50,7 +50,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Logic(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Logic(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -359,7 +359,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Map(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Map(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {
@@ -535,7 +535,7 @@
 	case A_TO:
 		// make map! [word val word val]
 		if (IS_BLOCK(arg) || IS_PAREN(arg) || IS_MAP(arg)) {
-			if (MT_Map(D_OUT, arg, 0)) return R_OUT;
+			if (MT_Map(D_OUT, arg, REB_MAP)) return R_OUT;
 			raise Error_Invalid_Arg(arg);
 //		} else if (IS_NONE(arg)) {
 //			n = 3; // just a start
@@ -553,7 +553,7 @@
 		break;
 
 	case A_COPY:
-		if (MT_Map(D_OUT, val, 0)) return R_OUT;
+		if (MT_Map(D_OUT, val, REB_MAP)) return R_OUT;
 		raise Error_Invalid_Arg(val);
 
 	case A_CLEAR:

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -42,7 +42,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_None(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_None(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -240,7 +240,7 @@ static REBSER *Trim_Object(REBSER *obj)
 
 /***********************************************************************
 **
-*/	REBFLG MT_Object(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Object(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -48,7 +48,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Pair(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Pair(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -43,7 +43,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Port(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Port(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1030,7 +1030,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 
 /***********************************************************************
 **
-*/	REBFLG MT_Routine(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ** format:
 ** make routine! [[

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -281,7 +281,7 @@ static REBSER *make_binary(REBVAL *arg, REBOOL make)
 
 /***********************************************************************
 **
-*/	REBFLG MT_String(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_String(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -634,7 +634,7 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 
 /***********************************************************************
 **
-*/	REBFLG MT_Struct(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
  * Format:
  * make struct! [

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -247,7 +247,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Time(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Time(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -46,7 +46,7 @@
 
 /***********************************************************************
 **
-*/	REBFLG MT_Tuple(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Tuple(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -177,7 +177,7 @@ const struct {
 
 /***********************************************************************
 **
-*/	REBFLG MT_Typeset(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Typeset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -437,7 +437,7 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 
 /***********************************************************************
 **
-*/	REBFLG MT_Vector(REBVAL *out, REBVAL *data, REBCNT type)
+*/	REBFLG MT_Vector(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 /*
 ***********************************************************************/
 {

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -250,7 +250,7 @@ struct Reb_Datatype {
 #endif
 
 #define EMPTY_BLOCK		ROOT_EMPTY_BLOCK
-#define EMPTY_SERIES	VAL_SERIES(ROOT_EMPTY_BLOCK)
+#define EMPTY_ARRAY		VAL_SERIES(ROOT_EMPTY_BLOCK)
 
 #define VAL_INT32(v)	(REBINT)((v)->data.integer)
 #define VAL_INT64(v)	((v)->data.integer)

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -24,7 +24,7 @@ binary-to-infix: func [
 ][
 	; SPEC-OF isn't defined yet at this point in the boot...
 	func (
-		insert (reflect :value 'spec) <infix>
+		head insert (reflect :value 'spec) <infix>
 	)(
 		; WORDS-OF isn't defined either...
 		compose [

--- a/src/mezz/mezz-func.r
+++ b/src/mezz/mezz-func.r
@@ -11,15 +11,9 @@ REBOL [
 	}
 ]
 
-clos: func [
-	{Defines a closure function.}
-	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
-	body [block!] {The body block of the function}
-][
-	make closure! copy/deep reduce [spec body]
-]
 
 closure: func [
+	; !!! Should have a unified constructor with FUNCTION
 	{Defines a closure function with all set-words as locals.}
 	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
 	body [block!] {The body block of the function}
@@ -27,18 +21,22 @@ closure: func [
 	object [object! block! map!] {The object or spec}
 	/extern words [block!] {These words are not local}
 ][
-	; Copy the spec and add /local to the end if not found
-	unless find spec: copy/deep spec /local [append spec [
+	; Copy the spec and add /local to the end if not found (no deep copy needed)
+	unless find spec: copy spec /local [append spec [
 		/local ; In a block so the generated source gets the newlines
 	]]
-	; Make a full copy of the body, to allow reuse of the original
-	body: copy/deep body
+
 	; Collect all set-words in the body as words to be used as locals, and add
 	; them to the spec. Don't include the words already in the spec or object.
 	insert find/tail spec /local collect-words/deep/set/ignore body either with [
 		; Make our own local object if a premade one is not provided
 		unless object? object [object: make object! object]
+
+		; Make a full copy of the body, to allow reuse of the original
+		body: copy/deep body
+
 		bind body object  ; Bind any object words found in the body
+
 		; Ignore the words in the spec and those in the object. The spec needs
 		; to be copied since the object words shouldn't be added to the locals.
 		append append append copy spec 'self words-of object words ; ignore 'self too
@@ -46,15 +44,8 @@ closure: func [
 		; Don't include the words in the spec, or any extern words.
 		either extern [append copy spec words] [spec]
 	]
-	make closure! reduce [spec body]
-]
 
-has: func [
-	{A shortcut to define a function that has local variables but no arguments.}
-	vars [block!] {List of words that are local to the function}
-	body [block!] {The body block of the function}
-][
-	make function! reduce [head insert copy/deep vars /local copy/deep body]
+	clos spec body
 ]
 
 map: func [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -214,6 +214,18 @@ try: func [
 ]
 
 
+; HAS is targeted for use to be the arity-1 parallel to OBJECT as arity-2,
+; (similar to the relationship between DOES and FUNCTION).
+;
+has: func [
+	{A shortcut to define a function that has local variables but no arguments.}
+	vars [block!] {List of words that are local to the function}
+	body [block!] {The body block of the function}
+][
+	func (head insert copy vars /local) body
+]
+
+
 ; To invoke this function, use `do <r3-legacy>` instead of calling it
 ; directly, as that will be a no-op in older Rebols.  Notice the word
 ; is defined in sys-base.r, as it needs to be visible pre-Mezzanine

--- a/src/mezz/mezz-tail.r
+++ b/src/mezz/mezz-tail.r
@@ -11,13 +11,4 @@ REBOL [
 	}
 ]
 
-funco: :func ; save it for expert usage
-
-; Final FUNC definition:
-func: funco [
-	{Defines a user function with given spec and body.}
-	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
-	body [block!] {The body block of the function}
-][
-	make function! copy/deep reduce [spec body] ; (now it deep copies)
-]
+;-- used to finalize the definition of FUNC, now native


### PR DESCRIPTION
This makes FUNC and CLOS natives, and does a thorough refactor
of the creation mechanics.  The overall improvements lead to a speed
increase of about 60% in optimized builds in func or clos creation.

(Note: The motivation was not to increase the speed, rather to mitigate
what would be an impending slowdown in speed for definitional return if
the two were not made native.)

It corrects a bug by which regardless of the series position passed in
for the spec or body components in a MAKE FUNCTION! call, the series
would be used at their head.  This involves taking out the "optimization"
of not copying the series used in MAKE FUNCTION! .  Because FUNC
is targeting the addition of a definitional RETURN that will *not* be
provided by MAKE FUNCTION! (which will only have non-definitional
EXIT), calling FUNC is the go-to way of ensuring that the generated call
will have RETURN available vs. writing it oneself in the generator.

Because the copying nature of the primitive means user code cannot
get access to modify a body or spec while running, an additional
optimization is made that empty spec or body series are not copied but
rather usages of a single global empty series.  (Hence DOES need not
copy its spec block from `func [] body`.

The factoring to make the natives "clean" involved splitting out the
REB_COMMAND code better.  Additional documentation notes are in
the comments about definitional returns and the nature of COMMAND!.
The changes make the code *significantly* clearer.