### PR TITLE
Reap benefits of self-aware errors

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -44,11 +44,6 @@ Internal: [
 	;
 	misc:				{RE_MISC error (if actually happens, add to %errors.r)}
 
-	; The error machinery expects a `raise` or `panic` macro to have signaled
-	; whether the error is meant to be trappable or to exit the process
-	;
-	no-prep:			{raise or panic "keyword" missing from error trigger}
-
 	; !!! Should there be a distinction made between different kinds of
 	; stack overflows?  (Call stack, Data stack?)
 	;
@@ -76,7 +71,6 @@ Internal: [
 	io-error:			{problem with IO}
 	max-words:			{too many words}
 	locked-series:		{locked series expansion}
-	no-saved-state:		{saved state frame is missing}
 	max-events:			{event queue overflow}
 	unexpected-case:	{no case in switch statement}
 	bad-size:			{expected size did not match}

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -96,15 +96,15 @@ static	BOOT_BLK *Boot_Block;
 	printf("%d %s\n", sizeof(dummy->all), "all");
 #endif
 
-	if (cast(REBCNT, VAL_TYPE(&val)) != 123) panic Error_0(RE_REBVAL_ALIGNMENT);
+	if (cast(REBCNT, VAL_TYPE(&val)) != 123) panic (Error(RE_REBVAL_ALIGNMENT));
 	if (sizeof(void *) == 8) {
-		if (sizeof(REBVAL) != 32) panic Error_0(RE_REBVAL_ALIGNMENT);
-		if (sizeof(REBGOB) != 84) panic Error_0(RE_BAD_SIZE);
+		if (sizeof(REBVAL) != 32) panic (Error(RE_REBVAL_ALIGNMENT));
+		if (sizeof(REBGOB) != 84) panic (Error(RE_BAD_SIZE));
 	} else {
-		if (sizeof(REBVAL) != 16) panic Error_0(RE_REBVAL_ALIGNMENT);
-		if (sizeof(REBGOB) != 64) panic Error_0(RE_BAD_SIZE);
+		if (sizeof(REBVAL) != 16) panic (Error(RE_REBVAL_ALIGNMENT));
+		if (sizeof(REBGOB) != 64) panic (Error(RE_BAD_SIZE));
 	}
-	if (sizeof(REBDAT) != 4) panic Error_0(RE_BAD_SIZE);
+	if (sizeof(REBDAT) != 4) panic (Error(RE_BAD_SIZE));
 
 	// The RXIARG structure mirrors the layouts of several value types
 	// for clients who want to extend Rebol but not depend on all of
@@ -128,7 +128,7 @@ static	BOOT_BLK *Boot_Block;
 		offsetof(struct Reb_Object, frame)
 		!= offsetof(struct Reb_Position, series)
 	) {
-		panic Error_0(RE_MISC);
+		panic (Error(RE_MISC));
 	}
 }
 
@@ -172,10 +172,10 @@ static	BOOT_BLK *Boot_Block;
 	if (rebind > 1) Bind_Values_Deep(BLK_HEAD(block), Sys_Context);
 
 	if (Do_At_Throws(&result, block, 0))
-		panic Error_No_Catch_For_Throw(&result);
+		panic (Error_No_Catch_For_Throw(&result));
 
 	if (!IS_UNSET(&result))
-		panic Error_0(RE_MISC);
+		panic (Error(RE_MISC));
 }
 
 
@@ -202,7 +202,7 @@ static	BOOT_BLK *Boot_Block;
 	);
 
 	if (!text || (STR_LEN(text) != NAT_UNCOMPRESSED_SIZE))
-		panic Error_0(RE_BOOT_DATA);
+		panic (Error(RE_BOOT_DATA));
 
 	boot = Scan_Source(STR_HEAD(text), NAT_UNCOMPRESSED_SIZE);
 	Free_Series(text);
@@ -212,9 +212,9 @@ static	BOOT_BLK *Boot_Block;
 	Boot_Block = cast(BOOT_BLK *, VAL_BLK_HEAD(BLK_HEAD(boot)));
 
 	if (VAL_TAIL(&Boot_Block->types) != REB_MAX)
-		panic Error_0(RE_BAD_BOOT_TYPE_BLOCK);
+		panic (Error(RE_BAD_BOOT_TYPE_BLOCK));
 	if (VAL_WORD_SYM(VAL_BLK_HEAD(&Boot_Block->types)) != SYM_TRASH_TYPE)
-		panic Error_0(RE_BAD_END_TYPE_WORD);
+		panic (Error(RE_BAD_END_TYPE_WORD));
 
 	// Create low-level string pointers (used by RS_ constants):
 	{
@@ -231,11 +231,11 @@ static	BOOT_BLK *Boot_Block;
 	}
 
 	if (COMPARE_BYTES(cb_cast("end!"), Get_Sym_Name(SYM_END_TYPE)) != 0)
-		panic Error_0(RE_BAD_END_CANON_WORD);
+		panic (Error(RE_BAD_END_CANON_WORD));
 	if (COMPARE_BYTES(cb_cast("true"), Get_Sym_Name(SYM_TRUE)) != 0)
-		panic Error_0(RE_BAD_TRUE_CANON_WORD);
+		panic (Error(RE_BAD_TRUE_CANON_WORD));
 	if (COMPARE_BYTES(cb_cast("newline"), BOOT_STR(RS_SCAN, 1)) != 0)
-		panic Error_0(RE_BAD_BOOT_STRING);
+		panic (Error(RE_BAD_BOOT_STRING));
 }
 
 
@@ -354,7 +354,7 @@ static	BOOT_BLK *Boot_Block;
 	if ((Native_Limit == 0 && *Native_Functions) || (Native_Count < Native_Limit))
 		Make_Native(D_OUT, VAL_SERIES(D_ARG(1)), *Native_Functions++, REB_NATIVE);
 	else
-		raise Error_0(RE_MAX_NATIVES);
+		fail (Error(RE_MAX_NATIVES));
 	Native_Count++;
 	return R_OUT;
 }
@@ -367,7 +367,7 @@ static	BOOT_BLK *Boot_Block;
 ***********************************************************************/
 {
 	Action_Count++;
-	if (Action_Count >= A_MAX_ACTION) panic Error_0(RE_ACTION_OVERFLOW);
+	if (Action_Count >= A_MAX_ACTION) panic (Error(RE_ACTION_OVERFLOW));
 	Make_Native(
 		D_OUT,
 		VAL_SERIES(D_ARG(1)),
@@ -442,7 +442,7 @@ static	BOOT_BLK *Boot_Block;
 	// native: native [spec [block!]]
 	word = VAL_BLK_SKIP(&Boot_Block->booters, 1);
 	if (!IS_SET_WORD(word) || VAL_WORD_SYM(word) != SYM_NATIVE)
-		panic Error_0(RE_NATIVE_BOOT);
+		panic (Error(RE_NATIVE_BOOT));
 	//val = BLK_SKIP(Sys_Context, SYS_CTX_NATIVE);
 	val = Append_Frame(Lib_Context, word, 0);
 	Make_Native(val, VAL_SERIES(word+2), Native_Functions[0], REB_NATIVE);
@@ -645,11 +645,11 @@ static	BOOT_BLK *Boot_Block;
 
 	// Evaluate the block (will eval FRAMEs within):
 	if (DO_ARRAY_THROWS(&result, &Boot_Block->sysobj))
-		panic Error_No_Catch_For_Throw(&result);
+		panic (Error_No_Catch_For_Throw(&result));
 
 	// Expects UNSET! by convention
 	if (!IS_UNSET(&result))
-		panic Error_0(RE_MISC);
+		panic (Error(RE_MISC));
 
 	// Create a global value for it:
 	value = Append_Frame(Lib_Context, 0, SYM_SYSTEM);
@@ -1117,13 +1117,22 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 **
 ***********************************************************************/
 {
-	const REBVAL *error;
+	REBSER *error_frame;
 	REBOL_STATE state;
 	REBVAL out;
 
 	const REBYTE transparent[] = "transparent";
 	const REBYTE infix[] = "infix";
 	const REBYTE local[] = "local";
+
+#if defined(TEST_EARLY_BOOT_PANIC)
+	// This is a good place to test if the "pre-booting panic" is working.
+	// It should be unable to present a format string, only the error code.
+	panic (Error(RE_NO_VALUE, NONE_VALUE));
+#elif defined(TEST_EARLY_BOOT_FAIL)
+	// A fail should have the same behavior as a panic at this boot phase.
+	fail (Error(RE_NO_VALUE, NONE_VALUE));
+#endif
 
 	DOUT("Main init");
 
@@ -1211,6 +1220,15 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	SET_UNSET(&Callback_Error);
 	PG_Boot_Phase = BOOT_ERRORS;
 
+#if defined(TEST_MID_BOOT_PANIC)
+	// At this point panics should be able to present the full message.
+	panic (Error(RE_NO_VALUE, NONE_VALUE));
+#elif defined(TEST_MID_BOOT_FAIL)
+	// With no PUSH_TRAP yet, fail should give a localized assert in a debug
+	// build but act like panic does in a release build.
+	fail (Error(RE_NO_VALUE, NONE_VALUE));
+#endif
+
 	// Although the goal is for the core not to depend on any specific
 	// "keywords", there are some native-optimized generators that are not
 	// conceptually "part of the core".  Hence, they rely on some keywords,
@@ -1244,25 +1262,28 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	SERIES_SET_FLAG(VAL_SERIES(ROOT_LOCAL_TAG), SER_PROT);
 
 	// Special pre-made errors:
-	Val_Init_Error(TASK_STACK_ERROR, Make_Error(RE_STACK_OVERFLOW, NULL));
-	Val_Init_Error(TASK_HALT_ERROR, Make_Error(RE_HALT, NULL));
+	Val_Init_Error(TASK_STACK_ERROR, Error(RE_STACK_OVERFLOW));
+	Val_Init_Error(TASK_HALT_ERROR, Error(RE_HALT));
 
 	// With error trapping enabled, set up to catch them if they happen.
-	PUSH_UNHALTABLE_TRAP(&error, &state);
+	PUSH_UNHALTABLE_TRAP(&error_frame, &state);
 
-// The first time through the following code 'error' will be NULL, but...
-// `raise Error` can longjmp here, so 'error' won't be NULL *if* that happens!
+// The first time through the following code 'error_frame' will be NULL, but...
+// `fail` can longjmp here, so 'error_frame' won't be NULL *if* that happens!
 
-	if (error) {
+	if (error_frame) {
+		REBVAL error;
+		Val_Init_Error(&error, error_frame);
+
 		// You shouldn't be able to halt during Init_Core() startup.
 		// The only way you should be able to stop Init_Core() is by raising
 		// an error, at which point the system will Panic out.
 		// !!! TBD: Enforce not being *able* to trigger HALT
-		assert(VAL_ERR_NUM(error) != RE_HALT);
+		assert(ERR_NUM(error_frame) != RE_HALT);
 
 		// If an error was raised during startup, print it and crash.
-		Print_Value(error, 1024, FALSE);
-		panic Error_0(RE_MISC);
+		Print_Value(&error, 1024, FALSE);
+		panic (Error(RE_MISC));
 	}
 
 	Init_Year();
@@ -1288,7 +1309,7 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 		// Note: You shouldn't be able to throw any uncaught values during
 		// Init_Core() startup, including throws implementing QUIT or EXIT.
 		assert(FALSE);
-		raise Error_No_Catch_For_Throw(&out);
+		fail (Error_No_Catch_For_Throw(&out));
 	}
 
 	// Success of the 'finish-init-core' Rebol code is signified by returning
@@ -1296,7 +1317,7 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 
 	if (!IS_UNSET(&out)) {
 		Debug_Fmt("** 'finish-init-core' returned non-none!: %r", &out);
-		panic Error_0(RE_MISC);
+		panic (Error(RE_MISC));
 	}
 
 	assert(DSP == -1 && !DSF);

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -335,7 +335,7 @@
 					for (; NOT_END(key); key++)
 						binds[VAL_TYPESET_CANON(key)] = 0;
 					RESET_TAIL(BUF_COLLECT);  // allow reuse
-					raise Error_1(RE_DUP_VARS, value);
+					fail (Error(RE_DUP_VARS, value));
 				}
 			}
 			continue;
@@ -344,7 +344,7 @@
 		if (ANY_EVAL_BLOCK(value) && (modes & BIND_DEEP))
 			Collect_Frame_Inner_Loop(binds, VAL_BLK_DATA(value), modes);
 		// In this mode (foreach native), do not allow non-words:
-		//else if (modes & BIND_GET) raise Error_Invalid_Arg(value);
+		//else if (modes & BIND_GET) fail (Error_Invalid_Arg(value));
 	}
 
 	TERM_ARRAY(BUF_COLLECT);
@@ -622,7 +622,7 @@
 	REBVAL *key = BLK_HEAD(VAL_OBJ_KEYLIST(value));
 
 	for (; NOT_END(key); key++)
-		if (VAL_GET_EXT(key, EXT_WORD_HIDE)) raise Error_0(RE_HIDDEN);
+		if (VAL_GET_EXT(key, EXT_WORD_HIDE)) fail (Error(RE_HIDDEN));
 }
 
 
@@ -637,11 +637,11 @@
 {
 	if (Do_Sys_Func_Throws(out, SYS_CTX_MAKE_MODULE_P, spec, 0)) {
 		// Gave back an unhandled RETURN, BREAK, CONTINUE, etc...
-		raise Error_No_Catch_For_Throw(out);
+		fail (Error_No_Catch_For_Throw(out));
 	}
 
 	// !!! Shouldn't this be testing for !IS_MODULE(out)?
-	if (IS_NONE(out)) raise Error_1(RE_INVALID_SPEC, spec);
+	if (IS_NONE(out)) fail (Error(RE_INVALID_SPEC, spec));
 }
 
 
@@ -757,7 +757,7 @@
 
 	CHECK_BIND_TABLE;
 
-	if (IS_PROTECT_SERIES(target)) raise Error_0(RE_PROTECTED);
+	if (IS_PROTECT_SERIES(target)) fail (Error(RE_PROTECTED));
 
 	if (IS_INTEGER(only_words)) { // Must be: 0 < i <= tail
 		i = VAL_INT32(only_words); // never <= 0
@@ -1088,7 +1088,7 @@
 	REBINT index;
 
 	index = Find_Param_Index(frame, VAL_WORD_SYM(word));
-	if (!index) raise Error_1(RE_NOT_IN_CONTEXT, word);
+	if (!index) fail (Error(RE_NOT_IN_CONTEXT, word));
 	VAL_WORD_FRAME(word) = frame;
 	VAL_WORD_INDEX(word) = -index;
 }
@@ -1253,7 +1253,7 @@
 				writable &&
 				VAL_GET_EXT(FRM_KEYS(context) + index, EXT_WORD_LOCK)
 			) {
-				if (trap) raise Error_1(RE_LOCKED_WORD, word);
+				if (trap) fail (Error(RE_LOCKED_WORD, word));
 				return NULL;
 			}
 
@@ -1300,7 +1300,7 @@
 							EXT_WORD_LOCK
 						)
 					) {
-						if (trap) raise Error_1(RE_LOCKED_WORD, word);
+						if (trap) fail (Error(RE_LOCKED_WORD, word));
 						return NULL;
 					}
 
@@ -1312,7 +1312,7 @@
 				call = PRIOR_DSF(call);
 			}
 
-			if (trap) raise Error_1(RE_NO_RELATIVE, word);
+			if (trap) fail (Error(RE_NO_RELATIVE, word));
 			return NULL;
 		}
 
@@ -1322,11 +1322,11 @@
 		// pointer to.  Use GET_VAR_INTO instead for that.
 
 		assert(!IS_SELFLESS(context));
-		if (trap) raise Error_0(RE_SELF_PROTECTED);
+		if (trap) fail (Error(RE_SELF_PROTECTED));
 		return NULL; // is this a case where we should *always* trap?
 	}
 
-	if (trap) raise Error_1(RE_NOT_BOUND, word);
+	if (trap) fail (Error(RE_NOT_BOUND, word));
 	return NULL;
 }
 
@@ -1387,7 +1387,7 @@
 				call = PRIOR_DSF(call);
 			}
 
-			raise Error_1(RE_NO_RELATIVE, word);
+			fail (Error(RE_NO_RELATIVE, word));
 		}
 
 		// Key difference between Get_Var_Into and Get_Var...fabricating
@@ -1401,7 +1401,7 @@
 		return;
 	}
 
-	raise Error_1(RE_NOT_BOUND, word);
+	fail (Error(RE_NOT_BOUND, word));
 }
 
 
@@ -1419,7 +1419,7 @@
 
 	assert(!THROWN(value));
 
-	if (!HAS_FRAME(word)) raise Error_1(RE_NOT_BOUND, word);
+	if (!HAS_FRAME(word)) fail (Error(RE_NOT_BOUND, word));
 
 	assert(VAL_WORD_FRAME(word));
 //  Print("Set %s to %s [frame: %x idx: %d]", Get_Word_Name(word), Get_Type_Name(value), VAL_WORD_FRAME(word), VAL_WORD_INDEX(word));
@@ -1435,17 +1435,17 @@
 		);
 
 		if (VAL_GET_EXT(FRM_KEYS(frm) + index, EXT_WORD_LOCK))
-			raise Error_1(RE_LOCKED_WORD, word);
+			fail (Error(RE_LOCKED_WORD, word));
 		FRM_VALUES(frm)[index] = *value;
 		return;
 	}
-	if (index == 0) raise Error_0(RE_SELF_PROTECTED);
+	if (index == 0) fail (Error(RE_SELF_PROTECTED));
 
 	// Find relative value:
 	call = DSF;
 	while (VAL_WORD_FRAME(word) != VAL_FUNC_PARAMLIST(DSF_FUNC(call))) {
 		call = PRIOR_DSF(call);
-		if (!call) raise Error_1(RE_NO_RELATIVE, word);
+		if (!call) fail (Error(RE_NO_RELATIVE, word));
 	}
 
 	assert(

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -209,7 +209,7 @@
 						}
 						// no other words supported, fall through to error
 					}
-					raise Error_1(RE_BAD_FUNC_DEF, item);
+					fail (Error(RE_BAD_FUNC_DEF, item));
 				}
 				break; // leading block handled if we get here, no more to do
 			}
@@ -291,7 +291,7 @@
 			break;
 
 		default:
-			raise Error_1(RE_BAD_FUNC_DEF, item);
+			fail (Error(RE_BAD_FUNC_DEF, item));
 		}
 	}
 
@@ -461,7 +461,7 @@ REBNATIVE(exit);
 	REBYTE func_flags = 0; // 8-bits in header, reserved type-specific flags
 
 	if (!IS_BLOCK(spec) || !IS_BLOCK(body))
-		raise Error_Bad_Func_Def(spec, body);
+		fail (Error_Bad_Func_Def(spec, body));
 
 	if (!has_return) {
 		// Simpler case: if `make function!` or `make closure!` are used
@@ -582,7 +582,7 @@ REBNATIVE(exit);
 					// cheaper not to.
 				}
 				else
-					raise Error_1(RE_BAD_FUNC_DEF, item);
+					fail (Error(RE_BAD_FUNC_DEF, item));
 			}
 			else if (ANY_WORD(item)) {
 				if (convert_local) {
@@ -608,7 +608,7 @@ REBNATIVE(exit);
 						//
 						// Consider that an error.
 
-						raise Error_1(RE_BAD_FUNC_DEF, item);
+						fail (Error(RE_BAD_FUNC_DEF, item));
 					}
 				}
 
@@ -916,7 +916,7 @@ REBNATIVE(exit);
 	}
 
 	action = Value_Dispatch[type];
-	if (!action) raise Error_Illegal_Action(type, VAL_FUNC_ACT(func));
+	if (!action) fail (Error_Illegal_Action(type, VAL_FUNC_ACT(func)));
 	ret = action(DSF, VAL_FUNC_ACT(func));
 
 	switch (ret) {

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -44,11 +44,11 @@
 {
 	if (Do_Sys_Func_Throws(out, SYS_CTX_MAKE_PORT_P, spec, 0)) {
 		// Gave back an unhandled RETURN, BREAK, CONTINUE, etc...
-		raise Error_No_Catch_For_Throw(out);
+		fail (Error_No_Catch_For_Throw(out));
 	}
 
 	// !!! Shouldn't this be testing for !IS_PORT( ) ?
-	if (IS_NONE(out)) raise Error_1(RE_INVALID_SPEC, spec);
+	if (IS_NONE(out)) fail (Error(RE_INVALID_SPEC, spec));
 }
 
 
@@ -183,7 +183,7 @@
 	else SET_NONE(&ref_only);
 	// Call the system awake function:
 	if (Apply_Func_Throws(&out, awake, port, &tmp, &ref_only, 0))
-		raise Error_No_Catch_For_Throw(&out);
+		fail (Error_No_Catch_For_Throw(&out));
 
 	// Awake function returns 1 for end of WAIT:
 	result = (IS_LOGIC(&out) && VAL_LOGIC(&out)) ? 1 : 0;
@@ -214,7 +214,7 @@
 	while (wt) {
 		if (GET_SIGNAL(SIG_ESCAPE)) {
 			CLR_SIGNAL(SIG_ESCAPE);
-			raise Error_Is(TASK_HALT_ERROR);
+			fail (VAL_ERR_OBJECT(TASK_HALT_ERROR));
 		}
 
 		// Process any waiting events:
@@ -325,7 +325,7 @@
 		// Must have a spec object:
 		!IS_OBJECT(BLK_SKIP(port, STD_PORT_SPEC))
 	) {
-		raise Error_0(RE_INVALID_PORT);
+		fail (Error(RE_INVALID_PORT));
 	}
 
 	// Get actor for port, if it has one:
@@ -338,7 +338,7 @@
 		return cast(REBPAF, VAL_FUNC_CODE(actor))(call_, port, action);
 
 	// actor must be an object:
-	if (!IS_OBJECT(actor)) raise Error_0(RE_INVALID_ACTOR);
+	if (!IS_OBJECT(actor)) fail (Error(RE_INVALID_ACTOR));
 
 	// Dispatch object function:
 	n = Find_Action(actor, action);
@@ -347,7 +347,7 @@
 		REBVAL action_word;
 		Val_Init_Word_Unbound(&action_word, REB_WORD, Get_Action_Sym(action));
 
-		raise Error_1(RE_NO_PORT_ACTION, &action_word);
+		fail (Error(RE_NO_PORT_ACTION, &action_word));
 	}
 
 	if (Redo_Func_Throws(actor)) {
@@ -412,7 +412,7 @@
 		|| !IS_FRAME(BLK_HEAD(port))
 		|| !IS_OBJECT(BLK_SKIP(port, STD_PORT_SPEC))
 	) {
-		raise Error_0(RE_INVALID_PORT);
+		fail (Error(RE_INVALID_PORT));
 	}
 }
 

--- a/src/core/c-task.c
+++ b/src/core/c-task.c
@@ -76,7 +76,7 @@
 	OS_TASK_READY(0);
 
 	if (Do_At_Throws(&ignored, body, 0))
-		raise Error_No_Catch_For_Throw(&ignored);
+		fail (Error_No_Catch_For_Throw(&ignored));
 
 	Debug_Str("End Task");
 }

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -111,7 +111,7 @@
 	if (!pnum) {
 		REBVAL temp;
 		SET_INTEGER(&temp, ser->tail + 1);
-		raise Error_1(RE_SIZE_LIMIT, &temp);
+		fail (Error(RE_SIZE_LIMIT, &temp));
 	}
 
 	assert(!Is_Array_Series(ser));

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -55,7 +55,7 @@ static REBREQ *Req_SIO;
 {
 	//OS_CALL_DEVICE(RDI_STDIO, RDC_INIT);
 	Req_SIO = OS_MAKE_DEVREQ(RDI_STDIO);
-	if (!Req_SIO) panic Error_0(RE_IO_ERROR);
+	if (!Req_SIO) panic (Error(RE_IO_ERROR));
 
 	// The device is already open, so this call will just setup
 	// the request fields properly.
@@ -92,7 +92,7 @@ static REBREQ *Req_SIO;
 
 	OS_DO_DEVICE(Req_SIO, RDC_WRITE);
 
-	if (Req_SIO->error) panic Error_0(RE_IO_ERROR);
+	if (Req_SIO->error) panic (Error(RE_IO_ERROR));
 }
 
 
@@ -115,7 +115,7 @@ static REBREQ *Req_SIO;
 	const REBYTE *bp = is_uni ? NULL : cast(const REBYTE *, p);
 	const REBUNI *up = is_uni ? cast(const REBUNI *, p) : NULL;
 
-	if (!p) panic Error_0(RE_NO_PRINT_PTR);
+	if (!p) panic (Error(RE_NO_PRINT_PTR));
 
 	// Determine length if not provided:
 	if (len == UNKNOWN) len = is_uni ? Strlen_Uni(up) : LEN_BYTES(bp);
@@ -138,7 +138,7 @@ static REBREQ *Req_SIO;
 		Req_SIO->common.data = m_cast(REBYTE *, bp);
 
 		OS_DO_DEVICE(Req_SIO, RDC_WRITE);
-		if (Req_SIO->error) panic Error_0(RE_IO_ERROR);
+		if (Req_SIO->error) panic (Error(RE_IO_ERROR));
 	}
 	else {
 		while ((len2 = len) > 0) {
@@ -156,7 +156,7 @@ static REBREQ *Req_SIO;
 			len -= len2;
 
 			OS_DO_DEVICE(Req_SIO, RDC_WRITE);
-			if (Req_SIO->error) panic Error_0(RE_IO_ERROR);
+			if (Req_SIO->error) panic (Error(RE_IO_ERROR));
 		}
 	}
 }
@@ -532,7 +532,7 @@ static REBREQ *Req_SIO;
 	REBCNT tail;
 	REBINT disabled = GC_Disabled;
 
