### PR TITLE
20151123 multiline proto parsing

### DIFF
--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -153,8 +153,13 @@ void Expand_Stack(REBCNT amount)
 // it, because we need to fulfill its arguments in the caller's
 // frame before we actually invoke the function.
 //
-struct Reb_Call *Make_Call(REBVAL *out, REBSER *block, REBCNT index, const REBVAL *label, const REBVAL *func)
-{
+struct Reb_Call *Make_Call(
+    REBVAL *out,
+    REBSER *block,
+    REBCNT index,
+    const REBVAL *label,
+    const REBVAL *func
+) {
     REBCNT num_vars = VAL_FUNC_NUM_PARAMS(func);
 
     REBCNT size = (

--- a/src/tools/c-lexicals.r
+++ b/src/tools/c-lexicals.r
@@ -1,0 +1,180 @@
+REBOL [
+    Title: "C Programming Language Lexical Definitions"
+    Rights: {
+		Copyright 2015 Brett Handley
+    }
+    License: {
+        Licensed under the Apache License, Version 2.0
+        See: http://www.apache.org/licenses/LICENSE-2.0
+    }
+    Author: "Brett Handley"
+    Purpose: {Parse C source text into preprocessing tokens.}
+]
+
+;
+; Based upon N1570 Committee Draft — April 12, 2011 ISO/IEC 9899:201x
+;
+; Trigraphs are not implemented.
+;
+; Do not put any actions in this file.
+;
+; To use these rules, copy them, call them from your own rules or
+; use rule injection to dynamically add emit actions.
+;
+
+c.lexical: context [
+
+    grammar: [
+
+        text: [some c-pp-token]
+
+        c-pp-token: [
+
+            white-space | preprocessing-token
+        ]
+
+        white-space: [
+            nl
+            | eol
+            | wsp
+            | span-comment
+            | line-comment
+        ]
+
+        ;
+        ; -- A.1.1 Lexical Elements
+        ; Order is significant
+
+        preprocessing-token: [
+
+            pp-number
+            | character-constant
+            | identifier
+            | string-literal
+            | header-name
+            | punctuator
+            | other-pp-token
+        ]
+
+        other-pp-token: not-wsp
+
+        ;
+        ; -- A.1.3 Identifiers
+
+        identifier: [id.nondigit any id.char]
+        id.nondigit: [nondigit | universal-character-name]
+
+        ;
+        ; -- A.1.4 Universal character names
+
+        universal-character-name: [{\U} 2 hex-quad | {\u} hex-quad]
+        hex-quad: [4 hexadecimal-digit]
+
+        ;
+        ; -- A.1.5 Constants
+
+        character-constant: [
+            #"'" some c-char #"'"
+            | {L'} some c-char #"'"
+            | {u'} some c-char #"'"
+            | {U'} some c-char #"'"
+        ]
+
+        escape-sequence: [
+            simple-escape-sequence
+            | octal-escape-sequence
+            | hexadecimal-escape-sequence
+            | universal-character-name
+        ]
+
+        simple-escape-sequence: [
+            {\'} | {\"} | {\?} | {\\}
+            | {\a} | {\b} | {\f} | {\n} | {\r} | {\t} | {\v}
+        ]
+
+        hexadecimal-escape-sequence: [{\x} hexadecimal-digit any hexadecimal-digit]
+
+        octal-escape-sequence: [#"\" 1 3 octal-digit]
+
+        ;
+        ; -- A.1.6 String literals
+
+        string-literal: [
+            opt encoding-prefix #"^"" any s-char #"^""
+        ]
+        encoding-prefix: [{u8} | #"L" | #"u" | #"U"]
+        s-char: [s-char.cs | escape-sequence]
+
+        ;
+        ; -- A.1.7 Punctuators
+
+        punctuator: [
+            {->} | {++} | {--} | {<<} | {>>} | {<=} | {>=} | {==} | {!=}
+            | {&&} | {||} | {...} | {*=} | {/=} | {%=} | {+=} | {<<=} | {>>=}
+            | {&=} | {^^=} | {|=} | {##} | {<:} | {:>} | {<%} | {%>}
+            | {%:%:} | {%:}
+            | p-char
+        ]
+
+        ;
+        ; -- A.1.8 Header names
+
+        header-name: [#"<" some h-char #">" | #"^"" some q-char #"^""]
+
+        ;
+        ; -- A.1.9 Preprocessing numbers
+
+        pp-number: [
+            [digit | #"." digit]
+            any [
+                digit
+                | id.nondigit
+                | #"."
+                | [#"e" | #"p" | #"E" | #"P"] sign
+            ]
+        ]
+
+        ;
+        ; -- Whitespace
+
+        nl: {\^/} ; Line break in logical line.
+        eol: newline ; End of logical line.
+        wsp: [some ws-char]
+        span-comment: [{/*} thru {*/}]
+        line-comment: [{//} to newline]
+
+    ]
+
+    charsets: context [
+
+        ; Header name
+        h-char: complement charset {^/<}
+        q-char: complement charset {^/"}
+
+        ; Identifier
+        nondigit: charset [#"_" #"a" - #"z" #"A" - #"Z"]
+        digit: charset {0123456789}
+        octal-digit: charset {01234567}
+        id.char: union nondigit digit
+        hexadecimal-digit: charset [#"0" - #"9" #"a" - #"f" #"A" - #"F"]
+
+        ; pp-number
+        sign: charset {+-}
+
+        ; character-constant
+        c-char: complement charset {'\^/}
+
+        ; string-literal
+        s-char.cs: complement charset {"\^/}
+
+        ; punctuator
+        p-char: charset "[](){}.&*+-~!/%<>^^|?:;=,#"
+
+        ; whitespace
+        ws-char: charset { ^-^/^K^L}
+        not-wsp: complement ws-char
+    ]
+
+    grammar: context bind grammar charsets
+    ; Grammar defined first in file.
+]

--- a/src/tools/c-lexicals.r
+++ b/src/tools/c-lexicals.r
@@ -1,7 +1,7 @@
 REBOL [
     Title: "C Programming Language Lexical Definitions"
     Rights: {
-		Copyright 2015 Brett Handley
+        Copyright 2015 Brett Handley
     }
     License: {
         Licensed under the Apache License, Version 2.0

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -154,8 +154,8 @@ proto-parser: context [
     parse.position: none
     notes: none
     lines: none
-	proto.id: none
-	proto.arg.1: none
+    proto.id: none
+    proto.arg.1: none
     data: none
     style: none
 
@@ -168,7 +168,7 @@ proto-parser: context [
         ]
 
         segment: [
-			(proto.id: proto.arg.1: none)
+            (proto.id: proto.arg.1: none)
             format2015-func-header
             | format2012-func-header
             | thru newline
@@ -220,10 +220,10 @@ proto-parser: context [
 
         function-proto: [
             proto-prefix copy proto [
-				some [
-					not #"(" not eol [copy proto.id identifier | skip]
-				] #"(" any white-space
-				opt [not #")" copy proto.arg.1 identifier]
+                some [
+                    not #"(" not eol [copy proto.id identifier | skip]
+                ] #"(" any white-space
+                opt [not #")" copy proto.arg.1 identifier]
                 any [not #")" [white-space | skip]] #")"
             ]
         ]

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -168,9 +168,8 @@ proto-parser: context [
         ]
 
         segment: [
-            (proto.id: proto.arg.1: none)
+            (style: proto.id: proto.arg.1: none)
             format2015-func-header
-            | format2012-func-header
             | thru newline
         ]
 
@@ -204,19 +203,6 @@ proto-parser: context [
             ][
                 none
             ]
-        ]
-
-        format2012-func-header: [
-            "/******" to newline
-            some ["^/**" any [#" " | #"^-"] to newline]
-            "^/*/" any [#" " | #"^-"]
-            proto-prefix copy proto to newline newline
-            opt ["/*" newline copy notes to "*/" "*/"]
-            (
-                print [{Warning: FORMAT2012 detected for prototype: } mold proto]
-                style: 'format2012
-                emit-proto proto
-            )
         ]
 
         function-proto: [

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -178,6 +178,7 @@ proto-parser: context [
             doubleslashed-lines
             and is-format2015-intro
             function-proto some white-space
+            #"{"
             (
                 style: 'format2015
                 emit-proto proto
@@ -220,9 +221,8 @@ proto-parser: context [
 
         function-proto: [
             proto-prefix copy proto [
-                some [
-                    not #"(" not eol [copy proto.id identifier | skip]
-                ] #"(" any white-space
+                some [not #"(" not #"=" [white-space | copy proto.id identifier | skip]] #"("
+                any white-space
                 opt [not #")" copy proto.arg.1 identifier]
                 any [not #")" [white-space | skip]] #")"
             ]

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -207,6 +207,7 @@ proto-parser: context [
 
         function-proto: [
             proto-prefix copy proto [
+                not white-space
                 some [not #"(" not #"=" [white-space | copy proto.id identifier | skip]] #"("
                 any white-space
                 opt [not #")" copy proto.arg.1 identifier]

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -210,7 +210,7 @@ proto-parser: context [
             "/******" to newline
             some ["^/**" any [#" " | #"^-"] to newline]
             "^/*/" any [#" " | #"^-"]
-            function-proto newline
+            proto-prefix copy proto to newline newline
             opt ["/*" newline copy notes to "*/" "*/"]
             (
                 print [{Warning: FORMAT2012 detected for prototype: } mold proto]

--- a/src/tools/make-reb-lib.r
+++ b/src/tools/make-reb-lib.r
@@ -147,11 +147,6 @@ emit-proto: func [
         emit-mlib [pads mlib.tail 35 " RL->" fn.name.lower args]
 
         comment-text: proto-parser/notes
-        if proto-parser/style = 'format2012 [
-            if position: find comment-text "****" [clear position]
-            decode-lines comment-text {**} {}
-            trim/auto comment-text
-        ]
         encode-lines comment-text {**} { }
 
         emit-mlib ["/*^/**^-" proto "^/**^/" comment-text "*/" newline]


### PR DESCRIPTION
Supports multiline function prototypes which may include arbitrary embedded comments.

Also adds parsing of function identifiers.

Uses C preprocessing token lexical parser, but only uses part of it.  As the preprocessing token lexical parser is not large, it seemed a better idea to just include it in case of future use, rather than inline bits of it.