### PR TITLE
Add <local> tag to FUNC + CLOS, move <infix>

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -29,10 +29,12 @@ unset-val		; a value of type UNSET!
 empty-block		; a value that is an empty BLOCK!
 noname			; noname function word
 
-;; Tags used in function specs
+;; Tags used in the native-optimized versions of user-function-generators
+;; FUNC and CLOS
 
 transparent-tag	; func w/o definitional return, ignores non-definitional ones
 infix-tag		; func is treated as "infix" (first parameter comes before it)
+local-tag		; marks the beginning of a list of "pure locals"
 
 ;; Natives needed as values by the system for throw names (they use their
 ;; own function values as names, to be agnostic about words)

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -177,7 +177,7 @@ standard: context [
 	; or #BODY, just asserts the positions are ISSUE!.
 	;
 	func-body: [
-		comment {Optimized, but acts "as if" the boilerplate code were there.}
+		comment {boilerplate is equivalent user code (simulated, optimized)}
 		return: make #TYPE [
 			[{Returns a value from a function.} value [any-value!]]
 			[throw/name :value bind-of 'return]

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1123,6 +1123,7 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 
 	const REBYTE transparent[] = "transparent";
 	const REBYTE infix[] = "infix";
+	const REBYTE local[] = "local";
 
 	DOUT("Main init");
 
@@ -1210,7 +1211,13 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	SET_UNSET(&Callback_Error);
 	PG_Boot_Phase = BOOT_ERRORS;
 
-	// We need these values around to compare to the tags we find in function
+	// Although the goal is for the core not to depend on any specific
+	// "keywords", there are some native-optimized generators that are not
+	// conceptually "part of the core".  Hence, they rely on some keywords,
+	// but a dissatisfied user could rewrite them with different ones
+	// (at only a cost in performance).
+	//
+	// We need these tags around to compare to the tags we find in function
 	// specs.  There may be a better place to put them or a better way to do
 	// it, but it didn't seem there was a "compare UTF8 byte array to
 	// arbitrary decoded REB_TAG which may or may not be REBUNI" routine.
@@ -1228,6 +1235,13 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	);
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_INFIX_TAG), SER_LOCK);
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_INFIX_TAG), SER_PROT);
+
+	Val_Init_Tag(
+		ROOT_LOCAL_TAG,
+		Append_UTF8(NULL, local, LEN_BYTES(local))
+	);
+	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_TAG), SER_LOCK);
+	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_TAG), SER_PROT);
 
 	// Special pre-made errors:
 	Val_Init_Error(TASK_STACK_ERROR, Make_Error(RE_STACK_OVERFLOW, NULL));

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -849,6 +849,8 @@ reevaluate:
 				// really put it wherever is convenient--no position rule.
 				//
 				// So just skip over it and go on to the next.
+				//
+				// Note: set-word conversion is is how FUNC implements <local>
 			}
 			else if (VAL_GET_EXT(param, EXT_TYPESET_QUOTE)) {
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -416,8 +416,6 @@ typedef REBYTE *(INFO_FUNC)(REBINT opts, void *lib);
 **
 ***********************************************************************/
 {
-	REBYTE func_exts; // extended bits for function value header
-
 	if (!IS_MODULE(extension) && !IS_OBJECT(extension)) goto bad_func_def;
 
 	// Check that handle and extension are somewhat valid (not used)
@@ -438,7 +436,7 @@ typedef REBYTE *(INFO_FUNC)(REBINT opts, void *lib);
 	VAL_FUNC_SPEC(out) =
 		Copy_Array_At_Deep_Managed(VAL_SERIES(spec), VAL_INDEX(spec));
 
-	VAL_FUNC_PARAMLIST(out) = Check_Func_Spec(VAL_FUNC_SPEC(spec), &func_exts);
+	VAL_FUNC_PARAMLIST(out) = Check_Func_Spec(VAL_FUNC_SPEC(spec));
 
 	// Make sure the command doesn't use any types for which an "RXT" parallel
 	// datatype (to a REB_XXX type) has not been published:
@@ -465,7 +463,6 @@ typedef REBYTE *(INFO_FUNC)(REBINT opts, void *lib);
 	MANAGE_SERIES(VAL_FUNC_BODY(out));
 
 	VAL_SET(out, REB_COMMAND); // clears exts and opts in header...
-	VAL_EXTS_DATA(out) = func_exts; // ...so we set this after that point
 
 	// Put the command REBVAL in slot 0 so that REB_COMMAND, like other
 	// function types, can find the function value from the paramlist.

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -265,7 +265,15 @@ dump-obj: function [
 	prin "USAGE:^/^-"
 
 	args: words-of :value
+
+	; !!! Historically, HELP would not show anything that happens after a
+	; /local.  The way it did this was to clear everything after /local
+	; in the WORDS-OF list.  But with the <local> tag, *the locals do
+	; not show up in the WORDS-OF list* because the FUNC generator
+	; converted them all
+	;
 	clear find args /local
+
 	either infix? :value [
 		print [args/1 word args/2]
 	][


### PR DESCRIPTION
With "Pure Local" generation offered via set-words, it has the problem of
being a bit "undifferentiated-looking":

    foo: func [date [date!] out: d1: d2:][
        out: [0 0]
        set [d1 d2] get-iso-year out/2: date/year

vs.

    foo: func [date [date!] /local out d1 d2][
        out: [0 0]
        set [d1 d2] get-iso-year out/2: date/year

The advantage of "pure locals" is that they aren't shown by WORDS-OF
and cannot be injected (e.g. by calling foo/local).  But the refinement lets
you use regular words and looks a little bit "less like code".

This modifies the FUNC generator to use the <local> tag as a cue to
convert WORD! following it into SET-WORD!, up to the next refinement.  It
will ignore any pure locals (set-words), and error on other kinds of words
(e.g. `<local> 'x #y :z`).  The appearance is better, and it gives "keyword-like
behavior" from a construct implementable entirely in userspace.

    foo: func [date [date!] <local> out d1 d2][
        out: [0 0]
        set [d1 d2] get-iso-year out/2: date/year

This also moves `<infix>` out of MAKE FUNCTION!.  It will probably not wind
up staying in FUNC either, but it definitely will not be a built in keyword  This also
makes MAKE FUNCTION! allow the generators to leave any ANY-STRING in the
spec that it wants (as an experiment)... to save the generators the trouble of
having to remove them.