-	if (!buf) panic Error_0(RE_NO_BUFFER);
+	if (!buf) panic (Error(RE_NO_BUFFER));
 
 	GC_Disabled = 1;
 

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -264,7 +264,7 @@
 	if (into) {
 		series = VAL_SERIES(into);
 
-		if (IS_PROTECT_SERIES(series)) raise Error_0(RE_PROTECTED);
+		if (IS_PROTECT_SERIES(series)) fail (Error(RE_PROTECTED));
 
 		if (ANY_ARRAY(into)) {
 			// When the target is an any-block, we can do an ordinary

--- a/src/core/f-deci.c
+++ b/src/core/f-deci.c
@@ -489,13 +489,13 @@ deci deci_add (deci a, deci b) {
 		/* significand normalization */
 		test = m_cmp (3, sc, P26_1);
 		if ((test > 0) || ((test == 0) && ((tc == 3) || ((tc == 2) && (sc[0] % 2 == 1))))) {
-			if (ea == 127) raise Error_0(RE_OVERFLOW);
+			if (ea == 127) fail (Error(RE_OVERFLOW));
 			ea++;
 			dsr (3, sc, 1, &tc);
 			/* the shift may be needed once again */
 			test = m_cmp (3, sc, P26_1);
 			if ((test > 0) || ((test == 0) && ((tc == 3) || ((tc == 2) && (sc[0] % 2 == 1))))) {
-				if (ea == 127) raise Error_0(RE_OVERFLOW);
+				if (ea == 127) fail (Error(RE_OVERFLOW));
 				ea++;
 				dsr (3, sc, 1, &tc);
 			}
@@ -553,19 +553,19 @@ REBI64 deci_to_int (const deci a) {
 	if (m_is_zero (3, sa) || (a.e < -26)) return (REBI64) 0;
 
 	/* handle exponent */
-	if (a.e >= 20) raise Error_0(RE_OVERFLOW);
+	if (a.e >= 20) fail (Error(RE_OVERFLOW));
 	if (a.e > 0)
-		if (m_cmp (3, P[20 - a.e], sa) <= 0) raise Error_0(RE_OVERFLOW);
+		if (m_cmp (3, P[20 - a.e], sa) <= 0) fail (Error(RE_OVERFLOW));
 		else dsl (3, sa, a.e);
 	else if (a.e < 0) dsr (3, sa, -a.e, &ta);
 
 	/* convert significand to integer */
-	if (m_cmp (3, sa, min_int64_t_as_deci) > 0) raise Error_0(RE_OVERFLOW);
+	if (m_cmp (3, sa, min_int64_t_as_deci) > 0) fail (Error(RE_OVERFLOW));
 	result = cast(REBI64, (cast(REBU64, sa[1]) << 32) | cast(REBU64, sa[0]));
 
 	/* handle sign */
 	if (a.s && result > MIN_I64) result = -result;
-	if (!a.s && (result < 0)) raise Error_0(RE_OVERFLOW);
+	if (!a.s && (result < 0)) fail (Error(RE_OVERFLOW));
 
 	return result;
 }
@@ -618,7 +618,7 @@ void m_ldexp (REBCNT a[4], REBINT *f, REBINT e, REBINT ta) {
 	}
 
 	/* take care of exponent overflow */
-	if (e >= 281) raise Error_0(RE_OVERFLOW);
+	if (e >= 281) fail (Error(RE_OVERFLOW));
 	if (e < -281) e = -282;
 
 	*f += e;
@@ -641,7 +641,7 @@ void m_ldexp (REBCNT a[4], REBINT *f, REBINT e, REBINT ta) {
 	/* decimally shift the significand to the left if needed */
 	if (*f > 127) {
 		if ((*f >= 153) || (m_cmp (3, P[153 - *f], a) <= 0))
-			raise Error_0(RE_OVERFLOW);
+			fail (Error(RE_OVERFLOW));
 		dsl (3, a, *f - 127);
 		*f = 127;
 	}
@@ -1072,7 +1072,7 @@ deci deci_divide (deci a, deci b) {
 	sb[2] = b.m2;
 	sb[3] = 0;
 
-	if (deci_is_zero (b)) raise Error_0(RE_ZERO_DIVIDE);
+	if (deci_is_zero (b)) fail (Error(RE_ZERO_DIVIDE));
 
 	/* compute sign */
 	c.s = (!a.s && b.s) || (a.s && !b.s);
@@ -1234,7 +1234,7 @@ deci deci_mod (deci a, deci b) {
 	sb[2] = b.m2;
 	sb[3] = 0; /* the additional place is for dsl */
 
-	if (deci_is_zero (b)) raise Error_0(RE_ZERO_DIVIDE);
+	if (deci_is_zero (b)) fail (Error(RE_ZERO_DIVIDE));
 	if (deci_is_zero (a)) return deci_zero;
 
 	e = a.e - b.e;
@@ -1339,7 +1339,7 @@ deci string_to_deci (const REBYTE *s, const REBYTE **endptr) {
 				d = *a - '0';
 				e = e * 10 + d;
 				if (e > 200000000) {
-					if (es == 1) raise Error_0(RE_OVERFLOW);
+					if (es == 1) fail (Error(RE_OVERFLOW));
 					else e = 200000000;
 				}
 			} else break;
@@ -1392,8 +1392,8 @@ deci binary_to_deci(const REBYTE s[12]) {
 	if (d.m2 >= 5421010u) {
 		if (d.m1 >= 3704098002u) {
 			if (d.m0 > 3825205247u || d.m1 > 3704098002u)
-				raise Error_0(RE_OVERFLOW);
-		} else if (d.m2 > 5421010u) raise Error_0(RE_OVERFLOW);
+				fail (Error(RE_OVERFLOW));
+		} else if (d.m2 > 5421010u) fail (Error(RE_OVERFLOW));
 	}
 	return d;
 }

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -186,7 +186,7 @@
 			limit = -1;
 		}
 		else if (!IS_BINARY(src_val))
-			raise Error_Invalid_Arg(src_val);
+			fail (Error_Invalid_Arg(src_val));
 	}
 	else if (IS_CHAR(src_val)) {
 		src_ser = Make_Series_Codepoint(VAL_CHAR(src_val));

--- a/src/core/f-random.c
+++ b/src/core/f-random.c
@@ -158,7 +158,7 @@ static REBI64 ran_arr_cycle()
 	REBU64 s, m, u;
 	if (r == 0) return 0;
 	s = (r < 0) ? -r : r;
-	if (!secure && s > MM) raise Error_0(RE_OVERFLOW);
+	if (!secure && s > MM) fail (Error(RE_OVERFLOW));
 	m = secure ? MAX_U64 - (MAX_U64 - s + 1) % s : MM - MM % s - 1; /* rejection limit */
 	do u = Random_Int(secure); while (u > m); /* get a random below the limit */
 	u = u % s + 1;

--- a/src/core/f-round.c
+++ b/src/core/f-round.c
@@ -92,7 +92,7 @@ enum {
 	REBI64 j;
 
 	if (GET_FLAG(flags, RF_TO)) {
-		if (scale == 0.0) raise Error_0(RE_ZERO_DIVIDE);
+		if (scale == 0.0) fail (Error(RE_ZERO_DIVIDE));
 		scale = fabs(scale);
 	} else scale = 1.0;
 
@@ -135,7 +135,7 @@ enum {
 		if (fabs(dec = dec * scale) != HUGE_VAL)
 			return dec;
 		else
-			raise Error_0(RE_OVERFLOW);
+			fail (Error(RE_OVERFLOW));
 	}
 	return ldexp(dec / scale, e);
 }
@@ -152,7 +152,7 @@ enum {
 	else if ((m = n + s) <= cast(REBU64, 1) << 63) \
 		num = -cast(REBI64, m); \
 	else \
-		raise Error_0(RE_OVERFLOW); \
+		fail (Error(RE_OVERFLOW)); \
 }
 
 #define Int_Ceil { \
@@ -161,7 +161,7 @@ enum {
 	else if ((m = n + s) < cast(REBU64, 1) << 63) \
 		num = m; \
 	else \
-		raise Error_0(RE_OVERFLOW); \
+		fail (Error(RE_OVERFLOW)); \
 }
 
 #define Int_Away { \
@@ -169,7 +169,7 @@ enum {
 		if (num < 0 && m == cast(REBU64, 1) << 63) \
 			num = m; \
 		else \
-			raise Error_0(RE_OVERFLOW); \
+			fail (Error(RE_OVERFLOW)); \
 	else \
 		num = (num > 0) ? cast(REBI64, m) : -cast(REBI64, m); \
 }
@@ -188,7 +188,7 @@ enum {
 	REBU64 sc, n, r, m, s;
 
 	if (GET_FLAG(flags, RF_TO)) {
-		if (scale == 0) raise Error_0(RE_ZERO_DIVIDE);
+		if (scale == 0) fail (Error(RE_ZERO_DIVIDE));
 		sc = Int_Abs(scale);
 	}
 	else sc = 1;
@@ -231,7 +231,7 @@ enum {
 	deci deci_one = {1u, 0u, 0u, 0u, 0};
 
 	if (GET_FLAG(flags, RF_TO)) {
-		if (deci_is_zero(scale)) raise Error_0(RE_ZERO_DIVIDE);
+		if (deci_is_zero(scale)) fail (Error(RE_ZERO_DIVIDE));
 		scale = deci_abs(scale);
 	}
 	else scale = deci_one;

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -129,7 +129,7 @@
 	case A_ODDQ:
 	case A_EVENQ:
 	case A_ABSOLUTE:
-		raise Error_Illegal_Action(VAL_TYPE(value), action);
+		fail (Error_Illegal_Action(VAL_TYPE(value), action));
 
 	default:
 		return -1;

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -86,18 +86,18 @@
 
 	if (IS_INTEGER(val)) {
 		if (VAL_INT64(val) > (i64)MAX_I32 || VAL_INT64(val) < (i64)MIN_I32)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		n = VAL_INT32(val);
 	}
 	else if (IS_DECIMAL(val) || IS_PERCENT(val)) {
 		if (VAL_DECIMAL(val) > MAX_I32 || VAL_DECIMAL(val) < MIN_I32)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		n = (REBINT)VAL_DECIMAL(val);
 	}
 	else if (IS_LOGIC(val))
 		n = (VAL_LOGIC(val) ? 1 : 2);
 	else
-		raise Error_Invalid_Arg(val);
+		fail (Error_Invalid_Arg(val));
 
 	return n;
 }
@@ -111,7 +111,7 @@
 {
 	if (fabs(f) > (REBD32)(0x7FFF)) {
 		DS_PUSH_DECIMAL(f);
-		raise Error_Out_Of_Range(DS_TOP);
+		fail (Error_Out_Of_Range(DS_TOP));
 	}
 	return (REBINT)f;
 }
@@ -127,11 +127,11 @@
 
 	if (IS_DECIMAL(val)) {
 		if (VAL_DECIMAL(val) > MAX_I32 || VAL_DECIMAL(val) < MIN_I32)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		n = (REBINT)VAL_DECIMAL(val);
 	} else {
 		if (VAL_INT64(val) > (i64)MAX_I32 || VAL_INT64(val) < (i64)MIN_I32)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		n = VAL_INT32(val);
 	}
 
@@ -155,12 +155,12 @@
 
 	if (IS_DECIMAL(val)) {
 		if (VAL_DECIMAL(val) > MAX_I32 || VAL_DECIMAL(val) < MIN_I32)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 
 		n = (REBINT)VAL_DECIMAL(val);
 	} else {
 		if (VAL_INT64(val) > (i64)MAX_I32 || VAL_INT64(val) < (i64)MIN_I32)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 
 		n = VAL_INT32(val);
 	}
@@ -173,7 +173,7 @@
 	)
 		return n;
 
-	raise Error_Out_Of_Range(val);
+	fail (Error_Out_Of_Range(val));
 }
 
 
@@ -190,7 +190,7 @@
 	if (IS_MONEY(val))
 		return deci_to_int(VAL_MONEY_AMOUNT(val));
 
-	raise Error_Invalid_Arg(val);
+	fail (Error_Invalid_Arg(val));
 }
 
 
@@ -207,7 +207,7 @@
 	if (IS_MONEY(val))
 		return deci_to_decimal(VAL_MONEY_AMOUNT(val));
 
-	raise Error_Invalid_Arg(val);
+	fail (Error_Invalid_Arg(val));
 }
 
 
@@ -227,7 +227,7 @@
 
 	if (IS_DECIMAL(val)) {
 		if (VAL_DECIMAL(val) > MAX_I64 || VAL_DECIMAL(val) < MIN_I64)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		n = (REBI64)VAL_DECIMAL(val);
 	} else {
 		n = VAL_INT64(val);
@@ -241,7 +241,7 @@
 	)
 		return n;
 
-	raise Error_Out_Of_Range(val);
+	fail (Error_Out_Of_Range(val));
 }
 
 
@@ -252,7 +252,7 @@
 ***********************************************************************/
 {
 	if (VAL_INT64(val) > cast(i64, 255) || VAL_INT64(val) < cast(i64, 0))
-		raise Error_Out_Of_Range(val);
+		fail (Error_Out_Of_Range(val));
 
 	return VAL_INT32(val);
 }
@@ -579,7 +579,7 @@
 	if (IS_DECIMAL(arg) || IS_PERCENT(arg))
 		return VAL_DECIMAL(arg) != 0.0;
 
-	raise Error_Invalid_Arg(arg);
+	fail (Error_Invalid_Arg(arg));
 }
 
 
@@ -607,7 +607,7 @@
 		if (is_ser && VAL_TYPE(sval) == VAL_TYPE(lval) && VAL_SERIES(sval) == VAL_SERIES(lval))
 			len = (REBINT)VAL_INDEX(lval) - (REBINT)VAL_INDEX(sval);
 		else
-			raise Error_1(RE_INVALID_PART, lval);
+			fail (Error(RE_INVALID_PART, lval));
 	}
 
 	if (is_ser) {
@@ -676,7 +676,7 @@
 		else if (bval && VAL_TYPE(bval) == VAL_TYPE(lval) && VAL_SERIES(bval) == VAL_SERIES(lval))
 			val = bval;
 		else
-			raise Error_1(RE_INVALID_PART, lval);
+			fail (Error(RE_INVALID_PART, lval));
 
 		len = (REBINT)VAL_INDEX(lval) - (REBINT)VAL_INDEX(val);
 	}
@@ -739,7 +739,7 @@
 {
 	i64 r = n + m;
 	if (r < -maxi || r > maxi) {
-		if (type) raise Error_1(RE_TYPE_LIMIT, Get_Type(type));
+		if (type) fail (Error(RE_TYPE_LIMIT, Get_Type(type)));
 		r = r > 0 ? maxi : -maxi;
 	}
 	return r;
@@ -753,7 +753,7 @@
 ***********************************************************************/
 {
 	i64 r = n * m;
-	if (r < -maxi || r > maxi) raise Error_1(RE_TYPE_LIMIT, Get_Type(type));
+	if (r < -maxi || r > maxi) fail (Error(RE_TYPE_LIMIT, Get_Type(type)));
 	return (int)r;
 }
 

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -180,7 +180,7 @@ typedef REBFLG (*MAKE_FUNC)(REBVAL *, REBVAL *, enum Reb_Kind);
 	return num;
 
 bad_hex:
-	raise Error_0(RE_INVALID_CHARS);
+	fail (Error(RE_INVALID_CHARS));
 }
 
 
@@ -284,7 +284,7 @@ bad_hex:
 	// !!! need check for NaN, and INF
 	*out = STRTOD(s_cast(buf), &se);
 
-	if (fabs(*out) == HUGE_VAL) raise Error_0(RE_OVERFLOW);
+	if (fabs(*out) == HUGE_VAL) fail (Error(RE_OVERFLOW));
 	return cp;
 }
 
@@ -400,7 +400,7 @@ bad_hex:
 	if ((REBCNT)(cp-bp) != len) return 0;
 	VAL_SET(value, REB_MONEY);
 	VAL_MONEY_AMOUNT(value) = atof((char*)(&buf[0]));
-	if (fabs(VAL_MONEY_AMOUNT(value)) == HUGE_VAL) raise Error_0(RE_OVERFLOW);
+	if (fabs(VAL_MONEY_AMOUNT(value)) == HUGE_VAL) fail (Error(RE_OVERFLOW));
 	return cp;
 #endif
 }

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -740,7 +740,7 @@ static void Propagate_All_GC_Marks(void);
 			}
 		#endif
 
-			panic Error_Invalid_Datatype(VAL_TYPE(val));
+			panic (Error_Invalid_Datatype(VAL_TYPE(val)));
 		}
 	}
 }

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -422,7 +422,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 	seg = cast(REBSEG *, ALLOC_ARRAY(char, mem_size));
 
-	if (!seg) panic Error_No_Memory(mem_size);
+	if (!seg) panic (Error_No_Memory(mem_size));
 
 	// !!! See notes above whether a more limited contract between the node
 	// types and the pools could prevent needing to zero all the units.
@@ -768,7 +768,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	assert(wide != 0 && length != 0);
 
 	if (cast(REBU64, length) * wide > MAX_I32)
-		raise Error_No_Memory(cast(REBU64, length) * wide);
+		fail (Error_No_Memory(cast(REBU64, length) * wide));
 
 	PG_Reb_Stats->Series_Made++;
 	PG_Reb_Stats->Series_Memory += length * wide;
@@ -807,7 +807,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 		if (!Series_Data_Alloc(series, length, wide, flags)) {
 			Free_Node(SERIES_POOL, cast(REBNOD*, series));
-			raise Error_No_Memory(length * wide);
+			fail (Error_No_Memory(length * wide));
 		}
 	}
 
@@ -956,7 +956,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	}
 
 	// Range checks:
-	if (delta & 0x80000000) raise Error_0(RE_PAST_END); // 2GB max
+	if (delta & 0x80000000) fail (Error(RE_PAST_END)); // 2GB max
 	if (index > series->tail) index = series->tail; // clip
 
 	// Width adjusted variables:
@@ -975,7 +975,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 		if ((SERIES_TAIL(series) + SERIES_BIAS(series)) * wide >= SERIES_TOTAL(series)) {
 			Dump_Series(series, "Overflow");
 			assert(FALSE);
-			panic Error_0(RE_MISC); // shouldn't be possible, but code here panic'd
+			panic (Error(RE_MISC)); // shouldn't be possible, but code here panic'd
 		}
 
 		return;
@@ -983,7 +983,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 	// We need to expand the current series allocation.
 
-	if (SERIES_GET_FLAG(series, SER_LOCK)) panic Error_0(RE_LOCKED_SERIES);
+	if (SERIES_GET_FLAG(series, SER_LOCK)) panic (Error(RE_LOCKED_SERIES));
 
 #ifndef NDEBUG
 	if (Reb_Opts->watch_expand) {
@@ -1025,7 +1025,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 		wide,
 		any_block ? (MKS_ARRAY | MKS_POWER_OF_2) : MKS_POWER_OF_2
 	)) {
-		raise Error_No_Memory((series->tail + delta + x) * wide);
+		fail (Error_No_Memory((series->tail + delta + x) * wide));
 	}
 
 	assert(SERIES_BIAS(series) == 0); // should be reset
@@ -1093,7 +1093,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	)) {
 		// Put series back how it was (there may be extant references)
 		series->data = data_old;
-		raise Error_No_Memory((units + 1) * wide);
+		fail (Error_No_Memory((units + 1) * wide));
 	}
 
 	if (flags & MKS_PRESERVE) {
@@ -1256,7 +1256,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 	)) {
 		// Put series back how it was (there may be extant references)
 		series->data = data_old;
-		raise Error_No_Memory((tail_old + 1) * sizeof(REBUNI));
+		fail (Error_No_Memory((tail_old + 1) * sizeof(REBUNI)));
 	}
 
 	bp = data_old;
@@ -1505,7 +1505,7 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
 	return count;
 crash:
-	panic Error_0(RE_CORRUPT_MEMORY);
+	panic (Error(RE_CORRUPT_MEMORY));
 }
 
 

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -238,7 +238,7 @@
 			// Add bias to head:
 			REBCNT bias = SERIES_BIAS(series);
 			if (REB_U32_ADD_OF(bias, len, &bias))
-				raise Error_0(RE_OVERFLOW);
+				fail (Error(RE_OVERFLOW));
 
 			if (bias > 0xffff) { //bias is 16-bit, so a simple SERIES_ADD_BIAS could overflow it
 				REBYTE *data = series->data;
@@ -413,7 +413,7 @@
 **
 ***********************************************************************/
 {
-	if (!buf) panic Error_0(RE_NO_BUFFER);
+	if (!buf) panic (Error(RE_NO_BUFFER));
 
 	RESET_TAIL(buf);
 	Unbias_Series(buf, TRUE);
@@ -488,8 +488,8 @@
 {
 	Debug_Fmt("Panic_Series() in %s at line %d", file, line);
 	if (*series->guard == 1020) // should make valgrind or asan alert
-		panic Error_0(RE_MISC);
-	panic Error_0(RE_MISC); // just in case it didn't crash
+		panic (Error(RE_MISC));
+	panic (Error(RE_MISC)); // just in case it didn't crash
 }
 
 #endif

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -114,7 +114,7 @@
 	if (into) {
 		assert(ANY_ARRAY(out));
 		series = VAL_SERIES(out);
-		if (IS_PROTECT_SERIES(series)) raise Error_0(RE_PROTECTED);
+		if (IS_PROTECT_SERIES(series)) fail (Error(RE_PROTECTED));
 		VAL_INDEX(out) = Insert_Series(
 			series, VAL_INDEX(out), cast(REBYTE*, values), len
 		);

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -111,12 +111,12 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 				if (TYPE_CHECK(val, VAL_TYPE(value))) return TRUE;
 			}
 			else
-				raise Error_1(RE_INVALID_TYPE, Type_Of(val));
+				fail (Error(RE_INVALID_TYPE, Type_Of(val)));
 		}
 		return FALSE;
 	}
 
-	raise Error_Invalid_Arg(types);
+	fail (Error_Invalid_Arg(types));
 }
 
 
@@ -142,7 +142,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 			if (IS_CONDITIONAL_FALSE(D_OUT)) {
 				// !!! Only copies 3 values (and flaky), see CC#2231
 				Val_Init_Block(D_OUT, Copy_Array_At_Max_Shallow(block, i, 3));
-				raise Error_1(RE_ASSERT_FAILED, D_OUT);
+				fail (Error(RE_ASSERT_FAILED, D_OUT));
 			}
 		}
 		SET_TRASH_SAFE(D_OUT);
@@ -162,16 +162,16 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 				val = D_OUT;
 			}
 			else
-				raise Error_Invalid_Arg(value);
+				fail (Error_Invalid_Arg(value));
 
 			type = value+1;
-			if (IS_END(type)) raise Error_0(RE_MISSING_ARG);
+			if (IS_END(type)) fail (Error(RE_MISSING_ARG));
 			if (IS_BLOCK(type) || IS_WORD(type) || IS_TYPESET(type) || IS_DATATYPE(type)) {
 				if (!Is_Type_Of(val, type))
-					raise Error_1(RE_WRONG_TYPE, value);
+					fail (Error(RE_WRONG_TYPE, value));
 			}
 			else
-				raise Error_Invalid_Arg(type);
+				fail (Error_Invalid_Arg(type));
 		}
 	}
 
@@ -239,7 +239,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 		assert(ANY_WORD(arg));
 		rel = (VAL_WORD_INDEX(arg) < 0);
 		frame = VAL_WORD_FRAME(arg);
-		if (!frame) raise Error_1(RE_NOT_BOUND, arg);
+		if (!frame) fail (Error(RE_NOT_BOUND, arg));
 	}
 
 	// Block or word to bind:
@@ -255,7 +255,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 			if (flags & BIND_ALL)
 				Append_Frame(frame, arg, 0); // not in context, so add it.
 			else
-				raise Error_1(RE_NOT_IN_CONTEXT, arg);
+				fail (Error(RE_NOT_IN_CONTEXT, arg));
 		}
 		return R_ARG1;
 	}
@@ -400,7 +400,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 			Init_Obj_Value(D_OUT, VAL_WORD_FRAME(word));
 			return R_OUT;
 		}
-		if (!D_REF(2) && !IS_SET(val)) raise Error_1(RE_NO_VALUE, word);
+		if (!D_REF(2) && !IS_SET(val)) fail (Error(RE_NO_VALUE, word));
 		*D_OUT = *val;
 	}
 	else if (ANY_PATH(word)) {
@@ -409,7 +409,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 		if (!val) {
 			val = D_OUT;
 		}
-		if (!D_REF(2) && !IS_SET(val)) raise Error_1(RE_NO_VALUE, word);
+		if (!D_REF(2) && !IS_SET(val)) fail (Error(RE_NO_VALUE, word));
 	}
 	else if (IS_OBJECT(word)) {
 		Assert_Public_Object(word);
@@ -475,7 +475,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 			return R_NONE;
 		}
 		else
-			raise Error_Invalid_Arg(word);
+			fail (Error_Invalid_Arg(word));
 	}
 
 	frame = IS_ERROR(val) ? VAL_ERR_OBJECT(val) : VAL_OBJ_FRAME(val);
@@ -585,7 +585,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 	REBOOL is_blk  = FALSE;
 
 	if (not_any && !IS_SET(val))
-		raise Error_1(RE_NEED_VALUE, word);
+		fail (Error(RE_NEED_VALUE, word));
 
 	if (ANY_WORD(word)) {
 		Set_Var(word, val);
@@ -616,14 +616,14 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 		tmp = val;
 		for (; NOT_END(key); key++) {
 			if (VAL_GET_EXT(key, EXT_WORD_LOCK))
-				raise Error_Protected_Key(key);
+				fail (Error_Protected_Key(key));
 			if (not_any && is_blk && !IS_END(tmp) && IS_UNSET(tmp++)) {
 				// (Loop won't advance past end)
 				REBVAL key_name;
 				Val_Init_Word_Unbound(
 					&key_name, REB_WORD, VAL_TYPESET_SYM(key)
 				);
-				raise Error_1(RE_NEED_VALUE, &key_name);
+				fail (Error(RE_NEED_VALUE, &key_name));
 			}
 		}
 
@@ -648,11 +648,11 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 				case REB_WORD:
 				case REB_SET_WORD:
 				case REB_LIT_WORD:
-					if (!IS_SET(tmp)) raise Error_1(RE_NEED_VALUE, word);
+					if (!IS_SET(tmp)) fail (Error(RE_NEED_VALUE, word));
 					break;
 				case REB_GET_WORD:
 					if (!IS_SET(IS_WORD(tmp) ? GET_VAR(tmp) : tmp))
-						raise Error_1(RE_NEED_VALUE, word);
+						fail (Error(RE_NEED_VALUE, word));
 				}
 			}
 		}
@@ -662,7 +662,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 			else if (IS_GET_WORD(word))
 				Set_Var(word, IS_WORD(val) ? GET_VAR(val) : val);
 			else
