### PR TITLE
Definitional Returns. Solved.

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -44,5 +44,14 @@ quit-native
 return-native
 exit-native
 
+;; The FUNC and CLOS function generators are native code, and quick access
+;; to a value preloaded with /LOCAL and RETURN is clearer and likely faster.
+;; Also [/local return] would be a common spec block for anything that
+;; started with an empty spec, so create just one copy of that.
+
+local-refinement
+return-word
+local-return-block
+
 boot			; boot block defined in boot.r (GC'd after boot is done)
 

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -167,6 +167,24 @@ script: context [
 
 standard: context [
 
+	; FUNC+CLOS implement a native-optimized variant of a function generator.
+	; This is the body template that it provides as the code *equivalent* of
+	; what it is doing (via a more specialized/internal method).  Though
+	; the only "real" body stored and used is the one the user provided
+	; (substituted in $1), this template is used to "lie" when asked what
+	; the BODY-OF the function is.
+	;
+	; (The substitution location is hardcoded at index 6 in the block.  It
+	; does not "scan" to find $1...just asserts the position is MONEY!)
+	;
+	func-body: [
+		return: make function! [
+			[{Returns a value from a function.} value [any-value!]]
+			[throw/name value bind-of 'return]
+		]
+		catch/name $1 bind-of 'return
+	]
+
 	error: context [ ; Template used for all errors:
 		code: 0
 		type: 'user

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -118,6 +118,7 @@ quit
 ;break ;-- covered by parse below
 ;return ;-- covered by parse below
 continue
+local ;-- needed by "fake" definitional return (FUNC, CLOS natives)
 
 ; Parse: - These words must not reserved above!!
 parse

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -527,6 +527,19 @@ static	BOOT_BLK *Boot_Block;
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_EMPTY_BLOCK), SER_PROT);
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_EMPTY_BLOCK), SER_LOCK);
 
+	// Used by FUNC and CLOS generators: /LOCAL and RETURN
+	Val_Init_Word_Unbound(ROOT_LOCAL_REFINEMENT, REB_REFINEMENT, SYM_LOCAL);
+	Val_Init_Word_Unbound(ROOT_RETURN_WORD, REB_WORD, SYM_RETURN);
+
+	// Make a series that's just [/local return], that is made often
+	// in function spec blocks (when the original spec was just []) and
+	// doesn't need unique mutable identity
+	Val_Init_Block(ROOT_LOCAL_RETURN_BLOCK, Make_Array(2));
+	Append_Value(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), ROOT_LOCAL_REFINEMENT);
+	Append_Value(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), ROOT_RETURN_WORD);
+	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), SER_PROT);
+	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), SER_LOCK);
+
 	// We can't actually put a REB_END value in the middle of a block,
 	// so we poke this one into a program global
 	SET_END(&PG_End_Val);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -699,6 +699,26 @@
 #endif
 
 
+
+/***********************************************************************
+**
+*/	ATTRIBUTE_NO_RETURN void Error_Bad_Func_Def(const REBVAL *spec, const REBVAL *body)
+/*
+***********************************************************************/
+{
+	// !!! Improve this error; it's simply a direct emulation of arity-1
+	// error that existed before refactoring code out of MT_Function().
+
+	REBVAL def;
+	REBSER *series = Make_Array(2);
+	Append_Value(series, spec);
+	Append_Value(series, body);
+	Val_Init_Block(&def, series);
+
+	Error_1(RE_BAD_FUNC_DEF, &def);
+}
+
+
 /***********************************************************************
 **
 */	ATTRIBUTE_NO_RETURN void Error_No_Arg(const REBVAL *label, const REBVAL *key)

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -467,6 +467,11 @@ typedef REBYTE *(INFO_FUNC)(REBINT opts, void *lib);
 	VAL_SET(out, REB_COMMAND); // clears exts and opts in header...
 	VAL_EXTS_DATA(out) = func_exts; // ...so we set this after that point
 
+	// Put the command REBVAL in slot 0 so that REB_COMMAND, like other
+	// function types, can find the function value from the paramlist.
+
+	*BLK_HEAD(VAL_FUNC_PARAMLIST(out)) = *out;
+
 	return;
 
 bad_func_def:

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1170,19 +1170,20 @@ was_caught:
 **
 */	REBNATIVE(return)
 /*
-**	The implementation of RETURN here is a simple THROWN() value and
-**	has no "definitional scoping".  It will be the only way to return
-**	from a MAKE FUNCTION! which has not defined a local specific
-**	definitional return.
+**	There is a RETURN native defined, and its native function spec is
+**	utilized to create the appropriate help and calling protocol
+**	information for values that have overridden its VAL_FUNC_CODE
+**	slot with a VAL_FUNC_RETURN_TO spec.
+**
+**	However: this native is unset and its actual code body should
+**	never be able to be called.  The non-definitional return construct
+**	that people should use if they need it would be EXIT and EXIT/WITH
 **
 ***********************************************************************/
 {
-	REBVAL *arg = D_ARG(1);
+	panic Error_0(RE_MISC);
 
-	*D_OUT = *ROOT_RETURN_NATIVE;
-	CONVERT_NAME_TO_THROWN(D_OUT, arg);
-
-	return R_OUT_IS_THROWN;
+	return R_NONE;
 }
 
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -285,8 +285,36 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 	REBVAL *word = D_ARG(1);
 
 	if (!HAS_FRAME(word)) return R_NONE;
