### PR TITLE
Second thoughts - back out datatype/word equality, GROUP/PAREN

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -144,7 +144,6 @@ options: context [  ; Options supplied to REBOL during startup
 	exit-functions-only: false
 	broken-case-semantics: false
 	do-runs-functions: false
-	datatype-word-strict: false
 	group-not-paren: false ;; bias the default to PAREN! vs GROUP! (for now...)
 	refinements-true: false
 	no-switch-evals: false

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -144,7 +144,6 @@ options: context [  ; Options supplied to REBOL during startup
 	exit-functions-only: false
 	broken-case-semantics: false
 	do-runs-functions: false
-	group-not-paren: false ;; bias the default to PAREN! vs GROUP! (for now...)
 	refinements-true: false
 	no-switch-evals: false
 	no-switch-fallthrough: false

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -35,8 +35,6 @@ datatypes
 ; this list is applied, so you only see typesets in this file.
 ;-----------------------------------------------------------------------------
 
-group! ;-- replacement for paren! type (incubating as normal word for now)
-
 native
 self
 none

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -287,7 +287,7 @@ enum {SINE, COSINE, TANGENT};
 
 /***********************************************************************
 **
-*/	REBOOL Compare_Modify_Values(REBVAL *a, REBVAL *b, REBINT strictness)
+*/	REBINT Compare_Modify_Values(REBVAL *a, REBVAL *b, REBINT strictness)
 /*
 **		Compare 2 values depending on level of strictness.  It leans
 **		upon the per-type comparison functions (that have a more typical
@@ -356,32 +356,6 @@ enum {SINE, COSINE, TANGENT};
 			}
 			break;
 
-		case REB_DATATYPE:
-			if (ANY_WORD(b)) {
-				// Let DATATYPE! compare as a word: `(type-of 3) = 'integer!`
-				REBCNT sym = VAL_TYPE_SYM(a); // save before modify
-
-			#if !defined(NDEBUG)
-				if (LEGACY(OPTIONS_DATATYPE_WORD_STRICT)) break;
-			#endif
-
-			#if !defined(NDEBUG)
-				if (
-					LEGACY(OPTIONS_GROUP_NOT_PAREN)
-					&& VAL_WORD_SYM(b) == SYM_GROUPX
-					&& VAL_TYPE_KIND(a) == REB_PAREN
-				) {
-					// If comparing PAREN! datatype to GROUP! word, mutate
-					// the fake word made from datatype to have group symbol
-					sym = SYM_GROUPX;
-				}
-			#endif
-
-				Val_Init_Word_Unbound(a, REB_WORD, sym);
-				goto compare;
-			}
-			break;
-
 		case REB_WORD:
 		case REB_SET_WORD:
 		case REB_GET_WORD:
@@ -389,30 +363,6 @@ enum {SINE, COSINE, TANGENT};
 		case REB_REFINEMENT:
 		case REB_ISSUE:
 			if (ANY_WORD(b)) goto compare;
-
-			if (IS_DATATYPE(b)) {
-				// Let DATATYPE! compare as a word: `(type-of 3) = 'integer!`
-				REBCNT sym = VAL_TYPE_SYM(b); // save before modify
-
-			#if !defined(NDEBUG)
-				if (LEGACY(OPTIONS_DATATYPE_WORD_STRICT)) break;
-			#endif
-
-			#if !defined(NDEBUG)
-				if (
-					LEGACY(OPTIONS_GROUP_NOT_PAREN)
-					&& VAL_WORD_SYM(a) == SYM_GROUPX
-					&& VAL_TYPE_KIND(b) == REB_PAREN
-				) {
-					// If comparing PAREN! datatype to GROUP! word, mutate
-					// the fake word made from datatype to have group symbol
-					sym = SYM_GROUPX;
-				}
-			#endif
-
-				Val_Init_Word_Unbound(b, REB_WORD, sym);
-				goto compare;
-			}
 			break;
 
 		case REB_STRING:
@@ -434,7 +384,7 @@ compare:
 	if (!(code = Compare_Types[VAL_TYPE(a)])) return FALSE;
 	result = code(a, b, strictness);
 	if (result < 0) raise Error_2(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b));
-	return result ? TRUE : FALSE;
+	return result;
 }
 
 

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -105,17 +105,6 @@
 			//return R_NONE;
 			raise Error_Bad_Make(kind, arg);
 		}
-
-		#if !defined(NDEBUG)
-			if (
-				LEGACY(OPTIONS_GROUP_NOT_PAREN)
-				&& IS_WORD(arg)
-				&& VAL_WORD_SYM(arg) == SYM_GROUPX
-			) {
-				VAL_WORD_SYM(arg) = SYM_FROM_KIND(REB_PAREN);
-			}
-		#endif
-
 		// if (IS_NONE(arg)) return R_NONE;
 		if (MT_Datatype(D_OUT, arg, REB_DATATYPE))
 			break;

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -95,16 +95,6 @@
 			}
 			else if (IS_DATATYPE(arg)) {
 				sym = VAL_TYPE_SYM(arg);
-
-			#if !defined(NDEBUG)
-				if (
-					LEGACY(OPTIONS_GROUP_NOT_PAREN)
-					&& VAL_TYPE_KIND(arg) == REB_PAREN
-				) {
-					// Override the symbol to return GROUP! instead of PAREN!
-					sym = SYM_GROUPX;
-				}
-			#endif
 			}
 			else if (IS_LOGIC(arg)) {
 				sym = VAL_LOGIC(arg) ? SYM_TRUE : SYM_FALSE;

--- a/src/mezz/base-constants.r
+++ b/src/mezz/base-constants.r
@@ -67,11 +67,18 @@ rebol.com: http://www.rebol.com
 ; evaluator (where "BLOCK! blocks evaluation of the contents, the GROUP!
 ; does normal evaluation but limits it to the group)...
 ;
-; There are some ways to bridge compatibility between GROUP! and PAREN!, but
-; since it's a big change the burden to bear in initial tests will be on
-; GROUP!.  So the datatype stays PAREN! by default with a special switch to
-; turn group on.  This will give an opportunity to try out the synonym
-; mechanisms on the new idea before a radical change on the old one.
+; Historically, changing the name of a type was especially burdensome because
+; the name would be encoded when you did a TO-WORD on it, such as in order
+; to perform a SWITCH.  (Rebol2 added TYPE?/WORD to make this convenient.)
+; There was an attempt to make GROUP! a "hacked" internal synonym for purposes
+; of comparison, but the real problem was realized to be SWITCH's inability
+; to evaluate.  Once you could `switch type-of x [:integer! [...]]` and have
+; the get-word fetch whatever integer was bound to, it opened the doors
+; for type synonyms and removed the need for hacks.
+;
+; It is still a question of what WORD! will own the concept, and what the
+; datatype will look like when it is molded out, but that can wait.  For now,
+; the word is the historical PAREN! but GROUP! is a synonym.
 
 group?: :paren?
 group!: :paren!

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -247,11 +247,6 @@ set 'r3-legacy* func [] [
 	system/options/none-instead-of-unsets: true
 	system/options/cant-unset-set-words: true
 
-	; False is already the default for this switch
-	; (e.g. `to-word type-of quote ()` is the word PAREN! and not GROUP!)
-	;
-	system/options/group-not-paren: false
-
 	append system/contexts/user compose [
 
 		and: (:and*)

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -238,7 +238,6 @@ set 'r3-legacy* func [] [
 	system/options/do-runs-functions: true
 	system/options/broken-case-semantics: true
 	system/options/exit-functions-only: true
-	system/options/datatype-word-strict: true
 	system/options/refinements-true: true
 	system/options/no-switch-evals: true
 	system/options/no-switch-fallthrough: true


### PR DESCRIPTION
These commits reverse the feature addition of the ability to compare datatypes and words as non-strict equal, e.g. `type-of 3 = 'integer!`.  That feature suggested mostly to support matches in switch:

    switch type-of 3 [
         integer! [print "people wanted this to print"]
         ....
    ]

That sort-of-hackish change is probably just asking for trouble, especially considering that an improvement to switch makes it possible to get *any* type synonym to work:

    switch type-of 3 [
         :integer! [print "get-word will evaluate..."]
         (first reduce [integer! string!]) [print "parens will evaluate too..."]
    ]

With this available, hacking up the core with some equality hacks seems misguided.

This also removes a word equivalence hack for the word GROUP! and the word PAREN! for the same reason... if evaluation is used, then any type synonym you like is available.