-				raise Error_Invalid_Arg(word);
+				fail (Error_Invalid_Arg(word));
 
 			if (is_blk) {
 				val++;
@@ -700,7 +700,7 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 	if (ANY_WORD(value)) {
 		word = value;
 
-		if (!HAS_FRAME(word)) raise Error_1(RE_NOT_BOUND, word);
+		if (!HAS_FRAME(word)) fail (Error(RE_NOT_BOUND, word));
 
 		var = GET_MUTABLE_VAR(word);
 		SET_UNSET(var);
@@ -710,9 +710,9 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 
 		for (word = VAL_BLK_DATA(value); NOT_END(word); word++) {
 			if (!ANY_WORD(word))
-				raise Error_Invalid_Arg(word);
+				fail (Error_Invalid_Arg(word));
 
-			if (!HAS_FRAME(word)) raise Error_1(RE_NOT_BOUND, word);
+			if (!HAS_FRAME(word)) fail (Error(RE_NOT_BOUND, word));
 
 			var = GET_MUTABLE_VAR(word);
 			SET_UNSET(var);

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -100,7 +100,7 @@ typedef enum {
 
 	// Hand-make a FRAME (done for for speed):
 	len = IS_BLOCK(spec) ? VAL_LEN(spec) : 1;
-	if (len == 0) raise Error_Invalid_Arg(spec);
+	if (len == 0) fail (Error_Invalid_Arg(spec));
 	frame = Make_Frame(len, FALSE);
 	SERIES_TAIL(frame) = len+1;
 	SERIES_TAIL(FRM_KEYLIST(frame)) = len + 1;
@@ -116,7 +116,7 @@ typedef enum {
 			// Prevent inconsistent GC state:
 			Free_Series(FRM_KEYLIST(frame));
 			Free_Series(frame);
-			raise Error_Invalid_Arg(spec);
+			fail (Error_Invalid_Arg(spec));
 		}
 		Val_Init_Typeset(word, ALL_64, VAL_WORD_SYM(spec));
 		word++;
@@ -169,7 +169,7 @@ typedef enum {
 		}
 
 	next_iteration:
-		if (VAL_TYPE(var) != type) raise Error_1(RE_INVALID_TYPE, var);
+		if (VAL_TYPE(var) != type) fail (Error(RE_INVALID_TYPE, var));
 		si = VAL_INDEX(var);
 	}
 
@@ -200,11 +200,11 @@ typedef enum {
 		}
 
 	next_iteration:
-		if (!IS_INTEGER(var)) raise Error_Has_Bad_Type(var);
+		if (!IS_INTEGER(var)) fail (Error_Has_Bad_Type(var));
 		start = VAL_INT64(var);
 
 		if (REB_I64_ADD_OF(start, incr, &start))
-			raise Error_0(RE_OVERFLOW);
+			fail (Error(RE_OVERFLOW));
 	}
 
 	return FALSE;
@@ -226,21 +226,21 @@ typedef enum {
 	else if (IS_DECIMAL(start) || IS_PERCENT(start))
 		s = VAL_DECIMAL(start);
 	else
-		raise Error_Invalid_Arg(start);
+		fail (Error_Invalid_Arg(start));
 
 	if (IS_INTEGER(end))
 		e = cast(REBDEC, VAL_INT64(end));
 	else if (IS_DECIMAL(end) || IS_PERCENT(end))
 		e = VAL_DECIMAL(end);
 	else
-		raise Error_Invalid_Arg(end);
+		fail (Error_Invalid_Arg(end));
 
 	if (IS_INTEGER(incr))
 		i = cast(REBDEC, VAL_INT64(incr));
 	else if (IS_DECIMAL(incr) || IS_PERCENT(incr))
 		i = VAL_DECIMAL(incr);
 	else
-		raise Error_Invalid_Arg(incr);
+		fail (Error_Invalid_Arg(incr));
 
 	VAL_SET(var, REB_DECIMAL);
 
@@ -259,7 +259,7 @@ typedef enum {
 		}
 
 	next_iteration:
-		if (!IS_DECIMAL(var)) raise Error_Has_Bad_Type(var);
+		if (!IS_DECIMAL(var)) fail (Error_Has_Bad_Type(var));
 		s = VAL_DECIMAL(var);
 	}
 
@@ -337,12 +337,12 @@ typedef enum {
 			}
 
 		next_iteration:
-			if (VAL_TYPE(var) != type) raise Error_Invalid_Arg(var);
+			if (VAL_TYPE(var) != type) fail (Error_Invalid_Arg(var));
 			VAL_INDEX(var) += inc;
 		}
 	}
 	else
-		raise Error_Invalid_Arg(var);
+		fail (Error_Invalid_Arg(var));
 
 	// !!!!! ???? allowed to write VAR????
 	*var = *D_ARG(1);
@@ -415,12 +415,12 @@ typedef enum {
 		series = VAL_OBJ_FRAME(data);
 		out = FRM_KEYLIST(series); // words (the out local reused)
 		index = 1;
-		//if (frame->tail > 3) raise Error_Invalid_Arg(FRM_KEY(frame, 3));
+		//if (frame->tail > 3) fail (Error_Invalid_Arg(FRM_KEY(frame, 3)));
 	}
 	else if (IS_MAP(data)) {
 		series = VAL_SERIES(data);
 		index = 0;
-		//if (frame->tail > 3) raise Error_Invalid_Arg(FRM_KEY(frame, 3));
+		//if (frame->tail > 3) fail (Error_Invalid_Arg(FRM_KEY(frame, 3)));
 	}
 	else {
 		series = VAL_SERIES(data);
@@ -473,7 +473,7 @@ typedef enum {
 								Val_Init_Word_Unbound(
 									&key_name, REB_WORD, VAL_TYPESET_SYM(keys)
 								);
-								raise Error_Invalid_Arg(&key_name);
+								fail (Error_Invalid_Arg(&key_name));
 							}
 							j++;
 						}
@@ -501,7 +501,7 @@ typedef enum {
 								Val_Init_Word_Unbound(
 									&key_name, REB_WORD, VAL_TYPESET_SYM(keys)
 								);
-								raise Error_Invalid_Arg(&key_name);
+								fail (Error_Invalid_Arg(&key_name));
 							}
 							j++;
 						}
@@ -909,7 +909,7 @@ skip_hidden: ;
 			return R_OUT_IS_THROWN;
 		}
 
-		if (IS_UNSET(D_OUT)) raise Error_0(RE_NO_RETURN);
+		if (IS_UNSET(D_OUT)) fail (Error(RE_NO_RETURN));
 
 	} while (IS_CONDITIONAL_FALSE(D_OUT));
 
@@ -946,7 +946,7 @@ skip_hidden: ;
 		}
 
 		if (IS_UNSET(&temp))
-			raise Error_0(RE_NO_RETURN);
+			fail (Error(RE_NO_RETURN));
 
 		if (IS_CONDITIONAL_FALSE(&temp)) {
 			// When the condition evaluates to a LOGIC! false or a NONE!,

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -88,7 +88,7 @@ enum {SINE, COSINE, TANGENT};
 ***********************************************************************/
 {
 	REBDEC dval = AS_DECIMAL(value);
-	if (kind != TANGENT && (dval < -1 || dval > 1)) raise Error_0(RE_OVERFLOW);
+	if (kind != TANGENT && (dval < -1 || dval > 1)) fail (Error(RE_OVERFLOW));
 
 	if (kind == SINE) dval = asin(dval);
 	else if (kind == COSINE) dval = acos(dval);
@@ -133,7 +133,7 @@ enum {SINE, COSINE, TANGENT};
 ***********************************************************************/
 {
 	REBDEC dval = Trig_Value(D_ARG(1), !D_REF(2), TANGENT);
-	if (Eq_Decimal(fabs(dval), pi1 / 2.0)) raise Error_0(RE_OVERFLOW);
+	if (Eq_Decimal(fabs(dval), pi1 / 2.0)) fail (Error(RE_OVERFLOW));
 	SET_DECIMAL(D_OUT, tan(dval));
 	return R_OUT;
 }
@@ -195,7 +195,7 @@ enum {SINE, COSINE, TANGENT};
 ***********************************************************************/
 {
 	REBDEC dval = AS_DECIMAL(D_ARG(1));
-	if (dval <= 0) raise Error_0(RE_POSITIVE);
+	if (dval <= 0) fail (Error(RE_POSITIVE));
 	SET_DECIMAL(D_OUT, log10(dval));
 	return R_OUT;
 }
@@ -208,7 +208,7 @@ enum {SINE, COSINE, TANGENT};
 ***********************************************************************/
 {
 	REBDEC dval = AS_DECIMAL(D_ARG(1));
-	if (dval <= 0) raise Error_0(RE_POSITIVE);
+	if (dval <= 0) fail (Error(RE_POSITIVE));
 	SET_DECIMAL(D_OUT, log(dval) / LOG2);
 	return R_OUT;
 }
@@ -221,7 +221,7 @@ enum {SINE, COSINE, TANGENT};
 ***********************************************************************/
 {
 	REBDEC dval = AS_DECIMAL(D_ARG(1));
-	if (dval <= 0) raise Error_0(RE_POSITIVE);
+	if (dval <= 0) fail (Error(RE_POSITIVE));
 	SET_DECIMAL(D_OUT, log(dval));
 	return R_OUT;
 }
@@ -234,7 +234,7 @@ enum {SINE, COSINE, TANGENT};
 ***********************************************************************/
 {
 	REBDEC dval = AS_DECIMAL(D_ARG(1));
-	if (dval < 0) raise Error_0(RE_POSITIVE);
+	if (dval < 0) fail (Error(RE_POSITIVE));
 	SET_DECIMAL(D_OUT, sqrt(dval));
 	return R_OUT;
 }
@@ -265,7 +265,7 @@ enum {SINE, COSINE, TANGENT};
 	} else {
 		if (b >= 64) {
 			if (D_REF(3)) VAL_INT64(a) = 0;
-			else if (VAL_INT64(a)) raise Error_0(RE_OVERFLOW);
+			else if (VAL_INT64(a)) fail (Error(RE_OVERFLOW));
 		} else
 			if (D_REF(3)) VAL_UNT64(a) <<= b;
 			else {
@@ -273,7 +273,7 @@ enum {SINE, COSINE, TANGENT};
 				d = VAL_INT64(a) < 0 ? -VAL_UNT64(a) : VAL_UNT64(a);
 				if (c <= d) {
 					if ((c < d) || (VAL_INT64(a) >= 0))
-						raise Error_0(RE_OVERFLOW);
+						fail (Error(RE_OVERFLOW));
 
 					VAL_INT64(a) = MIN_I64;
 				}
@@ -376,14 +376,14 @@ enum {SINE, COSINE, TANGENT};
 
 		if (strictness == 0 || strictness == 1) return FALSE;
 		//if (strictness >= 2)
-		raise Error_2(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b));
+		fail (Error(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b)));
 	}
 
 compare:
 	// At this point, both args are of the same datatype.
 	if (!(code = Compare_Types[VAL_TYPE(a)])) return FALSE;
 	result = code(a, b, strictness);
