### PR TITLE
Allow seeding of evaluator with value not in series

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -129,6 +129,11 @@ static void Assert_Basics(void)
     ) {
         panic (Error(RE_MISC));
     }
+
+    // Check special return values used to make sure they don't overlap
+    assert(THROWN_FLAG != END_FLAG);
+    assert(NOT_FOUND != END_FLAG);
+    assert(NOT_FOUND != THROWN_FLAG);
 }
 
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1291,10 +1291,6 @@ REBNATIVE(parse)
     parse.result = 0;
     parse.out = D_OUT;
 
-    // Check special return values used to make sure they don't overlap
-    assert(NOT_FOUND != END_FLAG);
-    assert(NOT_FOUND != THROWN_FLAG);
-
     index = Parse_Rules_Loop(&parse, VAL_INDEX(input), VAL_BLK_DATA(rules), 0);
 
     if (index == THROWN_FLAG) {

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -457,25 +457,50 @@ enum encoding_opts {
                 break; \
             } \
             (index_out) = Do_Core( \
-                (out), TRUE, (series), (index_in), (lookahead) \
+                (out), \
+                BLK_SKIP((series), (index_in)), \
+                TRUE, \
+                (series), \
+                (index_in) + 1, \
+                (lookahead) \
             ); \
         } while (FALSE)
 #else
     // Linux debug builds currently default to running the evaluator on
     // every value--whether it has evaluator behavior or not.
     #define DO_NEXT_MAY_THROW_CORE(index_out,out,series,index_in,lookahead) \
-        (index_out) = Do_Core((out), TRUE, (series), (index_in), (lookahead));
+        (index_out) = Do_Core( \
+            (out), \
+            BLK_SKIP((series), (index_in)), \
+            TRUE, \
+            (series), \
+            (index_in) + 1, \
+            (lookahead) \
+        );
 #endif
 
 #define DO_NEXT_MAY_THROW(index_out,out,series,index) \
     DO_NEXT_MAY_THROW_CORE((index_out), (out), (series), (index), TRUE)
 
 #define Do_At_Throws(out,series,index) \
-    (THROWN_FLAG == Do_Core((out), FALSE, (series), (index), TRUE))
+    (THROWN_FLAG == Do_Core( \
+        (out), \
+        BLK_SKIP((series), (index)), \
+        FALSE, \
+        (series), \
+        (index) + 1, \
+        TRUE \
+    ))
 
 #define DO_ARRAY_THROWS(out,array) \
     (THROWN_FLAG == Do_Core( \
-        (out), FALSE, VAL_SERIES(array), VAL_INDEX(array), TRUE))
+        (out), \
+        BLK_SKIP(VAL_SERIES(array), VAL_INDEX(array)), \
+        FALSE, \
+        VAL_SERIES(array), \
+        VAL_INDEX(array) + 1, \
+        TRUE \
+    ))
 
 
 /***********************************************************************

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -47,6 +47,10 @@ decode-url: none ; set in sys init
 
 r3-legacy*: none ; set in %mezz-legacy.r
 
+; used only by Ren-C++ as a test of how to patch the lib context prior to
+; boot at the higher levels.
+test-rencpp-low-level-hook: none
+
 ;-- Setup Codecs -------------------------------------------------------------
 
 for-each [codec handler] system/codecs [


### PR DESCRIPTION
Historically, the DO evaluator would take a series and an index offset
into that series.  The first step it would take would be to observe the value
at that index, and then proceed along from there.

This moves the first step of observing the value out so that the initial
value comes from the caller.  While most clients will treat this the same,
it makes it possible to simulate a head value for an evaluation that is
not resident in that series.  e.g. if one had the path `append/only` in
one location, and the series `[[a b c] [d e]]` in another, one would not
need to splice them together in order to `append/only [a b c] [d e]`
because that first value can be "pre-imaged" in the position at 0 cost.

*(This savings can be significant, as the array model of Rebol often must
"slide down" the memory--possibly involving an allocation/expansion--in
order to do such an insertion.)*

The functionality is now used by Ren-C++, to avoid doing temporary
insertions or creation of temporary series when the sole desire was to
effectively get the evaluator to do an "apply-like" operation without any
series mutation cost.  It is likely to have applications within the Ren-C
code as well.