### PR TITLE
Remove wasted transparents, COLLECT beautify

### DIFF
--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -84,7 +84,6 @@ use: func [
 ]
 
 object: func [
-	<transparent>
 	{Defines a unique object.}
 	blk [block!] {Object words and values (modified)}
 ][
@@ -92,7 +91,6 @@ object: func [
 ]
 
 module: func [
-	<transparent>
 	"Creates a new module."
 	spec [block!] "The header block of the module (modified)"
 	body [block!] "The body block of the module (modified)"

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -24,7 +24,6 @@ launch: func [
 ]
 
 wrap: func [
-	<transparent>
 	"Evaluates a block, wrapping all set-words as locals."
 	body [block!] "Block to evaluate"
 ][

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -12,7 +12,6 @@ REBOL [
 ]
 
 dt: delta-time: function [
-	<transparent>
 	{Delta-time - returns the time it takes to evaluate the block.}
 	block [block!]
 ][
@@ -22,7 +21,6 @@ dt: delta-time: function [
 ]
 
 dp: delta-profile: func [
-	<transparent>
 	{Delta-profile of running a specific block.}
 	block [block!]
 	/local start end

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -204,7 +204,6 @@ opt: :optional
 ; time...so TRY is left to linger without needing `do <r3-legacy>`
 ;
 try: func [
-	<transparent>
 	{Tries to DO a block and returns its value or an error.}
 	block [block!]
 	/except "On exception, evaluate this code block"

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -156,7 +156,6 @@ do*: function [
 ]
 
 make-module*: func [
-	<transparent>
 	"SYS: Called by system on MAKE of MODULE! datatype."
 	spec [block!] "As [spec-block body-block opt-mixins-object]"
 	/local body obj mixins hidden w


### PR DESCRIPTION
The original implementation of `<transparent>` was fairly trivial, and it
often marked cases of functions that would **do code** where the code
passed in was foreign.  So they weren't where the buck stopped with
a return, rather it would continue to the caller.

*That usage* of transparent is no longer interesting or necessary...a
passed in RETURN living inside of CODE knows its binding and where
to go.  But there are cases where <transparent> is actually needed, for
instance where instead of DO-ing foreign code you are using that code
as the body of a function as part of your implementation.

Two good case studies of this are USE and COLLECT.  And COLLECT
is such a good case study of the Zen of language extension using Rebol
that now that it's working, I wanted to clean it all the way up.  But there is
an issue in keeping `<r3-legacy>` mode working if it's changed, due to
a nuance interfering with the trick that usually lets "I want TRUE
refinements" vs. "I want WORD-valued refinements" live in peace.  :-/

But rather than just accept that I went ahead and made the code itself
conditional so that the real example could be read, not intermingled with
the ugly stuff.  Even with the APPLY and no definitional returns, "getting"
the original was one of my main inspirations for the pursuit of fixing the
missing system pieces to get it to its near-final (if not final) form...