### PR TITLE
Fix case-sensitivity in string sort, support unicode, #2170

### DIFF
--- a/src/core/f-qsort.c
+++ b/src/core/f-qsort.c
@@ -2,6 +2,24 @@
  * https://raw.github.com/android/platform_bionic/master/libc/upstream-freebsd/lib/libc/stdlib/qsort.c
  */
 
+
+// "The qsort_r() function is identical to qsort() except that the comparison
+// function takes a third argument. A pointer is passed to the comparison
+// function via [thunk]. In this way, the comparison function does not
+// need to use global variables to pass through arbitrary arguments, and
+// is therefore reentrant and safe to use in threads."
+//
+// This file can declare either qsort or qsort_r, and we'd like the latter.
+// Note that `qsort_r` is part of no portability standard, and this version
+// (used by Android) puts the "thunk" as the next to last parameter instead
+// of the last one.  :-/
+//
+#define I_AM_QSORT_R
+
+// When qsort_r is defined, it will actually wind up being named reb_qsort_r.
+#define qsort_r reb_qsort_r
+
+
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -41,8 +59,6 @@ __FBSDID("$FreeBSD$");
 */
 
 #include <stdlib.h>
-
-#define qsort reb_qsort
 
 #ifdef I_AM_QSORT_R
 typedef int		 cmp_t(void *, const void *, const void *);

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -30,11 +30,6 @@
 #include "sys-core.h"
 
 
-// !!! Should there be a qsort header so we don't redefine it here?
-typedef int cmp_t(const void *, const void *);
-extern void reb_qsort(void *a, size_t n, size_t es, cmp_t *cmp);
-
-
 /***********************************************************************
 **
 */	REBINT CT_Array(REBVAL *a, REBVAL *b, REBINT mode)
@@ -298,7 +293,7 @@ static struct {
 
 /***********************************************************************
 **
-*/	static int Compare_Val(const void *v1, const void *v2)
+*/	static int Compare_Val(void *thunk, const void *v1, const void *v2)
 /*
 ***********************************************************************/
 {
@@ -328,7 +323,7 @@ static struct {
 
 /***********************************************************************
 **
-*/	static int Compare_Call(const void *v1, const void *v2)
+*/	static int Compare_Call(void *thunk, const void *v1, const void *v2)
 /*
 ***********************************************************************/
 {
@@ -429,9 +424,9 @@ static struct {
 	if (skip > 1) len /= skip, size *= skip;
 
 	if (sort_flags.compare)
-		reb_qsort(VAL_BLK_DATA(block), len, size, Compare_Call);
+		reb_qsort_r(VAL_BLK_DATA(block), len, size, NULL, Compare_Call);
 	else
-		reb_qsort(VAL_BLK_DATA(block), len, size, Compare_Val);
+		reb_qsort_r(VAL_BLK_DATA(block), len, size, NULL, Compare_Val);
 
 }
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -71,6 +71,11 @@
 // Local includes:
 #include "reb-c.h"
 
+// !!! Is there a more ideal location for these prototypes?
+typedef int cmp_t(void *, const void *, const void *);
+extern void reb_qsort_r(void *a, size_t n, size_t es, void *thunk, cmp_t *cmp);
+
+
 // Must be defined at the end of reb-c.h, but not *in* reb-c.h so that
 // files including sys-core.h and reb-host.h can have differing
 // definitions of REBCHR.  (We want it opaque to the core, but the


### PR DESCRIPTION
(Completion of lingering incomplete fix from September 13, 2014 that had
died as a PR to GitHub rebol/rebol...being cleaned out during prep for source
code format conversion.)

In Rebol2:

    >> sort "ABCabcdefDEF"
    == "AaBbCcdDeEfF"

    >> sort/case "ABCabcdefDEF"
    == "ABCDEFabcdef"

In R3-Alpha:

    >> sort "ABCabcdefDEF"
    == "ABCDEFabcdef"

This fixes the behavior to be consistent with Rebol2.  It also adds support
for unicode characters, which were being "randomly" compared based on one
of their bytes.

To reduce the number of comparison functions that would have to be written
and avoid the use of global state, this imported the qsort_r implementation of
the quicksort instead of qsort.  (Fun fact: qsort_r() is not part of any standard...
so the parameter orders vary.  Rebol builds in the same version used by
Android Bionic.)