-	if (result < 0) raise Error_2(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b));
+	if (result < 0) fail (Error(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b)));
 	return result;
 }
 

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -60,7 +60,7 @@ enum {
 
 		if (ANY_ARRAY(val1)) {
 			if (!ANY_ARRAY(val2))
-				raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+				fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 			// As long as they're both arrays, we're willing to do:
 			//
@@ -77,13 +77,13 @@ enum {
 			//      <abcde>
 
 			if (IS_BINARY(val2))
-				raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+				fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 		}
 		else {
 			// Binaries only operate with other binaries
 
 			if (!IS_BINARY(val2))
-				raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+				fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 		}
 	}
 
@@ -227,7 +227,7 @@ enum {
 	// !!! Is this sensible?
 	if (IS_DATE(val1) || IS_DATE(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		Subtract_Date(val1, val2, D_OUT);
 		return R_OUT;
@@ -235,7 +235,7 @@ enum {
 
 	if (IS_BITSET(val1) || IS_BITSET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		Val_Init_Bitset(D_OUT, Xandor_Binary(A_XOR, val1, val2));
 		return R_OUT;
@@ -243,7 +243,7 @@ enum {
 
 	if (IS_TYPESET(val1) || IS_TYPESET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		*D_OUT = *val1;
 		VAL_TYPESET_BITS(D_OUT) ^= VAL_TYPESET_BITS(val2);
@@ -279,7 +279,7 @@ enum {
 
 	if (IS_BITSET(val1) || IS_BITSET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		// !!! 0 was said to be a "special case" in original code
 		Val_Init_Bitset(D_OUT, Xandor_Binary(0, val1, val2));
@@ -288,7 +288,7 @@ enum {
 
 	if (IS_TYPESET(val1) || IS_TYPESET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		*D_OUT = *val1;
 		VAL_TYPESET_BITS(D_OUT) &= ~VAL_TYPESET_BITS(val2);
@@ -320,7 +320,7 @@ enum {
 
 	if (IS_BITSET(val1) || IS_BITSET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		Val_Init_Bitset(D_OUT, Xandor_Binary(A_AND, val1, val2));
 		return R_OUT;
@@ -328,7 +328,7 @@ enum {
 
 	if (IS_TYPESET(val1) || IS_TYPESET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		*D_OUT = *val1;
 		VAL_TYPESET_BITS(D_OUT) &= VAL_TYPESET_BITS(val2);
@@ -360,7 +360,7 @@ enum {
 
 	if (IS_BITSET(val1) || IS_BITSET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		Val_Init_Bitset(D_OUT, Xandor_Binary(A_OR, val1, val2));
 		return R_OUT;
@@ -368,7 +368,7 @@ enum {
 
 	if (IS_TYPESET(val1) || IS_TYPESET(val2)) {
 		if (VAL_TYPE(val1) != VAL_TYPE(val2))
-			raise Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2));
+			fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
 
 		*D_OUT = *val1;
 		VAL_TYPESET_BITS(D_OUT) |= VAL_TYPESET_BITS(val2);

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -208,7 +208,7 @@ static struct digest {
 
 			REBINT crc32;
 			if (D_REF(ARG_CHECKSUM_SECURE) || D_REF(ARG_CHECKSUM_KEY))
-				raise Error_0(RE_BAD_REFINES);
+				fail (Error(RE_BAD_REFINES));
 			crc32 = cast(REBINT, CRC32(data, len));
 			SET_INTEGER(D_OUT, crc32);
 			return R_OUT;
@@ -221,7 +221,7 @@ static struct digest {
 
 			uLong adler = z_adler32(0L, data, len);
 			if (D_REF(ARG_CHECKSUM_SECURE) || D_REF(ARG_CHECKSUM_KEY))
-				raise Error_0(RE_BAD_REFINES);
+				fail (Error(RE_BAD_REFINES));
 			SET_INTEGER(D_OUT, adler);
 			return R_OUT;
 		}
@@ -284,7 +284,7 @@ static struct digest {
 			}
 		}
 
-		raise Error_Invalid_Arg(D_ARG(ARG_CHECKSUM_WORD));
+		fail (Error_Invalid_Arg(D_ARG(ARG_CHECKSUM_WORD)));
 	}
 	else if (D_REF(ARG_CHECKSUM_TCP)) { // /tcp
 		REBINT ipc = Compute_IPC(data, len);
@@ -417,7 +417,7 @@ static struct digest {
 	if (D_REF(2)) base = VAL_INT32(D_ARG(3)); // /base
 
 	if (!Decode_Binary(D_OUT, BIN_SKIP(ser, index), len, base, 0))
-		raise Error_1(RE_INVALID_DATA, D_ARG(1));
+		fail (Error(RE_INVALID_DATA, D_ARG(1)));
 
 	return R_OUT;
 }
@@ -453,7 +453,7 @@ static struct digest {
 		ser = Encode_Base2(arg, 0, FALSE);
 		break;
 	default:
-		raise Error_Invalid_Arg(D_ARG(3));
+		fail (Error_Invalid_Arg(D_ARG(3)));
 	}
 
 	Val_Init_String(D_OUT, ser);
@@ -474,7 +474,7 @@ static struct digest {
 	REBVAL *key  = D_ARG(2);
 
 	if (!Cloak(TRUE, VAL_BIN_DATA(data), VAL_LEN(data), (REBYTE*)key, 0, D_REF(3)))
-		raise Error_Invalid_Arg(key);
+		fail (Error_Invalid_Arg(key));
 
 	return R_ARG1;
 }
@@ -492,7 +492,7 @@ static struct digest {
 	REBVAL *key  = D_ARG(2);
 
 	if (!Cloak(FALSE, VAL_BIN_DATA(data), VAL_LEN(data), (REBYTE*)key, 0, D_REF(3)))
-		raise Error_Invalid_Arg(key);
+		fail (Error_Invalid_Arg(key));
 
 	return R_ARG1;
 }
@@ -694,7 +694,7 @@ static struct digest {
 	len = -1;
 	if (D_REF(2)) {	// /size
 		len = (REBINT) VAL_INT64(D_ARG(3));
-		if (len < 0) raise Error_Invalid_Arg(D_ARG(3));
+		if (len < 0) fail (Error_Invalid_Arg(D_ARG(3)));
 	}
 	if (IS_INTEGER(arg)) { // || IS_DECIMAL(arg)) {
 		if (len < 0 || len > MAX_HEX_LEN) len = MAX_HEX_LEN;
@@ -711,7 +711,7 @@ static struct digest {
 		*buf = 0;
 	}
 	else
-		raise Error_Invalid_Arg(arg);
+		fail (Error_Invalid_Arg(arg));
 
 //	SERIES_TAIL(series) = len;
 //	Val_Init_Series(D_OUT, REB_ISSUE, series);

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -36,7 +36,7 @@
 /*
 ***********************************************************************/
 {
-	raise Error_Is(TASK_HALT_ERROR);
+	fail (VAL_ERR_OBJECT(TASK_HALT_ERROR));
 }
 
 
@@ -230,7 +230,7 @@ const char *evoke_help = "Evoke values:\n"
 				Expand_Stack(Int32s(arg, 1));
 				break;
 			case SYM_CRASH:
-				panic Error_0(RE_MISC);
+				panic (Error(RE_MISC));
 			default:
 				Out_Str(cb_cast(evoke_help), 1);
 			}
@@ -376,7 +376,7 @@ const char *evoke_help = "Evoke values:\n"
 	}
 	return R_OUT;
 err:
-	raise Error_0(RE_BAD_SERIES);
+	fail (Error(RE_BAD_SERIES));
 }
 
 
@@ -421,7 +421,7 @@ err:
 	case SYM_IDENTIFY:
 		codi.action = CODI_ACT_IDENTIFY;
 	case SYM_DECODE:
-		if (!IS_BINARY(val)) raise Error_1(RE_INVALID_ARG, val);
+		if (!IS_BINARY(val)) fail (Error(RE_INVALID_ARG, val));
 		codi.data = VAL_BIN_DATA(D_ARG(3));
 		codi.len  = VAL_LEN(D_ARG(3));
 		break;
@@ -440,11 +440,11 @@ err:
 			codi.extra.other = VAL_BIN_DATA(val);
 		}
 		else
-			raise Error_1(RE_INVALID_ARG, val);
+			fail (Error(RE_INVALID_ARG, val));
 		break;
 
 	default:
-		raise Error_1(RE_INVALID_ARG, D_ARG(2));
+		fail (Error(RE_INVALID_ARG, D_ARG(2)));
 	}
 
 	// Nasty alias, but it must be done:
@@ -453,7 +453,7 @@ err:
 
 	if (codi.error != 0) {
 		if (result == CODI_CHECK) return R_FALSE;
-		raise Error_0(RE_BAD_MEDIA); // need better!!!
+		fail (Error(RE_BAD_MEDIA)); // need better!!!
 	}
 
 	switch (result) {
@@ -509,7 +509,7 @@ err:
 		break;
 
 	default:
-		raise Error_0(RE_BAD_MEDIA); // need better!!!
+		fail (Error(RE_BAD_MEDIA)); // need better!!!
 	}
 
 	return R_OUT;
@@ -528,7 +528,7 @@ err:
 	if (ANY_WORD(val)) {
 		if (VAL_WORD_INDEX(val) < 0) return R_TRUE;
 		frm = VAL_WORD_FRAME(val);
-		if (!frm) raise Error_1(RE_NOT_BOUND, val);
+		if (!frm) fail (Error(RE_NOT_BOUND, val));
 	}
 	else frm = VAL_OBJ_FRAME(D_ARG(1));
 

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -86,12 +86,12 @@
 		// This device is opened on the READ:
 		if (!IS_OPEN(req)) {
 			if (OS_DO_DEVICE(req, RDC_OPEN))
-				raise Error_On_Port(RE_CANNOT_OPEN, port, req->error);
+				fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
 		}
 		// Issue the read request:
 		CLR_FLAG(req->flags, RRF_WIDE); // allow byte or wide chars
 		result = OS_DO_DEVICE(req, RDC_READ);
-		if (result < 0) raise Error_On_Port(RE_READ_ERROR, port, req->error);
+		if (result < 0) fail (Error_On_Port(RE_READ_ERROR, port, req->error));
 		if (result > 0) return R_NONE; /* pending */
 
 		// Copy and set the string result:
@@ -119,11 +119,11 @@
 
 	case A_WRITE:
 		if (!IS_STRING(arg) && !IS_BINARY(arg))
-			raise Error_1(RE_INVALID_PORT_ARG, arg);
+			fail (Error(RE_INVALID_PORT_ARG, arg));
 		// This device is opened on the WRITE:
 		if (!IS_OPEN(req)) {
 			if (OS_DO_DEVICE(req, RDC_OPEN))
-				raise Error_On_Port(RE_CANNOT_OPEN, port, req->error);
+				fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
 		}
 
 		refs = Find_Refines(call_, ALL_WRITE_REFS);
@@ -170,13 +170,13 @@
 		result = OS_DO_DEVICE(req, RDC_WRITE);
 		SET_NONE(OFV(port, STD_PORT_DATA)); // GC can collect it
 
-		if (result < 0) raise Error_On_Port(RE_WRITE_ERROR, port, req->error);
+		if (result < 0) fail (Error_On_Port(RE_WRITE_ERROR, port, req->error));
 		//if (result == DR_DONE) SET_NONE(OFV(port, STD_PORT_DATA));
 		break;
 
 	case A_OPEN:
 		if (OS_DO_DEVICE(req, RDC_OPEN))
-			raise Error_On_Port(RE_CANNOT_OPEN, port, req->error);
+			fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
 		break;
 
 	case A_CLOSE:
@@ -188,7 +188,7 @@
 		return R_FALSE;
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_ARG1; // port

--- a/src/core/p-console.c
+++ b/src/core/p-console.c
@@ -64,7 +64,7 @@
 		// If not open, open it:
 		if (!IS_OPEN(req)) {
 			if (OS_DO_DEVICE(req, RDC_OPEN))
-				raise Error_On_Port(RE_CANNOT_OPEN, port, req->error);
+				fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
 		}
 
 		// If no buffer, create a buffer:
@@ -91,7 +91,7 @@
 #endif
 
 		result = OS_DO_DEVICE(req, RDC_READ);
-		if (result < 0) raise Error_On_Port(RE_READ_ERROR, port, req->error);
+		if (result < 0) fail (Error_On_Port(RE_READ_ERROR, port, req->error));
 
 #ifdef nono
 		// Does not belong here!!
@@ -128,7 +128,7 @@
 		return R_FALSE;
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -146,7 +146,7 @@
 		// Path did not end with /, so we better be wild:
 		if (wild == 0) {
 			// !!! Comment said `OS_FREE(dir->special.file.path);` (needed?)
-			raise Error_1(RE_BAD_FILE_PATH, path);
+			fail (Error(RE_BAD_FILE_PATH, path));
 		}
 		else if (wild < 0) {
 			dir->special.file.path[len++] = OS_MAKE_CH(OS_DIR_SEP);
@@ -180,12 +180,12 @@
 
 	// Validate and fetch relevant PORT fields:
 	spec  = BLK_SKIP(port, STD_PORT_SPEC);
-	if (!IS_OBJECT(spec)) raise Error_1(RE_INVALID_SPEC, spec);
+	if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
 	path = Obj_Value(spec, STD_PORT_SPEC_HEAD_REF);
-	if (!path) raise Error_1(RE_INVALID_SPEC, spec);
+	if (!path) fail (Error(RE_INVALID_SPEC, spec));
 
 	if (IS_URL(path)) path = Obj_Value(spec, STD_PORT_SPEC_HEAD_PATH);
-	else if (!IS_FILE(path)) raise Error_1(RE_INVALID_SPEC, path);
+	else if (!IS_FILE(path)) fail (Error(RE_INVALID_SPEC, path));
 
 	state = BLK_SKIP(port, STD_PORT_STATE); // if block, then port is open.
 
@@ -206,7 +206,7 @@
 			result = Read_Dir(&dir, VAL_SERIES(state));
 			///OS_FREE(dir.file.path);
 			if (result < 0)
-				raise Error_On_Port(RE_CANNOT_OPEN, port, dir.error);
+				fail (Error_On_Port(RE_CANNOT_OPEN, port, dir.error));
 			*D_OUT = *state;
 			SET_NONE(state);
 		}
@@ -228,12 +228,12 @@
 
 	case A_CREATE:
 		//Trap_Security(flags[POL_WRITE], POL_WRITE, path);
-		if (IS_BLOCK(state)) raise Error_1(RE_ALREADY_OPEN, path);
+		if (IS_BLOCK(state)) fail (Error(RE_ALREADY_OPEN, path));
 create:
 		Init_Dir_Path(&dir, path, 0, POL_WRITE | REMOVE_TAIL_SLASH); // Sets RFM_DIR too
 		result = OS_DO_DEVICE(&dir, RDC_CREATE);
 		///OS_FREE(dir.file.path);
-		if (result < 0) raise Error_1(RE_NO_CREATE, path);
+		if (result < 0) fail (Error(RE_NO_CREATE, path));
 		if (action == A_CREATE) {
 			// !!! Used to return R_ARG2, but create is single arity.  :-/
 			return R_ARG1;
@@ -242,18 +242,18 @@ create:
 		break;
 
 	case A_RENAME:
-		if (IS_BLOCK(state)) raise Error_1(RE_ALREADY_OPEN, path);
+		if (IS_BLOCK(state)) fail (Error(RE_ALREADY_OPEN, path));
 		else {
 			REBSER *target;
 
 			Init_Dir_Path(&dir, path, 0, POL_WRITE | REMOVE_TAIL_SLASH); // Sets RFM_DIR too
 			// Convert file name to OS format:
 			if (!(target = Value_To_OS_Path(D_ARG(2), TRUE)))
-				raise Error_1(RE_BAD_FILE_PATH, D_ARG(2));
+				fail (Error(RE_BAD_FILE_PATH, D_ARG(2)));
 			dir.common.data = BIN_DATA(target);
 			OS_DO_DEVICE(&dir, RDC_RENAME);
 			Free_Series(target);
-			if (dir.error) raise Error_1(RE_NO_RENAME, path);
+			if (dir.error) fail (Error(RE_NO_RENAME, path));
 		}
 		break;
 
@@ -265,22 +265,22 @@ create:
 		// !!! add recursive delete (?)
 		result = OS_DO_DEVICE(&dir, RDC_DELETE);
 		///OS_FREE(dir.file.path);
-		if (result < 0) raise Error_1(RE_NO_DELETE, path);
+		if (result < 0) fail (Error(RE_NO_DELETE, path));
 		// !!! Returned R_ARG2 before, but there is no second argument :-/
 		return R_ARG1;
 
 	case A_OPEN:
 		// !! If open fails, what if user does a READ w/o checking for error?
-		if (IS_BLOCK(state)) raise Error_1(RE_ALREADY_OPEN, path);
+		if (IS_BLOCK(state)) fail (Error(RE_ALREADY_OPEN, path));
 		//Trap_Security(flags[POL_READ], POL_READ, path);
 		args = Find_Refines(call_, ALL_OPEN_REFS);
 		if (args & AM_OPEN_NEW) goto create;
-		//if (args & ~AM_OPEN_READ) raise Error_1(RE_INVALID_SPEC, path);
+		//if (args & ~AM_OPEN_READ) fail (Error(RE_INVALID_SPEC, path));
 		Val_Init_Block(state, Make_Array(7));
 		Init_Dir_Path(&dir, path, 1, POL_READ);
 		result = Read_Dir(&dir, VAL_SERIES(state));
 		///OS_FREE(dir.file.path);
-		if (result < 0) raise Error_On_Port(RE_CANNOT_OPEN, port, dir.error);
+		if (result < 0) fail (Error_On_Port(RE_CANNOT_OPEN, port, dir.error));
 		break;
 
 	case A_OPENQ:
@@ -308,7 +308,7 @@ create:
 		break;
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -52,7 +52,7 @@
 
 	sock = cast(REBREQ*, Use_Port_State(port, RDI_DNS, sizeof(*sock)));
 	spec = OFV(port, STD_PORT_SPEC);
-	if (!IS_OBJECT(spec)) raise Error_0(RE_INVALID_PORT);
+	if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_PORT));
 
 	sock->timeout = 4000; // where does this go? !!!
 
@@ -61,7 +61,7 @@
 	case A_READ:
 		if (!IS_OPEN(sock)) {
 			if (OS_DO_DEVICE(sock, RDC_OPEN))
-				raise Error_On_Port(RE_CANNOT_OPEN, port, sock->error);
+				fail (Error_On_Port(RE_CANNOT_OPEN, port, sock->error));
 			sync = TRUE;
 		}
 
@@ -75,11 +75,11 @@
 			sock->common.data = VAL_BIN(arg);
 		}
 		else
-			raise Error_On_Port(RE_INVALID_SPEC, port, -10);
+			fail (Error_On_Port(RE_INVALID_SPEC, port, -10));
 
 		result = OS_DO_DEVICE(sock, RDC_READ);
 		if (result < 0)
-			raise Error_On_Port(RE_READ_ERROR, port, sock->error);
+			fail (Error_On_Port(RE_READ_ERROR, port, sock->error));
 
 		// Wait for it...
 		if (sync && result == DR_PEND) {
@@ -97,7 +97,7 @@
 
 	case A_PICK:  // FIRST - return result
 		if (!IS_OPEN(sock))
-			raise Error_On_Port(RE_NOT_OPEN, port, -12);
+			fail (Error_On_Port(RE_NOT_OPEN, port, -12));
 
 		len = Get_Num_Arg(arg); // Position
 pick:
@@ -105,7 +105,7 @@ pick:
 			if (!sock->special.net.host_info || !GET_FLAG(sock->flags, RRF_DONE)) return R_NONE;
 			if (sock->error) {
 				OS_DO_DEVICE(sock, RDC_CLOSE);
-				raise Error_On_Port(RE_READ_ERROR, port, sock->error);
+				fail (Error_On_Port(RE_READ_ERROR, port, sock->error));
 			}
 			if (GET_FLAG(sock->modes, RST_REVERSE)) {
 				Val_Init_String(D_OUT, Copy_Bytes(sock->common.data, LEN_BYTES(sock->common.data)));
@@ -115,12 +115,12 @@ pick:
 			OS_DO_DEVICE(sock, RDC_CLOSE);
 		}
 		else
-			raise Error_Out_Of_Range(arg);
+			fail (Error_Out_Of_Range(arg));
 		break;
 
 	case A_OPEN:
 		if (OS_DO_DEVICE(sock, RDC_OPEN))
-			raise Error_On_Port(RE_CANNOT_OPEN, port, -12);
+			fail (Error_On_Port(RE_CANNOT_OPEN, port, -12));
 		break;
 
 	case A_CLOSE:
@@ -135,7 +135,7 @@ pick:
 		return R_NONE;
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -88,7 +88,7 @@ REBREQ *req;		//!!! move this global
 	// Append to tail if room:
 	if (SERIES_FULL(VAL_SERIES(state))) {
 		if (VAL_TAIL(state) > EVENTS_LIMIT) {
-			panic Error_0(RE_MAX_EVENTS);
+			panic (Error(RE_MAX_EVENTS));
 		} else {
 			Extend_Series(VAL_SERIES(state), EVENTS_CHUNK);
 			//RL_Print("event queue increased to :%d\n", SERIES_REST(VAL_SERIES(state)));
@@ -162,7 +162,7 @@ REBREQ *req;		//!!! move this global
 	// Validate and fetch relevant PORT fields:
 	state = BLK_SKIP(port, STD_PORT_STATE);
 	spec  = BLK_SKIP(port, STD_PORT_SPEC);
-	if (!IS_OBJECT(spec)) raise Error_1(RE_INVALID_SPEC, spec);
+	if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
 
 	// Get or setup internal state data:
 	if (!IS_BLOCK(state)) Val_Init_Block(state, Make_Array(EVENTS_CHUNK - 1));
@@ -174,13 +174,13 @@ REBREQ *req;		//!!! move this global
 
 	// Normal block actions done on events:
 	case A_POKE:
-		if (!IS_EVENT(D_ARG(3))) raise Error_Invalid_Arg(D_ARG(3));
+		if (!IS_EVENT(D_ARG(3))) fail (Error_Invalid_Arg(D_ARG(3)));
 		goto act_blk;
 	case A_INSERT:
 	case A_APPEND:
 	//case A_PATH:		// not allowed: port/foo is port object field access
 	//case A_PATH_SET:	// not allowed: above
-		if (!IS_EVENT(arg)) raise Error_Invalid_Arg(arg);
+		if (!IS_EVENT(arg)) fail (Error_Invalid_Arg(arg));
 	case A_PICK:
 act_blk:
 		save_port = *D_ARG(1); // save for return
@@ -224,7 +224,7 @@ act_blk:
 	case A_FIND: // add it
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -55,11 +55,11 @@
 
 	// Validate PORT fields:
 	spec = OFV(port, STD_PORT_SPEC);
-	if (!IS_OBJECT(spec)) raise Error_0(RE_INVALID_PORT);
+	if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_PORT));
 	path = Obj_Value(spec, STD_PORT_SPEC_HEAD_REF);
-	if (!path) raise Error_1(RE_INVALID_SPEC, spec);
+	if (!path) fail (Error(RE_INVALID_SPEC, spec));
 
-	//if (!IS_FILE(path)) raise Error_1(RE_INVALID_SPEC, path);
+	//if (!IS_FILE(path)) fail (Error(RE_INVALID_SPEC, path));
 
 	req = cast(REBREQ*, Use_Port_State(port, RDI_SERIAL, sizeof(*req)));
 
@@ -71,7 +71,7 @@
 		case A_OPEN:
 			arg = Obj_Value(spec, STD_PORT_SPEC_SERIAL_PATH);  //Should Obj_Value really return a char* ?
 			if (! (IS_FILE(arg) || IS_STRING(arg) || IS_BINARY(arg)))
-				raise Error_1(RE_INVALID_PORT_ARG, arg);
+				fail (Error(RE_INVALID_PORT_ARG, arg));
 
 			req->special.serial.path = ALLOC_ARRAY(REBCHR, MAX_SERIAL_DEV_PATH);
 			OS_STRNCPY(
@@ -83,7 +83,7 @@
 			);
 			arg = Obj_Value(spec, STD_PORT_SPEC_SERIAL_SPEED);
 			if (! IS_INTEGER(arg))
-				raise Error_1(RE_INVALID_PORT_ARG, arg);
+				fail (Error(RE_INVALID_PORT_ARG, arg));
 
 			req->special.serial.baud = VAL_INT32(arg);
 			//Secure_Port(SYM_SERIAL, ???, path, ser);
@@ -92,7 +92,7 @@
 				|| VAL_INT64(arg) < 5
 				|| VAL_INT64(arg) > 8
 			) {
-				raise Error_1(RE_INVALID_PORT_ARG, arg);
+				fail (Error(RE_INVALID_PORT_ARG, arg));
 			}
 			req->special.serial.data_bits = VAL_INT32(arg);
 
@@ -101,7 +101,7 @@
 				|| VAL_INT64(arg) < 1
 				|| VAL_INT64(arg) > 2
 			) {
-				raise Error_1(RE_INVALID_PORT_ARG, arg);
+				fail (Error(RE_INVALID_PORT_ARG, arg));
 			}
 			req->special.serial.stop_bits = VAL_INT32(arg);
 
@@ -110,7 +110,7 @@
 				req->special.serial.parity = SERIAL_PARITY_NONE;
 			} else {
 				if (!IS_WORD(arg))
-					raise Error_1(RE_INVALID_PORT_ARG, arg);
+					fail (Error(RE_INVALID_PORT_ARG, arg));
 
 				switch (VAL_WORD_CANON(arg)) {
 					case SYM_ODD:
@@ -120,7 +120,7 @@
 						req->special.serial.parity = SERIAL_PARITY_EVEN;
 						break;
 					default:
-						raise Error_1(RE_INVALID_PORT_ARG, arg);
+						fail (Error(RE_INVALID_PORT_ARG, arg));
 				}
 			}
 
@@ -129,7 +129,7 @@
 				req->special.serial.flow_control = SERIAL_FLOW_CONTROL_NONE;
 			} else {
 				if (!IS_WORD(arg))
-					raise Error_1(RE_INVALID_PORT_ARG, arg);
+					fail (Error(RE_INVALID_PORT_ARG, arg));
 
 				switch (VAL_WORD_CANON(arg)) {
 					case SYM_HARDWARE:
@@ -139,12 +139,12 @@
 						req->special.serial.flow_control = SERIAL_FLOW_CONTROL_SOFTWARE;
 						break;
 					default:
-						raise Error_1(RE_INVALID_PORT_ARG, arg);
+						fail (Error(RE_INVALID_PORT_ARG, arg));
 				}
 			}
 
 			if (OS_DO_DEVICE(req, RDC_OPEN))
-				raise Error_On_Port(RE_CANNOT_OPEN, port, -12);
+				fail (Error_On_Port(RE_CANNOT_OPEN, port, -12));
 			SET_OPEN(req);
 			return R_OUT;
 
@@ -155,7 +155,7 @@
 			return R_FALSE;
 
 		default:
-			raise Error_On_Port(RE_NOT_OPEN, port, -12);
+			fail (Error_On_Port(RE_NOT_OPEN, port, -12));
 		}
 	}
 
@@ -181,7 +181,7 @@
 		printf("(max read length %d)", req->length);
 #endif
 		result = OS_DO_DEVICE(req, RDC_READ); // recv can happen immediately
-		if (result < 0) raise Error_On_Port(RE_READ_ERROR, port, req->error);
+		if (result < 0) fail (Error_On_Port(RE_READ_ERROR, port, req->error));
 #ifdef DEBUG_SERIAL
 		for (len = 0; len < req->actual; len++) {
 			if (len % 16 == 0) printf("\n");
@@ -211,7 +211,7 @@
 
 		//Print("(write length %d)", len);
 		result = OS_DO_DEVICE(req, RDC_WRITE); // send can happen immediately
-		if (result < 0) raise Error_On_Port(RE_WRITE_ERROR, port, req->error);
+		if (result < 0) fail (Error_On_Port(RE_WRITE_ERROR, port, req->error));
 		break;
 	case A_UPDATE:
 		// Update the port object after a READ or WRITE operation.
@@ -235,7 +235,7 @@
 		break;
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -136,7 +136,7 @@ static int sig_word_num(REBVAL *word)
 		case SYM_SIGXFSZ:
 			return SIGXFSZ;
 		default:
-			raise Error_1(RE_INVALID_SPEC, word);
+			fail (Error(RE_INVALID_SPEC, word));
 	}
 }
 
@@ -166,7 +166,7 @@ static int sig_word_num(REBVAL *word)
 			case A_OPEN:
 				val = Obj_Value(spec, STD_PORT_SPEC_SIGNAL_MASK);
 				if (!IS_BLOCK(val))
-					raise Error_1(RE_INVALID_SPEC, val);
+					fail (Error(RE_INVALID_SPEC, val));
 
 				sigemptyset(&req->special.signal.mask);
 				for(sig = VAL_BLK_SKIP(val, 0); NOT_END(sig); sig ++) {
@@ -175,20 +175,20 @@ static int sig_word_num(REBVAL *word)
 						if (VAL_WORD_CANON(sig) == SYM_ALL) {
 							if (sigfillset(&req->special.signal.mask) < 0) {
 								// !!! Needs better error
-								raise Error_1(RE_INVALID_SPEC, sig);
+								fail (Error(RE_INVALID_SPEC, sig));
 							}
 							break;
 						}
 
 						if (sigaddset(&req->special.signal.mask, sig_word_num(sig)) < 0)
-							raise Error_1(RE_INVALID_SPEC, sig);
+							fail (Error(RE_INVALID_SPEC, sig));
 					}
 					else
-						raise Error_1(RE_INVALID_SPEC, sig);
+						fail (Error(RE_INVALID_SPEC, sig));
 				}
 
 				if (OS_DO_DEVICE(req, RDC_OPEN))
-					raise Error_On_Port(RE_CANNOT_OPEN, port, req->error);
+					fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
 				if (action == A_OPEN) {
 					return R_ARG1; //port
 				}
@@ -203,7 +203,7 @@ static int sig_word_num(REBVAL *word)
 				break;
 
 			default:
-				raise Error_On_Port(RE_NOT_OPEN, port, -12);
+				fail (Error_On_Port(RE_NOT_OPEN, port, -12));
 		}
 	}
 
@@ -229,7 +229,7 @@ static int sig_word_num(REBVAL *word)
 			ser = Make_Binary(len * sizeof(siginfo_t));
 			req->common.data = BIN_HEAD(ser);
 			result = OS_DO_DEVICE(req, RDC_READ);
-			if (result < 0) raise Error_On_Port(RE_READ_ERROR, port, req->error);
+			if (result < 0) fail (Error_On_Port(RE_READ_ERROR, port, req->error));
 
 			arg = OFV(port, STD_PORT_DATA);
 			if (!IS_BLOCK(arg)) {
@@ -254,10 +254,10 @@ static int sig_word_num(REBVAL *word)
 			return R_TRUE;
 
 		case A_OPEN:
-			raise Error_1(RE_ALREADY_OPEN, D_ARG(1));
+			fail (Error(RE_ALREADY_OPEN, D_ARG(1)));
 
 		default:
-			raise Error_Illegal_Action(REB_PORT, action);
+			fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -61,7 +61,7 @@
 	// Validate and fetch relevant PORT fields:
 	state = BLK_SKIP(port, STD_PORT_STATE);
 	spec  = BLK_SKIP(port, STD_PORT_SPEC);
-	if (!IS_OBJECT(spec)) raise Error_1(RE_INVALID_SPEC, spec);
+	if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
 
 	// Get or setup internal state data:
 	if (!IS_BLOCK(state)) Val_Init_Block(state, Make_Array(127));
@@ -73,13 +73,13 @@
 
 	// Normal block actions done on events:
 	case A_POKE:
-		if (!IS_EVENT(D_ARG(3))) raise Error_Invalid_Arg(D_ARG(3));
+		if (!IS_EVENT(D_ARG(3))) fail (Error_Invalid_Arg(D_ARG(3)));
 		goto act_blk;
 	case A_INSERT:
 	case A_APPEND:
 	//case A_PATH:		// not allowed: port/foo is port object field access
 	//case A_PATH_SET:	// not allowed: above
-		if (!IS_EVENT(arg)) raise Error_Invalid_Arg(arg);
+		if (!IS_EVENT(arg)) fail (Error_Invalid_Arg(arg));
 	case A_PICK:
 act_blk:
 		save_port = *D_ARG(1); // save for return
@@ -111,7 +111,7 @@ act_blk:
 		break;
 
 	default:
-		raise Error_Illegal_Action(REB_PORT, action);
+		fail (Error_Illegal_Action(REB_PORT, action));
 	}
 
 	return R_OUT;

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -301,7 +301,7 @@ static REBCNT *CRC_Table;
 	if (!n) {
 		REBVAL temp;
 		SET_INTEGER(&temp, len);
-		raise Error_1(RE_SIZE_LIMIT, &temp);
+		fail (Error(RE_SIZE_LIMIT, &temp));
 	}
 
 	ser = Make_Series(n + 1, sizeof(REBCNT), MKS_NONE);

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -619,7 +619,7 @@ cp_same:
 
 		case REB_INTEGER:
 			if (VAL_INT64(val) > cast(i64, 255) || VAL_INT64(val) < 0)
-				raise Error_Out_Of_Range(val);
+				fail (Error_Out_Of_Range(val));
 			EXPAND_SERIES_TAIL(series, 1);
 			*BIN_SKIP(series, tail) = (REBYTE)VAL_INT32(val);
 			break;
@@ -657,7 +657,7 @@ cp_same:
 			break;
 
 		default:
-			raise Error_Invalid_Arg(val);
+			fail (Error_Invalid_Arg(val));
 		}
 
 		tail = series->tail;

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -379,7 +379,7 @@ static void Mold_String_Series(const REBVAL *value, REB_MOLD *mold)
 
 	// Empty string:
 	if (idx >= VAL_TAIL(value)) {
-		// !!! Comment said `raise Error_0(RE_PAST_END);`
+		// !!! Comment said `fail (Error(RE_PAST_END));`
 		Append_Unencoded(mold->series, "\"\"");
 		return;
 	}
@@ -1270,7 +1270,7 @@ static void Mold_Error(const REBVAL *value, REB_MOLD *mold, REBFLG molded)
 		break;
 
 	default:
-		panic Error_Invalid_Datatype(VAL_TYPE(value));
+		panic (Error_Invalid_Datatype(VAL_TYPE(value)));
 	}
 	return;
 
@@ -1387,7 +1387,7 @@ append:
 	REBSER *buf = BUF_MOLD;
 	REBINT len;
 
-	if (!buf) panic Error_0(RE_NO_BUFFER);
+	if (!buf) panic (Error(RE_NO_BUFFER));
 
 	if (SERIES_REST(buf) > MAX_COMMON)
 		Remake_Series(buf, MIN_COMMON, SERIES_WIDE(buf), MKS_NONE);

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -98,7 +98,7 @@
 	REBYTE *bp;
 	REBSER *src = VAL_SERIES(val);
 
-	if (index > tail) raise Error_0(RE_PAST_END);
+	if (index > tail) fail (Error(RE_PAST_END));
 
 	Resize_Series(BUF_FORM, max_len+1);
 	bp = BIN_HEAD(BUF_FORM);
@@ -113,7 +113,7 @@
 	for (; index < tail; index++) {
 		c = GET_ANY_CHAR(src, index);
 		if (opts < 2 && c >= 0x80) {
-			if (opts == 0) raise Error_0(RE_INVALID_CHARS);
+			if (opts == 0) fail (Error(RE_INVALID_CHARS));
 			len = Encode_UTF8_Char(bp, c);
 			max_len -= len;
 			bp += len;
@@ -124,19 +124,19 @@
 		}
 		else break;
 		if (max_len < 0)
-			raise Error_0(RE_TOO_LONG);
+			fail (Error(RE_TOO_LONG));
 	}
 
 	// Rest better be just spaces:
 	for (; index < tail; index++) {
 		c = GET_ANY_CHAR(src, index);
-		if (!IS_SPACE(c)) raise Error_0(RE_INVALID_CHARS);
+		if (!IS_SPACE(c)) fail (Error(RE_INVALID_CHARS));
 	}
 
 	*bp= 0;
 
 	len = bp - BIN_HEAD(BUF_FORM);
-	if (len == 0) raise Error_0(RE_TOO_SHORT);
+	if (len == 0) fail (Error(RE_TOO_SHORT));
 
 	if (length) *length = len;
 
@@ -726,7 +726,7 @@ static REBYTE seed_str[SEED_LEN] = {
 
 	// String series:
 
-	if (IS_PROTECT_SERIES(VAL_SERIES(val))) raise Error_0(RE_PROTECTED);
+	if (IS_PROTECT_SERIES(VAL_SERIES(val))) fail (Error(RE_PROTECTED));
 
 	len = Partial(val, 0, part, 0);
 	n = VAL_INDEX(val);

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -856,7 +856,7 @@ ConversionResult ConvertUTF8toUTF32 (
 		// !!! Not currently supported.
 		REBVAL num;
 		SET_INTEGER(&num, ch);
-		raise Error_1(RE_CODEPOINT_TOO_HIGH, &num);
+		fail (Error(RE_CODEPOINT_TOO_HIGH, &num));
 	}
 
 	*out = ch;
@@ -887,7 +887,7 @@ ConversionResult ConvertUTF8toUTF32 (
 	for (; len > 0; len--, src++) {
 		if ((ch = *src) >= 0x80) {
 			if (!(src = Back_Scan_UTF8_Char(&ch, src, &len)))
-				raise Error_0(RE_BAD_DECODE);
+				fail (Error(RE_BAD_DECODE));
 
 			if (ch > 0xff) flag = 1;
 		} if (ch == CR && ccr) {

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -96,7 +96,7 @@
 	if (IS_BLOCK(data)) {
 		REBINT len = Find_Max_Bit(data);
 		REBSER *ser;
-		if (len < 0 || len > 0xFFFFFF) raise Error_Invalid_Arg(data);
+		if (len < 0 || len > 0xFFFFFF) fail (Error_Invalid_Arg(data));
 		ser = Make_Bitset(len);
 		Set_Bits(ser, data, TRUE);
 		Val_Init_Bitset(out, ser);
@@ -312,7 +312,7 @@ retry:
 		return TRUE;
 	}
 
-	if (!ANY_ARRAY(val)) raise Error_Has_Bad_Type(val);
+	if (!ANY_ARRAY(val)) fail (Error_Has_Bad_Type(val));
 
 	val = VAL_BLK_DATA(val);
 	if (IS_SAME_WORD(val, SYM_NOT)) {
@@ -332,11 +332,11 @@ retry:
 				if (IS_CHAR(val)) {
 					n = VAL_CHAR(val);
 span_bits:
-					if (n < c) raise Error_1(RE_PAST_END, val);
+					if (n < c) fail (Error(RE_PAST_END, val));
 					for (; c <= n; c++) Set_Bit(bset, c, set);
 				}
 				else
-					raise Error_Invalid_Arg(val);
+					fail (Error_Invalid_Arg(val));
 			}
 			else Set_Bit(bset, c, set);
 			break;
@@ -352,7 +352,7 @@ span_bits:
 					goto span_bits;
 				}
 				else
-					raise Error_Invalid_Arg(val);
+					fail (Error_Invalid_Arg(val));
 			}
 			else Set_Bit(bset, n, set);
 			break;
@@ -411,7 +411,7 @@ span_bits:
 	if (ANY_BINSTR(val))
 		return Check_Bit_Str(bset, val, uncased);
 
-	if (!ANY_ARRAY(val)) raise Error_Has_Bad_Type(val);
+	if (!ANY_ARRAY(val)) fail (Error_Has_Bad_Type(val));
 
 	// Loop through block of bit specs:
 	for (val = VAL_BLK_DATA(val); NOT_END(val); val++) {
@@ -425,12 +425,12 @@ span_bits:
 				if (IS_CHAR(val)) {
 					n = VAL_CHAR(val);
 scan_bits:
-					if (n < c) raise Error_1(RE_PAST_END, val);
+					if (n < c) fail (Error(RE_PAST_END, val));
 					for (; c <= n; c++)
 						if (Check_Bit(bset, c, uncased)) goto found;
 				}
 				else
-					raise Error_Invalid_Arg(val);
+					fail (Error_Invalid_Arg(val));
 			}
 			else
 				if (Check_Bit(bset, c, uncased)) goto found;
@@ -447,7 +447,7 @@ scan_bits:
 					goto scan_bits;
 				}
 				else
-					raise Error_Invalid_Arg(val);
+					fail (Error_Invalid_Arg(val));
 			}
 			else
 				if (Check_Bit(bset, n, uncased)) goto found;
@@ -464,7 +464,7 @@ scan_bits:
 			break;
 
 		default:
-			raise Error_Has_Bad_Type(val);
+			fail (Error_Has_Bad_Type(val));
 		}
 	}
 	return FALSE;
@@ -534,7 +534,7 @@ found:
 
 	// Check must be in this order (to avoid checking a non-series value);
 	if (action >= A_TAKE && action <= A_SORT && IS_PROTECT_SERIES(VAL_SERIES(value)))
-		raise Error_0(RE_PROTECTED);
+		fail (Error(RE_PROTECTED));
 
 	switch (action) {
 
@@ -557,7 +557,7 @@ found:
 	case A_TO:
 		// Determine size of bitset. Returns -1 for errors.
 		len = Find_Max_Bit(arg);
-		if (len < 0 || len > 0x0FFFFFFF) raise Error_Invalid_Arg(arg);
+		if (len < 0 || len > 0x0FFFFFFF) fail (Error_Invalid_Arg(arg));
 
 		ser = Make_Bitset(len);
 		Val_Init_Bitset(value, ser);
@@ -581,12 +581,12 @@ found:
 set_bits:
 		if (BITS_NOT(VAL_SERIES(value))) diff = !diff;
 		if (Set_Bits(VAL_SERIES(value), arg, (REBOOL)diff)) break;
-		raise Error_Invalid_Arg(arg);
+		fail (Error_Invalid_Arg(arg));
 
 	case A_REMOVE:	// #"a" "abc"  remove/part bs "abcd"  yuk: /part ?
-		if (!D_REF(2)) raise Error_0(RE_MISSING_ARG); // /part required
+		if (!D_REF(2)) fail (Error(RE_MISSING_ARG)); // /part required
 		if (Set_Bits(VAL_SERIES(value), D_ARG(3), FALSE)) break;
-		raise Error_Invalid_Arg(D_ARG(3));
+		fail (Error_Invalid_Arg(D_ARG(3)));
 
 	case A_COPY:
 		Val_Init_Series_Index(
@@ -614,13 +614,13 @@ set_bits:
 	case A_OR:
 	case A_XOR:
 		if (!IS_BITSET(arg) && !IS_BINARY(arg))
-			raise Error_Math_Args(VAL_TYPE(arg), action);
+			fail (Error_Math_Args(VAL_TYPE(arg), action));
 		VAL_SERIES(value) = ser = Xandor_Binary(action, value, arg);
 		Trim_Tail_Zeros(ser);
 		break;
 
 	default:
-		raise Error_Illegal_Action(REB_BITSET, action);
+		fail (Error_Illegal_Action(REB_BITSET, action));
 	}
 
 	*D_OUT = *value;

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -59,7 +59,7 @@
 static void No_Nones(REBVAL *arg) {
 	arg = VAL_BLK_DATA(arg);
 	for (; NOT_END(arg); arg++) {
-		if (IS_NONE(arg)) raise Error_Invalid_Arg(arg);
+		if (IS_NONE(arg)) fail (Error_Invalid_Arg(arg));
 	}
 }
 
@@ -272,7 +272,7 @@ static void No_Nones(REBVAL *arg) {
 			Val_Init_Series(value, type, Make_Array(len));
 			return;
 		}
-		raise Error_Invalid_Arg(arg);
+		fail (Error_Invalid_Arg(arg));
 	}
 
 	ser = Copy_Values_Len_Shallow(arg, 1);
