### PR TITLE
Evaluate parens in refinement dispatch, ~10% speedup

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -145,7 +145,7 @@ Script: [
 
 	no-refine:          [:arg1 {has no refinement called} :arg2]
 	bad-refines:        {incompatible or invalid refinements}
-	bad-refine:         [{incompatible refinement:} :arg1]
+	bad-refine:         [{incompatible or duplicate refinement:} :arg1]
 	invalid-path:       [{cannot access} :arg2 {in path} :arg1]
 	bad-path-type:      [{path} :arg1 {is not valid for} :arg2 {type}]
 	bad-path-set:       [{cannot set} :arg2 {in path} :arg1]

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1443,7 +1443,7 @@
 
 	// Find relative value:
 	call = DSF;
-	while (VAL_WORD_FRAME(word) != VAL_WORD_FRAME(DSF_LABEL(call))) {
+	while (VAL_WORD_FRAME(word) != VAL_FUNC_PARAMLIST(DSF_FUNC(call))) {
 		call = PRIOR_DSF(call);
 		if (!call) raise Error_1(RE_NO_RELATIVE, word);
 	}

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -242,58 +242,26 @@
 			&call->label, REB_WORD, SYM_FROM_KIND(VAL_TYPE(func))
 		);
 	}
-	else {
+	else
 		call->label = *label;
-	}
-	// !!! Not sure why this is needed; seems the label word should be unbound
-	// if anything...
-	VAL_WORD_FRAME(&call->label) = VAL_FUNC_PARAMLIST(func);
+
 	assert(IS_WORD(DSF_LABEL(call)));
 
-	// Fill call frame's args with default of NONE!.  Have to do this in
-	// advance because refinement filling often skips around; if you have
-	// 'foo: func [/bar a /baz b] [...]' and you call foo/baz, it will jump
-	// ahead to process positions 3 and 4, then determine there are no more
-	// refinements, and not revisit slots 1 and 2.
-	//
-	// It's also necessary because the slots must be GC-safe values, in case
-	// there is a Recycle() during argument fulfillment.
-
-	// !!! The underlying loop could be made more efficient, but there are
-	// some changes to the way that path evaluation is done that should make
-	// it possible to finesse it so that arguments do not need to be
-	// initialized in advance.
-
 	call->num_vars = num_vars;
+
+	// Make_Call does not fill the args in the frame--that is up to Do_Core
+	// and Apply_Block to do as they go along.  But the frame has to survive
+	// Recycle() during arg fulfillment...slots can't be left uninitialized.
+	// Set to UNSET in the release build, but "GC safe" trash in the debug
+	// build to help catch skipped slots that aren't written intentionally.
 	{
-		REBFLG has_return = VAL_GET_EXT(func, EXT_FUNC_HAS_RETURN);
 		REBCNT var_index;
 		for (var_index = 0; var_index < num_vars; var_index++) {
-			if (has_return) {
-				REBVAL *param = VAL_FUNC_PARAM(func, var_index + 1);
-				if (
-					VAL_GET_EXT(param, EXT_WORD_HIDE)
-					&& SAME_SYM(VAL_TYPESET_SYM(param), SYM_RETURN)
-				) {
-					// We use the (hidden from the public) RETURN native's
-					// function value to give the definitional return its
-					// prototype, but overwrite its code pointer to hold the
-					// paramlist of the target.
-
-					call->vars[var_index] = *ROOT_RETURN_NATIVE;
-					VAL_FUNC_RETURN_TO(&call->vars[var_index]) = (
-						VAL_FUNC_PARAMLIST(func)
-					);
-
-					// Do_Native_Throws() sees when someone tries to execute
-					// one of these "native returns" and instead interprets it
-					// as a THROW whose /NAME is the function value.  The
-					// paramlist has that value (it's the REBVAL in slot #0)
-					continue;
-				}
-			}
-
-			SET_NONE(&call->vars[var_index]);
+		#ifdef NDEBUG
+			SET_UNSET(&call->vars[var_index]);
+		#else
+			SET_TRASH_SAFE(&call->vars[var_index]);
+		#endif
 		}
 	}
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1336,8 +1336,14 @@ struct Reb_Function {
 #define VAL_FUNC_ACT(v)       ((v)->data.func.func.act)
 #define VAL_FUNC_INFO(v)      ((v)->data.func.func.info)
 
-// An EXT_FUNC_HAS_RETURN function overwrites REBNATIVE(return)'s
-// VAL_FUNC_CODE with the identifying series or frame it wants to return to.
+// EXT_FUNC_HAS_RETURN functions use the RETURN native's function value to give
+// the definitional return its prototype, but overwrite its code pointer to
+// hold the paramlist of the target.
+//
+// Do_Native_Throws() sees when someone tries to execute one of these "native
+// returns"...and instead interprets it as a THROW whose /NAME is the function
+// value.  The paramlist has that value (it's the REBVAL in slot #0)
+//
 #define VAL_FUNC_RETURN_TO(v) VAL_FUNC_BODY(v)
 
 typedef struct Reb_Path_Value {


### PR DESCRIPTION
The previous semi-hack of an evaluation trick so that get-words would
evaluate in paths has been upgraded to a much less hacky trick.  This
now allows for the evaluation of parens to also be used to get the words
to use as refinements in dispatch:

    >> append/(first [only])/(to-word "dup") [a b c] [d e] 2
    == [a b c [d e] [d e]]

The method by which this is done--as well as reducing the number of
writes done into call frames--has improved performance in a build of
the hostilefork.com using the static builder by 10%.  This means Ren/C
optimized non-debug builds are--for the first time--ever so slightly
faster than the rebolsource download (in that measurement).