### PR TITLE
Move IF/ONLY and relatives to r3-legacy

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -69,7 +69,6 @@ case: native [
 	{Evaluates each condition, and when true, evaluates what follows it.}
 	block [block!] {Block of cases (conditions followed by values)}
 	/all {Evaluate all cases (do not stop at first TRUE? case)}
-	/only {Return block values instead of evaluating them.}
 ]
 
 catch: native [
@@ -143,11 +142,10 @@ eval: native [
 ]
 
 either: native [
-	{If TRUE condition return first arg, else second; evaluate blocks by default.}
+	{If TRUE? condition return 1st branch, else 2nd--evaluate blocks as code.}
 	condition
 	true-branch [any-value!]
 	false-branch [any-value!]
-	/only "Suppress evaluation of block args."
 ]
 
 every: native [
@@ -218,10 +216,9 @@ halt: native [
 ]
 
 if: native [
-	{If TRUE condition, return arg; evaluate blocks by default.}
+	{If TRUE? condition, return the branch--with blocks evaluated as code.}
 	condition
 	true-branch [any-value!]
-	/only "Return block arg instead of evaluating it."
 ]
 
 loop: native [
@@ -338,10 +335,9 @@ trap: native [
 ]
 
 unless: native [
-	{If FALSE condition, return arg; evaluate blocks by default.}
+	{If FALSE? condition, return the branch--with blocks evaluated as code.}
 	condition
 	false-branch [any-value!]
-	/only "Return block arg instead of evaluating it."
 ]
 
 until: native [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -281,6 +281,54 @@ set 'r3-legacy* func [] [
 				]
 			]
 		])
+
+		; For reasons of optimization, underuse, aesthetics, and a better
+		; future strategy for the feature... /only has been removed from
+		; the conditionals.
+
+		if: (func [
+			{If TRUE condition, return arg; evaluate blocks by default.}
+			condition
+			true-branch [any-value!]
+			/only "Return block arg instead of evaluating it."
+		][
+			lib/either all [only block? :true-branch] [
+				lib/if :condition [:true-branch]
+			][
+				lib/if :condition :true-branch
+			]
+		])
+
+		either: (func [
+			{If TRUE condition return first arg, else second; evaluate blocks by default.}
+			condition
+			true-branch [any-value!]
+			false-branch [any-value!]
+			/only "Suppress evaluation of block args."
+		][
+			lib/either :condition [
+				lib/either all [only block? :true-branch] [
+					:true-branch
+				] :true-branch
+			][
+				lib/either all [only block? :false-branch] [
+					:false-branch
+				] :false-branch
+			]
+		])
+
+		unless: (func [
+			{If FALSE condition, return arg; evaluate blocks by default.}
+			condition
+			false-branch [any-value!]
+			/only "Return block arg instead of evaluating it."
+		][
+			lib/either all [only block? :false-branch] [
+				lib/unless :condition [:false-branch]
+			][
+				lib/unless :condition :false-branch
+			]
+		])
 	]
 
 	return none


### PR DESCRIPTION
Though being a suggestion from myself, IF/ONLY and its friends
have not turned out to be all that popular.  In addition to being used
very rarely, they present a barrier to optimization in the evaluator,
which becomes more pressing as the unset changes open doors to
the use of IF for rapid chaining and "opting out".  Should IF, UNLESS,
and EITHER be constrained to not having refinements, and join ANY
and ALL...then these natives can be folded into the evaluator loop
sans call frames.

Syntactically, the construction `if a [[b]]` may be contracted down to
`if a '[b]` under future ideas of "lit bit".  In the meantime accepting the
idea that the branches don't have to be blocks is an overall "win", so
that change that came in the same commit will be retained as this one
is removed.

Support still exists in the `do <r3-legacy>` mode.