@@ -342,25 +342,25 @@ static struct {
 
 	args = BLK_SKIP(VAL_FUNC_PARAMLIST(sort_flags.compare), 1);
 	if (NOT_END(args) && !TYPE_CHECK(args, VAL_TYPE(cast(const REBVAL*, v1)))) {
-		raise Error_3(
+		fail (Error(
 			RE_EXPECT_ARG,
 			Type_Of(sort_flags.compare),
 			args,
 			Type_Of(cast(const REBVAL*, v1))
-		);
+		));
 	}
 	++ args;
 	if (NOT_END(args) && !TYPE_CHECK(args, VAL_TYPE(cast(const REBVAL*, v2)))) {
-		raise Error_3(
+		fail (Error(
 			RE_EXPECT_ARG,
 			Type_Of(sort_flags.compare),
 			args,
 			Type_Of(cast(const REBVAL*, v2))
-		);
+		));
 	}
 
 	if (Apply_Func_Throws(&out, sort_flags.compare, v1, v2, 0))
-		raise Error_No_Catch_For_Throw(&out);
+		fail (Error_No_Catch_For_Throw(&out));
 
 	if (IS_LOGIC(&out)) {
 		if (VAL_LOGIC(&out)) result = 1;
@@ -417,7 +417,7 @@ static struct {
 	if (!IS_UNSET(skipv)) {
 		skip = Get_Num_Arg(skipv);
 		if (skip <= 0 || len % skip != 0 || skip > len)
-			raise Error_Out_Of_Range(skipv);
+			fail (Error_Out_Of_Range(skipv));
 	}
 
 	// Use fast quicksort library function:
@@ -609,7 +609,7 @@ static struct {
 
 	// Check must be in this order (to avoid checking a non-series value);
 	if (action >= A_TAKE && action <= A_SORT && IS_PROTECT_SERIES(ser))
-		raise Error_0(RE_PROTECTED);
+		fail (Error(RE_PROTECTED));
 
 	switch (action) {
 
@@ -641,7 +641,7 @@ repick:
 			if (!value) goto is_none;
 			*D_OUT = *value;
 		} else {
-			if (!value) raise Error_Out_Of_Range(arg);
+			if (!value) fail (Error_Out_Of_Range(arg));
 			arg = D_ARG(3);
 			*value = *arg;
 			*D_OUT = *arg;
@@ -654,7 +654,7 @@ repick:
 		if (len > 0) index--;
 		if (len == 0 || index < 0 || index >= tail) {
 			if (action == A_PICK) goto is_none;
-			raise Error_Out_Of_Range(arg);
+			fail (Error_Out_Of_Range(arg));
 		}
 		if (action == A_PICK) {
 pick_it:
@@ -776,14 +776,14 @@ zero_blk:
 
 	case A_TRIM:
 		args = Find_Refines(call_, ALL_TRIM_REFS);
-		if (args & ~(AM_TRIM_HEAD|AM_TRIM_TAIL)) raise Error_0(RE_BAD_REFINES);
+		if (args & ~(AM_TRIM_HEAD|AM_TRIM_TAIL)) fail (Error(RE_BAD_REFINES));
 		Trim_Block(ser, index, args);
 		break;
 
 	case A_SWAP:
 		if (SERIES_WIDE(ser) != SERIES_WIDE(VAL_SERIES(arg)))
-			raise Error_Invalid_Arg(arg);
-		if (IS_PROTECT_SERIES(VAL_SERIES(arg))) raise Error_0(RE_PROTECTED);
+			fail (Error_Invalid_Arg(arg));
+		if (IS_PROTECT_SERIES(VAL_SERIES(arg))) fail (Error(RE_PROTECTED));
 		if (index < tail && VAL_INDEX(arg) < VAL_TAIL(arg)) {
 			val = *VAL_BLK_DATA(value);
 			*VAL_BLK_DATA(value) = *VAL_BLK_DATA(arg);
@@ -818,8 +818,8 @@ zero_blk:
 		break;
 
 	case A_RANDOM:
-		if (!IS_BLOCK(value)) raise Error_Illegal_Action(VAL_TYPE(value), action);
-		if (D_REF(2)) raise Error_0(RE_BAD_REFINES); // seed
+		if (!IS_BLOCK(value)) fail (Error_Illegal_Action(VAL_TYPE(value), action));
+		if (D_REF(2)) fail (Error(RE_BAD_REFINES)); // seed
 		if (D_REF(4)) { // /only
 			if (index >= tail) goto is_none;
 			len = (REBCNT)Random_Int(D_REF(3)) % (tail - index);  // /secure
@@ -832,7 +832,7 @@ zero_blk:
 		break;
 
 	default:
-		raise Error_Illegal_Action(VAL_TYPE(value), action);
+		fail (Error_Illegal_Action(VAL_TYPE(value), action));
 	}
 
 	if (!value)

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -71,7 +71,7 @@
 		else if (IS_DECIMAL(val))
 			arg = (REBINT)VAL_DECIMAL(val);
 		else
-			raise Error_Math_Args(REB_CHAR, action);
+			fail (Error_Math_Args(REB_CHAR, action));
 	}
 
 	switch (action) {
@@ -86,11 +86,11 @@
 		break;
 	case A_MULTIPLY: chr *= arg; break;
 	case A_DIVIDE:
-		if (arg == 0) raise Error_0(RE_ZERO_DIVIDE);
+		if (arg == 0) fail (Error(RE_ZERO_DIVIDE));
 		chr /= arg;
 		break;
 	case A_REMAINDER:
-		if (arg == 0) raise Error_0(RE_ZERO_DIVIDE);
+		if (arg == 0) fail (Error(RE_ZERO_DIVIDE));
 		chr %= arg;
 		break;
 
@@ -164,22 +164,22 @@
 
 		case REB_STRING:
 			if (VAL_INDEX(val) >= VAL_TAIL(val))
-				raise Error_Bad_Make(REB_CHAR, val);
+				fail (Error_Bad_Make(REB_CHAR, val));
 			chr = GET_ANY_CHAR(VAL_SERIES(val), VAL_INDEX(val));
 			break;
 
 		default:
 bad_make:
-		raise Error_Bad_Make(REB_CHAR, val);
+		fail (Error_Bad_Make(REB_CHAR, val));
 	}
 		break;
 
 	default:
-		raise Error_Illegal_Action(REB_CHAR, action);
+		fail (Error_Illegal_Action(REB_CHAR, action));
 	}
 
 	if ((chr >> 16) != 0 && (chr >> 16) != 0xffff)
-		raise Error_1(RE_TYPE_LIMIT, Get_Type(REB_CHAR));
+		fail (Error(RE_TYPE_LIMIT, Get_Type(REB_CHAR)));
 	SET_CHAR(D_OUT, chr);
 	return R_OUT;
 

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -94,7 +94,7 @@
 			);
 		}
 		else
-			raise Error_Cannot_Reflect(VAL_TYPE(value), arg);
+			fail (Error_Cannot_Reflect(VAL_TYPE(value), arg));
 		break;
 
 	case A_MAKE:
@@ -103,16 +103,16 @@
 			act = Value_Dispatch[kind];
 			if (act) return act(call_, action);
 			//return R_NONE;
-			raise Error_Bad_Make(kind, arg);
+			fail (Error_Bad_Make(kind, arg));
 		}
 		// if (IS_NONE(arg)) return R_NONE;
 		if (MT_Datatype(D_OUT, arg, REB_DATATYPE))
 			break;
 
-		raise Error_Bad_Make(REB_DATATYPE, arg);
+		fail (Error_Bad_Make(REB_DATATYPE, arg));
 
 	default:
-		raise Error_Illegal_Action(REB_DATATYPE, action);
+		fail (Error_Illegal_Action(REB_DATATYPE, action));
 	}
 
 	return R_OUT;

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -324,7 +324,7 @@
 	}
 
 	if (year < 0 || year > MAX_YEAR)
-		raise Error_1(RE_TYPE_LIMIT, Get_Type(REB_DATE));
+		fail (Error(RE_TYPE_LIMIT, Get_Type(REB_DATE)));
 
 	dr.date.year = year;
 	dr.date.month = month+1;
@@ -385,7 +385,7 @@
 
 	diff  = Diff_Date(VAL_DATE(d1), VAL_DATE(d2));
 	if (cast(REBCNT, abs(diff)) > (((1U << 31) - 1) / SECS_IN_DAY))
-		raise Error_0(RE_OVERFLOW);
+		fail (Error(RE_OVERFLOW));
 
 	t1 = VAL_TIME(d1);
 	if (t1 == NO_TIME) t1 = 0L;
@@ -463,7 +463,7 @@
 
 	if (IS_TIME(arg)) {
 		tz = (REBINT)(VAL_TIME(arg) / (ZONE_MINS * MIN_SEC));
-		if (tz < -MAX_ZONE || tz > MAX_ZONE) raise Error_Out_Of_Range(arg);
+		if (tz < -MAX_ZONE || tz > MAX_ZONE) fail (Error_Out_Of_Range(arg));
 		arg++;
 	}
 
@@ -540,7 +540,7 @@
 		tz    = VAL_ZONE(data);
 		if (i > 8) Split_Time(secs, &time);
 	}
-	else panic Error_Invalid_Arg(data); // this should never happen
+	else panic (Error_Invalid_Arg(data)); // this should never happen
 
 	if (val == 0) {
 		val = pvs->store;
@@ -663,7 +663,7 @@
 				time.n = 0;
 			}
 			else {
-				//if (f < 0.0) raise Error_Out_Of_Range(val);
+				//if (f < 0.0) fail (Error_Out_Of_Range(val));
 				time.s = (REBINT)VAL_DECIMAL(val);
 				time.n = (REBINT)((VAL_DECIMAL(val) - time.s) * SEC_SEC);
 			}
@@ -713,7 +713,7 @@ setDate:
 		secs  = VAL_TIME(val);
 	}
 	else if (!(IS_DATATYPE(val) && (action == A_MAKE || action == A_TO)))
-		raise Error_Invalid_Arg(val);
+		fail (Error_Invalid_Arg(val));
 
 	if (DS_ARGC > 1) arg = D_ARG(2);
 
@@ -797,7 +797,7 @@ setDate:
 //				secs = nsec = day = month = year = tz = 0;
 //				goto fixTime;
 //			}
-			raise Error_Bad_Make(REB_DATE, arg);
+			fail (Error_Bad_Make(REB_DATE, arg));
 
 		case A_RANDOM:	//!!! needs further definition ?  random/zero
 			if (D_REF(2)) {
@@ -818,7 +818,7 @@ setDate:
 			goto setDate;
 		}
 	}
-	raise Error_Illegal_Action(REB_DATE, action);
+	fail (Error_Illegal_Action(REB_DATE, action));
 
 fixTime:
 	Normalize_Time(&secs, &day);

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -187,7 +187,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 /*
 ***********************************************************************/
 {
-	if (!FINITE(dval)) raise Error_0(RE_OVERFLOW);
+	if (!FINITE(dval)) fail (Error(RE_OVERFLOW));
 }
 
 
@@ -287,7 +287,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 
 			case A_DIVIDE:
 			case A_REMAINDER:
-				if (d2 == 0.0) raise Error_0(RE_ZERO_DIVIDE);
+				if (d2 == 0.0) fail (Error(RE_ZERO_DIVIDE));
 				if (action == A_DIVIDE) d1 /= d2;
 				else d1 = fmod(d1, d2);
 				goto setDec;
@@ -299,13 +299,13 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 					goto setDec;
 				}
 				//if (d1 < 0 && d2 < 1 && d2 != -1)
-				//  raise Error_0(RE_POSITIVE);
+				//  fail (Error(RE_POSITIVE));
 				d1 = pow(d1, d2);
 				goto setDec;
 
 			}
 		}
-		raise Error_Math_Args(VAL_TYPE(val), action);
+		fail (Error_Math_Args(VAL_TYPE(val), action));
 	}
 	else {
 		type = VAL_TYPE(val);
@@ -376,7 +376,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 					if (type == REB_PERCENT) break;
 					goto setDec;
 				}
-				raise Error_Bad_Make(type, val);
+				fail (Error_Bad_Make(type, val));
 			}
 
 			case REB_BINARY:
@@ -391,7 +391,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 				REBCNT len;
 				bp = Temp_Byte_Chars_May_Fail(val, MAX_HEX_LEN, &len, FALSE);
 				if (Scan_Hex(&VAL_INT64(D_OUT), bp, len, len) == 0)
-					raise Error_Bad_Make(REB_DECIMAL, val);
+					fail (Error_Bad_Make(REB_DECIMAL, val));
 				d1 = VAL_DECIMAL(D_OUT);
 				break;
 			}
@@ -405,14 +405,14 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 					else if (IS_DECIMAL(arg) || IS_PERCENT(val))
 						d1 = VAL_DECIMAL(arg);
 					else
-						raise Error_Bad_Make(REB_DECIMAL, arg);
+						fail (Error_Bad_Make(REB_DECIMAL, arg));
 
 					if (IS_INTEGER(++arg))
 						exp = (REBDEC)VAL_INT64(arg);
 					else if (IS_DECIMAL(arg) || IS_PERCENT(val))
 						exp = VAL_DECIMAL(arg);
 					else
-						raise Error_Bad_Make(REB_DECIMAL, arg);
+						fail (Error_Bad_Make(REB_DECIMAL, arg));
 
 					while (exp >= 1)            // funky. There must be a better way
 						exp--, d1 *= 10.0, Check_Overflow(d1);
@@ -420,7 +420,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 						exp++, d1 /= 10.0;
 				}
 				else
-					raise Error_Bad_Make(type, val);
+					fail (Error_Bad_Make(type, val));
 			}
 
 			if (type == REB_PERCENT) d1 /= 100.0;
@@ -437,7 +437,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 					SET_TYPE(D_OUT, REB_MONEY);
 					return R_OUT;
 				}
-				if (IS_TIME(arg)) raise Error_Invalid_Arg(arg);
+				if (IS_TIME(arg)) fail (Error_Invalid_Arg(arg));
 
 				d1 = Round_Dec(d1, num, Dec64(arg));
 				if (IS_INTEGER(arg)) {
@@ -474,16 +474,16 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 		}
 	}
 
-	raise Error_Illegal_Action(VAL_TYPE(val), action);
+	fail (Error_Illegal_Action(VAL_TYPE(val), action));
 
 setDec:
-	if (!FINITE(d1)) raise Error_0(RE_OVERFLOW);
+	if (!FINITE(d1)) fail (Error(RE_OVERFLOW));
 #ifdef not_required
 	if (type == REB_PERCENT) {
 		// Keep percent in smaller range (not to use e notation).
 		if (d1 != 0) {
 			num = (REBINT)floor(log10(fabs(d1)));
-			if (num > 12 || num < -6) raise Error_0(RE_OVERFLOW); // use gcvt
+			if (num > 12 || num < -6) fail (Error(RE_OVERFLOW)); // use gcvt
 		}
 	}
 #endif

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -90,7 +90,7 @@
 					return TRUE;
 				}
 			}
-			raise Error_Invalid_Arg(val);
+			fail (Error_Invalid_Arg(val));
 		}
 		return FALSE;
 
@@ -203,7 +203,7 @@
 			val = &safe;
 		}
 		if (!Set_Event_Var(evt, var, val))
-			raise Error_2(RE_BAD_FIELD_SET, var, Type_Of(val));
+			fail (Error(RE_BAD_FIELD_SET, var, Type_Of(val)));
 	}
 }
 
@@ -402,20 +402,20 @@ is_none:
 		if (IS_EVENT(value)) return R_ARG1;
 		else if (IS_DATATYPE(value)) {
 			if (IS_EVENT(arg)) return R_ARG2;
-			//raise Error_Bad_Make(REB_EVENT, value);
+			//fail (Error_Bad_Make(REB_EVENT, value));
 			VAL_SET(D_OUT, REB_EVENT);
 			CLEARS(&(D_OUT->data.event));
 		}
 		else
 is_arg_error:
-			raise Error_Unexpected_Type(REB_EVENT, VAL_TYPE(arg));
+			fail (Error_Unexpected_Type(REB_EVENT, VAL_TYPE(arg)));
 
 		// Initialize GOB from block:
 		if (IS_BLOCK(arg)) Set_Event_Vars(D_OUT, VAL_BLK_DATA(arg));
 		else goto is_arg_error;
 	}
 	else
-		raise Error_Illegal_Action(REB_EVENT, action);
+		fail (Error_Illegal_Action(REB_EVENT, action));
 
 	return R_OUT;
 }
@@ -434,12 +434,12 @@ is_arg_error:
 //			case SYM_SHIFT:   index = EF_SHIFT; break;
 //			case SYM_CONTROL: index = EF_CONTROL; break;
 //			case SYM_DOUBLE_CLICK: index = EF_DCLICK; break;
-			default: raise Error_1(RE_INVALID_PATH, arg);
+			default: fail (Error(RE_INVALID_PATH, arg));
 			}
 			goto pick_it;
 		}
 		else if (!IS_INTEGER(arg))
-			raise Error_1(RE_INVALID_PATH, arg);
+			fail (Error(RE_INVALID_PATH, arg));
 		// fall thru
 
 
@@ -447,7 +447,7 @@ is_arg_error:
 		index = num = Get_Num_Arg(arg);
 		if (num > 0) index--;
 		if (num == 0 || index < 0 || index > EF_DCLICK) {
-			if (action == A_POKE) raise Error_Out_Of_Range(arg);
+			if (action == A_POKE) fail (Error_Out_Of_Range(arg));
 			goto is_none;
 		}
 pick_it:

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -143,12 +143,12 @@ static REBOOL Same_Func(REBVAL *val, REBVAL *arg)
 		break;
 
 	case A_MAKE:
-		if (!IS_DATATYPE(value)) raise Error_Invalid_Arg(value);
+		if (!IS_DATATYPE(value)) fail (Error_Invalid_Arg(value));
 
 		// MT_Function checks for `[[spec] [body]]` arg if function/closure
 		// and for `[[spec] extension command-num]` if command
 		if (!MT_Function(D_OUT, arg, VAL_TYPE_KIND(value)))
-			raise Error_Bad_Make(VAL_TYPE_KIND(value), arg);
+			fail (Error_Bad_Make(VAL_TYPE_KIND(value), arg));
 		return R_OUT;
 
 	case A_COPY:
@@ -215,10 +215,10 @@ static REBOOL Same_Func(REBVAL *val, REBVAL *arg)
 			return R_OUT;
 
 		default:
-			raise Error_Cannot_Reflect(VAL_TYPE(value), arg);
+			fail (Error_Cannot_Reflect(VAL_TYPE(value), arg));
 		}
 		break;
 	}
 
-	raise Error_Illegal_Action(VAL_TYPE(value), action);
+	fail (Error_Illegal_Action(VAL_TYPE(value), action));
 }

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -198,7 +198,7 @@ const REBCNT Gob_Flag_Words[] = {
 			}
 		}
 		else
-			raise Error_Invalid_Arg(val);
+			fail (Error_Invalid_Arg(val));
 	}
 	arg = sarg;
 
@@ -231,7 +231,7 @@ const REBCNT Gob_Flag_Words[] = {
 		if (IS_WORD(val)) val = GET_VAR(val);
 		if (IS_GOB(val)) {
 			// !!! Temporary error of some kind (supposed to trap, not panic?)
-			if (GOB_PARENT(VAL_GOB(val))) raise Error_0(RE_MISC);
+			if (GOB_PARENT(VAL_GOB(val))) fail (Error(RE_MISC));
 			*ptr++ = VAL_GOB(val);
 			GOB_PARENT(VAL_GOB(val)) = gob;
 			SET_GOB_STATE(VAL_GOB(val), GOBS_NEW);
@@ -609,12 +609,12 @@ is_none:
 		var = blk++;
 		val = blk++;
 		if (!IS_SET_WORD(var))
-			raise Error_2(RE_EXPECT_VAL, Get_Type(REB_SET_WORD), Type_Of(var));
+			fail (Error(RE_EXPECT_VAL, Get_Type(REB_SET_WORD), Type_Of(var)));
 		if (IS_END(val) || IS_UNSET(val) || IS_SET_WORD(val))
-			raise Error_1(RE_NEED_VALUE, var);
+			fail (Error(RE_NEED_VALUE, var));
 		Get_Simple_Value_Into(&safe, val);
 		if (!Set_GOB_Var(gob, var, val))
-			raise Error_2(RE_BAD_FIELD_SET, var, Type_Of(val));
+			fail (Error(RE_BAD_FIELD_SET, var, Type_Of(val)));
 	}
 }
 
@@ -719,7 +719,7 @@ is_none:
 					// !!! Gob and Struct do "sub-dispatch" which may throw
 					// No "PE_THREW" return, however.  (should there be?)
 
-					raise Error_No_Catch_For_Throw(pvs->store);
+					fail (Error_No_Catch_For_Throw(pvs->store));
 				}
 
 				Set_GOB_Var(gob, sel, pvs->store); // write it back to gob
@@ -768,7 +768,7 @@ is_none:
 		tail = GOB_PANE(gob) ? GOB_TAIL(gob) : 0;
 	}
 	else if (!(IS_DATATYPE(val) && action == A_MAKE))
-		raise Error_Invalid_Arg(val);
+		fail (Error_Invalid_Arg(val));
 
 	// unary actions
 	switch(action) {
@@ -799,7 +799,7 @@ is_none:
 			ngob->size.y = VAL_PAIR_Y(arg);
 		}
 		else
-			raise Error_Bad_Make(REB_GOB, arg);
+			fail (Error_Bad_Make(REB_GOB, arg));
 		// Allow NONE as argument:
 //		else if (!IS_NONE(arg))
 //			goto is_arg_error;
@@ -807,7 +807,7 @@ is_none:
 		break;
 
 	case A_PICK:
-		if (!IS_NUMBER(arg) && !IS_NONE(arg)) raise Error_Invalid_Arg(arg);
+		if (!IS_NUMBER(arg) && !IS_NONE(arg)) fail (Error_Invalid_Arg(arg));
 		if (!GOB_PANE(gob)) goto is_none;
 		index += Get_Num_Arg(arg) - 1;
 		if (index >= tail) goto is_none;
@@ -820,12 +820,12 @@ is_none:
 		arg = D_ARG(3);
 	case A_CHANGE:
 		if (!IS_GOB(arg)) goto is_arg_error;
-		if (!GOB_PANE(gob) || index >= tail) raise Error_0(RE_PAST_END);
+		if (!GOB_PANE(gob) || index >= tail) fail (Error(RE_PAST_END));
 		if (
 			action == A_CHANGE
 			&& (D_REF(AN_PART) || D_REF(AN_ONLY) || D_REF(AN_DUP))
 		) {
-			raise Error_0(RE_NOT_DONE);
+			fail (Error(RE_NOT_DONE));
 		}
 		Insert_Gobs(gob, arg, index, 1, 0);
 		//ngob = *GOB_SKIP(gob, index);
@@ -842,7 +842,7 @@ is_none:
 		index = tail;
 	case A_INSERT:
 		if (D_REF(AN_PART) || D_REF(AN_ONLY) || D_REF(AN_DUP))
-			raise Error_0(RE_NOT_DONE);
+			fail (Error(RE_NOT_DONE));
 		if (IS_GOB(arg)) len = 1;
 		else if (IS_BLOCK(arg)) {
 			len = VAL_BLK_LEN(arg);
@@ -939,7 +939,7 @@ is_none:
 		return R_ARG1;
 
 	default:
-		raise Error_Illegal_Action(REB_GOB, action);
+		fail (Error_Illegal_Action(REB_GOB, action));
 	}
 	return R_OUT;
 
@@ -953,7 +953,7 @@ is_none:
 	return R_NONE;
 
 is_arg_error:
-	raise Error_Unexpected_Type(REB_GOB, VAL_TYPE(arg));
+	fail (Error_Unexpected_Type(REB_GOB, VAL_TYPE(arg)));
 
 is_false:
 	return R_FALSE;

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -412,7 +412,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 
 	if (w > 0xFFFF || h > 0xFFFF) {
 		if (error)
-			raise Error_1(RE_SIZE_LIMIT, Get_Type(REB_IMAGE));
+			fail (Error(RE_SIZE_LIMIT, Get_Type(REB_IMAGE)));
 		return 0;
 	}
 
@@ -497,12 +497,12 @@ REBCNT ARGB_To_BGR(REBCNT i)
 		}
 	}
 	else if (IS_BLOCK(block)) {
-		if ((w = Valid_Tuples(block))) raise Error_Invalid_Arg(block + w - 1);
+		if ((w = Valid_Tuples(block))) fail (Error_Invalid_Arg(block + w - 1));
 		Tuples_To_RGBA(ip, size, VAL_BLK_DATA(block), VAL_LEN(block));
 	}
 	else if (!IS_END(block)) return 0;
 
-	//if (!IS_END(block)) raise Error_Invalid_Arg(block);
+	//if (!IS_END(block)) fail (Error_Invalid_Arg(block));
 
 	return val;
 }
@@ -548,7 +548,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 
 	// Validate that block arg is all tuple values:
 	if (IS_BLOCK(arg) && (n = Valid_Tuples(arg)))
-		raise Error_Invalid_Arg(VAL_BLK_SKIP(arg, n-1));
+		fail (Error_Invalid_Arg(VAL_BLK_SKIP(arg, n-1)));
 
 	// Get the /dup refinement. It specifies fill size.
 	if (D_REF(6)) {
@@ -569,7 +569,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 			if (dupx == 0 || dupy == 0) return value;
 		}
 		else
-			raise Error_Has_Bad_Type(count);
+			fail (Error_Has_Bad_Type(count));
 	}
 
 	// Get the /part refinement. Only allowed when arg is a series.
@@ -580,14 +580,14 @@ REBCNT ARGB_To_BGR(REBCNT i)
 			} else if (IS_BINARY(len)) {
 				part = (VAL_INDEX(len) - VAL_INDEX(arg)) / 4;
 			} else
