### PR TITLE
Move APPLY to user-mode, legacy

### DIFF
--- a/src/boot/core.r
+++ b/src/boot/core.r
@@ -67,7 +67,7 @@ to-png: command [
 ;       dir [file!]
 ;][
 ;   if dir [dir: lib/replace/all to-local-file dir "/" "//"]
-;   if result: apply :req-dir [title text path dir] [
+;   if result: req-dir/title/path text dir [
 ;       return to-rebol-file result
 ;   ]
 ;]

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -328,32 +328,6 @@ REBNATIVE(any)
 
 
 //
-//  apply: native [
-//  
-//  "Apply a function to a reduced block of arguments."
-//  
-//      func [any-function!] "Function value to apply"
-//      block [block!] "Block of args, reduced first (unless /only)"
-//      /only "Use arg values as-is, do not reduce the block"
-//  ]
-//
-REBNATIVE(apply)
-{
-    REBVAL * func = D_ARG(1);
-    REBVAL * block = D_ARG(2);
-    REBOOL reduce = !D_REF(3);
-
-    if (Apply_Block_Throws(
-        D_OUT, func, VAL_SERIES(block), VAL_INDEX(block), reduce, NULL
-    )) {
-        return R_OUT_IS_THROWN;
-    }
-
-    return R_OUT;
-}
-
-
-//
 //  attempt: native [
 //  
 //  {Tries to evaluate a block and returns result or NONE on error.}


### PR DESCRIPTION
There have been considerable enhancements to the evaluator--with
features like unset arguments to refinements revoking the request for
that refinement--and get-words or parens able to be used to evaluate
a refinement within a path.  These enhancements provide a general
replacement for the rather brittle positional mechanisms of APPLY.

Advantages to removing the now-deprecated APPLY implementation
out of the C code to userspace are numerous.  It means that there
can be a focus on just one evaluator, that can be tuned and sped up,
without worries about the numerous bugs that result from having two
parallel C codebases that must be adjusted when the bit-level needs
of the evaluator change.

This user-mode apply does not support infix functions.  It could be
modified to do so, but as it is being deprecated in the first place the
code complexity is likely not warranted.  It will certainly be slower,
but the correct response to that is to use the new mechanisms.

https://trello.com/c/46zJ9lZj