### PR TITLE
Starting overhaul of errors incl. "self-awareness"

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -88,7 +88,7 @@ Internal: [
 	bad-series:         {invalid series}
 	limit-hit:          [{internal limit reached:} :arg1]
 	bad-sys-func:       [{invalid or missing system function:} :arg1]
-	invalid-error:      {error object or fields were not valid}
+	invalid-error:      [{error object or fields were not valid:} :arg1]
 	bad-evaltype:		{invalid datatype for evaluation}
 	hash-overflow:		{Hash ran out of space}
 	no-print-ptr:		{print is missing string pointer}
@@ -289,26 +289,7 @@ Command: [
 	command-fail:		["Command failed"]
 ]
 
-Unused-700-799: [
-	; Padding categories required for math done by Find_Error_Info
-	code: 700
-	type: "reserved 700-799"
-]
+; If new category added, be sure to update RE_MAX in %make-boot.r
+; (currently RE_COMMAND_MAX because `Command: [...]` is the last category)
 
-Unused-800-899: [
-	; Padding categories required for math done by Find_Error_Info
-	code: 800
-	type: "reserved 800-899"
-]
-
-Unused-900-999: [
-	; Padding categories required for math done by Find_Error_Info
-	code: 900
-	type: "reserved 900-999"
-]
-
-User: [
-	code: 1000
-	type: "user error"
-	message: [:arg1]
-]
+; Note that 1000 is the hardcoded constant in %make-boot.r used for RE_USER

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -161,6 +161,7 @@ options: context [  ; Options supplied to REBOL during startup
 	; as not being in the mezzanine and following a different rule.)
 
 	cant-unset-set-words: false
+	arg1-arg2-arg3-error: false
 ]
 
 script: context [
@@ -195,15 +196,16 @@ standard: context [
 	]
 
 	error: context [ ; Template used for all errors:
-		code: 0
+		code: none
 		type: 'user
 		id:   'message
-		arg1:
-		arg2:
-		arg3:
+		message:
 		near:
 		where:
 			none
+
+		; Arguments will be allocated in the frame at creation time if
+		; necessary (errors with no arguments will just have a message)
 	]
 
 	script: context [

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -316,3 +316,12 @@ pid
 ;call/info
 id
 exit-code
+
+; used as error fields in debug builds for C's __FILE__ and __LINE__ of origin
+__FILE__
+__LINE__
+
+; required by OPTIONS_ARG1_ARG2_ARG3_ERROR, assumed to be sequential symbol #s
+arg1
+arg2
+arg3

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -925,7 +925,6 @@ static void Mold_Object(const REBVAL *value, REB_MOLD *mold)
 static void Mold_Error(const REBVAL *value, REB_MOLD *mold, REBFLG molded)
 {
 	ERROR_OBJ *err;
-	REBVAL *msg;  // Error message block
 	REBSER *frame;
 
 	// Protect against recursion. !!!!
@@ -943,14 +942,12 @@ static void Mold_Error(const REBVAL *value, REB_MOLD *mold, REBFLG molded)
 	Emit(mold, "** WB", &err->type, RS_ERRS+0);
 
 	// Append: error message ARG1, ARG2, etc.
-	msg = Find_Error_Info(err, 0);
-	if (msg) {
-		if (IS_BLOCK(msg))
-			Form_Block_Series(VAL_SERIES(msg), 0, mold, frame);
-		else
-			Mold_Value(mold, msg, 0);
-	} else
-		Append_Boot_Str(mold->series, RS_ERRS+1);
+	if (IS_BLOCK(&err->message))
+		Form_Block_Series(VAL_SERIES(&err->message), 0, mold, frame);
+	else if (IS_STRING(&err->message))
+		Mold_Value(mold, &err->message, 0);
+	else
+		Append_Boot_Str(mold->series, RS_ERRS + 1);
 
 	// Form: ** Where: function
 	value = &err->where;

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -444,7 +444,7 @@ upgrade: function [
 	fail "Automatic upgrade checking is currently not supported."
 ]
 
-why?: func [
+why?: function [
 	"Explain the last error in more detail."
 	'err [word! path! error! none! unset!] "Optional error value"
 ][
@@ -458,6 +458,18 @@ why?: func [
 		error? err: any [:err system/state/last-error]
 		err/type ; avoids lower level error types (like halt)
 	][
+		; In non-"NDEBUG" (No DEBUG) builds, if an error originated from the
+		; C sources then it will have a file and line number included of where
+		; the error was triggered.
+		if all [
+			file: attempt [system/state/last-error/__FILE__]
+			line: attempt [system/state/last-error/__LINE__]
+		][
+			print ["DEBUG BUILD INFO:"]
+			print ["    __FILE__ =" file]
+			print ["    __LINE__ =" line]
+		]
+
 		say-browser
 		err: lowercase ajoin [err/type #"-" err/id]
 		browse join http://www.rebol.com/r3/docs/errors/ [err ".html"]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -237,6 +237,7 @@ set 'r3-legacy* func [] [
 	system/options/print-forms-everything: true
 	system/options/break-with-overrides: true
 	system/options/none-instead-of-unsets: true
+	system/options/arg1-arg2-arg3-error: true
 
 	append system/contexts/user compose [
 

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -1018,9 +1018,10 @@ for-each [category info] boot-errors [
 emit-end
 
 emit {
-#define RE_INTERNAL_FIRST RE_MISC // update if no longer first
-#define RE_USER RE_MESSAGE
-#define RE_MAX RE_USER_MAX // update if another category added
+#define RE_USER 1000 // Hardcoded, update in %make-boot.r
+
+#define RE_INTERNAL_FIRST RE_MISC // GENERATED! update in %make-boot.r
+#define RE_MAX RE_COMMAND_MAX // GENERATED! update in %make-boot.r
 }
 
 write inc/tmp-errnums.h out


### PR DESCRIPTION
This change brings about new flexibilities in the error design as
well as some new features.  It is large in terms of number of lines of
code, yet many of those lines of code are asserts and checks to make
sure the assumptions are correct.  Because the tests provided the list
of what most of those assumptions were, it did not change them and can
pass core-tests.r with nearly no modification...in both legacy mode and in
normal mode.

Key features include eliminating the fixed idea of `arg1: arg2: arg3:` as
the parameterization, letting you define named properties of an error
object that are more meaningful.  It also lets you define a template that
will do substitutions when the error is printed, as system errors could:

    >> err: make error! [message: ["the" :animal "has claws"] animal: "cat"]
    == make error! [
        code: 1000
        type: 'user
        id: 'message
        message: ["the" :animal "has claws"]
        near: none
        where: none
        animal: "cat"
    ]

    >> err/animal
    == "cat"

    >> fail err
    ** user error: the "cat" has claws

It also has provisions for the internal code to be conscious of how many
arguments are in an error template and check this automatically in a
call.  This should replace the `Error_0, Error_1, Error_2`... macros in the
C code (in an upcoming commit) and be more robust.  The names of the
arguments in the templates could also be changed, though for the moment
[they are still left as :arg1 :arg2 :arg3](https://github.com/metaeducation/ren-c/blob/827d5a4c7db591966f05c7484aaea9ecd050e63c/src/boot/errors.r#L124).

As an added benefit it has output showing the source file and line number
in the C code (in the debug build) for any error originating from source.  This
can be seen directly in the error, or if you didn't probe it as an object but
were just notified the error through a failure message, the info is added to
the `why?` command:

    >> trap [1 / 0]
    == make error! [
        code: 400
        type: 'Math
        id: 'zero-divide
        message: "attempt to divide by zero"
        near: [:value1 :value2]
        where: [action! / trap]
        __FILE__: %../src/core/t-integer.c
        __LINE__: 359
    ]

    >> 1 / 0
    ** Math error: attempt to divide by zero
    ** Where: action! /
    ** Near: :value1 :value2

    >> why?
    DEBUG BUILD INFO:
        __FILE__ = ../src/core/t-integer.c
        __LINE__ = 359