-				raise Error_Invalid_Arg(len);
+				fail (Error_Invalid_Arg(len));
 			part = MAX(part, 0);
 		} else if (IS_IMAGE(arg)) {
 			if (IS_INTEGER(len)) {
 				part = VAL_INT32(len);
 				part = MAX(part, 0);
 			} else if (IS_IMAGE(len)) {
-				if (!VAL_IMAGE_WIDE(len)) raise Error_Invalid_Arg(len);
+				if (!VAL_IMAGE_WIDE(len)) fail (Error_Invalid_Arg(len));
 				partx = VAL_INDEX(len) - VAL_INDEX(arg);
 				party = partx / VAL_IMAGE_WIDE(len);
 				party = MAX(party, 1);
@@ -607,10 +607,10 @@ REBCNT ARGB_To_BGR(REBCNT i)
 				if (partx == 0 || party == 0) return value;
 			}
 			else
-				raise Error_Has_Bad_Type(len);
+				fail (Error_Has_Bad_Type(len));
 		}
 		else
-			raise Error_Invalid_Arg(arg); // /part not allowed
+			fail (Error_Invalid_Arg(arg)); // /part not allowed
 	}
 	else {
 		if (IS_IMAGE(arg)) { // Use image for /part sizes
@@ -627,7 +627,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 			part = VAL_LEN(arg);
 		}
 		else if (!IS_INTEGER(arg) && !IS_TUPLE(arg))
-			raise Error_Has_Bad_Type(arg);
+			fail (Error_Has_Bad_Type(arg));
 	}
 
 	// Expand image data if necessary:
@@ -647,7 +647,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 		ip += index * 4;
 		if (IS_INTEGER(arg)) { // Alpha channel
 			n = VAL_INT32(arg);
-			if ((n < 0) || (n > 255)) raise Error_Out_Of_Range(arg);
+			if ((n < 0) || (n > 255)) fail (Error_Out_Of_Range(arg));
 			if (IS_PAIR(count)) // rectangular fill
 				Fill_Alpha_Rect((REBCNT *)ip, (REBYTE)n, w, dupx, dupy);
 			else
@@ -672,7 +672,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 			Tuples_To_RGBA(ip, part, VAL_BLK_DATA(arg), part);
 	}
 	else
-		raise Error_Has_Bad_Type(arg);
+		fail (Error_Has_Bad_Type(arg));
 
 	Reset_Height(value);
 
@@ -721,8 +721,8 @@ REBCNT ARGB_To_BGR(REBCNT i)
 
 	for (n = 0; n < 8; n++) // (zero based)
 		if (D_REF((REBINT)no_refs[n]))
-			raise Error_0(RE_BAD_REFINE);
-//			raise Error_2(RE_CANNOT_USE, FRM_KEYS(me, (REBINT)no_refs[n]), Get_Global(REB_IMAGE));
+			fail (Error(RE_BAD_REFINE));
+//			fail (Error(RE_CANNOT_USE, FRM_KEYS(me, (REBINT)no_refs[n]), Get_Global(REB_IMAGE)));
 
 	if (IS_TUPLE(arg)) {
 		only = (REBOOL)(VAL_TUPLE_LEN(arg) < 4);
@@ -730,7 +730,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 		p = Find_Color(ip, TO_PIXEL_TUPLE(arg), len, only);
 	} else if (IS_INTEGER(arg)) {
 		n = VAL_INT32(arg);
-		if (n < 0 || n > 255) raise Error_Out_Of_Range(arg);
+		if (n < 0 || n > 255) fail (Error_Out_Of_Range(arg));
 		p = Find_Alpha(ip, n, len);
 	} else if (IS_IMAGE(arg)) {
 		p = 0;
@@ -738,7 +738,7 @@ REBCNT ARGB_To_BGR(REBCNT i)
 		p = 0;
 	}
 	else
-		raise Error_Has_Bad_Type(arg);
+		fail (Error_Has_Bad_Type(arg));
 
 	// Post process the search (failure or apply /match and /tail):
 	if (p) {
@@ -850,7 +850,7 @@ find_none:
 
 	// Check must be in this order (to avoid checking a non-series value);
 	if (action >= A_TAKE && action <= A_SORT && IS_PROTECT_SERIES(series))
-		raise Error_0(RE_PROTECTED);
+		fail (Error(RE_PROTECTED));
 
 	// Dispatch action:
 	switch (action) {
@@ -918,7 +918,7 @@ find_none:
 
 		if (diff == 0 || index < 0 || index >= tail) {
 			if (action == A_POKE)
-				raise Error_Out_Of_Range(arg);
+				fail (Error_Out_Of_Range(arg));
 			goto is_none;
 		}
 
@@ -940,7 +940,7 @@ find_none:
 			else if (IS_CHAR(arg))
 				n = VAL_CHAR(arg);
 			else
-				raise Error_Invalid_Arg(arg);
+				fail (Error_Invalid_Arg(arg));
 
 			*dp = (*dp & 0xffffff) | (n << 24);
 			*D_OUT = *arg;
@@ -966,11 +966,11 @@ find_none:
 			if (IS_INTEGER(val)) {
 				len = VAL_INT32(val);
 			} else if (IS_IMAGE(val)) {
-				if (!VAL_IMAGE_WIDE(val)) raise Error_Invalid_Arg(val);
+				if (!VAL_IMAGE_WIDE(val)) fail (Error_Invalid_Arg(val));
 				len = VAL_INDEX(val) - VAL_INDEX(value); // may not be same, is ok
 			}
 			else
-				raise Error_Has_Bad_Type(val);
+				fail (Error_Has_Bad_Type(val));
 		}
 		else len = 1;
 
@@ -997,13 +997,13 @@ find_none:
 			//value = Make_Image(ROUND_TO_INT(GOB_W(VAL_GOB(arg))), ROUND_TO_INT(GOB_H(VAL_GOB(arg))));
 			//*D_OUT = *value;
 			series = OS_GOB_TO_IMAGE(VAL_GOB(arg));
-			if (!series) raise Error_Bad_Make(REB_IMAGE, arg);
+			if (!series) fail (Error_Bad_Make(REB_IMAGE, arg));
 			Val_Init_Image(value, series);
 			break;
 		}
 		else if (IS_BINARY(arg)) {
 			diff = VAL_LEN(arg) / 4;
-			if (diff == 0) raise Error_Bad_Make(REB_IMAGE, arg);
+			if (diff == 0) fail (Error_Bad_Make(REB_IMAGE, arg));
 			if (diff < 100) w = diff;
 			else if (diff < 10000) w = 100;
 			else w = 500;
@@ -1014,7 +1014,7 @@ find_none:
 			Bin_To_RGBA(IMG_DATA(series), w*h, VAL_BIN_DATA(arg), VAL_LEN(arg)/4, 0);
 			break;
 		}
-		raise Error_Has_Bad_Type(arg);
+		fail (Error_Has_Bad_Type(arg));
 
 	case A_MAKE:
 		// make image! img
@@ -1045,7 +1045,7 @@ find_none:
 		else if (IS_BLOCK(arg)) {
 			if (Create_Image(VAL_BLK_DATA(arg), value, 0)) break;
 		}
-		raise Error_Has_Bad_Type(arg);
+		fail (Error_Has_Bad_Type(arg));
 		break;
 
 	case A_COPY:  // copy series /part len
@@ -1056,7 +1056,7 @@ find_none:
 		arg = D_ARG(3); // can be image, integer, pair.
 		if (IS_IMAGE(arg)) {
 			if (VAL_SERIES(arg) != VAL_SERIES(value))
-				raise Error_Invalid_Arg(arg);
+				fail (Error_Invalid_Arg(arg));
 			len = VAL_INDEX(arg) - VAL_INDEX(value);
 			arg = value;
 			goto makeCopy2;
@@ -1086,7 +1086,7 @@ find_none:
 //			VAL_IMAGE_TRANSP(D_OUT) = VAL_IMAGE_TRANSP(value);
 			return R_OUT;
 		}
-		raise Error_Has_Bad_Type(arg);
+		fail (Error_Has_Bad_Type(arg));
 
 makeCopy:
 		// Src image is arg.
@@ -1107,7 +1107,7 @@ makeCopy2:
 		break;
 
 	default:
-		raise Error_Illegal_Action(VAL_TYPE(value), action);
+		fail (Error_Illegal_Action(VAL_TYPE(value), action));
 	}
 
 	*D_OUT = *value;

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -73,7 +73,7 @@
 	}
 	if (IS_DECIMAL(value) || IS_PERCENT(value)) {
 		if (VAL_DECIMAL(value) < MIN_D64 || VAL_DECIMAL(value) >= MAX_D64)
-			raise Error_0(RE_OVERFLOW);
+			fail (Error(RE_OVERFLOW));
 
 		*out = cast(REBI64, VAL_DECIMAL(value));
 		goto check_sign;
@@ -159,7 +159,7 @@
 		// Not using BigNums (yet) so max representation is 8 bytes after
 		// leading 0x00 or 0xFF stripped away
 		if (n > 8)
-			raise Error_1(RE_OUT_OF_RANGE, value);
+			fail (Error(RE_OUT_OF_RANGE, value));
 
 		// Pad out to make sure any missing upper bytes match sign
 		for (fill = n; fill < 8; fill++)
@@ -176,7 +176,7 @@
 
 		if (no_sign && *out < 0) {
 			// bits may become signed via shift due to 63-bit limit
-			raise Error_1(RE_OUT_OF_RANGE, value);
+			fail (Error(RE_OUT_OF_RANGE, value));
 		}
 
 		return;
@@ -193,16 +193,16 @@
 
 		if (len > MAX_HEX_LEN) {
 			// Lacks BINARY!'s accommodation of leading 00s or FFs
-			raise Error_1(RE_OUT_OF_RANGE, value);
+			fail (Error(RE_OUT_OF_RANGE, value));
 		}
 
 		if (!Scan_Hex(out, bp, len, len))
-			raise Error_Bad_Make(REB_INTEGER, value);
+			fail (Error_Bad_Make(REB_INTEGER, value));
 
 		// !!! Unlike binary, always assumes unsigned (should it?).  Yet still
 		// might run afoul of 64-bit range limit.
 		if (*out < 0)
-			raise Error_1(RE_OUT_OF_RANGE, value);
+			fail (Error(RE_OUT_OF_RANGE, value));
 
 		return;
 	}
@@ -222,20 +222,20 @@
 					goto check_sign;
 				}
 
-				raise Error_0(RE_OVERFLOW);
+				fail (Error(RE_OVERFLOW));
 			}
 		}
 		if (Scan_Integer(out, bp, len))
 			goto check_sign;
 
-		raise Error_Bad_Make(REB_INTEGER, value);
+		fail (Error_Bad_Make(REB_INTEGER, value));
 	}
 	else if (IS_LOGIC(value)) {
 		// Rebol's choice is that no integer is uniquely representative of
 		// "falsehood" condition, e.g. `if 0 [print "this prints"]`.  So to
 		// say TO FALSE is 0 would be disingenuous.
 
-		raise Error_Bad_Make(REB_INTEGER, value);
+		fail (Error_Bad_Make(REB_INTEGER, value));
 	}
 	else if (IS_CHAR(value)) {
 		*out = VAL_CHAR(value);
@@ -248,11 +248,11 @@
 		return;
 	}
 	else
-		raise Error_Bad_Make(REB_INTEGER, value);
+		fail (Error_Bad_Make(REB_INTEGER, value));
 
 check_sign:
 	if (no_sign && *out < 0)
-		raise Error_0(RE_POSITIVE);
+		fail (Error(RE_POSITIVE));
 }
 
 
@@ -334,30 +334,30 @@ check_sign:
 					if (IS_DATE(val2)) return T_Date(call_, action);
 				}
 			}
-			raise Error_Math_Args(REB_INTEGER, action);
+			fail (Error_Math_Args(REB_INTEGER, action));
 		}
 	}
 
 	switch (action) {
 
 	case A_ADD:
-		if (REB_I64_ADD_OF(num, arg, &anum)) raise Error_0(RE_OVERFLOW);
+		if (REB_I64_ADD_OF(num, arg, &anum)) fail (Error(RE_OVERFLOW));
 		num = anum;
 		break;
 
 	case A_SUBTRACT:
-		if (REB_I64_SUB_OF(num, arg, &anum)) raise Error_0(RE_OVERFLOW);
+		if (REB_I64_SUB_OF(num, arg, &anum)) fail (Error(RE_OVERFLOW));
 		num = anum;
 		break;
 
 	case A_MULTIPLY:
-		if (REB_I64_MUL_OF(num, arg, &p)) raise Error_0(RE_OVERFLOW);
+		if (REB_I64_MUL_OF(num, arg, &p)) fail (Error(RE_OVERFLOW));
 		num = p;
 		break;
 
 	case A_DIVIDE:
-		if (arg == 0) raise Error_0(RE_ZERO_DIVIDE);
-		if (num == MIN_I64 && arg == -1) raise Error_0(RE_OVERFLOW);
+		if (arg == 0) fail (Error(RE_ZERO_DIVIDE));
+		if (num == MIN_I64 && arg == -1) fail (Error(RE_OVERFLOW));
 		if (num % arg == 0) {
 			num = num / arg;
 			break;
@@ -370,7 +370,7 @@ check_sign:
 		return T_Decimal(call_, action);
 
 	case A_REMAINDER:
-		if (arg == 0) raise Error_0(RE_ZERO_DIVIDE);
+		if (arg == 0) fail (Error(RE_ZERO_DIVIDE));
 		num = REM2(num, arg);
 		break;
 
@@ -379,14 +379,14 @@ check_sign:
 	case A_XOR: num ^= arg; break;
 
 	case A_NEGATE:
-		if (num == MIN_I64) raise Error_0(RE_OVERFLOW);
+		if (num == MIN_I64) fail (Error(RE_OVERFLOW));
 		num = -num;
 		break;
 
 	case A_COMPLEMENT: num = ~num; break;
 
 	case A_ABSOLUTE:
-		if (num == MIN_I64) raise Error_0(RE_OVERFLOW);
+		if (num == MIN_I64) fail (Error(RE_OVERFLOW));
 		if (num < 0) num = -num;
 		break;
 
@@ -412,7 +412,7 @@ check_sign:
 				SET_TYPE(D_OUT, VAL_TYPE(val2));
 				return R_OUT;
 			}
-			if (IS_TIME(val2)) raise Error_Invalid_Arg(val2);
+			if (IS_TIME(val2)) fail (Error_Invalid_Arg(val2));
 			arg = VAL_INT64(val2);
 		}
 		else arg = 0L;
@@ -462,7 +462,7 @@ check_sign:
 		return R_OUT;
 
 	default:
-		raise Error_Illegal_Action(REB_INTEGER, action);
+		fail (Error_Illegal_Action(REB_INTEGER, action));
 	}
 
 	SET_INTEGER(D_OUT, num);

--- a/src/core/t-library.c
+++ b/src/core/t-library.c
@@ -57,10 +57,10 @@
 			//RL_Print("%s, %d, Make library action\n", __func__, __LINE__);
 		case A_TO:
 			if (!IS_DATATYPE(val)) {
-				raise Error_Unexpected_Type(REB_LIBRARY, VAL_TYPE(val));
+				fail (Error_Unexpected_Type(REB_LIBRARY, VAL_TYPE(val)));
 			}
 			if (!IS_FILE(arg)) {
-				raise Error_Unexpected_Type(REB_FILE, VAL_TYPE(arg));
+				fail (Error_Unexpected_Type(REB_FILE, VAL_TYPE(arg)));
 			} else {
 				void *lib = NULL;
 				REBCNT error = 0;
@@ -68,7 +68,7 @@
 				lib = OS_OPEN_LIBRARY(cast(REBCHR*, SERIES_DATA(path)), &error);
 				Free_Series(path);
 				if (!lib)
-					raise Error_Bad_Make(REB_LIBRARY, arg);
+					fail (Error_Bad_Make(REB_LIBRARY, arg));
 
 				VAL_LIB_SPEC(D_OUT) = Make_Array(1);
 				MANAGE_SERIES(VAL_LIB_SPEC(D_OUT));
@@ -87,7 +87,7 @@
 			SET_UNSET(D_OUT);
 			break;
 		default:
-			raise Error_Illegal_Action(REB_LIBRARY, action);
+			fail (Error_Illegal_Action(REB_LIBRARY, action));
 	}
 	return R_OUT;
 }

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -76,7 +76,7 @@
 		else if (IS_NONE(arg))
 			val2 = FALSE;
 		else
-			raise Error_Unexpected_Type(REB_LOGIC, VAL_TYPE(arg));
+			fail (Error_Unexpected_Type(REB_LOGIC, VAL_TYPE(arg)));
 	}
 
 	switch (action) {
@@ -110,7 +110,7 @@
 		goto is_true;
 
 	default:
-		raise Error_Illegal_Action(REB_LOGIC, action);
+		fail (Error_Illegal_Action(REB_LOGIC, action));
 	}
 
 	// Keep other fields AS IS!

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -115,7 +115,7 @@
 	// Compute hash for value:
 	len = hser->tail;
 	hash = Hash_Value(key, len);
-	if (!hash) raise Error_Has_Bad_Type(key);
+	if (!hash) fail (Error_Has_Bad_Type(key));
 
 	// Determine skip and first index:
 	skip  = (len == 0) ? 0 : (hash & 0x0000FFFF) % len;
@@ -253,7 +253,7 @@
 				}
 			}
 			else
-				raise Error_Has_Bad_Type(key);
+				fail (Error_Has_Bad_Type(key));
 
 			if (!val) return 0;
 			Append_Value(series, key);
@@ -496,7 +496,7 @@
 	// Check must be in this order (to avoid checking a non-series value);
 	if (action >= A_TAKE && action <= A_SORT) {
 		if(IS_PROTECT_SERIES(series))
-			raise Error_0(RE_PROTECTED);
+			fail (Error(RE_PROTECTED));
 	}
 
 	switch (action) {
@@ -510,7 +510,7 @@
 
 	case A_INSERT:
 	case A_APPEND:
-		if (!IS_BLOCK(arg)) raise Error_Invalid_Arg(val);
+		if (!IS_BLOCK(arg)) fail (Error_Invalid_Arg(val));
 		*D_OUT = *val;
 		if (D_REF(AN_DUP)) {
 			n = Int32(D_ARG(AN_COUNT));
@@ -534,16 +534,16 @@
 		// make map! [word val word val]
 		if (IS_BLOCK(arg) || IS_PAREN(arg) || IS_MAP(arg)) {
 			if (MT_Map(D_OUT, arg, REB_MAP)) return R_OUT;
-			raise Error_Invalid_Arg(arg);
+			fail (Error_Invalid_Arg(arg));
 //		} else if (IS_NONE(arg)) {
 //			n = 3; // just a start
 		// make map! 10000
 		} else if (IS_NUMBER(arg)) {
-			if (action == A_TO) raise Error_Invalid_Arg(arg);
+			if (action == A_TO) fail (Error_Invalid_Arg(arg));
 			n = Int32s(arg, 0);
 		}
 		else
-			raise Error_Bad_Make(REB_MAP, Type_Of(arg));
+			fail (Error_Bad_Make(REB_MAP, Type_Of(arg)));
 
 		// positive only
 		series = Make_Map(n);
@@ -552,7 +552,7 @@
 
 	case A_COPY:
 		if (MT_Map(D_OUT, val, REB_MAP)) return R_OUT;
-		raise Error_Invalid_Arg(val);
+		fail (Error_Invalid_Arg(val));
 
 	case A_CLEAR:
 		Reset_Array(series);
@@ -570,7 +570,7 @@
 		else if (action == OF_BODY)
 			n = 0;
 		else
-			raise Error_Cannot_Reflect(REB_MAP, arg);
+			fail (Error_Cannot_Reflect(REB_MAP, arg));
 		series = Map_To_Block(series, n);
 		Val_Init_Block(D_OUT, series);
 		break;
@@ -579,7 +579,7 @@
 		return (Length_Map(series) == 0) ? R_TRUE : R_FALSE;
 
 	default:
-		raise Error_Illegal_Action(REB_MAP, action);
+		fail (Error_Illegal_Action(REB_MAP, action));
 	}
 
 	return R_OUT;

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -97,7 +97,7 @@
 	}
 #endif
 	else
-		raise Error_Invalid_Arg(val);
+		fail (Error_Invalid_Arg(val));
 
 	memcpy(buf + 12 - len, buf, len); // shift to right side
 	memset(buf, 0, 12 - len);
@@ -131,7 +131,7 @@
 			arg = D_OUT;
 		}
 		else
-			raise Error_Math_Args(REB_MONEY, action);
+			fail (Error_Math_Args(REB_MONEY, action));
 
 		switch (action) {
 		case A_ADD:
@@ -177,7 +177,7 @@
 			break;
 
 		default:
-			raise Error_Illegal_Action(REB_MONEY, action);
+			fail (Error_Illegal_Action(REB_MONEY, action));
 		}
 
 		SET_TYPE(D_OUT, REB_MONEY);
@@ -200,7 +200,7 @@
 				VAL_MONEY_AMOUNT(arg) = int_to_deci(VAL_INT64(arg));
 			else if (IS_DECIMAL(arg) || IS_PERCENT(arg))
 				VAL_MONEY_AMOUNT(arg) = decimal_to_deci(VAL_DECIMAL(arg));
-			else if (!IS_MONEY(arg)) raise Error_Invalid_Arg(arg);
+			else if (!IS_MONEY(arg)) fail (Error_Invalid_Arg(arg));
 		}
 		VAL_MONEY_AMOUNT(D_OUT) = Round_Deci(
 			VAL_MONEY_AMOUNT(val),
@@ -251,7 +251,7 @@
 			const REBYTE *end;
 			str = Temp_Byte_Chars_May_Fail(arg, MAX_SCAN_MONEY, 0, FALSE);
 			VAL_MONEY_AMOUNT(D_OUT) = string_to_deci(str, &end);
-			if (end == str || *end != 0) raise Error_Bad_Make(REB_MONEY, arg);
+			if (end == str || *end != 0) fail (Error_Bad_Make(REB_MONEY, arg));
 			break;
 		}
 
@@ -268,12 +268,12 @@
 
 		default:
 		err:
-			raise Error_Bad_Make(REB_MONEY, arg);
+			fail (Error_Bad_Make(REB_MONEY, arg));
 		}
 		break;
 
 	default:
-		raise Error_Illegal_Action(REB_MONEY, action);
+		fail (Error_Illegal_Action(REB_MONEY, action));
 	}
 
 	SET_TYPE(D_OUT, REB_MONEY);

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -83,7 +83,7 @@
 		if (IS_NONE(val)) return R_NONE;
 	default:
 	trap_it:
-		raise Error_Illegal_Action(VAL_TYPE(val), action);
+		fail (Error_Illegal_Action(VAL_TYPE(val), action));
 	}
 
 	return R_OUT;

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -111,14 +111,14 @@
 	else if (IS_INTEGER(a))
 		aa.x = aa.y = (REBD32)VAL_INT64(a);
 	else
-		raise Error_Invalid_Arg(a);
+		fail (Error_Invalid_Arg(a));
 
 	if (IS_PAIR(b))
 		bb = VAL_PAIR(b);
 	else if (IS_INTEGER(b))
 		bb.x = bb.y = (REBD32)VAL_INT64(b);
 	else
-		raise Error_Invalid_Arg(b);
+		fail (Error_Invalid_Arg(b));
 
 	SET_TYPE(out, REB_PAIR);
 	cc = &VAL_PAIR(out);
@@ -202,7 +202,7 @@
 		else if (n == REB_DECIMAL || n == REB_PERCENT) {
 			x2 = y2 = (REBD32)VAL_DECIMAL(arg);
 		}
-		else raise Error_Math_Args(REB_PAIR, action);
+		else fail (Error_Math_Args(REB_PAIR, action));
 
 		switch (action) {
 
@@ -223,7 +223,7 @@
 
 		case A_DIVIDE:
 		case A_REMAINDER:
-			if (x2 == 0 || y2 == 0) raise Error_0(RE_ZERO_DIVIDE);
+			if (x2 == 0 || y2 == 0) fail (Error(RE_ZERO_DIVIDE));
 			if (action == A_DIVIDE) {
 				x1 /= x2;
 				y1 /= y2;
@@ -235,7 +235,7 @@
 			goto setPair;
 		}
 
-		raise Error_Math_Args(REB_PAIR, action);
+		fail (Error_Math_Args(REB_PAIR, action));
 	}
 	// Unary actions:
 	else {
@@ -285,7 +285,7 @@
 			goto setPair;
 
 		case A_RANDOM:
-			if (D_REF(2)) raise Error_0(RE_BAD_REFINES); // seed
+			if (D_REF(2)) fail (Error(RE_BAD_REFINES)); // seed
 			x1 = (REBD32)Random_Range((REBINT)x1, (REBOOL)D_REF(3));
 			y1 = (REBD32)Random_Range((REBINT)y1, (REBOOL)D_REF(3));
 			goto setPair;
@@ -298,11 +298,11 @@
 				else if (VAL_WORD_CANON(arg) == SYM_Y)
 					n = 1;
 				else
-					raise Error_Invalid_Arg(arg);
+					fail (Error_Invalid_Arg(arg));
 			}
 			else {
 				n = Get_Num_Arg(arg);
-				if (n < 1 || n > 2) raise Error_Out_Of_Range(arg);
+				if (n < 1 || n > 2) fail (Error_Out_Of_Range(arg));
 				n--;
 			}
 ///		case A_POKE:
@@ -316,7 +316,7 @@
 ///					if (index == 0) x1 = (REBINT)VAL_DECIMAL(arg);
 ///					else y1 = (REBINT)VAL_DECIMAL(arg);
 ///				} else
-///					raise Error_Invalid_Arg(arg);
+///					fail (Error_Invalid_Arg(arg));
 ///				goto setPair;
 ///			}
 			SET_DECIMAL(D_OUT, n == 0 ? x1 : y1);
@@ -351,11 +351,11 @@
 					return R_OUT;
 			}
 
-			raise Error_Bad_Make(REB_PAIR, val);
+			fail (Error_Bad_Make(REB_PAIR, val));
 		}
 	}
 
-	raise Error_Illegal_Action(REB_PAIR, action);
+	fail (Error_Illegal_Action(REB_PAIR, action));
 
 setPair:
 	VAL_SET(D_OUT, REB_PAIR);

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -87,13 +87,13 @@
 		return T_Object(call_, action);
 
 	case A_MAKE:
-		if (!IS_DATATYPE(value)) raise Error_Bad_Make(REB_PORT, value);
+		if (!IS_DATATYPE(value)) fail (Error_Bad_Make(REB_PORT, value));
 		Make_Port(value, arg);
 		break;
 
 	case A_TO:
 		if (!(IS_DATATYPE(value) && IS_OBJECT(arg)))
