### PR TITLE
Redo_Func_Throws patch for definitional return

### DIFF
--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -432,7 +432,7 @@ encrypt-data: func [
 		; MAC code
 		mac: checksum/method/key rejoin [
 			to-bin ctx/seq-num-w 8				; sequence number (64-bit int in R3)
-			any [msg-type #{17}]				; msg type
+			any [:msg-type #{17}]				; msg type
 			ctx/version							; version
 			to-bin length data 2				; msg content length
 			data								; msg content

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -176,9 +176,19 @@ make-scheme: func [
 	; If actor is block build a non-contextual actor object:
 	if block? :def/actor [
 		actor: make object! (length def/actor) / 4
-		for-each [name func* args body] def/actor [ ; (maybe PARSE is better here)
-			name: to word! name ; bug!!! (should not be necessary?)
-			repend actor [name func args body]
+		for-each [name func* args body] def/actor [
+			; !!! Comment here said "Maybe PARSE is better here", though
+			; knowing would depend on understanding precisely what the goal
+			; is in only allowing FUNC vs. alternative function generators.
+			assert [
+				set-word? name
+				func* = 'func
+				block? args
+				block? body
+			]
+			append actor reduce [
+				name (func args body) ; add function! to object! w/name
+			]
 		]
 		def/actor: actor
 	]


### PR DESCRIPTION
This corrects an issue that was preventing HTTPS from working after
definitional returns were introduced.  Port actions such as OPEN
were implemented in user-code, but archetypally established as an
ACTION! definition.  The function call frame was established for the
definition of that action, e.g. `foo: action [port [port!]]`, but then each
port type could implement it with differences in the frame such as
`foo-impl: func [port [integer! port!] /local x y z]`.  Hence the frame
would have to be "redone" to get it prepared for the implementation.

The trick used to implement definitional returns was missing in building
these redone frames.  This adds that trick, as well as comments on the
issue and corrections for unset refinement arguments.