### PR TITLE
Eval_Table skips unnecessary evals, ~6% (?) speedup

### DIFF
--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -22,6 +22,9 @@ REBOL [
 		path		- it supports various path forms (* for same as typeclass)
 		make		- It can be made with #[datatype] method
 		typesets	- what typesets the type belongs to
+
+		If the (CLASS) is in a paren that means it has evaluator behavior,
+		vs. being passed through as-is.  (e.g. a lit-word is "evaluative")
 	}
 ]
 
@@ -60,12 +63,12 @@ image       image       +		+       *		*		[series]
 vector      vector      -		-       *		*		[series]
 
 block       array       *		f*      *		*		[series array]
-paren       array       *		f*      *		*		[series array]
+paren       (array)      *		f*      *		*		[series array]
 
-path        array       *		*       *		*		[series path array]
-set-path    array       *		*       *		*		[series path array]
-get-path    array       *		*       *		*		[series path array]
-lit-path    array       *		*       *		*		[series path array]
+path        (array)     *		*       *		*		[series path array]
+set-path    (array)     *		*       *		*		[series path array]
+get-path    (array)     *		*       *		*		[series path array]
+lit-path    (array)     *		*       *		*		[series path array]
 
 map         map         +		f*      *		*		-
 
@@ -74,21 +77,23 @@ typeset     typeset     +		f*      -		*		-
 
 ;-- Order dependent: next few words
 
-word        word        +        *       -      -		word
-set-word    word        +        *       -      -		word
-get-word    word        +        *       -      -		word
-lit-word    word        +        *       -      -		word
+word        (word)      +        *       -      -		word
+set-word    (word)      +        *       -      -		word
+get-word    (word)      +        *       -      -		word
+lit-word    (word)      +        *       -      -		word
 refinement  word        +        *       -      -		word
 issue       word        +        *       -      -		word
 
-native      function    *        -       -      *		function
-action      function    *        -       -      *		function
-routine     routine     *        -       -      *		function
-command     function    -        -       -      *		function
-closure     function    *        -       -      *		function
-function    function    *        -       -      *		function
+native      (function)  *        -       -      *		function
+action      (function)  *        -       -      *		function
+routine     (routine)   *        -       -      *		function
+command     (function)  -        -       -      *		function
+closure     (function)  *        -       -      *		function
+function    (function)  *        -       -      *		function
 
-frame       frame       -        -       *      -		-
+;-- we make FRAME! evaluative so the evaluator can see it to crash on it...
+frame       (frame)     -        -       *      -		-
+
 object      object      *        f*      *      *		object
 module      object      *        f*      *      *		object
 error       object      +        f+      *      *		object

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -733,7 +733,8 @@ reevaluate:
 		break;
 
 	case REB_SET_WORD:
-		index = Do_Core(out, TRUE, block, index + 1, TRUE);
+		// `index` and `out` are modified
+		DO_NEXT_MAY_THROW_CORE(index, out, block, index + 1, TRUE);
 
 		if (index == THROWN_FLAG) goto return_index;
 
