### PR TITLE
Make default return-value from line-of explicit.

### DIFF
--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -75,6 +75,8 @@ line-of: function [
         position: at text position
     ]
 
+    line: none
+
     count-line: [(line: 1 + any [line 0])]
 
     parse/all copy/part text next position [


### PR DESCRIPTION
This fixes a bug where ren-c cannot build itself due to an error in line-of caused by FUNCTION defaulting local variables to Unset! instead of None!