### PR TITLE
Kill OPT_VALUE_REEVALUATE, EVAL inside evaluator

### DIFF
--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -85,7 +85,6 @@ typedef struct Reb_Series REBSER;
 enum {
     OPT_VALUE_LINE = 0, // Line break occurs before this value
     OPT_VALUE_THROWN,   // Value is /NAME of a THROW (arg via THROWN_ARG)
-    OPT_VALUE_REEVALUATE, // Reevaluate result value
     OPT_VALUE_MAX
 };
 


### PR DESCRIPTION
There was a bit reserved in every value for whether that value was
a "reevaluating" value. This bit was the mechanism by which the now-dead
RETURN/REDO worked, but also how DO was able to return a FUNCTION!
and then have the evaluator go back and execute it inline with the next
arguments. When EVAL was introduced it used a similar mechanism.

Having an arbitrary "re-execute" bit that lives inside of each and every value
not only takes up a rare bit (that could be used for something else), but it's
also design-wise a very precarious idea. The settlement of the issue in
Ren-C is to have exactly one full-spectrum function that can do this, and
EVAL is that function.

https://trello.com/c/YMAb89dv

This handles the issue by merely recognizing eval as a NATIVE! specially,
and handling it in the evaluator directly. That reclaims the bit, and has the
advantage of making EVAL very efficient.