### PR TITLE
SET-WORD! in func spec are "true locals", permit RETURN:

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -45,13 +45,13 @@ return-native
 exit-native
 
 ;; The FUNC and CLOS function generators are native code, and quick access
-;; to a value preloaded with /LOCAL and RETURN is clearer and likely faster.
-;; Also [/local return] would be a common spec block for anything that
-;; started with an empty spec, so create just one copy of that.
+;; to a block containing [RETURN:] is useful to share across all of the
+;; instances of functions like those created by DOES.  Having a filled
+;; REBVAL of the word alone saves a call to Val_Init_Word_Unbound with
+;; the symbol as well.
 
-local-refinement
-return-word
-local-return-block
+return-set-word
+return-block
 
 boot			; boot block defined in boot.r (GC'd after boot is done)
 

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -180,7 +180,7 @@ standard: context [
 	func-body: [
 		return: make function! [
 			[{Returns a value from a function.} value [any-value!]]
-			[throw/name value bind-of 'return]
+			[throw/name :value bind-of 'return]
 		]
 		catch/name $1 bind-of 'return
 	]

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -118,7 +118,6 @@ quit
 ;break ;-- covered by parse below
 ;return ;-- covered by parse below
 continue
-local ;-- needed by "fake" definitional return (FUNC, CLOS natives)
 
 ; Parse: - These words must not reserved above!!
 parse

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -527,18 +527,17 @@ static	BOOT_BLK *Boot_Block;
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_EMPTY_BLOCK), SER_PROT);
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_EMPTY_BLOCK), SER_LOCK);
 
-	// Used by FUNC and CLOS generators: /LOCAL and RETURN
-	Val_Init_Word_Unbound(ROOT_LOCAL_REFINEMENT, REB_REFINEMENT, SYM_LOCAL);
-	Val_Init_Word_Unbound(ROOT_RETURN_WORD, REB_WORD, SYM_RETURN);
+	// Used by FUNC and CLOS generators: RETURN:
+	Val_Init_Word_Unbound(ROOT_RETURN_SET_WORD, REB_SET_WORD, SYM_RETURN);
 
-	// Make a series that's just [/local return], that is made often
-	// in function spec blocks (when the original spec was just []) and
-	// doesn't need unique mutable identity
-	Val_Init_Block(ROOT_LOCAL_RETURN_BLOCK, Make_Array(2));
-	Append_Value(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), ROOT_LOCAL_REFINEMENT);
-	Append_Value(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), ROOT_RETURN_WORD);
-	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), SER_PROT);
-	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_RETURN_BLOCK), SER_LOCK);
+	// Make a series that's just [return:], that is made often in function
+	// spec blocks (when the original spec was just []).  Unlike the paramlist
+	// a function spec doesn't need unique mutable identity, so a shared
+	// series saves on allocation time and space...
+	Val_Init_Block(ROOT_RETURN_BLOCK, Make_Array(1));
+	Append_Value(VAL_SERIES(ROOT_RETURN_BLOCK), ROOT_RETURN_SET_WORD);
+	SERIES_SET_FLAG(VAL_SERIES(ROOT_RETURN_BLOCK), SER_PROT);
+	SERIES_SET_FLAG(VAL_SERIES(ROOT_RETURN_BLOCK), SER_LOCK);
 
 	// We can't actually put a REB_END value in the middle of a block,
 	// so we poke this one into a program global

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -272,8 +272,7 @@
 			if (has_return) {
 				REBVAL *param = VAL_FUNC_PARAM(func, var_index + 1);
 				if (
-					!VAL_GET_EXT(param, EXT_TYPESET_QUOTE)
-					&& VAL_GET_EXT(param, EXT_TYPESET_EVALUATE)
+					VAL_GET_EXT(param, EXT_WORD_HIDE)
 					&& SAME_SYM(VAL_TYPESET_SYM(param), SYM_RETURN)
 				) {
 					// We use the (hidden from the public) RETURN native's


### PR DESCRIPTION
While implementing the native FUNC and CLOS generators and
needing to work with adding locals, it became apparent that finding
and managing the relationship with /LOCAL was unnecessary overhead.
It also brought another instance of a "special" word into the system...
at the same time it was ensuring RETURN was not special.

(For the record, there was no SYM_LOCAL reference internally prior
to the definitional return work...so it had to introduce it.)

With definitional returns finished, this takes a step back on that and adds
a more useful feature.  SET-WORD! in function specs are "true locals".
This means that they will be bound and will be in the function frame, but
will be invisible to and un-injectable by the outside world.  They will not
appear in WORDS-OF or other outside inspections.

*(Note: By saying that they "are true locals" this is to say that is the way 
that they will behave as far as a pure MAKE FUNCTION! is concerned.  A
generator similar to FUNC or any other non-function-making-looking-thing
can pre-process and give them entirely different meaning before passing
down to MAKE FUNCTION!.  --This is an important point.--)*

There are no rules on where in the function spec a true local appears...
it is skipped when arguments are being gathered.  This makes it useful
for function generators that wish to add words but do not want to worry
about the position.

By convention, users may prefer to continue using /local...and there are
good reasons to do so if one is not a generator.  For instance: if you are
defining one function inside another, you may not want to burden your
frame with locals because a function you defined is using set-words.

This lines up with Red's choice to use RETURN: for function in the
sense that a RETURN: is not a signal disabling definitional return, and
it is planned that a leading block in a spec before any ordinary words
will count as a return typeset.  So **foo: func [return: [integer!] ...] [...]**
can idiomatically be a way of writing function specs, even though Ren/C
effectively considers the return: to be documentation (you could spell it
wrong and it would just give you another local by that name, as well as
a proper definitional return.