-			raise Error_Bad_Make(REB_PORT, arg);
+			fail (Error_Bad_Make(REB_PORT, arg));
 		value = arg;
 		VAL_SET(value, REB_PORT);
 		break;

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -199,7 +199,7 @@
 		ffi_type *rtype,
 		ffi_type **atypes
 	) {
-		raise Error_0(RE_NOT_FFI_BUILD);
+		fail (Error(RE_NOT_FFI_BUILD));
 	}
 
 	ffi_status ffi_prep_cif_var(
@@ -210,7 +210,7 @@
 		ffi_type *rtype,
 		ffi_type **atypes
 	) {
-		raise Error_0(RE_NOT_FFI_BUILD);
+		fail (Error(RE_NOT_FFI_BUILD));
 	}
 
 	void ffi_call(
@@ -219,7 +219,7 @@
 		void *rvalue,
 		void **avalue
 	) {
-		raise Error_0(RE_NOT_FFI_BUILD);
+		fail (Error(RE_NOT_FFI_BUILD));
 	}
 
 	// The closure is a "black box" but client code takes the sizeof() to
@@ -230,7 +230,7 @@
 	} ffi_closure;
 
 	void *ffi_closure_alloc(size_t size, void **code) {
-		raise Error_0(RE_NOT_FFI_BUILD);
+		fail (Error(RE_NOT_FFI_BUILD));
 	}
 
 	ffi_status ffi_prep_closure_loc(
@@ -240,11 +240,11 @@
 		void *user_data,
 		void *codeloc
 	) {
-		panic Error_0(RE_NOT_FFI_BUILD);
+		panic (Error(RE_NOT_FFI_BUILD));
 	}
 
 	void ffi_closure_free (void *closure) {
-		panic Error_0(RE_NOT_FFI_BUILD);
+		panic (Error(RE_NOT_FFI_BUILD));
 	}
 #endif // HAVE_LIBFFI_AVAILABLE
 
@@ -347,7 +347,7 @@ static ffi_type* struct_to_ffi(const REBVAL *out, REBSER *fields, REBOOL make)
 		struct Struct_Field *field = (struct Struct_Field*)SERIES_SKIP(fields, i);
 		if (field->type == STRUCT_TYPE_REBVAL) {
 			/* don't see a point to pass a rebol value to external functions */
-			raise Error_Invalid_Arg(out);
+			fail (Error_Invalid_Arg(out));
 		} else if (field->type != STRUCT_TYPE_STRUCT) {
 			if (struct_type_to_ffi[field->type]) {
 				REBCNT n = 0;
@@ -497,7 +497,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 	switch (args[idx]->type) {
 		case FFI_TYPE_UINT8:
 			if (!IS_INTEGER(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 #ifdef BIG_ENDIAN
 				u8 i = (u8) VAL_INT64(arg);
@@ -507,7 +507,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 			}
 		case FFI_TYPE_SINT8:
 			if (!IS_INTEGER(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 #ifdef BIG_ENDIAN
 				i8 i = (i8) VAL_INT64(arg);
@@ -517,7 +517,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 			}
 		case FFI_TYPE_UINT16:
 			if (!IS_INTEGER(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 #ifdef BIG_ENDIAN
 				u16 i = (u16) VAL_INT64(arg);
@@ -527,7 +527,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 			}
 		case FFI_TYPE_SINT16:
 			if (!IS_INTEGER(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 #ifdef BIG_ENDIAN
 				i16 i = (i16) VAL_INT64(arg);
@@ -537,7 +537,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 			}
 		case FFI_TYPE_UINT32:
 			if (!IS_INTEGER(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 #ifdef BIG_ENDIAN
 				u32 i = (u32) VAL_INT64(arg);
@@ -547,7 +547,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 			}
 		case FFI_TYPE_SINT32:
 			if (!IS_INTEGER(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 #ifdef BIG_ENDIAN
 				i32 i = (i32) VAL_INT64(arg);
@@ -558,7 +558,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 		case FFI_TYPE_UINT64:
 		case FFI_TYPE_SINT64:
 			if (!IS_INTEGER(arg))
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			return &VAL_INT64(arg);
 		case FFI_TYPE_POINTER:
 			switch (VAL_TYPE(arg)) {
@@ -573,12 +573,12 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 					ptrs[idx] = VAL_ROUTINE_DISPATCHER(arg);
 					return &ptrs[idx];
 				default:
-					raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+					fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			}
 		case FFI_TYPE_FLOAT:
 			/* hackish, store the signle precision floating point number in a double precision variable */
 			if (!IS_DECIMAL(arg)) {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			} else {
 				float a = (float)VAL_DECIMAL(arg);
 				memcpy(&VAL_DECIMAL(arg), &a, sizeof(a));
@@ -586,24 +586,24 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
 			}
 		case FFI_TYPE_DOUBLE:
 			if (!IS_DECIMAL(arg))
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			return &VAL_DECIMAL(arg);
 		case FFI_TYPE_STRUCT:
 			if (idx == 0) {/* returning a struct */
 				Copy_Struct(&VAL_ROUTINE_RVALUE(rot), &VAL_STRUCT(arg));
 			} else {
 				if (!IS_STRUCT(arg))
-					raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+					fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			}
 			return SERIES_SKIP(VAL_STRUCT_DATA_BIN(arg), VAL_STRUCT_OFFSET(arg));
 		case FFI_TYPE_VOID:
 			if (!idx) {
 				return NULL;
 			} else {
-				raise Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg);
+				fail (Error_Arg_Type(DSF, BLK_SKIP(rebol_args, idx), arg));
 			}
 		default:
-			raise Error_Invalid_Arg(arg);
+			fail (Error_Invalid_Arg(arg));
 	}
 	return NULL;
 }
@@ -635,7 +635,7 @@ static void prep_rvalue(REBRIN *rin,
 			SET_UNSET(val);
 			break;
 		default:
-			raise Error_Invalid_Arg(val);
+			fail (Error_Invalid_Arg(val));
 	}
 }
 
@@ -695,7 +695,7 @@ static void ffi_to_rebol(REBRIN *rin,
 		case FFI_TYPE_VOID:
 			break;
 		default:
-			raise Error_Invalid_Arg(rebol_ret);
+			fail (Error_Invalid_Arg(rebol_ret));
 	}
 }
 
@@ -729,17 +729,17 @@ static void ffi_to_rebol(REBRIN *rin,
 	if (VAL_ROUTINE_LIB(rot) != NULL) {
 		// lib is NULL when routine is constructed from address directly
 		if (IS_CLOSED_LIB(VAL_ROUTINE_LIB(rot)))
-			raise Error_0(RE_BAD_LIBRARY);
+			fail (Error(RE_BAD_LIBRARY));
 	}
 
 	if (is_vararg_routine) {
 		varargs = BLK_HEAD(args);
 		if (!IS_BLOCK(varargs))
-			raise Error_Invalid_Arg(varargs);
+			fail (Error_Invalid_Arg(varargs));
 
 		n_fixed = SERIES_TAIL(VAL_ROUTINE_FIXED_ARGS(rot)) - 1; /* first arg is 'self */
 		if ((VAL_LEN(varargs) - n_fixed) % 2)
-			raise Error_Invalid_Arg(varargs);
+			fail (Error_Invalid_Arg(varargs));
 
 		ser = Make_Series(
 			n_fixed + (VAL_LEN(varargs) - n_fixed) / 2,
@@ -773,22 +773,22 @@ static void ffi_to_rebol(REBRIN *rin,
 			REBVAL *reb_arg = VAL_BLK_SKIP(varargs, i - 1);
 			if (i <= n_fixed) { /* fix arguments */
 				if (!TYPE_CHECK(BLK_SKIP(VAL_ROUTINE_FIXED_ARGS(rot), i), VAL_TYPE(reb_arg))) {
-					raise Error_Arg_Type(
+					fail (Error_Arg_Type(
 						DSF,
 						BLK_SKIP(VAL_ROUTINE_FIXED_ARGS(rot), i),
 						reb_arg
-					);
+					));
 				}
 			} else {
 				/* initialize rin->args */
 				REBVAL *reb_type = NULL;
 				REBVAL *v = NULL;
 				if (i == SERIES_TAIL(VAL_SERIES(varargs))) /* type is missing */
-					raise Error_Invalid_Arg(reb_arg);
+					fail (Error_Invalid_Arg(reb_arg));
 
 				reb_type = VAL_BLK_SKIP(varargs, i);
 				if (!IS_BLOCK(reb_type))
-					raise Error_Invalid_Arg(reb_type);
+					fail (Error_Invalid_Arg(reb_type));
 
 				v = Alloc_Tail_Array(VAL_ROUTINE_ALL_ARGS(rot));
 				Val_Init_Typeset(v, 0, SYM_ELLIPSIS); //FIXME, be clear
@@ -816,7 +816,7 @@ static void ffi_to_rebol(REBRIN *rin,
 				arg_types[0], /* return type */
 				&arg_types[1])) {
 			//RL_Print("Couldn't prep CIF_VAR\n");
-			raise Error_Invalid_Arg(varargs);
+			fail (Error_Invalid_Arg(varargs));
 		}
 	} else {
 		for (i = 1; i < SERIES_TAIL(VAL_ROUTINE_FFI_ARG_TYPES(rot)); i ++) {
@@ -830,7 +830,7 @@ static void ffi_to_rebol(REBRIN *rin,
 			 VAL_ROUTINE_FUNCPTR(rot),
 			 rvalue,
 			 ffi_args);
-	if (IS_ERROR(&Callback_Error)) raise Error_Is(&Callback_Error);
+	if (IS_ERROR(&Callback_Error)) fail (VAL_ERR_OBJECT(&Callback_Error));
 
 	ffi_to_rebol(VAL_ROUTINE_INFO(rot), ((ffi_type**)SERIES_DATA(VAL_ROUTINE_FFI_ARG_TYPES(rot)))[0], rvalue, ret);
 
@@ -875,26 +875,26 @@ static void process_type_block(const REBVAL *out, REBVAL *blk, REBCNT n, REBOOL 
 
 			++ t;
 			if (!IS_BLOCK(t) || VAL_LEN(blk) != 2)
-				raise Error_Invalid_Arg(blk);
+				fail (Error_Invalid_Arg(blk));
 
 			if (!MT_Struct(&tmp, t, REB_STRUCT))
-				raise Error_Invalid_Arg(blk);
+				fail (Error_Invalid_Arg(blk));
 
 			if (!rebol_type_to_ffi(out, &tmp, n, make))
-				raise Error_Invalid_Arg(blk);
+				fail (Error_Invalid_Arg(blk));
 
 			DROP_GUARD_VALUE(&tmp);
 		}
 		else {
 			if (VAL_LEN(blk) != 1)
-				raise Error_Invalid_Arg(blk);
+				fail (Error_Invalid_Arg(blk));
 
 			if (!rebol_type_to_ffi(out, t, n, make))
-				raise Error_Invalid_Arg(t);
+				fail (Error_Invalid_Arg(t));
 		}
 	}
 	else
-		raise Error_Invalid_Arg(blk);
+		fail (Error_Invalid_Arg(blk));
 
 }
 
@@ -907,17 +907,17 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 	REBVAL safe;
 
 	REBOL_STATE state;
-	const REBVAL *error;
+	REBSER *error_frame;
 
 	if (IS_ERROR(&Callback_Error)) return;
 
-	PUSH_TRAP(&error, &state);
+	PUSH_TRAP(&error_frame, &state);
 
-// The first time through the following code 'error' will be NULL, but...
-// Trap()s can longjmp here, so 'error' won't be NULL *if* that happens!
+// The first time through the following code 'error_frame' will be NULL, but...
+// `fail` can longjmp here, so 'error_frame' won't be NULL *if* that happens!
 
-	if (error) {
-		Callback_Error = *error;
+	if (error_frame) {
+		Val_Init_Error(&Callback_Error, error_frame);
 		return;
 	}
 
@@ -965,7 +965,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 				break;
 			case FFI_TYPE_STRUCT:
 				if (!IS_STRUCT(BLK_SKIP(RIN_ARGS_STRUCTS(rin), i + 1)))
-					raise Error_Invalid_Arg(BLK_SKIP(RIN_ARGS_STRUCTS(rin), i + 1));
+					fail (Error_Invalid_Arg(BLK_SKIP(RIN_ARGS_STRUCTS(rin), i + 1)));
 
 				Copy_Struct_Val(BLK_SKIP(RIN_ARGS_STRUCTS(rin), i + 1), elem);
 				memcpy(SERIES_SKIP(VAL_STRUCT_DATA_BIN(elem), VAL_STRUCT_OFFSET(elem)),
@@ -973,15 +973,15 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 					   VAL_STRUCT_LEN(elem));
 				break;
 			default:
-				// !!! was raise Error_Invalid_Arg(elem), but elem is uninitizalized here
-				raise Error_0(RE_MISC);
+				// !!! was fail (Error_Invalid_Arg(elem)), but elem is uninitizalized here
+				fail (Error(RE_MISC));
 		}
 	}
 
 	if (Do_At_Throws(&safe, ser, 0)) {
 		// !!! Does not check for thrown cases...what should this
 		// do in case of THROW, BREAK, QUIT?
-		raise Error_No_Catch_For_Throw(&safe);
+		fail (Error_No_Catch_For_Throw(&safe));
 	}
 
 	elem = &safe;
@@ -1019,7 +1019,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 				   VAL_STRUCT_LEN(elem));
 			break;
 		default:
-			raise Error_Invalid_Arg(elem);
+			fail (Error_Invalid_Arg(elem));
 	}
 
 	// !!! Could be a Free_Series if not managed/saved to use with DO
@@ -1120,19 +1120,19 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 		REBVAL lib;
 
 		if (!IS_BLOCK(&blk[0]))
-			raise Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(&blk[0]));
+			fail (Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(&blk[0])));
 
 		DO_NEXT_MAY_THROW(fn_idx, &lib, VAL_SERIES(data), 1);
 		if (fn_idx == THROWN_FLAG)
-			raise Error_No_Catch_For_Throw(&lib);
+			fail (Error_No_Catch_For_Throw(&lib));
 
 		if (IS_INTEGER(&lib)) {
 			if (NOT_END(&blk[fn_idx]))
-				raise Error_Invalid_Arg(&blk[fn_idx]);
+				fail (Error_Invalid_Arg(&blk[fn_idx]));
 
 			//treated as a pointer to the function
 			if (VAL_INT64(&lib) == 0)
-				raise Error_Invalid_Arg(&lib);
+				fail (Error_Invalid_Arg(&lib));
 
 			// Cannot cast directly to a function pointer from a 64-bit value
 			// on 32-bit systems; first cast to int that holds Unsigned PoinTer
@@ -1141,23 +1141,23 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 			);
 		} else {
 			if (!IS_LIBRARY(&lib))
-				raise Error_Invalid_Arg(&lib);
+				fail (Error_Invalid_Arg(&lib));
 
 			if (!IS_STRING(&blk[fn_idx]))
-				raise Error_Invalid_Arg(&blk[fn_idx]);
+				fail (Error_Invalid_Arg(&blk[fn_idx]));
 
 			if (NOT_END(&blk[fn_idx + 1]))
-				raise Error_Invalid_Arg(&blk[fn_idx + 1]);
+				fail (Error_Invalid_Arg(&blk[fn_idx + 1]));
 
 			VAL_ROUTINE_LIB(out) = VAL_LIB_HANDLE(&lib);
 			if (!VAL_ROUTINE_LIB(out)) {
-				raise Error_Invalid_Arg(&lib);
+				fail (Error_Invalid_Arg(&lib));
 				//RL_Print("lib is not open\n");
 			}
 			TERM_SEQUENCE(VAL_SERIES(&blk[fn_idx]));
 			func = OS_FIND_FUNCTION(LIB_FD(VAL_ROUTINE_LIB(out)), s_cast(VAL_DATA(&blk[fn_idx])));
 			if (!func) {
-				raise Error_Invalid_Arg(&blk[fn_idx]);
+				fail (Error_Invalid_Arg(&blk[fn_idx]));
 				//printf("Couldn't find function: %s\n", VAL_DATA(&blk[2]));
 			} else {
 				VAL_ROUTINE_FUNCPTR(out) = func;
@@ -1168,17 +1168,17 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 		REBVAL fun;
 
 		if (!IS_BLOCK(&blk[0]))
-			raise Error_Invalid_Arg(&blk[0]);
+			fail (Error_Invalid_Arg(&blk[0]));
 
 		DO_NEXT_MAY_THROW(fn_idx, &fun, VAL_SERIES(data), 1);
 		if (fn_idx == THROWN_FLAG)
-			raise Error_No_Catch_For_Throw(&fun);
+			fail (Error_No_Catch_For_Throw(&fun));
 
 		if (!IS_FUNCTION(&fun))
-			raise Error_Invalid_Arg(&fun);
+			fail (Error_Invalid_Arg(&fun));
 		VAL_CALLBACK_FUNC(out) = VAL_FUNC(&fun);
 		if (NOT_END(&blk[fn_idx]))
-			raise Error_Invalid_Arg(&blk[fn_idx]);
+			fail (Error_Invalid_Arg(&blk[fn_idx]));
 
 		//printf("RIN: %p, func: %p\n", VAL_ROUTINE_INFO(out), &blk[1]);
 	}
@@ -1194,7 +1194,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 					if (VAL_WORD_CANON(blk) == SYM_ELLIPSIS) {
 						REBVAL *v = NULL;
 						if (ROUTINE_GET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARARGS)) {
-							raise Error_Invalid_Arg(blk); /* duplicate ellipsis */
+							fail (Error_Invalid_Arg(blk)); /* duplicate ellipsis */
 						}
 						ROUTINE_SET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARARGS);
 						//Change the argument list to be a block
@@ -1207,7 +1207,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 						REBVAL *v = NULL;
 						if (ROUTINE_GET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARARGS)) {
 							//... has to be the last argument
-							raise Error_Invalid_Arg(blk);
+							fail (Error_Invalid_Arg(blk));
 						}
 						v = Alloc_Tail_Array(VAL_ROUTINE_ARGS(out));
 						Val_Init_Typeset(v, 0, VAL_WORD_SYM(blk));
@@ -1224,7 +1224,7 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 					case SYM_ABI:
 						++ blk;
 						if (!IS_WORD(blk) || has_abi > 1)
-							raise Error_Invalid_Arg(blk);
+							fail (Error_Invalid_Arg(blk));
 
 						switch (VAL_WORD_CANON(blk)) {
 							case SYM_DEFAULT:
@@ -1283,24 +1283,24 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 								break;
 #endif //X86_WIN64
 							default:
-								raise Error_Invalid_Arg(blk);
+								fail (Error_Invalid_Arg(blk));
 						}
 						has_abi ++;
 						break;
 					case SYM_RETURN:
 						if (has_return > 1) {
-							raise Error_Invalid_Arg(blk);
+							fail (Error_Invalid_Arg(blk));
 						}
 						has_return ++;
 						++ blk;
 						process_type_block(out, blk, 0, TRUE);
 						break;
 					default:
-						raise Error_Invalid_Arg(blk);
+						fail (Error_Invalid_Arg(blk));
 				}
 				break;
 			default:
-				raise Error_Invalid_Arg(blk);
+				fail (Error_Invalid_Arg(blk));
 		}
 		++ blk;
 		if (IS_STRING(blk)) { /* notes, ignoring */
@@ -1372,10 +1372,10 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 			//RL_Print("%s, %d, Make routine action\n", __func__, __LINE__);
 		case A_TO:
 			if (IS_ROUTINE(val)) {
-				raise Error_Unexpected_Type(REB_ROUTINE, VAL_TYPE(arg));
+				fail (Error_Unexpected_Type(REB_ROUTINE, VAL_TYPE(arg)));
 			}
 			else if (!IS_BLOCK(arg) || !MT_Routine(ret, arg, REB_ROUTINE)) {
-				raise Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(arg));
+				fail (Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(arg)));
 			}
 			break;
 		case A_REFLECT:
@@ -1392,12 +1392,12 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 						SET_INTEGER(ret, cast(REBUPT, VAL_ROUTINE_FUNCPTR(val)));
 						break;
 					default:
-						raise Error_Cannot_Reflect(REB_STRUCT, arg);
+						fail (Error_Cannot_Reflect(REB_STRUCT, arg));
 				}
 			}
 			break;
 		default:
-			raise Error_Illegal_Action(REB_ROUTINE, action);
+			fail (Error_Illegal_Action(REB_ROUTINE, action));
 	}
 	return R_OUT;
 }
@@ -1422,10 +1422,10 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 			//RL_Print("%s, %d, Make routine action\n", __func__, __LINE__);
 		case A_TO:
 			if (IS_ROUTINE(val)) {
-				raise Error_Unexpected_Type(REB_ROUTINE, VAL_TYPE(arg));
+				fail (Error_Unexpected_Type(REB_ROUTINE, VAL_TYPE(arg)));
 			}
 			else if (!IS_BLOCK(arg) || !MT_Routine(ret, arg, REB_CALLBACK)) {
-				raise Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(arg));
+				fail (Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(arg)));
 			}
 			break;
 		case A_REFLECT:
@@ -1442,12 +1442,12 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
 						SET_INTEGER(ret, (REBUPT)VAL_ROUTINE_DISPATCHER(val));
 						break;
 					default:
-						raise Error_Cannot_Reflect(REB_STRUCT, arg);
+						fail (Error_Cannot_Reflect(REB_STRUCT, arg));
 				}
 			}
 			break;
 		default:
-			raise Error_Illegal_Action(REB_CALLBACK, action);
+			fail (Error_Illegal_Action(REB_CALLBACK, action));
 	}
 	return R_OUT;
 }

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -161,7 +161,7 @@ static REBSER *make_string(REBVAL *arg, REBOOL make)
 			len -= 3;
 			break;
 		default:
-			raise Error_0(RE_BAD_DECODE);
+			fail (Error(RE_BAD_DECODE));
 		}
 		ser = Decode_UTF_String(bp, len, 8); // UTF-8
 	}
@@ -368,7 +368,7 @@ enum COMPARE_CHR_FLAGS {
 	if (!IS_UNSET(skipv)) {
 		skip = Get_Num_Arg(skipv);
 		if (skip <= 0 || len % skip != 0 || skip > len)
-			raise Error_Invalid_Arg(skipv);
+			fail (Error_Invalid_Arg(skipv));
 	}
 
 	// Use fast quicksort library function:
@@ -426,7 +426,7 @@ enum COMPARE_CHR_FLAGS {
 		c = Int32(val);
 		if (c > MAX_CHAR || c < 0) return PE_BAD_SET;
 		if (IS_BINARY(data)) { // special case for binary
-			if (c > 0xff) raise Error_Out_Of_Range(val);
+			if (c > 0xff) fail (Error_Out_Of_Range(val));
 			BIN_HEAD(ser)[n] = (REBYTE)c;
 			return PE_OK;
 		}
@@ -518,7 +518,7 @@ enum COMPARE_CHR_FLAGS {
 
 	// Check must be in this order (to avoid checking a non-series value);
 	if (action >= A_TAKE && action <= A_SORT && IS_PROTECT_SERIES(VAL_SERIES(value)))
-		raise Error_0(RE_PROTECTED);
+		fail (Error(RE_PROTECTED));
 
 	switch (action) {
 
@@ -551,11 +551,11 @@ find:
 			args |= AM_FIND_CASE;
 
 			if (!IS_BINARY(arg) && !IS_INTEGER(arg) && !IS_BITSET(arg))
-				raise Error_0(RE_NOT_SAME_TYPE);
+				fail (Error(RE_NOT_SAME_TYPE));
 
 			if (IS_INTEGER(arg)) {
 				if (VAL_INT64(arg) < 0 || VAL_INT64(arg) > 255)
-					raise Error_Out_Of_Range(arg);
+					fail (Error_Out_Of_Range(arg));
 				len = 1;
 			}
 		}
@@ -601,7 +601,7 @@ find:
 			|| REB_I32_ADD_OF(index, len, &index)
 			|| index < 0 || index >= tail) {
 			if (action == A_PICK) goto is_none;
-			raise Error_Out_Of_Range(arg);
+			fail (Error_Out_Of_Range(arg));
 		}
 		if (action == A_PICK) {
 pick_it:
@@ -620,11 +620,11 @@ pick_it:
 			else if (IS_INTEGER(arg) && VAL_UNT64(arg) <= MAX_CHAR)
 				c = VAL_INT32(arg);
 			else
-				raise Error_Invalid_Arg(arg);
+				fail (Error_Invalid_Arg(arg));
 
 			ser = VAL_SERIES(value);
 			if (IS_BINARY(value)) {
-				if (c > 0xff) raise Error_Out_Of_Range(arg);
+				if (c > 0xff) fail (Error_Out_Of_Range(arg));
 				BIN_HEAD(ser)[index] = (REBYTE)c;
 			}
 			else {
@@ -690,28 +690,28 @@ zero_str:
 		type = VAL_TYPE(value);
 		if (type == REB_DATATYPE) type = VAL_TYPE_KIND(value);
 
-		if (IS_NONE(arg)) raise Error_Bad_Make(type, arg);
+		if (IS_NONE(arg)) fail (Error_Bad_Make(type, arg));
 
 		ser = (type != REB_BINARY)
 			? make_string(arg, (REBOOL)(action == A_MAKE))
 			: make_binary(arg, (REBOOL)(action == A_MAKE));
 
 		if (ser) goto str_exit;
-		raise Error_Invalid_Arg(arg);
+		fail (Error_Invalid_Arg(arg));
 
 	//-- Bitwise:
 
 	case A_AND:
 	case A_OR:
 	case A_XOR:
-		if (!IS_BINARY(arg)) raise Error_Invalid_Arg(arg);
+		if (!IS_BINARY(arg)) fail (Error_Invalid_Arg(arg));
 		VAL_LIMIT_SERIES(value);
 		VAL_LIMIT_SERIES(arg);
 		ser = Xandor_Binary(action, value, arg);
 		goto ser_exit;
 
 	case A_COMPLEMENT:
-		if (!IS_BINARY(value)) raise Error_Invalid_Arg(value);
+		if (!IS_BINARY(value)) fail (Error_Invalid_Arg(value));
 		ser = Complement_Binary(value);
 		goto ser_exit;
 
@@ -726,7 +726,7 @@ zero_str:
 			((args & AM_TRIM_AUTO) &&
 			(args & (AM_TRIM_HEAD | AM_TRIM_TAIL | AM_TRIM_LINES | AM_TRIM_ALL | AM_TRIM_WITH)))
 		) {
-			raise Error_0(RE_BAD_REFINES);
+			fail (Error(RE_BAD_REFINES));
 		}
 
 		Trim_String(VAL_SERIES(value), VAL_INDEX(value), VAL_LEN(value), args, D_ARG(ARG_TRIM_STR));
@@ -734,10 +734,10 @@ zero_str:
 
 	case A_SWAP:
 		if (VAL_TYPE(value) != VAL_TYPE(arg))
-			raise Error_0(RE_NOT_SAME_TYPE);
+			fail (Error(RE_NOT_SAME_TYPE));
 
 		if (IS_PROTECT_SERIES(VAL_SERIES(arg)))
-			raise Error_0(RE_PROTECTED);
+			fail (Error(RE_PROTECTED));
 
 		if (index < tail && VAL_INDEX(arg) < VAL_TAIL(arg))
 			swap_chars(value, arg);
@@ -774,7 +774,7 @@ zero_str:
 		break;
 
 	default:
-		raise Error_Illegal_Action(VAL_TYPE(value), action);
+		fail (Error_Illegal_Action(VAL_TYPE(value), action));
 	}
 
 	*D_OUT = *value;

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -196,12 +196,12 @@
 	}
 	else if (IS_INTEGER(val)) {
 		if (VAL_INT64(val) < -MAX_SECONDS || VAL_INT64(val) > MAX_SECONDS)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		secs = VAL_INT64(val) * SEC_SEC;
 	}
 	else if (IS_DECIMAL(val)) {
 		if (VAL_DECIMAL(val) < (REBDEC)(-MAX_SECONDS) || VAL_DECIMAL(val) > (REBDEC)MAX_SECONDS)
-			raise Error_Out_Of_Range(val);
+			fail (Error_Out_Of_Range(val));
 		secs = DEC_TO_SECS(VAL_DECIMAL(val));
 	}
 	else if (ANY_ARRAY(val) && VAL_BLK_LEN(val) <= 3) {
@@ -344,7 +344,7 @@
 		case 2:
 			if (IS_DECIMAL(val)) {
 				f = VAL_DECIMAL(val);
-				if (f < 0.0) raise Error_Out_Of_Range(val);
+				if (f < 0.0) fail (Error_Out_Of_Range(val));
 				tf.s = (REBINT)f;
 				tf.n = (REBINT)((f - tf.s) * SEC_SEC);
 			}
@@ -401,14 +401,14 @@
 				goto fixTime;
 
 			case A_DIVIDE:
-				if (secs2 == 0) raise Error_0(RE_ZERO_DIVIDE);
+				if (secs2 == 0) fail (Error(RE_ZERO_DIVIDE));
 				//secs /= secs2;
 				VAL_SET(D_OUT, REB_DECIMAL);
 				VAL_DECIMAL(D_OUT) = (REBDEC)secs / (REBDEC)secs2;
 				return R_OUT;
 
 			case A_REMAINDER:
-				if (secs2 == 0) raise Error_0(RE_ZERO_DIVIDE);
+				if (secs2 == 0) fail (Error(RE_ZERO_DIVIDE));
 				secs %= secs2;
 				goto setTime;
 			}
@@ -429,17 +429,17 @@
 			case A_MULTIPLY:
 				secs *= num;
 				if (secs < -MAX_TIME || secs > MAX_TIME)
-					raise Error_1(RE_TYPE_LIMIT, Get_Type(REB_TIME));
+					fail (Error(RE_TYPE_LIMIT, Get_Type(REB_TIME)));
 				goto setTime;
 
 			case A_DIVIDE:
-				if (num == 0) raise Error_0(RE_ZERO_DIVIDE);
+				if (num == 0) fail (Error(RE_ZERO_DIVIDE));
 				secs /= num;
 				SET_INTEGER(D_OUT, secs);
 				goto setTime;
 
 			case A_REMAINDER:
-				if (num == 0) raise Error_0(RE_ZERO_DIVIDE);
+				if (num == 0) fail (Error(RE_ZERO_DIVIDE));
 				secs %= num;
 				goto setTime;
 			}