-	if (VAL_WORD_INDEX(word) < 0) return R_TRUE;
-	Val_Init_Object(D_OUT, VAL_WORD_FRAME(word));
+
+	if (VAL_WORD_INDEX(word) < 0) {
+		// Function frames use negative numbers to indicate they are
+		// "stack relative" bindings.  Hence there is no way to get
+		// their value if the function is not running.  (This is why
+		// if you leak a local word to your caller and they look it
+		// up they get an error).
+		//
+		// Historically there was nothing you could do with a function
+		// word frame.  But then slot 0 (which had been unused, as the
+		// params start at 1) was converted to hold the value of the
+		// function the params belong to.  This returns that stored value.
+
+		*D_OUT = *BLK_HEAD(VAL_WORD_FRAME(word));
+
+		// You should never get a way to a stack relative binding of a
+		// closure.  They make an object on each call.
+
+		assert(IS_FUNCTION(D_OUT));
+	}
+	else {
+		// It's just an object.  Note that if objects were adapted to use
+		// the same technique (they will be) then it would be possible to
+		// get a "full value"-sized objects (if an object were not entirely
+		// recoverable from a series value alone, which for instance a
+		// MODULE! would not be.)
+
+		Val_Init_Object(D_OUT, VAL_WORD_FRAME(word));
+	}
+
 	return R_OUT;
 }
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -794,8 +794,18 @@ static void Mold_Function(const REBVAL *value, REB_MOLD *mold)
 
 	Mold_Block_Series(mold, VAL_FUNC_SPEC(value), 0, 0); //// & ~(1<<MOPT_MOLD_ALL)); // Never literalize it (/all).
 
-	if (IS_FUNCTION(value) || IS_CLOSURE(value))
-		Mold_Block_Series(mold, VAL_FUNC_BODY(value), 0, 0);
+	if (IS_FUNCTION(value) || IS_CLOSURE(value)) {
+		// MOLD is an example of user-facing code that needs to be complicit
+		// in the "lie" about the effective bodies of the functions made
+		// by the optimized generators FUNC and CLOS...
+
+		REBFLG is_fake;
+		REBSER *body = Get_Maybe_Fake_Func_Body(&is_fake, value);
+
+		Mold_Block_Series(mold, body, 0, 0);
+
+		if (is_fake) Free_Series(body); // was shallow copy
+	}
 
 	Append_Codepoint_Raw(mold->series, ']');
 	End_Mold(mold);

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -158,13 +158,13 @@ series?: :any-series?
 ;
 any-type!: :any-value!
 
-; !!! These have not been renamed yet, because of questions over what they
-; actually return.  CONTEXT-OF was a candidate, however the current behavior
-; of just returning TRUE from BIND? when the word is linked to a function
-; arg or local is being reconsidered to perhaps return the function, and to
-; be able to use functions as targets for BIND as well.  So binding-of might
-; be the better name, or bind-of as it's shorter.
+; !!! BIND? and BOUND? will have to go, but it's not clear exactly if
+; BIND-OF or CONTEXT-OF or what is the right term.  So a mass renaming
+; effort has not been undertaken, especially given the number of bootstrap
+; references.  When the new name final decision comes, then BIND? and BOUND?
+; will be the ones with their home in the legacy module...
 
+bind-of: :bound?
 ;bind?
 ;bound?
 


### PR DESCRIPTION
You heard it here first.  The console says it all... ;-P

    >> foo: func [x] [return x 20]
    == make function! [[x /local return][
        return: make function! [
            ["Returns a value from a function." value [any-value!]]
            [throw/name value bind-of 'return]
        ]
        catch/name [
            return x 20
        ] bind-of 'return
    ]]

    >> foo 10
    == 10

If you do not wish to have your function bind or provide a definitional return use
`<transparent>`:

    >> bar: func [<transparent> y] [return y 304]
    == make function! [[y][return y 304]]

    >> bar 1020
    ** User error: {RETURN called--but no function generator providing it in use}

...of course, the console does NOT tell the whole story.  The code may not either
but there are a lot of comments.  Blog posts and videos forthcoming.

Happy Halloween 2015... and Ren/C'ing is Ren/beliving...