### PR TITLE
Allow ANY-STRING! and ANY-BLOCK! types in set ops

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -495,8 +495,8 @@ delect: native [
 
 difference: native [
 	{Returns the special difference of two values.}
-	set1 [block! string! binary! bitset! date! typeset!] "First data set"
-	set2 [block! string! binary! bitset! date! typeset!] "Second data set"
+	set1 [any-array! any-string! binary! bitset! date! typeset!] "First data set"
+	set2 [any-array! any-string! binary! bitset! date! typeset!] "Second data set"
 	/case {Uses case-sensitive comparison}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]
@@ -504,8 +504,8 @@ difference: native [
 
 exclude: native [
 	{Returns the first data set less the second data set.}
-	set1 [block! string! binary! bitset! typeset!] "First data set"
-	set2 [block! string! binary! bitset! typeset!] "Second data set"
+	set1 [any-array! any-string! binary! bitset! typeset!] "First data set"
+	set2 [any-array! any-string! binary! bitset! typeset!] "Second data set"
 	/case {Uses case-sensitive comparison}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]
@@ -513,8 +513,8 @@ exclude: native [
 
 intersect: native [
 	{Returns the intersection of two data sets.}
-	set1 [block! string! binary! bitset! typeset!] "first set"
-	set2 [block! string! binary! bitset! typeset!] "second set"
+	set1 [any-array! any-string! binary! bitset! typeset!] "first set"
+	set2 [any-array! any-string! binary! bitset! typeset!] "second set"
 	/case {Uses case-sensitive comparison}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]
@@ -522,8 +522,8 @@ intersect: native [
 
 union: native [
 	{Returns the union of two data sets.}
-	set1 [block! string! binary! bitset! typeset!] "first set"
-	set2 [block! string! binary! bitset! typeset!] "second set"
+	set1 [any-array! any-string! binary! bitset! typeset!] "first set"
+	set2 [any-array! any-string! binary! bitset! typeset!] "second set"
 	/case {Use case-sensitive comparison}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]
@@ -531,7 +531,7 @@ union: native [
 
 unique: native [
 	{Returns the data set with duplicates removed.}
-	set1 [block! string! binary! bitset! typeset!]
+	set1 [any-array! any-string! binary! bitset! typeset!]
 	/case  {Use case-sensitive comparison (except bitsets)}
 	/skip {Treat the series as records of fixed size}
 	size [integer!]

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -331,7 +331,7 @@ static REBCNT *CRC_Table;
 
 /***********************************************************************
 **
-*/	REBSER *Hash_Block(REBVAL *block, REBCNT cased)
+*/	REBSER *Hash_Block(const REBVAL *block, REBCNT cased)
 /*
 **		Hash ALL values of a block. Return hash array series.
 **		Used for SET logic (unique, union, etc.)


### PR DESCRIPTION
Previously the set operations would only allow BLOCK! and STRING!.
This makes it possible to use any two ANY-STRING! or ANY-BLOCK!
types together on set operations:

    >> exclude quote (a b c d e) 'd/e/f/d/e
    == (a b c)

    >> intersect <abcde> "defde"
    == <de>

The result type will be the type of the first parameter.

(This was the by-product of a reorganization to try and locate a bug in the
series termination logic, and was easy enough to do after that was found.)