@@ -461,7 +461,7 @@
 				goto setTime;
 
 			case A_DIVIDE:
-				if (dec == 0.0) raise Error_0(RE_ZERO_DIVIDE);
+				if (dec == 0.0) fail (Error(RE_ZERO_DIVIDE));
 				secs = (REBI64)(secs / dec);
 				goto setTime;
 
@@ -477,7 +477,7 @@
 			*D_ARG(2) = *D_ARG(3);
 			return T_Date(call_, action);
 		}
-		raise Error_Math_Args(REB_TIME, action);
+		fail (Error_Math_Args(REB_TIME, action));
 	}
 	else {
 		// unary actions
@@ -518,7 +518,7 @@
 					VAL_SET(arg, REB_INTEGER);
 					return R_ARG3;
 				}
-				else raise Error_Invalid_Arg(arg);
+				else fail (Error_Invalid_Arg(arg));
 			}
 			else {
 				secs = Round_Int(secs, Get_Round_Flags(call_) | 1, SEC_SEC);
@@ -548,11 +548,11 @@
 			assert(arg);
 
 			secs = Make_Time(arg);
-			if (secs == NO_TIME) raise Error_Bad_Make(REB_TIME, arg);
+			if (secs == NO_TIME) fail (Error_Bad_Make(REB_TIME, arg));
 			goto setTime;
 		}
 	}
-	raise Error_Illegal_Action(REB_TIME, action);
+	fail (Error_Illegal_Action(REB_TIME, action));
 
 fixTime:
 setTime:

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -195,7 +195,7 @@
 		vp = VAL_TUPLE(value);
 		len = VAL_TUPLE_LEN(value);
 	} else if (!(IS_DATATYPE(value) && (action == A_MAKE || action == A_TO)))
-		raise Error_Invalid_Arg(value);
+		fail (Error_Invalid_Arg(value));
 
 	if (IS_BINARY_ACT(action)) {
 		assert(vp);
@@ -214,7 +214,7 @@
 				len = VAL_TUPLE_LEN(value) = alen;
 		}
 		else
-			raise Error_Math_Args(REB_TUPLE, action);
+			fail (Error_Math_Args(REB_TUPLE, action));
 
 		for (;len > 0; len--, vp++) {
 			REBINT v = *vp;
@@ -231,22 +231,22 @@
 				break;
 			case A_DIVIDE:
 				if (IS_DECIMAL(arg) || IS_PERCENT(arg)) {
-					if (dec == 0.0) raise Error_0(RE_ZERO_DIVIDE);
+					if (dec == 0.0) fail (Error(RE_ZERO_DIVIDE));
 					v=(REBINT)Round_Dec(v/dec, 0, 1.0);
 				} else {
-					if (a == 0) raise Error_0(RE_ZERO_DIVIDE);
+					if (a == 0) fail (Error(RE_ZERO_DIVIDE));
 					v /= a;
 				}
 				break;
 			case A_REMAINDER:
-				if (a == 0) raise Error_0(RE_ZERO_DIVIDE);
+				if (a == 0) fail (Error(RE_ZERO_DIVIDE));
 				v %= a;
 				break;
 			case A_AND:	v &= a; break;
 			case A_OR:	v |= a; break;
 			case A_XOR:	v ^= a; break;
 			default:
-				raise Error_Illegal_Action(REB_TUPLE, action);
+				fail (Error_Illegal_Action(REB_TUPLE, action));
 			}
 
 			if (v > 255) v = 255;
@@ -263,7 +263,7 @@
 		goto ret_value;
 	}
 	if (action == A_RANDOM) {
-		if (D_REF(2)) raise Error_0(RE_BAD_REFINES); // seed
+		if (D_REF(2)) fail (Error(RE_BAD_REFINES)); // seed
 		for (;len > 0; len--, vp++) {
 			if (*vp)
 				*vp = (REBYTE)(Random_Int(D_REF(3)) % (1+*vp));
@@ -314,14 +314,14 @@
 		a = Get_Num_Arg(arg);
 		if (a <= 0 || a > len) {
 			if (action == A_PICK) return R_NONE;
-			raise Error_Out_Of_Range(arg);
+			fail (Error_Out_Of_Range(arg));
 		}
 		if (action == A_PICK) {
 			SET_INTEGER(D_OUT, vp[a-1]);
 			return R_OUT;
 		}
 		// Poke:
-		if (!IS_INTEGER(D_ARG(3))) raise Error_Invalid_Arg(D_ARG(3));
+		if (!IS_INTEGER(D_ARG(3))) fail (Error_Invalid_Arg(D_ARG(3)));
 		v = VAL_INT32(D_ARG(3));
 		if (v < 0)
 			v = 0;
@@ -355,7 +355,7 @@
 
 		if (ANY_ARRAY(arg)) {
 			if (!MT_Tuple(D_OUT, VAL_BLK_DATA(arg), REB_TUPLE))
-				raise Error_Bad_Make(REB_TUPLE, arg);
+				fail (Error_Bad_Make(REB_TUPLE, arg));
 			return R_OUT;
 		}
 
@@ -388,10 +388,10 @@
 		goto ret_value;
 
 bad_arg:
-		raise Error_Bad_Make(REB_TUPLE, arg);
+		fail (Error_Bad_Make(REB_TUPLE, arg));
 	}
 
-	raise Error_Illegal_Action(REB_TUPLE, action);
+	fail (Error_Illegal_Action(REB_TUPLE, action));
 
 ret_value:
 	*D_OUT = *value;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -167,7 +167,7 @@ const struct {
 			VAL_TYPESET_BITS(value) |= VAL_TYPESET_BITS(val);
 		} else {
 			if (load) return FALSE;
-			raise Error_Invalid_Arg(block);
+			fail (Error_Invalid_Arg(block));
 		}
 	}
 
@@ -264,7 +264,7 @@ const struct {
 		if (IS_DATATYPE(arg)) {
 			DECIDE(TYPE_CHECK(val, VAL_TYPE_KIND(arg)));
 		}
-		raise Error_Invalid_Arg(arg);
+		fail (Error_Invalid_Arg(arg));
 
 	case A_MAKE:
 	case A_TO:
@@ -279,13 +279,13 @@ const struct {
 	//		return R_ARG2;
 	//	}
 		if (IS_TYPESET(arg)) return R_ARG2;
-		raise Error_Bad_Make(REB_TYPESET, arg);
+		fail (Error_Bad_Make(REB_TYPESET, arg));
 
 	case A_AND:
 	case A_OR:
 	case A_XOR:
 		if (IS_DATATYPE(arg)) VAL_TYPESET_BITS(arg) = FLAGIT_64(VAL_TYPE_KIND(arg));
-		else if (!IS_TYPESET(arg)) raise Error_Invalid_Arg(arg);
+		else if (!IS_TYPESET(arg)) fail (Error_Invalid_Arg(arg));
 
 		if (action == A_OR) VAL_TYPESET_BITS(val) |= VAL_TYPESET_BITS(arg);
 		else if (action == A_AND) VAL_TYPESET_BITS(val) &= VAL_TYPESET_BITS(arg);
@@ -297,7 +297,7 @@ const struct {
 		return R_ARG1;
 
 	default:
-		raise Error_Illegal_Action(REB_TYPESET, action);
+		fail (Error_Illegal_Action(REB_TYPESET, action));
 	}
 
 is_true:

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -177,7 +177,7 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 				f = VAL_DECIMAL(val);
 				if (bits <= VTUI64) i = (REBINT)(f);
 			}
-			else raise Error_Invalid_Arg(val);
+			else fail (Error_Invalid_Arg(val));
 			//if (n >= ser->tail) Expand_Vector(ser);
 			set_vect(bits, ser->data, n++, i, f);
 		}
@@ -207,7 +207,7 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 	REBVAL *val;
 
 	if (len <= 0)
-		raise Error_Invalid_Arg(vect);
+		fail (Error_Invalid_Arg(vect));
 
 	ser = Make_Array(len);
 	val = BLK_HEAD(ser);
@@ -241,7 +241,7 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 	REBCNT b2 = VECT_TYPE(VAL_SERIES(v2));
 
 	if ((b1 >= VTSF08 && b2 < VTSF08) || (b2 >= VTSF08 && b1 < VTSF08))
-		raise Error_0(RE_NOT_SAME_TYPE);
+		fail (Error(RE_NOT_SAME_TYPE));
 
 	for (n = 0; n < len; n++) {
 		i1 = get_vect(b1, d1, n + VAL_INDEX(v1));
@@ -549,7 +549,7 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 
 	// Check must be in this order (to avoid checking a non-series value);
 	if (action >= A_TAKE && action <= A_SORT && IS_PROTECT_SERIES(vect))
-		raise Error_0(RE_PROTECTED);
+		fail (Error(RE_PROTECTED));
 
 	switch (action) {
 
@@ -598,19 +598,19 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 		break;
 
 	case A_RANDOM:
-		if (D_REF(2) || D_REF(4)) raise Error_0(RE_BAD_REFINES); // /seed /only
+		if (D_REF(2) || D_REF(4)) fail (Error(RE_BAD_REFINES)); // /seed /only
 		Shuffle_Vector(value, D_REF(3));
 		return R_ARG1;
 
 	default:
-		raise Error_Illegal_Action(VAL_TYPE(value), action);
+		fail (Error_Illegal_Action(VAL_TYPE(value), action));
 	}
 
 	*D_OUT = *value;
 	return R_OUT;
 
 bad_make:
-	raise Error_Bad_Make(REB_VECTOR, arg);
+	fail (Error_Bad_Make(REB_VECTOR, arg));
 }
 
 

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -85,13 +85,13 @@
 				bp = Temp_Byte_Chars_May_Fail(arg, MAX_SCAN_WORD, &len, TRUE);
 				if (type == REB_ISSUE) sym = Scan_Issue(bp, len);
 				else sym = Scan_Word(bp, len);
-				if (!sym) raise Error_1(RE_BAD_CHAR, arg);
+				if (!sym) fail (Error(RE_BAD_CHAR, arg));
 			}
 			else if (IS_CHAR(arg)) {
 				REBYTE buf[8];
 				sym = Encode_UTF8_Char(&buf[0], VAL_CHAR(arg)); //returns length
 				sym = Scan_Word(&buf[0], sym);
-				if (!sym) raise Error_1(RE_BAD_CHAR, arg);
+				if (!sym) fail (Error(RE_BAD_CHAR, arg));
 			}
 			else if (IS_DATATYPE(arg)) {
 				sym = VAL_TYPE_SYM(arg);
@@ -100,14 +100,14 @@
 				sym = VAL_LOGIC(arg) ? SYM_TRUE : SYM_FALSE;
 			}
 			else
-				raise Error_Unexpected_Type(REB_WORD, VAL_TYPE(arg));
+				fail (Error_Unexpected_Type(REB_WORD, VAL_TYPE(arg)));
 
 			Val_Init_Word_Unbound(D_OUT, type, sym);
 		}
 		break;
 
 	default:
-		raise Error_Illegal_Action(type, action);
+		fail (Error_Illegal_Action(type, action));
 	}
 
 	return R_OUT;

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -190,7 +190,7 @@ static const char *Dia_Fmt = "DELECT - cmd: %s length: %d missed: %d total: %d";
 		if (DO_ARRAY_THROWS(&safe, value)) {
 			// !!! Does not check for thrown cases...what should this
 			// do in case of THROW, BREAK, QUIT?
-			raise Error_No_Catch_For_Throw(&safe);
+			fail (Error_No_Catch_For_Throw(&safe));
 		}
 		DS_PUSH(&safe);
 		value = DS_TOP;
@@ -562,7 +562,7 @@ again:
 
 	if (D_REF(4)) { // in
 		if (!IS_BLOCK(dia.contexts = D_ARG(5)))
-			raise Error_Invalid_Arg(dia.contexts);
+			fail (Error_Invalid_Arg(dia.contexts));
 		dia.contexts = VAL_BLK_DATA(dia.contexts);
 	}
 
@@ -588,7 +588,7 @@ again:
 		if (dia.missed) Debug_Fmt(Dia_Fmt, Get_Field_Name(dia.dialect, dia.cmd), dia.out->tail, dia.missed, Total_Missed);
 	}
 
-	if (err < 0) raise Error_Invalid_Arg(D_ARG(2)); // !!! needs better error
+	if (err < 0) fail (Error_Invalid_Arg(D_ARG(2))); // !!! needs better error
 
 	return R_ARG2;
 }

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -215,7 +215,7 @@ void Print_Parse_Index(enum Reb_Kind type, const REBVAL *rules, REBSER *series, 
 		break;
 
 	default:
-		raise Error_1(RE_PARSE_RULE, item);
+		fail (Error(RE_PARSE_RULE, item));
 	}
 
 	return index;
@@ -465,7 +465,7 @@ found1:
 	return index + (is_thru ? 1 : 0);
 
 bad_target:
-	raise Error_1(RE_PARSE_RULE, item);
+	fail (Error(RE_PARSE_RULE, item));
 }
 
 
@@ -598,7 +598,7 @@ bad_target:
 		if (n == SYM_QUOTE) {
 			item = item + 1;
 			(*rule)++;
-			if (IS_END(item)) raise Error_1(RE_PARSE_END, item - 2);
+			if (IS_END(item)) fail (Error(RE_PARSE_END, item - 2));
 			if (IS_PAREN(item)) {
 				// might GC
 				if (DO_ARRAY_THROWS(&save, item)) {
@@ -614,9 +614,9 @@ bad_target:
 
 			item = item + 1;
 			(*rule)++;
-			if (IS_END(item)) raise Error_1(RE_PARSE_END, item - 2);
+			if (IS_END(item)) fail (Error(RE_PARSE_END, item - 2));
 			item = Get_Parse_Value(&save, item); // sub-rules
-			if (!IS_BLOCK(item)) raise Error_1(RE_PARSE_RULE, item - 2);
+			if (!IS_BLOCK(item)) fail (Error(RE_PARSE_RULE, item - 2));
 			if (!ANY_BINSTR(&value) && !ANY_ARRAY(&value)) return NOT_FOUND;
 
 			sub_parse.series = VAL_SERIES(&value);
@@ -636,7 +636,7 @@ bad_target:
 			return NOT_FOUND;
 		}
 		else if (n > 0)
-			raise Error_1(RE_PARSE_RULE, item);
+			fail (Error(RE_PARSE_RULE, item));
 		else
 			item = Get_Parse_Value(&save, item); // variable
 	}
@@ -644,7 +644,7 @@ bad_target:
 		item = Get_Parse_Value(&save, item); // variable
 	}
 	else if (IS_SET_WORD(item) || IS_GET_WORD(item) || IS_SET_PATH(item) || IS_GET_PATH(item))
-		raise Error_1(RE_PARSE_RULE, item);
+		fail (Error(RE_PARSE_RULE, item));
 
 	if (IS_NONE(item)) {
 		return (VAL_TYPE(&value) > REB_NONE) ? NOT_FOUND : index;
@@ -695,7 +695,7 @@ bad_target:
 	const REBVAL *rule_head = rules;
 	REBVAL save;
 
-	if (C_STACK_OVERFLOWING(&flags)) raise Trap_Stack_Overflow();
+	if (C_STACK_OVERFLOWING(&flags)) Trap_Stack_Overflow();
 	//if (depth > MAX_PARSE_DEPTH) vTrap_Word(RE_LIMIT_HIT, SYM_PARSE, 0);
 	flags = 0;
 	word = 0;
@@ -727,7 +727,7 @@ bad_target:
 
 				if (!IS_WORD(item)) {
 					// SET or GET not allowed
-					raise Error_1(RE_PARSE_COMMAND, item);
+					fail (Error(RE_PARSE_COMMAND, item));
 				}
 
 				if (cmd <= SYM_BREAK) { // optimization
@@ -756,8 +756,8 @@ bad_target:
 						SET_FLAG(flags, PF_SET_OR_COPY);
 						item = rules++;
 						if (!(IS_WORD(item) || IS_SET_WORD(item)))
-							raise Error_1(RE_PARSE_VARIABLE, item);
-						if (VAL_CMD(item)) raise Error_1(RE_PARSE_COMMAND, item);
+							fail (Error(RE_PARSE_VARIABLE, item));
+						if (VAL_CMD(item)) fail (Error(RE_PARSE_COMMAND, item));
 						word = item;
 						continue;
 
@@ -833,7 +833,7 @@ bad_target:
 					case SYM_IF:
 						item = rules++;
 						if (IS_END(item)) goto bad_end;
-						if (!IS_PAREN(item)) raise Error_1(RE_PARSE_RULE, item);
+						if (!IS_PAREN(item)) fail (Error(RE_PARSE_RULE, item));
 
 						// might GC
 						if (DO_ARRAY_THROWS(&save, item)) {
@@ -849,7 +849,7 @@ bad_target:
 						}
 
 					case SYM_LIMIT:
-						raise Error_0(RE_NOT_DONE);
+						fail (Error(RE_NOT_DONE));
 						//val = Get_Parse_Value(&save, rules++);
 					//	if (IS_INTEGER(val)) limit = index + Int32(val);
 					//	else if (ANY_SERIES(val)) limit = VAL_INDEX(val);
@@ -881,7 +881,7 @@ bad_target:
 					// !!! Should mutability be enforced?
 					item = GET_MUTABLE_VAR(item);
 					if (!ANY_SERIES(item)) // #1263
-						raise Error_1(RE_PARSE_SERIES, rules - 1);
+						fail (Error(RE_PARSE_SERIES, rules - 1));
 					index = Set_Parse_Series(parse, item);
 					series = parse->series;
 					continue;
@@ -925,7 +925,7 @@ bad_target:
 					item = &save;
 					// CureCode #1263 change
 					//		if (parse->type != VAL_TYPE(item) || VAL_SERIES(item) != parse->series)
-					if (!ANY_SERIES(item)) raise Error_1(RE_PARSE_SERIES, path);
+					if (!ANY_SERIES(item)) fail (Error(RE_PARSE_SERIES, path));
 					index = Set_Parse_Series(parse, item);
 					item = NULL;
 				}
@@ -954,11 +954,11 @@ bad_target:
 			SET_FLAG(flags, PF_WHILE);
 			mincount = maxcount = Int32s(item, 0);
 			item = Get_Parse_Value(&save, rules++);
-			if (IS_END(item)) raise Error_1(RE_PARSE_END, rules - 2);
+			if (IS_END(item)) fail (Error(RE_PARSE_END, rules - 2));
 			if (IS_INTEGER(item)) {
 				maxcount = Int32s(item, 0);
 				item = Get_Parse_Value(&save, rules++);
-				if (IS_END(item)) raise Error_1(RE_PARSE_END, rules - 2);
+				if (IS_END(item)) fail (Error(RE_PARSE_END, rules - 2));
 			}
 		}
 		// else fall through on other values and words
@@ -1217,7 +1217,7 @@ post:
 					}
 					// CHECK FOR QUOTE!!
 					item = Get_Parse_Value(&save, item); // new value
-					if (IS_UNSET(item)) raise Error_1(RE_NO_VALUE, rules - 1);
+					if (IS_UNSET(item)) fail (Error(RE_NO_VALUE, rules - 1));
 					if (IS_END(item)) goto bad_end;
 					if (IS_BLOCK_INPUT(parse)) {
 						index = Modify_Array(GET_FLAG(flags, PF_CHANGE) ? A_CHANGE : A_INSERT,
@@ -1252,9 +1252,9 @@ post:
 	return index;
 
 bad_rule:
-	raise Error_1(RE_PARSE_RULE, rules - 1);
+	fail (Error(RE_PARSE_RULE, rules - 1));
 bad_end:
-	raise Error_1(RE_PARSE_END, rules - 1);
+	fail (Error(RE_PARSE_END, rules - 1));
 	return 0;
 }
 
@@ -1279,7 +1279,7 @@ bad_end:
 	if (IS_NONE(rules) || IS_STRING(rules)) {
 		// !!! Temporary...more informative than having a simple "does not
 		// take type" response based on the spec not accepting string/none
-		raise Error_0(RE_USE_SPLIT_SIMPLE);
+		fail (Error(RE_USE_SPLIT_SIMPLE));
 	}
 
 	assert(IS_BLOCK(rules));

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -109,9 +109,12 @@ TVAR struct Reb_Call *CS_Root;	// Root call frame (head of first chunk)
 
 TVAR REBOL_STATE *Saved_State; // Saved state for Catch (CPU state, etc.)
 
-TVAR enum Reb_Fail_Prep TG_Fail_Prep;
-TVAR const char *TG_Fail_C_File;
-TVAR int TG_Fail_C_Line;
+#if !defined(NDEBUG)
+	// In debug builds, the `panic` and `fail` macros capture the file and
+	// line number of instantiation so any Make_Error can pick it up.
+	TVAR const char *TG_Erroring_C_File;
+	TVAR int TG_Erroring_C_Line;
+#endif
 
 //-- Evaluation variables:
 TVAR REBI64	Eval_Cycles;	// Total evaluation counter (upward)

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -602,7 +602,7 @@ enum {
 #define UNPROTECT_SERIES(s)  SERIES_CLR_FLAG(s, SER_PROT)
 #define IS_PROTECT_SERIES(s) SERIES_GET_FLAG(s, SER_PROT)
 
-#define TRAP_PROTECT(s) if (IS_PROTECT_SERIES(s)) raise Error_0(RE_PROTECTED)
+#define TRAP_PROTECT(s) if (IS_PROTECT_SERIES(s)) fail (Error(RE_PROTECTED))
 
 #ifdef SERIES_LABELS
 #define LABEL_SERIES(s,l) s->label = (l)


### PR DESCRIPTION
This commit is expansive and looks large, but simplifying.

Prior to the error system knowing for each error num how many template
arguments that error had, a variadic error creation function was not
feasible.  Hence macros like Error_0, Error_1, Error_2 had to be made.
Once the system could understand %errors.r well enough to check it, a
true variadic Error(...) function could be written.

Debate on the word to trigger errors originated for a while, apparently
starting with `cause` and then moved to `raise`, ultimately settling upon
simply `fail`.  The advantage of `fail` is that it suggests an error condition
by its very nature, while `cause error` and `raise error` suggest the need
for another component to make the suggestion.  For the same reasons
the native was called FAIL the internal function was renamed thusly.

The "cute" hack to simulate a keyword was removed, in favor of parens.
So what used to be:

     raise Error_2(RE_ARG2_ERROR, arg1, arg2);

Is now:

    fail (Error(RE_ARG2_ERROR, arg1, arg2));

The belief being that the "keywordishness" and stand-outness can be
suggested strongly enough by a lowercase short name and a space,
without the penalty of the problems that the "trick" to omit the parens
cost.  The readability improvements by no longer needing to mention
the arity of the error are thought to outweigh the loss.

This shift cleans up concerns about design first voiced by
@ShixinZeng, and undoes the previous trick in favor of a more pleasing
trick, which has provably tested well on early boot panics reporting
errors in an informative way.  So during an early boot:

     panic (Error(RE_ARG2_ERROR, arg1, arg2));

In that expression, the core error generator is the one who knows it's
too early to report an error...and actually exits out the process, without
ever making it to the panic call.  This consolidates the error reporting
mechanisms during early and late boot to a common pattern.

The undoing of the prior hack means that the error generation
functions are themselves reusable, and do not terminate by their nature.
They return frames and not values, which also streamlines the trap
mechanism in cases where values are not needed.