@@ -968,7 +969,9 @@ reevaluate:
 							|| IS_GET_PATH(quoted)
 						)
 					) {
-						index = Do_Core(arg, TRUE, block, index, !infix);
+						DO_NEXT_MAY_THROW_CORE(
+							index, arg, block, index, !infix
+						);
 						if (index == THROWN_FLAG) {
 							*out = *arg;
 							Free_Call(call);
@@ -1061,7 +1064,7 @@ reevaluate:
 				//     >> foo 1 + 2
 				//     a is 3
 				//
-				index = Do_Core(arg, TRUE, block, index, !infix);
+				DO_NEXT_MAY_THROW_CORE(index, arg, block, index, !infix);
 				if (index == THROWN_FLAG) {
 					*out = *arg;
 					Free_Call(call);
@@ -1199,7 +1202,7 @@ reevaluate:
 		break;
 
 	case REB_SET_PATH:
-		index = Do_Core(out, TRUE, block, index + 1, TRUE);
+		DO_NEXT_MAY_THROW_CORE(index, out, block, index + 1, TRUE);
 
 		assert(index != END_FLAG || IS_UNSET(out)); // unset if END_FLAG
 		if (IS_UNSET(out)) raise Error_1(RE_NEED_VALUE, value);
@@ -1316,7 +1319,7 @@ return_index:
 
 	while (index < BLK_LEN(block)) {
 		REBVAL reduced;
-		index = Do_Next_May_Throw(&reduced, block, index);
+		DO_NEXT_MAY_THROW(index, &reduced, block, index);
 		if (index == THROWN_FLAG) {
 			*out = reduced;
 			DS_DROP_TO(dsp_orig);
@@ -1406,7 +1409,7 @@ return_index:
 		}
 		else {
 			REBVAL reduced;
-			index = Do_Next_May_Throw(&reduced, block, index);
+			DO_NEXT_MAY_THROW(index, &reduced, block, index);
 			if (index == THROWN_FLAG) {
 				*out = reduced;
 				DS_DROP_TO(dsp_orig);
@@ -1647,7 +1650,7 @@ return_index:
 			*arg = *value;
 		}
 		else if (reduce) {
-			index = Do_Next_May_Throw(arg, block, index);
+			DO_NEXT_MAY_THROW(index, arg, block, index);
 			if (index == THROWN_FLAG) {
 				*out = *arg; // `arg` may be equal to `out` (if `too_many`)
 				Free_Call(call);

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -276,7 +276,7 @@ enum {
 	SET_TRUE(D_OUT);
 
 	while (index < SERIES_TAIL(block)) {
-		index = Do_Next_May_Throw(D_OUT, block, index);
+		DO_NEXT_MAY_THROW(index, D_OUT, block, index);
 		if (index == THROWN_FLAG) return R_OUT_IS_THROWN;
 
 		if (IS_CONDITIONAL_FALSE(D_OUT)) return R_NONE;
@@ -310,7 +310,7 @@ enum {
 	REBCNT index = VAL_INDEX(D_ARG(1));
 
 	while (index < SERIES_TAIL(block)) {
-		index = Do_Next_May_Throw(D_OUT, block, index);
+		DO_NEXT_MAY_THROW(index, D_OUT, block, index);
 		if (index == THROWN_FLAG) return R_OUT_IS_THROWN;
 
 		if (IS_CONDITIONAL_TRUE(D_OUT)) return R_OUT;
@@ -429,7 +429,7 @@ enum {
 
 	while (index < SERIES_TAIL(block)) {
 
-		index = Do_Next_May_Throw(condition_result, block, index);
+		DO_NEXT_MAY_THROW(index, condition_result, block, index);
 
 		if (index == THROWN_FLAG) {
 			*D_OUT = *condition_result; // is a RETURN, BREAK, THROW...
@@ -475,7 +475,7 @@ enum {
 		}
 	#endif
 
-		index = Do_Next_May_Throw(body_result, block, index);
+		DO_NEXT_MAY_THROW(index, body_result, block, index);
 
 		if (index == THROWN_FLAG) {
 			*D_OUT = *body_result; // is a RETURN, BREAK, THROW...
@@ -840,8 +840,8 @@ was_caught:
 	case REB_BLOCK:
 	case REB_PAREN:
 		if (D_REF(4)) { // next
-			VAL_INDEX(value) = Do_Next_May_Throw(
-				D_OUT, VAL_SERIES(value), VAL_INDEX(value)
+			DO_NEXT_MAY_THROW(
+				VAL_INDEX(value), D_OUT, VAL_SERIES(value), VAL_INDEX(value)
 			);
 
 			if (VAL_INDEX(value) == THROWN_FLAG) {

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -135,7 +135,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 
 		while (index < SERIES_TAIL(block)) {
 			i = index;
-			index = Do_Next_May_Throw(D_OUT, block, index);
+			DO_NEXT_MAY_THROW(index, D_OUT, block, index);
 
 			if (index == THROWN_FLAG) return R_OUT_IS_THROWN;
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1343,7 +1343,7 @@ append:
 	// per thread?
 
 	while (index < BLK_LEN(block)) {
-		index = Do_Next_May_Throw(out, block, index);
+		DO_NEXT_MAY_THROW(index, out, block, index);
 		if (index == THROWN_FLAG) {
 			DS_DROP_TO(start);
 			return TRUE;

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1122,7 +1122,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 		if (!IS_BLOCK(&blk[0]))
 			raise Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(&blk[0]));
 
-		fn_idx = Do_Next_May_Throw(&lib, VAL_SERIES(data), 1);
+		DO_NEXT_MAY_THROW(fn_idx, &lib, VAL_SERIES(data), 1);
 		if (fn_idx == THROWN_FLAG)
 			raise Error_No_Catch_For_Throw(&lib);
 
@@ -1170,7 +1170,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 		if (!IS_BLOCK(&blk[0]))
 			raise Error_Invalid_Arg(&blk[0]);
 
-		fn_idx = Do_Next_May_Throw(&fun, VAL_SERIES(data), 1);
+		DO_NEXT_MAY_THROW(fn_idx, &fun, VAL_SERIES(data), 1);
 		if (fn_idx == THROWN_FLAG)
 			raise Error_No_Catch_For_Throw(&fun);
 

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -743,8 +743,11 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 
 					++ blk;
 				} else {
-					eval_idx = Do_Next_May_Throw(
-						init, VAL_SERIES(data), blk - VAL_BLK_DATA(data)
+					DO_NEXT_MAY_THROW(
+						eval_idx,
+						init,
+						VAL_SERIES(data),
+						blk - VAL_BLK_DATA(data)
 					);
 					if (eval_idx == THROWN_FLAG)
 						raise Error_No_Catch_For_Throw(init);

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -579,7 +579,7 @@ bad_target:
 	}
 
 	// Evaluate next N input values:
-	index = Do_Next_May_Throw(&value, parse->series, index);
+	DO_NEXT_MAY_THROW(index, &value, parse->series, index);
 
 	if (index == THROWN_FLAG) {
 		// Value is a THROW, RETURN, BREAK, etc...we have to stop processing

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1721,16 +1721,6 @@ struct Reb_Value
 	union Reb_Value_Data data;
 };
 
-#define ANY_SERIES(v)		(VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_LIT_PATH)
-#define ANY_STR(v)			(VAL_TYPE(v) >= REB_STRING && VAL_TYPE(v) <= REB_TAG)
-#define ANY_BINSTR(v)		(VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_TAG)
-#define ANY_ARRAY(v)		(VAL_TYPE(v) >= REB_BLOCK  && VAL_TYPE(v) <= REB_LIT_PATH)
-#define	ANY_WORD(v)			(VAL_TYPE(v) >= REB_WORD   && VAL_TYPE(v) <= REB_ISSUE)
-#define	ANY_PATH(v)			(VAL_TYPE(v) >= REB_PATH   && VAL_TYPE(v) <= REB_LIT_PATH)
-#define ANY_FUNC(v)			(VAL_TYPE(v) >= REB_NATIVE && VAL_TYPE(v) <= REB_FUNCTION)
-#define ANY_EVAL_BLOCK(v)	(VAL_TYPE(v) >= REB_BLOCK  && VAL_TYPE(v) <= REB_PAREN)
-#define ANY_OBJECT(v)		(VAL_TYPE(v) >= REB_OBJECT && VAL_TYPE(v) <= REB_PORT)
-
 #pragma pack()
 
 #endif // value.h


### PR DESCRIPTION
The evaluator loop is fairly optimized in the release build, but it
still costs more than not calling a function at all. This makes a new
note in the type table about whether that type has any behavior in
the evaluator at all... and that is used to generate a small TRUE/FALSE
table of whether each REB_XXX type needs the evaluator. This is
used in a new macro implementation for DO_NEXT_MAY_THROW in
order to bypass evaluation altogether.

The test isn't actually as simple as just checking the next value, due
to the behavior of infix. Even `foo [x] + [y]` might have some meaning
for an infix operator. Hence to take advantage of the skip there must be
*two* inert values in a row, like `foo [x] [y]` or `foo {a} 2`. (For these
purposes, REB_END counts as an inert value, so `foo [x]` is also able
to be optimized.)

Casual performance testing showed that this is beneficial enough to be
worth doing, as a 6% or so speedup in building hostilefork.com. Further
tests would have to be done to know how typical or atypical that is.