### PR TITLE
Unset unused refinement args, MAJOR changes

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -146,6 +146,8 @@ Script: [
 	no-refine:          [:arg1 {has no refinement called} :arg2]
 	bad-refines:        {incompatible or invalid refinements}
 	bad-refine:         [{incompatible or duplicate refinement:} :arg1]
+	bad-refine-revoke:  {refinement's args must be either all unset or all set}
+
 	invalid-path:       [{cannot access} :arg2 {in path} :arg1]
 	bad-path-type:      [{path} :arg1 {is not valid for} :arg2 {type}]
 	bad-path-set:       [{cannot set} :arg2 {in path} :arg1]

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -802,7 +802,7 @@
 	// Done by marking all source words (in bind table):
 	keys = FRM_KEYS(source) + 1;
 	for (n = 1; NOT_END(keys); n++, keys++) {
-		if (IS_NONE(only_words) || binds[VAL_TYPESET_CANON(keys)])
+		if (IS_UNSET(only_words) || binds[VAL_TYPESET_CANON(keys)])
 			binds[VAL_TYPESET_CANON(keys)] = n;
 	}
 

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -55,7 +55,14 @@
 	REBINT index;
 #endif
 
-	if (dups < 0) return (action == A_APPEND) ? 0 : dst_idx;
+	if (IS_UNSET(src_val) || dups < 0) {
+		// If they are effectively asking for "no action" then all we have
+		// to do is return the natural index result for the operation.
+		// (APPEND will return 0, insert the tail of the insertion...so index)
+
+		return (action == A_APPEND) ? 0 : dst_idx;
+	}
+
 	if (action == A_APPEND || dst_idx > tail) dst_idx = tail;
 
 	// Check /PART, compute LEN:

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -596,8 +596,8 @@
 	REBINT maxlen;
 	REBINT is_ser = ANY_SERIES(sval);
 
-	// If lval = NONE, use the current len of the target value:
-	if (IS_NONE(lval)) {
+	// If lval is not set, use the current len of the target value:
+	if (IS_UNSET(lval)) {
 		if (!is_ser) return 1;
 		if (VAL_INDEX(sval) >= VAL_TAIL(sval)) return 0;
 		return (VAL_TAIL(sval) - VAL_INDEX(sval));
@@ -652,8 +652,8 @@
 	REBINT len;
 	REBINT maxlen;
 
-	// If lval = NONE, use the current len of the target value:
-	if (IS_NONE(lval)) {
+	// If lval is unset, use the current len of the target value:
+	if (IS_UNSET(lval)) {
 		val = (bval && ANY_SERIES(bval)) ? bval : aval;
 		if (VAL_INDEX(val) >= VAL_TAIL(val)) return 0;
 		return (VAL_TAIL(val) - VAL_INDEX(val));

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -252,17 +252,12 @@
 	// Make_Call does not fill the args in the frame--that is up to Do_Core
 	// and Apply_Block to do as they go along.  But the frame has to survive
 	// Recycle() during arg fulfillment...slots can't be left uninitialized.
-	// Set to UNSET in the release build, but "GC safe" trash in the debug
-	// build to help catch skipped slots that aren't written intentionally.
+	// It is important to set to UNSET for bookkeeping so that refinement
+	// scanning knows when it has filled a refinement or not.
 	{
-		REBCNT var_index;
-		for (var_index = 0; var_index < num_vars; var_index++) {
-		#ifdef NDEBUG
-			SET_UNSET(&call->vars[var_index]);
-		#else
-			SET_TRASH_SAFE(&call->vars[var_index]);
-		#endif
-		}
+		REBCNT index;
+		for (index = 0; index < num_vars; index++)
+			SET_UNSET(&call->vars[index]);
 	}
 
 	assert(size == DSF_SIZE(call));

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -414,7 +414,7 @@ static struct {
 	if (len <= 1) return;
 
 	// Skip factor:
-	if (!IS_NONE(skipv)) {
+	if (!IS_UNSET(skipv)) {
 		skip = Get_Num_Arg(skipv);
 		if (skip <= 0 || len % skip != 0 || skip > len)
 			raise Error_Out_Of_Range(skipv);

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -366,7 +366,7 @@ enum COMPARE_CHR_FLAGS {
 	if (len <= 1) return;
 
 	// Skip factor:
-	if (!IS_NONE(skipv)) {
+	if (!IS_UNSET(skipv)) {
 		skip = Get_Num_Arg(skipv);
 		if (skip <= 0 || len % skip != 0 || skip > len)
 			raise Error_Invalid_Arg(skipv);

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -59,7 +59,8 @@ function: func [
 
 		; Ignore the words in the spec and those in the object. The spec needs
 		; to be copied since the object words shouldn't be added to the locals.
-		append append append copy spec 'self words-of object words ; ignore 'self too
+		; ignore 'self too
+		compose [(spec) 'self (words-of object) (:words)]
 	][
 		; Don't include the words in the spec, or any extern words.
 		either extern [append copy spec words] [spec]

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -105,8 +105,8 @@ tenth: func [
 last: func [
 	{Returns the last value of a series.}
 	value [any-series! tuple! gob!]
-	/local len
-] [
+	<local> len
+][
 	case [
 		any-series? value [pick back tail value 1]
 		tuple? value [pick value length value]
@@ -120,7 +120,7 @@ last: func [
 
 			pick back tail value 1
 		]
-		true [
+		'default [
 			; C code said "let the action throw the error", but by virtue
 			; of type checking this case should not happen.
 			pick value 0
@@ -135,24 +135,33 @@ last: func [
 
 repend: func [
 	"Appends a reduced value to a series and returns the series head."
-	series [any-series! port! map! gob! object! bitset!] {Series at point to insert (modified)}
-	value {The value to insert}
+	series [any-series! port! map! gob! object! bitset!]
+		{Series at point to insert (modified)}
+	value [any-value! unset!] {The value to insert}
 	/part {Limits to a given length or position}
 	limit [any-number! any-series! pair!]
 	/only {Inserts a series as a series}
 	/dup {Duplicates the insert a specified number of times}
 	count [any-number! pair!]
 ][
-	apply :append [series reduce :value part limit only dup count]
+	either set? :value [
+		append/part/:only/dup series reduce :value :limit :count
+	][
+		head series ;-- simulating result of appending () returns the head
+	]
 ]
 
 join: func [
 	"Concatenates values."
-	value "Base value"
-	rest "Value or block of values"
+	value "Base value" [unset! any-value!]
+	rest "Value or block of values" [unset! any-value!]
 ][
-	value: either any-series? :value [copy value] [form :value]
-	repend value :rest
+	either set? :value [
+		value: either any-series? :value [copy value] [form :value]
+		repend value :rest
+	][
+		reduce rest
+	]
 ]
 
 reform: func [

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -103,7 +103,7 @@ maximum-of: func [
 	size [integer!]
 	/local spot
 ][
-	size: any [size 1]
+	size: any [:size 1]
 	if 1 > size [cause-error 'script 'out-of-range size]
 	spot: series
 	forskip series size [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -105,7 +105,7 @@ array: func [
 	]
 	block: make block! size
 	case [
-		block? rest [
+		block? :rest [
 			loop size [block: insert/only block array/initial rest :value]
 		]
 		any-series? :value [
@@ -345,14 +345,14 @@ extract: func [
 	unless index [pos: 1]
 	either block? pos [
 		unless parse pos [some [any-number! | logic!]] [cause-error 'Script 'invalid-arg reduce [pos]]
-		unless output [output: make series len * length pos]
+		if unset? :output [output: make series len * length pos]
 		if all [not default any-string? output] [value: copy ""]
 		forskip series width [forall pos [
 			if none? set/any 'val pick series pos/1 [set/any 'val value]
 			output: insert/only output :val
 		]]
 	][
-		unless output [output: make series len]
+		if unset? :output [output: make series len]
 		if all [not default any-string? output] [value: copy ""]
 		forskip series width [
 			if none? set/any 'val pick series pos [set/any 'val value]
@@ -401,6 +401,11 @@ collect: func [
 	; instead of intermingled.  :-)
 
 	either system/options/refinements-true [
+		; Note: because this is a Mezzanine it was loaded with the word valued
+		; refinements and unset-unused-refinements, and remembers that...even
+		; when the legacy mode is enabled.  Compatibility to not touch code.
+		if unset? :output [output: none]
+
 		;; Rebol2, R3-Alpha, Red ;;
 
 		unless output [output: make block! 16]
@@ -414,7 +419,7 @@ collect: func [
 	][
 		;; Ren/C ;;
 
-		unless output [output: make block! 16]
+		output: any [:output make block! 16]
 		eval func [<transparent> keep] body func [
 			value [any-value!] /only
 		][
@@ -448,7 +453,7 @@ format: function [
 	values
 	/pad p
 ][
-	p: any [p #" "]
+	p: any [:p #" "]
 	unless block? :rules [rules: reduce [:rules]]
 	unless block? :values [values: reduce [:values]]
 

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -97,9 +97,9 @@ do*: function [
 	either all [string? value  not is-module] [
 		; Return result without script overhead
 		do-needs hdr  ; Load the script requirements
-		if empty? data [if var [set var data]  exit] ; Shortcut return empty
+		if empty? data [if next [set var data] return ()]
 		intern data   ; Bind the user script
-		catch/quit either var [[do/next data var]] [data]
+		catch/quit [do/next data :var]
 	][ ; Otherwise we are in script mode
 
 		; When we run a script, the "current" directory is changed to the
@@ -141,11 +141,11 @@ do*: function [
 			either is-module [ ; Import the module and set the var
 				spec: reduce [hdr data do-needs/no-user hdr]
 				also import catch/quit [make module! spec]
-					if var [set var tail data]
+					if next [set var tail data]
 			][
 				do-needs hdr  ; Load the script requirements
 				intern data   ; Bind the user script
-				catch/quit either var [[do/next data var]] [data]
+				catch/quit [do/next data :var]
 			]
 		)(
 			; Restore system/script and the dir

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -211,8 +211,9 @@ config-system: func [
 	]
 
 	id: any [
-		; first choice is a literal tuple that was passed in
-		id
+		; first choice is a literal tuple that was passed in (unset means
+		; no vote in the ANY)
+		:id
 
 		; If version was none and asked to /guess, use opts if given
 		if all [guess hint] [


### PR DESCRIPTION
This is a MAJOR change--that also corrects a bug introduced in
0c76e51 where the evaluator handled refinements used out of
order incorrectly.

Rather than being NONE!, an unused refinements args will now
be UNSET! when not running in legacy mode.  The switch for
controlling whether this is done is the same switch as the one that
controls whether refinement words are TRUE when used vs the
word of their refinement--so it is not possible to enable one without
getting the other.

The code most drastically affected by this change was the module
system, which would frequently take advantage of the NONE!
without testing whether the refinement was provided or not.  However
the advantages of the new rules are readily apparent--especially
when combined with the rule that an unset refinement argument
will "revoke" that refinement, even if it is used.  e.g.

    >> append/dup [a b c] [d e] if false [3]
    == [a b c d e]