### PR TITLE
New REBFRM model + type incompatible with REBSER

### DIFF
--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -281,13 +281,18 @@ REBCNT Last_Word_Num(void)
 // 
 // Initialize an ANY-WORD! type with a binding to a context.
 //
-void Val_Init_Word(REBVAL *value, REBCNT type, REBINT sym, REBSER *frame, REBCNT index)
-{
+void Val_Init_Word(
+    REBVAL *value,
+    enum Reb_Kind type,
+    REBINT sym,
+    REBFRM *frame,
+    REBCNT index
+) {
     VAL_SET(value, type);
     assert(sym != SYM_0);
     VAL_WORD_SYM(value) = sym;
     assert(frame);
-    VAL_WORD_FRAME(value) = frame;
+    VAL_WORD_TARGET(value) = FRAME_VARLIST(frame);
     VAL_WORD_INDEX(value) = index;
     assert(ANY_WORD(value));
 }
@@ -301,7 +306,7 @@ void Val_Init_Word(REBVAL *value, REBCNT type, REBINT sym, REBSER *frame, REBCNT
 void Val_Init_Word_Unbound(REBVAL *value, REBCNT type, REBCNT sym)
 {
     VAL_SET(value, type);
-    VAL_WORD_FRAME(value) = NULL;
+    VAL_WORD_TARGET(value) = NULL;
     assert(sym != SYM_0);
     VAL_WORD_SYM(value) = sym;
 #ifndef NDEBUG

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -45,8 +45,11 @@
 // use the more advanced modes.  This allows the same interface
 // to be used for `panic Error_XXX(...)` and `fail (Error_XXX(...))`.
 //
-ATTRIBUTE_NO_RETURN void Panic_Core(REBCNT id, REBSER *maybe_frame, va_list *args)
-{
+ATTRIBUTE_NO_RETURN void Panic_Core(
+    REBCNT id,
+    REBFRM *maybe_frame,
+    va_list *args
+) {
     char title[PANIC_TITLE_SIZE];
     char message[PANIC_MESSAGE_SIZE];
 
@@ -54,6 +57,8 @@ ATTRIBUTE_NO_RETURN void Panic_Core(REBCNT id, REBSER *maybe_frame, va_list *arg
     message[0] = '\0';
 
     if (maybe_frame) {
+        ASSERT_FRAME(maybe_frame);
+        assert(VAL_TYPE(maybe_frame) == REB_ERROR);
         assert(id == 0);
         id = ERR_NUM(maybe_frame);
     }

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -112,7 +112,7 @@ REBINT Do_Series_Action(struct Reb_Call *call_, REBCNT action, REBVAL *value, RE
 
     case A_REMOVE:
         // /PART length
-        FAIL_IF_PROTECTED(VAL_SERIES(value));
+        FAIL_IF_PROTECTED_SERIES(VAL_SERIES(value));
         len = D_REF(2) ? Partial(value, 0, D_ARG(3), 0) : 1;
         index = (REBINT)VAL_INDEX(value);
         if (index < tail && len != 0)

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1325,19 +1325,19 @@ void Manage_Series(REBSER *series)
 // specifically.  If you've poked in a wordlist from somewhere
 // else you might not be able to use this.
 //
-void Manage_Frame_Debug(REBSER *frame)
+void Manage_Frame_Debug(REBFRM *frame)
 {
     if (
-        SERIES_GET_FLAG(frame, SER_MANAGED)
-        != SERIES_GET_FLAG(FRM_KEYLIST(frame), SER_MANAGED)
+        SERIES_GET_FLAG(FRAME_VARLIST(frame), SER_MANAGED)
+        != SERIES_GET_FLAG(FRAME_KEYLIST(frame), SER_MANAGED)
     ) {
         // Only one of these will trip...
-        ASSERT_SERIES_MANAGED(frame);
-        ASSERT_SERIES_MANAGED(FRM_KEYLIST(frame));
+        ASSERT_SERIES_MANAGED(FRAME_VARLIST(frame));
+        ASSERT_SERIES_MANAGED(FRAME_KEYLIST(frame));
     }
 
-    MANAGE_SERIES(FRM_KEYLIST(frame));
-    MANAGE_SERIES(frame);
+    MANAGE_SERIES(FRAME_KEYLIST(frame));
+    MANAGE_SERIES(FRAME_VARLIST(frame));
 }
 
 
@@ -1413,12 +1413,12 @@ REBFLG Is_Value_Managed(const REBVAL *value, REBFLG thrown_or_end_ok)
 #endif
 
     if (ANY_CONTEXT(value)) {
-        REBSER *frame = VAL_FRAME(value);
-        if (SERIES_GET_FLAG(frame, SER_MANAGED)) {
-            ASSERT_SERIES_MANAGED(FRM_KEYLIST(frame));
+        REBFRM *frame = VAL_FRAME(value);
+        if (SERIES_GET_FLAG(FRAME_VARLIST(frame), SER_MANAGED)) {
+            ASSERT_SERIES_MANAGED(FRAME_KEYLIST(frame));
             return TRUE;
         }
-        assert(!SERIES_GET_FLAG(FRM_KEYLIST(frame), SER_MANAGED));
+        assert(!SERIES_GET_FLAG(FRAME_KEYLIST(frame), SER_MANAGED));
         return FALSE;
     }
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -559,21 +559,27 @@ REBNATIVE(do_codec)
 //  
 //  "Returns true if the context doesn't bind 'self."
 //  
-//      context [any-word! any-context!]
-//          "A reference to the target context"
+//      value [any-word! any-context!]
+//          "Context or example word bound to the target context"
 //  ]
 //
 REBNATIVE(selfless_q)
 {
-    REBVAL *val = D_ARG(1);
-    REBSER *frm;
+    PARAM(1, value);
 
-    if (ANY_WORD(val)) {
-        if (VAL_WORD_INDEX(val) < 0) return R_TRUE;
-        frm = VAL_WORD_FRAME(val);
-        if (!frm) fail (Error(RE_NOT_BOUND, val));
+    REBFRM *frame;
+
+    if (ANY_WORD(ARG(value))) {
+        if (VAL_WORD_INDEX(ARG(value)) < 0)
+            return R_TRUE;
+
+        frame = AS_FRAME(VAL_WORD_TARGET(ARG(value)));
+
+        if (!frame)
+            fail (Error(RE_NOT_BOUND, ARG(value)));
     }
-    else frm = VAL_FRAME(D_ARG(1));
+    else
+        frame = VAL_FRAME(ARG(value));
 
-    return IS_SELFLESS(frm) ? R_TRUE : R_FALSE;
+    return IS_SELFLESS(frame) ? R_TRUE : R_FALSE;
 }

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -33,7 +33,7 @@
 //
 //  Clipboard_Actor: C
 //
-static REB_R Clipboard_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Clipboard_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBREQ *req;
     REBINT result;
@@ -52,7 +52,7 @@ static REB_R Clipboard_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action
     case A_UPDATE:
         // Update the port object after a READ or WRITE operation.
         // This is normally called by the WAKE-UP function.
-        arg = OFV(port, STD_PORT_DATA);
+        arg = FRAME_VAR(port, STD_PORT_DATA);
         if (req->command == RDC_READ) {
             // this could be executed twice:
             // once for an event READ, once for the CLOSE following the READ
@@ -94,7 +94,7 @@ static REB_R Clipboard_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action
         if (result > 0) return R_NONE; /* pending */
 
         // Copy and set the string result:
-        arg = OFV(port, STD_PORT_DATA);
+        arg = FRAME_VAR(port, STD_PORT_DATA);
 
         len = req->actual;
         if (GET_FLAG(req->flags, RRF_WIDE)) {
@@ -163,14 +163,14 @@ static REB_R Clipboard_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action
         req->length = len * sizeof(REBUNI);
 
         // Setup the write:
-        *OFV(port, STD_PORT_DATA) = *arg;   // keep it GC safe
+        *FRAME_VAR(port, STD_PORT_DATA) = *arg;   // keep it GC safe
         req->actual = 0;
 
         result = OS_DO_DEVICE(req, RDC_WRITE);
-        SET_NONE(OFV(port, STD_PORT_DATA)); // GC can collect it
+        SET_NONE(FRAME_VAR(port, STD_PORT_DATA)); // GC can collect it
 
         if (result < 0) fail (Error_On_Port(RE_WRITE_ERROR, port, req->error));
-        //if (result == DR_DONE) SET_NONE(OFV(port, STD_PORT_DATA));
+        //if (result == DR_DONE) SET_NONE(FRAME_VAR(port, STD_PORT_DATA));
         break;
 
     case A_OPEN:

--- a/src/core/p-console.c
+++ b/src/core/p-console.c
@@ -42,7 +42,7 @@
 //
 //  Console_Actor: C
 //
-static REB_R Console_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Console_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBREQ *req;
     REBINT result;
@@ -67,7 +67,7 @@ static REB_R Console_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
         }
 
         // If no buffer, create a buffer:
-        arg = OFV(port, STD_PORT_DATA);
+        arg = FRAME_VAR(port, STD_PORT_DATA);
         if (!IS_STRING(arg) && !IS_BINARY(arg)) {
             Val_Init_Binary(arg, MAKE_OS_BUFFER(OUT_BUF_SIZE));
         }

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -159,7 +159,7 @@ static void Init_Dir_Path(REBREQ *dir, REBVAL *path, REBINT wild, REBCNT policy)
 // 
 // Internal port handler for file directories.
 //
-static REB_R Dir_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Dir_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBVAL *spec;
     REBVAL *path;
@@ -176,7 +176,7 @@ static REB_R Dir_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     CLEARS(&dir);
 
     // Validate and fetch relevant PORT fields:
-    spec  = BLK_SKIP(port, STD_PORT_SPEC);
+    spec = FRAME_VAR(port, STD_PORT_SPEC);
     if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
     path = Obj_Value(spec, STD_PORT_SPEC_HEAD_REF);
     if (!path) fail (Error(RE_INVALID_SPEC, spec));
@@ -184,7 +184,7 @@ static REB_R Dir_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     if (IS_URL(path)) path = Obj_Value(spec, STD_PORT_SPEC_HEAD_PATH);
     else if (!IS_FILE(path)) fail (Error(RE_INVALID_SPEC, path));
 
-    state = BLK_SKIP(port, STD_PORT_STATE); // if block, then port is open.
+    state = FRAME_VAR(port, STD_PORT_STATE); // if block, then port is open.
 
     //flags = Security_Policy(SYM_FILE, path);
 

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -34,7 +34,7 @@
 //
 //  DNS_Actor: C
 //
-static REB_R DNS_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R DNS_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBVAL *spec;
     REBREQ *sock;
@@ -50,7 +50,7 @@ static REB_R DNS_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     *D_OUT = *D_ARG(1);
 
     sock = cast(REBREQ*, Use_Port_State(port, RDI_DNS, sizeof(*sock)));
-    spec = OFV(port, STD_PORT_SPEC);
+    spec = FRAME_VAR(port, STD_PORT_SPEC);
     if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_PORT));
 
     sock->timeout = 4000; // where does this go? !!!

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -143,7 +143,7 @@ REBVAL *Find_Last_Event(REBINT model, REBINT type)
 // 
 // Internal port handler for events.
 //
-static REB_R Event_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Event_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBVAL *spec;
     REBVAL *state;
@@ -157,8 +157,8 @@ static REB_R Event_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     *D_OUT = *D_ARG(1);
 
     // Validate and fetch relevant PORT fields:
-    state = BLK_SKIP(port, STD_PORT_STATE);
-    spec  = BLK_SKIP(port, STD_PORT_SPEC);
+    state = FRAME_VAR(port, STD_PORT_STATE);
+    spec = FRAME_VAR(port, STD_PORT_SPEC);
     if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
 
     // Get or setup internal state data:

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -109,33 +109,29 @@ static void Set_File_Date(REBREQ *file, REBVAL *val)
 // 
 // Query file and set RET value to resulting STD_FILE_INFO object.
 //
-void Ret_Query_File(REBSER *port, REBREQ *file, REBVAL *ret)
+void Ret_Query_File(REBFRM *port, REBREQ *file, REBVAL *ret)
 {
     REBVAL *info = In_Object(port, STD_PORT_SCHEME, STD_SCHEME_INFO, 0);
-    REBSER *frame;
+    REBFRM *frame;
     REBSER *ser;
 
     if (!info || !IS_OBJECT(info))
         fail (Error_On_Port(RE_INVALID_SPEC, port, -10));
 
-    frame = Copy_Array_Shallow(VAL_FRAME(info));
-    FRM_KEYLIST(frame) = FRM_KEYLIST(VAL_FRAME(info));
-    VAL_FRAME(FRM_CONTEXT(frame)) = frame;
-    SERIES_SET_FLAG(frame, SER_FRAME);
-    MANAGE_SERIES(frame);
+    frame = Copy_Frame_Shallow_Managed(VAL_FRAME(info));
 
     Val_Init_Object(ret, frame);
     Val_Init_Word_Unbound(
-        OFV(frame, STD_FILE_INFO_TYPE),
+        FRAME_VAR(frame, STD_FILE_INFO_TYPE),
         REB_WORD,
         GET_FLAG(file->modes, RFM_DIR) ? SYM_DIR : SYM_FILE
     );
-    SET_INTEGER(OFV(frame, STD_FILE_INFO_SIZE), file->special.file.size);
-    Set_File_Date(file, OFV(frame, STD_FILE_INFO_DATE));
+    SET_INTEGER(FRAME_VAR(frame, STD_FILE_INFO_SIZE), file->special.file.size);
+    Set_File_Date(file, FRAME_VAR(frame, STD_FILE_INFO_DATE));
 
     ser = To_REBOL_Path(file->special.file.path, 0, OS_WIDE, 0);
 
-    Val_Init_File(OFV(frame, STD_FILE_INFO_NAME), ser);
+    Val_Init_File(FRAME_VAR(frame, STD_FILE_INFO_NAME), ser);
 }
 
 
@@ -144,7 +140,7 @@ void Ret_Query_File(REBSER *port, REBREQ *file, REBVAL *ret)
 // 
 // Open a file port.
 //
-static void Open_File_Port(REBSER *port, REBREQ *file, REBVAL *path)
+static void Open_File_Port(REBFRM *port, REBREQ *file, REBVAL *path)
 {
     if (Is_Port_Open(port))
         fail (Error(RE_ALREADY_OPEN, path));
@@ -198,7 +194,7 @@ static REBCNT Set_Mode_Value(REBREQ *file, REBCNT mode, REBVAL *val)
 // 
 // Read from a file port.
 //
-static void Read_File_Port(REBVAL *out, REBSER *port, REBREQ *file, REBVAL *path, REBCNT args, REBCNT len)
+static void Read_File_Port(REBVAL *out, REBFRM *port, REBREQ *file, REBVAL *path, REBCNT args, REBCNT len)
 {
     REBSER *ser;
 
@@ -313,7 +309,7 @@ static void Set_Seek(REBREQ *file, REBVAL *arg)
 // 
 // Internal port handler for files.
 //
-static REB_R File_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R File_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBVAL *spec;
     REBVAL *path;
@@ -329,7 +325,7 @@ static REB_R File_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     *D_OUT = *D_ARG(1);
 
     // Validate PORT fields:
-    spec = BLK_SKIP(port, STD_PORT_SPEC);
+    spec = FRAME_VAR(port, STD_PORT_SPEC);
     if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
     path = Obj_Value(spec, STD_PORT_SPEC_HEAD_REF);
     if (!path) fail (Error(RE_INVALID_SPEC, spec));

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -36,7 +36,7 @@
 //
 //  Serial_Actor: C
 //
-static REB_R Serial_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Serial_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBREQ *req;    // IO request
     REBVAL *spec;   // port spec
@@ -53,7 +53,7 @@ static REB_R Serial_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     *D_OUT = *D_ARG(1);
 
     // Validate PORT fields:
-    spec = OFV(port, STD_PORT_SPEC);
+    spec = FRAME_VAR(port, STD_PORT_SPEC);
     if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_PORT));
     path = Obj_Value(spec, STD_PORT_SPEC_HEAD_REF);
     if (!path) fail (Error(RE_INVALID_SPEC, spec));
@@ -165,7 +165,7 @@ static REB_R Serial_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
         refs = Find_Refines(call_, ALL_READ_REFS);
 
         // Setup the read buffer (allocate a buffer if needed):
-        arg = OFV(port, STD_PORT_DATA);
+        arg = FRAME_VAR(port, STD_PORT_DATA);
         if (!IS_STRING(arg) && !IS_BINARY(arg)) {
             Val_Init_Binary(arg, Make_Binary(32000));
         }
@@ -203,7 +203,7 @@ static REB_R Serial_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
         }
 
         // Setup the write:
-        *OFV(port, STD_PORT_DATA) = *spec;  // keep it GC safe
+        *FRAME_VAR(port, STD_PORT_DATA) = *spec;  // keep it GC safe
         req->length = len;
         req->common.data = VAL_BIN_DATA(spec);
         req->actual = 0;
@@ -216,7 +216,7 @@ static REB_R Serial_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     case A_UPDATE:
         // Update the port object after a READ or WRITE operation.
         // This is normally called by the WAKE-UP function.
-        arg = OFV(port, STD_PORT_DATA);
+        arg = FRAME_VAR(port, STD_PORT_DATA);
         if (req->command == RDC_READ) {
             if (ANY_BINSTR(arg)) VAL_TAIL(arg) += req->actual;
         }

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -45,7 +45,7 @@ static void update(REBREQ *req, REBINT len, REBVAL *arg)
     Extend_Series(VAL_SERIES(arg), len);
 
     for (i = 0; i < len; i ++) {
-        REBSER *obj = Alloc_Frame(2, TRUE);
+        REBFRM *obj = Alloc_Frame(2, TRUE);
         REBVAL *val = Append_Frame(
             obj, NULL, Make_Word(signal_no, LEN_BYTES(signal_no))
         );
@@ -143,7 +143,7 @@ static int sig_word_num(REBVAL *word)
 //
 //  Signal_Actor: C
 //
-static REB_R Signal_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Signal_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBREQ *req;
     REBINT result;
@@ -157,7 +157,7 @@ static REB_R Signal_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     Validate_Port(port, action);
 
     req = cast(REBREQ*, Use_Port_State(port, RDI_SIGNAL, sizeof(REBREQ)));
-    spec = OFV(port, STD_PORT_SPEC);
+    spec = FRAME_VAR(port, STD_PORT_SPEC);
 
     if (!IS_OPEN(req)) {
         switch (action) {
@@ -211,7 +211,7 @@ static REB_R Signal_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
         case A_UPDATE:
             // Update the port object after a READ or WRITE operation.
             // This is normally called by the WAKE-UP function.
-            arg = OFV(port, STD_PORT_DATA);
+            arg = FRAME_VAR(port, STD_PORT_DATA);
             if (req->command == RDC_READ) {
                 len = req->actual;
                 if (len > 0) {
@@ -223,7 +223,7 @@ static REB_R Signal_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
         case A_READ:
             // This device is opened on the READ:
             // Issue the read request:
-            arg = OFV(port, STD_PORT_DATA);
+            arg = FRAME_VAR(port, STD_PORT_DATA);
 
             len = req->length = 8;
             ser = Make_Binary(len * sizeof(siginfo_t));
@@ -231,7 +231,7 @@ static REB_R Signal_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
             result = OS_DO_DEVICE(req, RDC_READ);
             if (result < 0) fail (Error_On_Port(RE_READ_ERROR, port, req->error));
 
-            arg = OFV(port, STD_PORT_DATA);
+            arg = FRAME_VAR(port, STD_PORT_DATA);
             if (!IS_BLOCK(arg)) {
                 Val_Init_Block(arg, Make_Array(len));
             }

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -44,7 +44,7 @@
 //
 //  Event_Actor: C
 //
-static REB_R Event_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
+static REB_R Event_Actor(struct Reb_Call *call_, REBFRM *port, REBCNT action)
 {
     REBVAL *spec;
     REBVAL *state;
@@ -58,8 +58,8 @@ static REB_R Event_Actor(struct Reb_Call *call_, REBSER *port, REBCNT action)
     *D_OUT = *D_ARG(1);
 
     // Validate and fetch relevant PORT fields:
-    state = BLK_SKIP(port, STD_PORT_STATE);
-    spec  = BLK_SKIP(port, STD_PORT_SPEC);
+    state = FRAME_VAR(port, STD_PORT_STATE);
+    spec  = FRAME_VAR(port, STD_PORT_SPEC);
     if (!IS_OBJECT(spec)) fail (Error(RE_INVALID_SPEC, spec));
 
     // Get or setup internal state data:

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -727,7 +727,7 @@ void Change_Case(REBVAL *out, REBVAL *val, REBVAL *part, REBOOL upper)
 
     // String series:
 
-    FAIL_IF_PROTECTED(VAL_SERIES(val));
+    FAIL_IF_PROTECTED_SERIES(VAL_SERIES(val));
 
     len = Partial(val, 0, part, 0);
     n = VAL_INDEX(val);

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -524,7 +524,7 @@ REBTYPE(Bitset)
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= A_TAKE && action <= A_SORT)
-        FAIL_IF_PROTECTED(VAL_SERIES(value));
+        FAIL_IF_PROTECTED_SERIES(VAL_SERIES(value));
 
     switch (action) {
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -527,7 +527,7 @@ REBINT PD_Array(REBPVS *pvs)
         return PE_NONE;
     }
 
-    if (pvs->setval) FAIL_IF_PROTECTED(VAL_SERIES(pvs->value));
+    if (pvs->setval) FAIL_IF_PROTECTED_SERIES(VAL_SERIES(pvs->value));
     pvs->value = VAL_BLK_SKIP(pvs->value, n);
     // if valset - check PROTECT on block
     //if (NOT_END(pvs->path+1)) Next_Path(pvs); return PE_OK;
@@ -602,7 +602,7 @@ REBTYPE(Array)
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= A_TAKE && action <= A_SORT)
-        FAIL_IF_PROTECTED(ser);
+        FAIL_IF_PROTECTED_SERIES(ser);
 
     switch (action) {
 
@@ -777,7 +777,7 @@ zero_blk:
     case A_SWAP:
         if (SERIES_WIDE(ser) != SERIES_WIDE(VAL_SERIES(arg)))
             fail (Error_Invalid_Arg(arg));
-        FAIL_IF_PROTECTED(VAL_SERIES(arg));
+        FAIL_IF_PROTECTED_SERIES(VAL_SERIES(arg));
         if (index < tail && VAL_INDEX(arg) < VAL_TAIL(arg)) {
             val = *VAL_BLK_DATA(value);
             *VAL_BLK_DATA(value) = *VAL_BLK_DATA(arg);

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -65,7 +65,7 @@ REBTYPE(Datatype)
     REBVAL *arg = D_ARG(2);
     REBACT act;
     enum Reb_Kind kind = VAL_TYPE_KIND(value);
-    REBSER *obj;
+    REBFRM *obj;
     REBINT n;
 
     switch (action) {
@@ -77,7 +77,7 @@ REBTYPE(Datatype)
             Set_Object_Values(
                 obj,
                 BLK_HEAD(
-                    VAL_TYPE_SPEC(BLK_SKIP(Lib_Context, SYM_FROM_KIND(kind)))
+                    VAL_TYPE_SPEC(FRAME_VAR(Lib_Context, SYM_FROM_KIND(kind)))
                 )
             );
             Val_Init_Object(D_OUT, obj);
@@ -86,7 +86,7 @@ REBTYPE(Datatype)
             Val_Init_String(
                 D_OUT,
                 Copy_Array_Shallow(VAL_SERIES(BLK_HEAD(
-                    VAL_TYPE_SPEC(BLK_SKIP(Lib_Context, SYM_FROM_KIND(kind)))
+                    VAL_TYPE_SPEC(FRAME_VAR(Lib_Context, SYM_FROM_KIND(kind)))
                 )))
             );
         }

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -94,11 +94,11 @@ static REBFLG Set_Event_Var(REBVAL *value, const REBVAL *word, const REBVAL *val
     case SYM_PORT:
         if (IS_PORT(val)) {
             VAL_EVENT_MODEL(value) = EVM_PORT;
-            VAL_EVENT_SER(value) = VAL_FRAME(val);
+            VAL_EVENT_SER(value) = FRAME_VARLIST(VAL_FRAME(val));
         }
         else if (IS_OBJECT(val)) {
             VAL_EVENT_MODEL(value) = EVM_OBJECT;
-            VAL_EVENT_SER(value) = VAL_FRAME(val);
+            VAL_EVENT_SER(value) = FRAME_VARLIST(VAL_FRAME(val));
         }
         else if (IS_NONE(val)) {
             VAL_EVENT_MODEL(value) = EVM_GUI;
@@ -232,11 +232,15 @@ static REBFLG Get_Event_Var(const REBVAL *value, REBCNT sym, REBVAL *val)
         }
         // Event holds a port:
         else if (IS_EVENT_MODEL(value, EVM_PORT)) {
-            Val_Init_Port(val, VAL_EVENT_SER(m_cast(REBVAL*, value)));
+            Val_Init_Port(
+                val, AS_FRAME(VAL_EVENT_SER(m_cast(REBVAL*, value)))
+            );
         }
         // Event holds an object:
         else if (IS_EVENT_MODEL(value, EVM_OBJECT)) {
-            Val_Init_Object(val, VAL_EVENT_SER(m_cast(REBVAL*, value)));
+            Val_Init_Object(
+                val, AS_FRAME(VAL_EVENT_SER(m_cast(REBVAL*, value)))
+            );
         }
         else if (IS_EVENT_MODEL(value, EVM_CALLBACK)) {
             *val = *Get_System(SYS_PORTS, PORTS_CALLBACK);
@@ -246,7 +250,7 @@ static REBFLG Get_Event_Var(const REBVAL *value, REBCNT sym, REBVAL *val)
             // Event holds the IO-Request, which has the PORT:
             req = VAL_EVENT_REQ(value);
             if (!req || !req->port) goto is_none;
-            Val_Init_Port(val, cast(REBSER*, req->port));
+            Val_Init_Port(val, AS_FRAME(cast(REBSER*, req->port)));
         }
         break;
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -428,7 +428,7 @@ static REBFLG Set_GOB_Var(REBGOB *gob, const REBVAL *word, const REBVAL *val)
         SET_GOB_DTYPE(gob, GOBD_NONE);
         if (IS_OBJECT(val)) {
             SET_GOB_DTYPE(gob, GOBD_OBJECT);
-            SET_GOB_DATA(gob, VAL_FRAME(val));
+            SET_GOB_DATA(gob, FRAME_VARLIST(VAL_FRAME(val)));
         }
         else if (IS_BLOCK(val)) {
             SET_GOB_DTYPE(gob, GOBD_BLOCK);
@@ -554,7 +554,7 @@ is_none:
 
     case SYM_DATA:
         if (GOB_DTYPE(gob) == GOBD_OBJECT) {
-            Val_Init_Object(val, GOB_DATA(gob));
+            Val_Init_Object(val, AS_FRAME(GOB_DATA(gob)));
         }
         else if (GOB_DTYPE(gob) == GOBD_BLOCK) {
             Val_Init_Block(val, GOB_DATA(gob));

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -701,9 +701,8 @@ REBVAL *Find_Image(struct Reb_Call *call_)
     if (!len) goto find_none;
 
     for (n = 0; n < 8; n++) // (zero based)
-        if (D_REF((REBINT)no_refs[n]))
+        if (D_REF(no_refs[n]))
             fail (Error(RE_BAD_REFINE));
-//          fail (Error(RE_CANNOT_USE, FRM_KEYS(me, (REBINT)no_refs[n]), Get_Global(REB_IMAGE)));
 
     if (IS_TUPLE(arg)) {
         only = (REBOOL)(VAL_TUPLE_LEN(arg) < 4);
@@ -827,7 +826,7 @@ REBTYPE(Image)
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= A_TAKE && action <= A_SORT)
-        FAIL_IF_PROTECTED(series);
+        FAIL_IF_PROTECTED_SERIES(series);
 
     // Dispatch action:
     switch (action) {
@@ -1215,7 +1214,7 @@ REBINT PD_Image(REBPVS *pvs)
     index += n;
     if (n > 0) index--;
 
-    FAIL_IF_PROTECTED(series);
+    FAIL_IF_PROTECTED_SERIES(series);
 
     // Out of range:
     if (n == 0 || index < 0 || index >= (REBINT)series->tail) {

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -56,7 +56,7 @@ REBTYPE(Port)
 {
     REBVAL *value = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
-    REBSER *frame;
+    REBFRM *frame;
 
     switch (action) {
 
@@ -98,14 +98,8 @@ REBTYPE(Port)
         // vs. making it as a port to begin with (?)  Look into why
         // system/standard/port is made with CONTEXT and not with MAKE PORT!
         //
-        frame = Copy_Array_Shallow(VAL_FRAME(arg));
-        MANAGE_SERIES(frame);
-        SERIES_SET_FLAG(frame, SER_FRAME);
-        FRM_KEYLIST(frame) = VAL_CONTEXT_KEYLIST(arg);
-        VAL_SET(FRM_CONTEXT(frame), REB_PORT);
-        VAL_FRAME(FRM_CONTEXT(frame)) = frame;
-        FRM_SPEC(frame) = EMPTY_ARRAY;
-        FRM_BODY(frame) = NULL;
+        frame = Copy_Frame_Shallow_Managed(VAL_FRAME(arg));
+        VAL_SET(FRAME_CONTEXT(frame), REB_PORT);
         Val_Init_Port(D_OUT, frame);
         return R_OUT;
     }

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -931,17 +931,17 @@ static void callback_dispatcher(ffi_cif *cif, void *ret, void **args, void *user
     REBVAL safe;
 
     REBOL_STATE state;
-    REBSER *error_frame;
+    REBFRM *error;
 
     if (IS_ERROR(&Callback_Error)) return;
 
-    PUSH_TRAP(&error_frame, &state);
+    PUSH_TRAP(&error, &state);
 
-// The first time through the following code 'error_frame' will be NULL, but...
-// `fail` can longjmp here, so 'error_frame' won't be NULL *if* that happens!
+// The first time through the following code 'error' will be NULL, but...
+// `fail` can longjmp here, so 'error' won't be NULL *if* that happens!
 
-    if (error_frame) {
-        Val_Init_Error(&Callback_Error, error_frame);
+    if (error) {
+        Val_Init_Error(&Callback_Error, error);
         return;
     }
 

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -439,7 +439,7 @@ REBINT PD_String(REBPVS *pvs)
     else
         return PE_BAD_SELECT;
 
-    FAIL_IF_PROTECTED(ser);
+    FAIL_IF_PROTECTED_SERIES(ser);
 
     if (BYTE_SIZE(ser) && c > 0xff) Widen_String(ser, TRUE);
     SET_ANY_CHAR(ser, n, c);
@@ -516,7 +516,7 @@ REBTYPE(String)
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= A_TAKE && action <= A_SORT)
-        FAIL_IF_PROTECTED(VAL_SERIES(value));
+        FAIL_IF_PROTECTED_SERIES(VAL_SERIES(value));
 
     switch (action) {
 
@@ -734,7 +734,7 @@ zero_str:
         if (VAL_TYPE(value) != VAL_TYPE(arg))
             fail (Error(RE_NOT_SAME_TYPE));
 
-        FAIL_IF_PROTECTED(VAL_SERIES(arg));
+        FAIL_IF_PROTECTED_SERIES(VAL_SERIES(arg));
 
         if (index < tail && VAL_INDEX(arg) < VAL_TAIL(arg))
             swap_chars(value, arg);

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -146,7 +146,7 @@ REBFLG Make_Typeset(REBVAL *block, REBVAL *value, REBFLG load)
         if (IS_WORD(block)) {
             //Print("word: %s", Get_Word_Name(block));
             sym = VAL_WORD_SYM(block);
-            if (VAL_WORD_FRAME(block)) { // Get word value
+            if (VAL_WORD_TARGET(block)) { // Get word value
                 val = GET_VAR(block);
             } else if (IS_KIND_SYM(sym)) { // Accept datatype word
                 TYPE_SET(value, KIND_FROM_SYM(sym));

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -492,7 +492,7 @@ REBINT PD_Vector(REBPVS *pvs)
     }
 
     //--- Set Value...
-    FAIL_IF_PROTECTED(vect);
+    FAIL_IF_PROTECTED_SERIES(vect);
 
     if (n <= 0 || (REBCNT)n > vect->tail) return PE_BAD_RANGE;
 
@@ -540,7 +540,7 @@ REBTYPE(Vector)
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= A_TAKE && action <= A_SORT)
-        FAIL_IF_PROTECTED(vect);
+        FAIL_IF_PROTECTED_SERIES(vect);
 
     switch (action) {
 

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -40,11 +40,11 @@ REBINT CT_Word(REBVAL *a, REBVAL *b, REBINT mode)
     if (mode >= 0) {
         e = VAL_WORD_CANON(a) == VAL_WORD_CANON(b);
         if (mode == 1) e &= VAL_WORD_INDEX(a) == VAL_WORD_INDEX(b)
-            && VAL_WORD_FRAME(a) == VAL_WORD_FRAME(b);
+            && VAL_WORD_TARGET(a) == VAL_WORD_TARGET(b);
         else if (mode >= 2) {
             e = (VAL_WORD_SYM(a) == VAL_WORD_SYM(b) &&
                 VAL_WORD_INDEX(a) == VAL_WORD_INDEX(b) &&
-                VAL_WORD_FRAME(a) == VAL_WORD_FRAME(b));
+                VAL_WORD_TARGET(a) == VAL_WORD_TARGET(b));
         }
     } else {
         diff = Compare_Word(a, b, FALSE);

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -58,7 +58,7 @@ static int window_bits_gzip_raw = -(MAX_WBITS | 16); // is "raw gzip" a thing?
 // Zlib gives back string error messages.  We use them or fall
 // back on the integer code if there is no message.
 //
-static REBSER *Error_Compression(const z_stream *strm, int ret)
+static REBFRM *Error_Compression(const z_stream *strm, int ret)
 {
     REBVAL arg;
 
@@ -191,7 +191,7 @@ REBSER *Compress(REBSER *input, REBINT index, REBCNT len, REBFLG gzip, REBFLG ra
 REBSER *Decompress(const REBYTE *input, REBCNT len, REBINT max, REBFLG gzip, REBFLG raw)
 {
     REBOL_STATE state;
-    REBSER *error_frame;
+    REBFRM *error;
 
     REBCNT buf_size;
     REBSER *output;
@@ -274,15 +274,15 @@ REBSER *Decompress(const REBYTE *input, REBCNT len, REBINT max, REBFLG gzip, REB
     // Since we do the trap anyway, this is the way we handle explicit errors
     // called in the code below also.
 
-    PUSH_UNHALTABLE_TRAP(&error_frame, &state);
+    PUSH_UNHALTABLE_TRAP(&error, &state);
 
-// The first time through the following code 'error_frame' will be NULL, but...
-// `fail` can longjmp here, so 'error_frame' won't be NULL *if* that happens!
+// The first time through the following code 'error' will be NULL, but...
+// `fail` can longjmp here, so 'error' won't be NULL *if* that happens!
 
-    if (error_frame) {
+    if (error) {
         // output will already have been freed
         inflateEnd(&strm);
-        fail (error_frame);
+        fail (error);
     }
 
     // Since the initialization succeeded, go ahead and make the output buffer

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -53,8 +53,8 @@ PVAR WORD_TABLE PG_Word_Table; // Symbol values accessed by hash
 
 //-- Main contexts:
 PVAR ROOT_CTX *Root_Context; // System root variables
-PVAR REBSER   *Lib_Context;
-PVAR REBSER   *Sys_Context;
+PVAR REBFRM *Lib_Context;
+PVAR REBFRM *Sys_Context;
 
 //-- Various char tables:
 PVAR REBYTE *White_Chars;
@@ -97,7 +97,7 @@ PVAR REBSER *PG_Return_Paramlist; // RETURN native's paramlist (never GC'd)
 ***********************************************************************/
 
 TVAR TASK_CTX *Task_Context; // Main per-task variables
-TVAR REBSER *Task_Series;   // Series that holds Task_Context
+TVAR REBFRM *Task_Frame;    // Frame that holds Task_Context
 TVAR REBSER *TG_Task_Words; // word list for task frame
 
 TVAR REBVAL TG_Thrown_Arg;  // Non-GC protected argument to THROW

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -98,7 +98,7 @@ typedef struct Rebol_State {
     struct Reb_Call *call;
     REBCNT series_guard_tail;
     REBCNT value_guard_tail;
-    REBSER *error_frame;
+    REBFRM *error;
     REBINT gc_disable;      // Count of GC_Disables at time of Push
 
     REBCNT manuals_tail;    // Where GC_Manuals was when state started
@@ -146,9 +146,9 @@ typedef struct Rebol_State {
         } else { \
             /* this runs if before the DROP_TRAP a longjmp() happens */ \
             if (Trapped_Helper_Halted(s)) \
-                fail ((s)->error_frame); /* proxy the halt up the stack */ \
+                fail ((s)->error); /* proxy the halt up the stack */ \
             else \
-                *(e) = (s)->error_frame; \
+                *(e) = (s)->error; \
         } \
     } while (0)
 
@@ -178,7 +178,7 @@ typedef struct Rebol_State {
         } else { \
             /* this runs if before the DROP_TRAP a longjmp() happens */ \
             cast(void, Trapped_Helper_Halted(s)); \
-            *(e) = (s)->error_frame; \
+            *(e) = (s)->error; \
         } \
     } while (0)
 
@@ -203,6 +203,6 @@ typedef struct Rebol_State {
 //
 #define DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(s) \
     do { \
-        assert(!(s)->error_frame); \
+        assert(!(s)->error); \
         Saved_State = (s)->last_state; \
     } while (0)


### PR DESCRIPTION
The death of the FRAME! datatype was helpful in terminology, since
a "FRAME" was more generally a series which represented the key
and value pairings inside an object (or other context-like value).  This
series was implemented as two distinct series, which were historically
known as the "words" and "values".

This drives forward a new set of invariants, asserts, names, and rules
for a FRAME series...and also gives them their own datatype.  This
means that a REBFRM* and a REBSER* cannot be passed as equivalent
without some kind of cast.

That change alone meant having to touch a lot of code (that would not
compile until the change was pushed through).  But also, this tries to
nail down some other terms.  Because the "word list" does not contain
words (it contains typesets and a cached symbol) the name "keylist"
was deemed more appropriate.  And since "value" is very generic, the
idea of having a name for the corresponding slot to a key which was
a little different was good... the name "var" had been already adopted by
routines like `Get_Var` which would find the value slot in a frame for a
given word.

The routines for accessing keys and vars were simplified, assertions
strengthened in the debug build, and some general interface cleanup.
During debugging this required going in and handling some routines
that have changes which would be difficult to separate out in light of all
the other changes, so this includes those as well...with the hope that the
increase in asserts and correctness will make finding any bugs relatively
easy regardless.

This includes one functionality change made while fixing up the handling
of SET with objects.  Values that have been treated with PROTECT/HIDE
do not prevent a set, they merely are removed from the consideration:

    >> obj: object [a: 0 b: 0 c: 0]
    >> protect 'obj/b
    >> set obj [3 4]
    >> obj
    [a: 3 c: 4]

This should be helpful when SELF: is migrated to being a hidden <local>
of the object, similar to RETURN: in definitional scoped functions.