### PR TITLE
SPELLING-OF as native function

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -597,6 +597,11 @@ set: native [
 	/pad {For objects, if block is too short, remaining words are set to NONE}
 ]
 
+spelling-of: native [
+	{Gives the delimiter-less spelling of words or strings}
+	value [any-word! any-string!]
+]
+
 to-hex: native [
 	{Converts numeric value to a hex issue! datatype (with leading # and 0's).}
 	value [integer! tuple!] {Value to be converted}

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -133,6 +133,39 @@ static struct digest {
 
 /***********************************************************************
 **
+*/	REBNATIVE(spelling_of)
+/*
+**	This is a native implementation of SPELLING-OF from rebol-proposals.
+**
+***********************************************************************/
+{
+	REBVAL * const value = D_ARG(1);
+	REBSER *series;
+
+	// Shouldn't take binary types...
+	assert(!IS_BINARY(value));
+
+	if (ANY_BINSTR(value)) {
+		// Grab the data out of all string types, which has no delimiters
+		// included (they are added in the forming process)
+
+		series = Copy_String(VAL_SERIES(value), VAL_INDEX(value), -1);
+	}
+	else {
+		// turn all words into regular words so they'll have no delimiters
+		// during the FORMing process
+
+		VAL_SET(value, REB_WORD);
+		series = Copy_Mold_Value(value, TRUE);
+	}
+
+	Val_Init_String(D_OUT, series);
+	return R_OUT;
+}
+
+
+/***********************************************************************
+**
 */	REBNATIVE(checksum)
 /*
 **		Computes checksum or hash value.


### PR DESCRIPTION
This adds the SPELLING-OF native from the rebol-proposals repository.
It works on ANY-STRING! or ANY-WORD!, and extracts the "pre-formed"
string data from them:

    >> spelling-of <abc>
    "abc"

    >> spelling-of quote def:
    "def"

    >> spelling-of "ghi"
    "ghi"

Very easy to write as a native, somewhat harder to engineer from outside
the system (especially as Rebol2 would to-string on a SET-WORD! as
the spelling, while R3-Alpha had the delimiter...)