### PR TITLE
SELFlessness Part 1: SYM_SELF out of binding

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -17,7 +17,6 @@ REBOL [
     Note: "See Task Context for per-task globals"
 ]
 
-self            ; (hand-built CONTEXT! value - but, has no WORD table!)
 system          ; system object
 errobj          ; error object template
 strings         ; low-level strings accessed via Boot_Strs[] (GC protection)

--- a/src/boot/task.r
+++ b/src/boot/task.r
@@ -15,7 +15,6 @@ REBOL [
     }
 ]
 
-self
 stack           ; data stack
 ballast         ; current memory ballast (used for GC)
 max-ballast     ; ballast reset value

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1102,18 +1102,27 @@ RL_API u32 *RL_Words_Of_Object(REBSER *obj)
 {
     REBCNT index;
     u32 *syms;
-    REBVAL *keys;
+    REBVAL *key;
     REBFRM *frame = AS_FRAME(obj);
 
-    keys = FRAME_KEY(frame, 1);
+    key = FRAME_KEYS_HEAD(frame);
 
-    // SELF not included, but terminated by 0.
+    // We don't include hidden keys (e.g. SELF), but terminate by 0.
+    // Conservative estimate that there are no hidden keys, add one.
+    //
     syms = OS_ALLOC_N(u32, FRAME_LEN(frame) + 1);
 
-    for (index = 0; index < FRAME_LEN(frame); keys++, index++) {
-        syms[index] = VAL_TYPESET_CANON(keys);
+    index = 0;
+    for (; NOT_END(key); key++) {
+        if (VAL_GET_EXT(key, EXT_WORD_HIDE))
+            continue;
+
+        syms[index] = VAL_TYPESET_CANON(key);
+        index++;
     }
-    syms[index] = SYM_0;
+
+    syms[index] = SYM_0; // Null terminate
+
     return syms;
 }
 

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -114,16 +114,15 @@ void Check_Bind_Table(void)
 // configured, hence this is an "Alloc" instead of a "Make" (because there
 // is still work to be done before it will pass ASSERT_FRAME).
 //
-REBFRM *Alloc_Frame(REBINT len, REBOOL has_self)
+REBFRM *Alloc_Frame(REBINT len)
 {
     REBFRM *frame;
     REBARR *keylist;
     REBVAL *value;
 
-    keylist = Make_Array(len + 1); // size + room for SELF
-    frame = AS_FRAME(Make_Series(
-        (len + 1) + 1, sizeof(REBVAL), MKS_ARRAY | MKS_FRAME
-    ));
+    keylist = Make_Array(len + 1); // size + room for ROOTKEY (SYM_0)
+    frame = AS_FRAME(Make_Array(len + 1));
+    ARRAY_SET_FLAG(FRAME_VARLIST(frame), SER_FRAME);
 
     // Note: cannot use Append_Frame for first word.
 
@@ -156,12 +155,10 @@ REBFRM *Alloc_Frame(REBINT len, REBOOL has_self)
     SET_END(FRAME_VARS_HEAD(frame));
     SET_ARRAY_LEN(FRAME_VARLIST(frame), 1);
 
-    // !!! keylist[0] is currently either the symbol SELF or the symbol 0
-    // depending.  This is to be reviewed with the deprecation of SELF as a
-    // keyword in the language.
+    // keylist[0] is the "rootkey" which we currently initialize to SYM_0
     //
     value = Alloc_Tail_Array(keylist);
-    Val_Init_Typeset(value, ALL_64, has_self ? SYM_SELF : SYM_0);
+    Val_Init_Typeset(value, ALL_64, SYM_0);
 
     return frame;
 }
@@ -300,114 +297,180 @@ REBFRM *Copy_Frame_Shallow_Managed(REBFRM *src) {
 //
 void Collect_Keys_Start(REBCNT modes)
 {
-    REBINT *binds = WORDS_HEAD(Bind_Table); // GC safe to do here
-
     CHECK_BIND_TABLE;
 
     assert(ARRAY_LEN(BUF_COLLECT) == 0); // should be empty
 
-    // Add the SELF key (or unused key) to slot zero
-    if (modes & BIND_NO_SELF)
-        Val_Init_Typeset(ARRAY_HEAD(BUF_COLLECT), ALL_64, SYM_0);
-    else {
-        Val_Init_Typeset(ARRAY_HEAD(BUF_COLLECT), ALL_64, SYM_SELF);
-        binds[SYM_SELF] = -1;  // (cannot use zero here)
-    }
+    // Add a key to slot zero.  When the keys are copied out to be the
+    // keylist for a frame it will be the FRAME_ROOTKEY in the [0] slot.
+    //
+    Val_Init_Typeset(ARRAY_HEAD(BUF_COLLECT), ALL_64, SYM_0);
 
     SET_ARRAY_LEN(BUF_COLLECT, 1);
 }
 
 
 //
-//  Collect_Keys_End: C
-// 
-// Finish collecting words, and free the Bind_Table for reuse.
+//  Grab_Collected_Keylist_Managed: C
 //
-REBARR *Collect_Keys_End(REBFRM *prior)
+// The BUF_COLLECT is used to gather keys, which may wind up not requiring any
+// new keys from the `prior` that was passed in.  If this is the case, then
+// that prior keylist is returned...otherwise a new one is created.
+//
+// !!! "Grab" is used because "Copy_Or_Reuse" is long, and is picked to draw
+// attention to look at the meaning.  Better short communicative name?
+//
+REBARR *Grab_Collected_Keylist_Managed(REBFRM *prior)
 {
     REBARR *keylist;
-    REBVAL *words;
-    REBINT *binds = WORDS_HEAD(Bind_Table); // GC safe to do here
 
     // We didn't terminate as we were collecting, so terminate now.
     //
+    assert(ARRAY_LEN(BUF_COLLECT) >= 1); // always at least [0] for rootkey
     TERM_ARRAY(BUF_COLLECT);
 
-    // Reset binding table (note BUF_COLLECT may have expanded):
-    for (words = ARRAY_HEAD(BUF_COLLECT); NOT_END(words); words++)
-        binds[VAL_TYPESET_CANON(words)] = 0;
-
-    // If no new words, prior frame
+#if !defined(NDEBUG)
     //
-    // !!! Review the +1 logic to account for context/rootkey, is this right?
+    // When the key collecting is done, we may be asked to give back a keylist
+    // and when we do, if nothing was added beyond the `prior` then that will
+    // be handed back.  The array handed back will always be managed, so if
+    // we create it then it will be, and if we reuse the prior it will be.
+    //
+    if (prior) ASSERT_ARRAY_MANAGED(FRAME_KEYLIST(prior));
+#endif
+
+    // If no new words, prior frame.  Note length must include the slot
+    // for the rootkey...and note also this means the rootkey cell *may*
+    // be shared between all keylists when you pass in a prior.
     //
     if (prior && ARRAY_LEN(BUF_COLLECT) == FRAME_LEN(prior) + 1) {
-        SET_ARRAY_LEN(BUF_COLLECT, 0);  // allow reuse
         keylist = FRAME_KEYLIST(prior);
     }
     else {
         keylist = Copy_Array_Shallow(BUF_COLLECT);
-        SET_ARRAY_LEN(BUF_COLLECT, 0);  // allow reuse
+        MANAGE_ARRAY(keylist);
     }
-
-    CHECK_BIND_TABLE;
 
     return keylist;
 }
 
 
 //
+//  Collect_Keys_End: C
+//
+// Free the Bind_Table for reuse and empty the BUF_COLLECT.
+//
+void Collect_Keys_End(void)
+{
+    REBVAL *key;
+    REBINT *binds = WORDS_HEAD(Bind_Table);
+
+    // We didn't terminate as we were collecting, so terminate now.
+    //
+    assert(ARRAY_LEN(BUF_COLLECT) >= 1); // always at least [0] for rootkey
+    TERM_ARRAY(BUF_COLLECT);
+
+    // Reset binding table (note BUF_COLLECT may have expanded)
+    //
+    for (key = ARRAY_HEAD(BUF_COLLECT); NOT_END(key); key++) {
+        assert(IS_TYPESET(key));
+        binds[VAL_TYPESET_CANON(key)] = 0;
+    }
+
+    SET_ARRAY_LEN(BUF_COLLECT, 0); // allow reuse
+
+    CHECK_BIND_TABLE;
+}
+
+
+//
 //  Collect_Context_Keys: C
 // 
-// Collect words from a prior object.
+// Collect words from a prior context.  If `reset` is passed in then the
+// buffer is restarted and there is no check for duplciates in the frame.
+// Otherwise the keys are added to the end and duplicates are removed.
 //
-void Collect_Context_Keys(REBFRM *prior)
+void Collect_Context_Keys(REBFRM *frame, REBFLG check_dups)
 {
-    REBVAL *keys = FRAME_KEYS_HEAD(prior);
+    REBVAL *key = FRAME_KEYS_HEAD(frame);
     REBINT *binds = WORDS_HEAD(Bind_Table);
-    REBINT n;
+    REBINT bind_index = ARRAY_LEN(BUF_COLLECT);
+    REBVAL *collect; // can't set until after potential expansion...
+
+    // The BUF_COLLECT buffer should at least have the SYM_0 in its first slot
+    // to use as a "rootkey" in the generated keylist (and also that the first
+    // binding index we give out is at least 1, since 0 is used in the
+    // Bind_Table to mean "word not collected yet").
+    //
+    assert(bind_index >= 1);
 
     // this is necessary for memcpy below to not overwrite memory BUF_COLLECT
-    // does not own.  (It may make the series one larger than necessary if
-    // SELF is not required.)
+    // does not own.  (It may make the buffer capacity bigger than necessary
+    // if duplicates are found, but the actual buffer length will be set
+    // correctly by the end.)
     //
-    RESIZE_SERIES(ARRAY_SERIES(BUF_COLLECT), FRAME_LEN(prior) + 1);
+    EXPAND_SERIES_TAIL(ARRAY_SERIES(BUF_COLLECT), FRAME_LEN(frame));
 
-    // Copy the keys, leaving a one cell gap in the beginning of the collect
-    // buffer if the frame has a SELF.  Because these are typesets with a
-    // symbol, they can be safely memcpy'd as the new typeset values do not
-    // need any kind of independent identity.
+    // EXPAND_SERIES_TAIL will increase the ARRAY_LEN, even though we intend
+    // to overwrite it with a possibly shorter length.  Put the length back
+    // and now that the expansion is done, get the pointer to where we want
+    // to start collecting new typesets.
     //
-    memcpy(
-        IS_SELFLESS(prior)
-            ? ARRAY_HEAD(BUF_COLLECT)
-            : ARRAY_AT(BUF_COLLECT, 1),
-        keys,
-        (FRAME_LEN(prior)) * sizeof(REBVAL)
-    );
+    SET_SERIES_LEN(ARRAY_SERIES(BUF_COLLECT), bind_index);
+    collect = ARRAY_TAIL(BUF_COLLECT);
 
-    if (IS_SELFLESS(prior)) {
+    if (check_dups) {
+        // We're adding onto the end of the collect buffer and need to
+        // check for duplicates of what's already there.
         //
-        // For a selfless frame we didn't leave a gap for self, so the length
-        // is one less than the length of the frame.
+        for (; NOT_END(key); key++) {
+            REBCNT canon = VAL_TYPESET_CANON(key);
+
+            if (binds[canon] != 0) {
+                //
+                // If we found the typeset's symbol in the bind table already
+                // then don't collect it in the buffer again.
+                //
+                continue;
+            }
+
+            // !!! At the moment objects do not heed the typesets in the
+            // keys.  If they did, what sort of rule should the typesets
+            // have when being inherited?
+            //
+            *collect++ = *key;
+
+            binds[canon] = bind_index++;
+        }
+
+        // Increase the length of BUF_COLLLECT by how far `collect` advanced
+        // (would be 0 if all the keys were duplicates...)
         //
-        SET_ARRAY_LEN(BUF_COLLECT, FRAME_LEN(prior));
+        SET_ARRAY_LEN(
+            BUF_COLLECT,
+            ARRAY_LEN(BUF_COLLECT) + (collect - ARRAY_TAIL(BUF_COLLECT))
+        );
     }
     else {
+        // Optimized copy of the keys.  We can use `memcpy` because these are
+        // typesets that are just 64-bit bitsets plus a symbol ID; there is
+        // no need to clone the REBVALs to give the copies new identity.
         //
-        // !!! The system key of self is the key in slot 0 for frames, and
-        // is being deprecated.  However we still must collect it if the
-        // frame has it (for now).
+        // Add the keys and bump the length of the collect buffer after
+        // (prior to that, the tail should be on the END marker of
+        // the existing content--if any)
         //
-        *ARRAY_HEAD(BUF_COLLECT) = *ARRAY_HEAD(FRAME_KEYLIST(prior));
-        SET_ARRAY_LEN(BUF_COLLECT, FRAME_LEN(prior) + 1);
+        memcpy(collect, key, FRAME_LEN(frame) * sizeof(REBVAL));
+        SET_ARRAY_LEN(BUF_COLLECT, ARRAY_LEN(BUF_COLLECT) + FRAME_LEN(frame));
+
+        for (; NOT_END(key); key++) {
+            REBCNT canon = VAL_TYPESET_CANON(key);
+            binds[canon] = bind_index++;
+        }
     }
 
-    // !!! Note that this collection of binds will not include SELF (?)
-    //
-    n = 1;
-    for (; NOT_END(keys); keys++)
-        binds[VAL_TYPESET_CANON(keys)] = n++;
+    // BUF_COLLECT doesn't get terminated as its being built, but it gets
+    // terminated in Collect_Keys_End()
 }
 
 
@@ -456,33 +519,74 @@ static void Collect_Frame_Inner_Loop(REBINT *binds, REBVAL value[], REBCNT modes
 
 
 //
-//  Collect_Frame: C
-// 
-// Scans a block for words to use in the frame. The list of
-// words can then be used to create a frame. The Bind_Table is
-// used to quickly determine duplicate entries.
-// 
+//  Collect_Keylist_Managed: C
+//
+// Scans a block for words to extract and make into typeset keys to go in
+// a frame.  The Bind_Table is used to quickly determine duplicate entries.
+//
+// A `prior` frame can be provided to serve as a basis; all the keys in
+// the prior will be returned, with only new entries contributed by the
+// data coming from the value[] array.  If no new values are needed (the
+// array has no relevant words, or all were just duplicates of words already
+// in prior) then then `prior`'s keylist may be returned.  The result is
+// always pre-managed, because it may not be legal to free prior's keylist.
+//
 // Returns:
-//     A block of words that can be used for a frame word list.
+//     A block of typesets that can be used for a frame keylist.
 //     If no new words, the prior list is returned.
 // 
 // Modes:
 //     BIND_ALL  - scan all words, or just set words
 //     BIND_DEEP - scan sub-blocks too
 //     BIND_GET  - substitute :word with actual word
-//     BIND_NO_SELF - do not add implicit SELF to the frame
+//     BIND_SELF - make sure a SELF key is added (if not already in prior)
 //
-REBARR *Collect_Frame(REBFRM *prior, REBVAL value[], REBCNT modes)
-{
+REBARR *Collect_Keylist_Managed(
+    REBCNT *self_index_out, // which frame index SELF is in (if BIND_SELF)
+    REBVAL value[],
+    REBFRM *prior,
+    REBCNT modes
+) {
+    REBINT *binds = WORDS_HEAD(Bind_Table);
+    REBARR *keylist;
+
     Collect_Keys_Start(modes);
 
-    // Setup binding table with existing words:
-    if (prior) Collect_Context_Keys(prior);
+    if (modes & BIND_SELF) {
+        if (
+            !prior ||
+            (*self_index_out = Find_Word_Index(prior, SYM_SELF, TRUE)) == 0
+        ) {
+            // No prior or no SELF in prior, so we'll add it as the first key
+            //
+            REBVAL *self_key = ARRAY_AT(BUF_COLLECT, 1);
+            Val_Init_Typeset(self_key, ALL_64, SYM_SELF);
+            VAL_SET_EXT(self_key, EXT_WORD_HIDE);
+            binds[VAL_TYPESET_CANON(self_key)] = 1;
+            *self_index_out = 1;
+            SET_ARRAY_LEN(BUF_COLLECT, 2); // TASK_BUF_COLLECT is at least 2
+        }
+        else {
+            // No need to add SELF if it's going to be added via the `prior`
+            // so just return the `self_index_out` as-is.
+        }
+    }
+    else {
+        assert(self_index_out == NULL);
+    }
+
+    // Setup binding table with existing words, no need to check duplicates
+    //
+    if (prior) Collect_Context_Keys(prior, FALSE);
 
     // Scan for words, adding them to BUF_COLLECT and bind table:
     Collect_Frame_Inner_Loop(WORDS_HEAD(Bind_Table), &value[0], modes);
 
-    return Collect_Keys_End(prior);
+    keylist = Grab_Collected_Keylist_Managed(prior);
+
+    Collect_Keys_End();
+
+    return keylist;
 }
 
 
@@ -529,6 +633,7 @@ REBARR *Collect_Words(REBVAL value[], REBVAL prior_value[], REBCNT modes)
 
     start = ARRAY_LEN(BUF_COLLECT);
     Collect_Words_Inner_Loop(binds, &value[0], modes);
+    TERM_ARRAY(BUF_COLLECT);
 
     // Reset word markers:
     for (value = ARRAY_HEAD(BUF_COLLECT); NOT_END(value); value++)
@@ -541,44 +646,6 @@ REBARR *Collect_Words(REBVAL value[], REBVAL prior_value[], REBCNT modes)
 
     CHECK_BIND_TABLE;
     return array;
-}
-
-
-//
-//  Create_Frame: C
-// 
-// Create a new frame from a word list.
-// The values of the frame are initialized to NONE.
-//
-REBFRM *Create_Frame(REBARR *keylist, REBSER *spec)
-{
-    REBINT len = ARRAY_LEN(keylist);
-
-    // Make a frame of same size as keylist (END already accounted for)
-    //
-    REBFRM *frame = AS_FRAME(Make_Series(
-        len + 1, sizeof(REBVAL), MKS_ARRAY | MKS_FRAME
-    ));
-
-    REBVAL *value = ARRAY_HEAD(FRAME_VARLIST(frame));
-
-    SET_ARRAY_LEN(FRAME_VARLIST(frame), len);
-
-    // frame[0] is an instance value of the OBJECT!/PORT!/ERROR!/MODULE!
-    //
-    FRAME_CONTEXT(frame)->payload.any_context.frame = frame;
-    FRAME_KEYLIST(frame) = keylist;
-    VAL_CONTEXT_SPEC(value) = NULL;
-    VAL_CONTEXT_BODY(value) = NULL;
-
-    value++;
-    len--;
-
-    for (; len > 0; len--, value++)
-        SET_NONE(value);
-    SET_END(value);
-
-    return frame;
 }
 
 
@@ -600,8 +667,8 @@ void Rebind_Frame_Deep(REBFRM *src_frame, REBFRM *dst_frame, REBFLG modes)
 
 
 //
-//  Make_Frame_Detect: C
-// 
+//  Make_Selfish_Frame_Detect: C
+//
 // Create a frame by detecting top-level set-words in an array of values.
 // So if the values were the contents of the block `[a: 10 b: 20]` then the
 // resulting frame would be for two words, `a` and `b`.
@@ -609,7 +676,19 @@ void Rebind_Frame_Deep(REBFRM *src_frame, REBFRM *dst_frame, REBFLG modes)
 // Optionally a parent frame may be passed in, which will contribute its
 // keylist of words to the result if provided.
 //
-REBFRM *Make_Frame_Detect(
+// The resulting frame will have a SELF: defined as a hidden key (will not
+// show up in `words-of` but will be bound during creation).  As part of
+// the migration away from SELF being a keyword, the logic for adding and
+// managing SELF has been confined to this function (called by `make object!`
+// and some other context-creating routines).  This will ultimately turn
+// into something paralleling the non-keyword definitional RETURN:, where
+// the generators (like OBJECT) will be taking responsibility for it.
+//
+// This routine will *always* make a frame with a SELF.  This lacks the
+// nuance that is expected of the generators, which will have an equivalent
+// to <transparent>.
+//
+REBFRM *Make_Selfish_Frame_Detect(
     enum Reb_Kind kind,
     REBFRM *spec,
     REBARR *body,
@@ -618,6 +697,7 @@ REBFRM *Make_Frame_Detect(
 ) {
     REBARR *keylist;
     REBFRM *frame;
+    REBCNT self_index;
 
 #if !defined(NDEBUG)
     PG_Reb_Stats->Objects++;
@@ -625,26 +705,90 @@ REBFRM *Make_Frame_Detect(
 
     if (IS_END(value)) {
         if (opt_parent) {
+            self_index = Find_Word_Index(opt_parent, SYM_SELF, TRUE);
+
             frame = AS_FRAME(Copy_Array_Core_Managed(
                 FRAME_VARLIST(opt_parent),
                 0, // at
-                FRAME_LEN(opt_parent) + 1, // tail (+1 for context/rootkey)
-                0, // extra
+                FRAME_LEN(opt_parent) + 1, // tail (+1 for rootvar)
+                (self_index == 0) ? 1 : 0, // one extra slot if self needed
                 TRUE, // deep
                 TS_CLONE // types
             ));
             ARRAY_SET_FLAG(FRAME_VARLIST(frame), SER_FRAME);
-            FRAME_KEYLIST(frame) = FRAME_KEYLIST(opt_parent);
+
+            if (self_index == 0) {
+                //
+                // If we didn't find a SELF in the parent frame, add it.
+                // (this means we need a new keylist, too)
+                //
+                FRAME_KEYLIST(frame) = Copy_Array_Core_Managed(
+                    FRAME_KEYLIST(opt_parent),
+                    0, // at
+                    FRAME_LEN(opt_parent) + 1, // tail (+1 for rootkey)
+                    1, // one extra for self
+                    FALSE, // !deep (keylists shouldn't need it...)
+                    TS_CLONE // types (overkill for a keylist?)
+                );
+
+                self_index = FRAME_LEN(opt_parent) + 1;
+                Val_Init_Typeset(
+                    FRAME_KEY(frame, self_index), ALL_64, SYM_SELF
+                );
+                VAL_SET_EXT(FRAME_KEY(frame, self_index), EXT_WORD_HIDE);
+            }
+            else {
+                // The parent had a SELF already, so we can reuse its keylist
+                //
+                FRAME_KEYLIST(frame) = FRAME_KEYLIST(opt_parent);
+            }
+
             VAL_FRAME(FRAME_CONTEXT(frame)) = frame;
         }
         else {
-            frame = Alloc_Frame(0, TRUE);
+            frame = Alloc_Frame(1); // just a self
+            self_index = 1;
+            Val_Init_Typeset(
+                Alloc_Tail_Array(FRAME_KEYLIST(frame)), ALL_64, SYM_SELF
+            );
+            VAL_SET_EXT(FRAME_KEY(frame, self_index), EXT_WORD_HIDE);
+            Alloc_Tail_Array(FRAME_VARLIST(frame));
             MANAGE_FRAME(frame);
         }
     }
     else {
-        keylist = Collect_Frame(opt_parent, &value[0], BIND_ONLY); // GC safe
-        frame = Create_Frame(keylist, NULL); // GC safe
+        REBVAL *var;
+        REBCNT len;
+
+        keylist = Collect_Keylist_Managed(
+            &self_index, &value[0], opt_parent, BIND_ONLY | BIND_SELF
+        );
+        len = ARRAY_LEN(keylist);
+
+        // Make a frame of same size as keylist (END already accounted for)
+        //
+        frame = AS_FRAME(Make_Array(len));
+        ARRAY_SET_FLAG(FRAME_VARLIST(frame), SER_FRAME);
+        FRAME_KEYLIST(frame) = keylist;
+        MANAGE_ARRAY(FRAME_VARLIST(frame));
+
+        // frame[0] is an instance value of the OBJECT!/PORT!/ERROR!/MODULE!
+        //
+        FRAME_CONTEXT(frame)->payload.any_context.frame = frame;
+        VAL_CONTEXT_SPEC(FRAME_CONTEXT(frame)) = NULL;
+        VAL_CONTEXT_BODY(FRAME_CONTEXT(frame)) = NULL;
+
+        // !!! This code was inlined from Create_Frame() because it was only
+        // used once here, and it filled the frame vars with NONE!.  For
+        // Ren-C we probably want to go with UNSET!, and also the filling
+        // of parent vars will overwrite the work here.  Review.
+        //
+        SET_ARRAY_LEN(FRAME_VARLIST(frame), len);
+        var = FRAME_VARS_HEAD(frame);
+        for (; len > 1; len--, var++) // 1 is rootvar (context), already done
+            SET_NONE(var);
+        SET_END(var);
+
         if (opt_parent) {
             if (Reb_Opts->watch_obj_copy)
                 Debug_Fmt(
@@ -654,6 +798,7 @@ REBFRM *Make_Frame_Detect(
                 );
 
             // Bitwise copy parent values (will have bits fixed by Clonify)
+            //
             memcpy(
                 FRAME_VARS_HEAD(frame),
                 FRAME_VARS_HEAD(opt_parent),
@@ -662,22 +807,11 @@ REBFRM *Make_Frame_Detect(
 
             // For values we copied that were blocks and strings, replace
             // their series components with deep copies of themselves:
+            //
             Clonify_Values_Len_Managed(
                 FRAME_VAR(frame, 1), FRAME_LEN(frame), TRUE, TS_CLONE
             );
-
-            // The *word series* might have been reused from the parent,
-            // based on whether any words were added, or we could have gotten
-            // a fresh one back.  Force our invariant here (as the screws
-            // tighten...)
-            ENSURE_ARRAY_MANAGED(FRAME_KEYLIST(frame));
-            MANAGE_ARRAY(FRAME_VARLIST(frame));
         }
-        else {
-            MANAGE_FRAME(frame);
-        }
-
-        assert(keylist == FRAME_KEYLIST(frame));
     }
 
     VAL_RESET_HEADER(FRAME_CONTEXT(frame), kind);
@@ -685,6 +819,28 @@ REBFRM *Make_Frame_Detect(
 
     FRAME_SPEC(frame) = spec;
     FRAME_BODY(frame) = body;
+
+    // We should have a SELF key in all cases here.  Set it to be a copy of
+    // the object we just created.  (It is indeed a copy of the [0] element,
+    // but it doesn't need to be protected because the user overwriting it
+    // won't destroy the integrity of the frame.)
+    //
+    assert(FRAME_KEY_CANON(frame, self_index) == SYM_SELF);
+    *FRAME_VAR(frame, self_index) = *FRAME_CONTEXT(frame);
+
+    // !!! In Ren-C, the idea that functions are rebound when a frame is
+    // inherited is being deprecated.  It simply isn't viable for objects
+    // with N methods to have those N methods permanently cloned in the
+    // copies and have their bodies rebound to the new object.  A more
+    // conventional method of `this->method()` access is needed with
+    // cooperation from the evaluator, and that is slated to be `/method`
+    // as a practical use of paths that implicitly start from "wherever
+    // you dispatched from"
+    //
+    // Temporarily the old behavior is kept, so we deep copy and rebind.
+    //
+    if (opt_parent)
+        Rebind_Frame_Deep(opt_parent, frame, REBIND_FUNC);
 
     ASSERT_ARRAY_MANAGED(FRAME_VARLIST(frame));
     ASSERT_ARRAY_MANAGED(FRAME_KEYLIST(frame));
@@ -706,7 +862,7 @@ REBFRM *Construct_Frame(
     REBFLG as_is,
     REBFRM *opt_parent
 ) {
-    REBFRM *frame = Make_Frame_Detect(
+    REBFRM *frame = Make_Selfish_Frame_Detect(
         kind, // type
         NULL, // spec
         NULL, // body
@@ -783,14 +939,14 @@ void Assert_Public_Object(const REBVAL *value)
 
 
 //
-//  Merge_Frames: C
+//  Merge_Frames_Selfish: C
 // 
 // Create a child frame from two parent frames. Merge common fields.
 // Values from the second parent take precedence.
 // 
 // Deep copy and rebind the child.
 //
-REBFRM *Merge_Frames(REBFRM *parent1, REBFRM *parent2)
+REBFRM *Merge_Frames_Selfish(REBFRM *parent1, REBFRM *parent2)
 {
     REBARR *keylist;
     REBFRM *child;
@@ -803,13 +959,17 @@ REBFRM *Merge_Frames(REBFRM *parent1, REBFRM *parent2)
 
     // Merge parent1 and parent2 words.
     // Keep the binding table.
-    Collect_Keys_Start(BIND_ALL);
-    // Setup binding table and BUF_COLLECT with parent1 words:
-    Collect_Context_Keys(parent1);
-    // Add parent2 words to binding table and BUF_COLLECT:
-    Collect_Frame_Inner_Loop(
-        binds, FRAME_KEYS_HEAD(parent2), BIND_ALL
-    );
+    Collect_Keys_Start(BIND_ALL | BIND_SELF);
+
+    // Setup binding table and BUF_COLLECT with parent1 words.  Don't bother
+    // checking for duplicates, buffer is empty.
+    //
+    Collect_Context_Keys(parent1, FALSE);
+
+    // Add parent2 words to binding table and BUF_COLLECT, and since we know
+    // BUF_COLLECT isn't empty then *do* check for duplicates.
+    //
+    Collect_Context_Keys(parent2, TRUE);
 
     // Collect_Keys_End() terminates, but Collect_Frame_Inner_Loop() doesn't.
     //
@@ -817,9 +977,9 @@ REBFRM *Merge_Frames(REBFRM *parent1, REBFRM *parent2)
 
     // Allocate child (now that we know the correct size):
     keylist = Copy_Array_Shallow(BUF_COLLECT);
-    child = AS_FRAME(Make_Series(
-        ARRAY_LEN(keylist) + 1, sizeof(REBVAL), MKS_ARRAY | MKS_FRAME
-    ));
+    child = AS_FRAME(Make_Array(ARRAY_LEN(keylist)));
+    ARRAY_SET_FLAG(FRAME_VARLIST(child), SER_FRAME);
+
     value = Alloc_Tail_Array(FRAME_VARLIST(child));
 
     // !!! Currently we assume the child will be of the same type as the
@@ -867,7 +1027,15 @@ REBFRM *Merge_Frames(REBFRM *parent1, REBFRM *parent2)
     Rebind_Frame_Deep(parent2, child, REBIND_FUNC | REBIND_TABLE);
 
     // release the bind table
-    Collect_Keys_End(child);
+    Collect_Keys_End();
+
+    // We should have gotten a SELF in the results, one way or another.
+    {
+        REBCNT self_index = Find_Word_Index(child, SYM_SELF, TRUE);
+        assert(self_index != 0);
+        assert(FRAME_KEY_CANON(child, self_index) == SYM_SELF);
+        *FRAME_VAR(child, self_index) = *FRAME_CONTEXT(child);
+    }
 
     return child;
 }
@@ -903,7 +1071,14 @@ void Resolve_Context(
         if (i > FRAME_LEN(target)) return;
     }
 
-    Collect_Keys_Start(BIND_NO_SELF);  // DO NOT TRAP IN THIS SECTION
+    // !!! This function does its own version of resetting the bind table
+    // and hence the Collect_Keys_End that would be performed in the case of
+    // a `fail (Error(...))` will not properly reset it.  Because the code
+    // does array expansion it cannot guarantee a fail won't happen, hence
+    // the method needs to be reviewed to something that could properly
+    // reset in the case of an out of memory error.
+    //
+    Collect_Keys_Start(BIND_ONLY);
 
     n = 0;
 
@@ -996,7 +1171,10 @@ void Resolve_Context(
 
     CHECK_BIND_TABLE;
 
-    SET_ARRAY_LEN(BUF_COLLECT, 0);  // allow reuse, trapping ok now
+    // !!! Note we explicitly do *not* use Collect_Keys_End().  See warning
+    // about errors, out of memory issues, etc. at Collect_Keys_Start()
+    //
+    SET_ARRAY_LEN(BUF_COLLECT, 0);  // allow reuse
 }
 
 
@@ -1012,8 +1190,6 @@ static void Bind_Values_Inner_Loop(
     REBFRM *frame,
     REBCNT mode
 ) {
-    REBFLG selfish = !IS_SELFLESS(frame);
-
     for (; NOT_END(value); value++) {
         if (ANY_WORD(value)) {
             //Print("Word: %s", Get_Sym_Name(VAL_WORD_CANON(value)));
@@ -1024,10 +1200,6 @@ static void Bind_Values_Inner_Loop(
                 assert(n <= FRAME_LEN(frame));
                 // Word is in frame, bind it:
                 VAL_WORD_INDEX(value) = n;
-                VAL_WORD_TARGET(value) = FRAME_VARLIST(frame);
-            }
-            else if (selfish && VAL_WORD_CANON(value) == SYM_SELF) {
-                VAL_WORD_INDEX(value) = 0;
                 VAL_WORD_TARGET(value) = FRAME_VARLIST(frame);
             }
             else {
@@ -1489,7 +1661,6 @@ REBVAL *Get_Var_Core(const REBVAL *word, REBOOL trap, REBOOL writable)
         // !!! When SELF is eliminated as a system concept there will not
         // be a need for the GET_VAR_INTO distinction.
 
-        assert(!IS_SELFLESS(AS_FRAME(target)));
         if (trap) fail (Error(RE_SELF_PROTECTED));
         return NULL; // is this a case where we should *always* trap?
     }
@@ -1577,7 +1748,6 @@ void Get_Var_Into_Core(REBVAL *out, const REBVAL *word)
         // !!! With the elimination of SELF as a system concept, there should
         // be no need for Get_Var_Into.
 
-        assert(!IS_SELFLESS(AS_FRAME(target)));
         assert(ANY_CONTEXT(FRAME_CONTEXT(AS_FRAME(target))));
         *out = *FRAME_CONTEXT(AS_FRAME(target));
         return;
@@ -1686,8 +1856,12 @@ void Init_Frame(void)
     // "just holds typesets, no GC behavior" (!!! until typeset symbols or
     // embedded tyeps are GC'd...!)
     //
+    // Note that the logic inside Collect_Keylist managed assumes it's at
+    // least 2 long to hold the rootkey (SYM_0) and a possible SYM_SELF
+    // hidden actual key.
+    //
     Set_Root_Series(
-        TASK_BUF_COLLECT, ARRAY_SERIES(Make_Array(100)), "word cache"
+        TASK_BUF_COLLECT, ARRAY_SERIES(Make_Array(2 + 98)), "word cache"
     );
 }
 
@@ -1759,13 +1933,14 @@ void Assert_Frame_Core(REBFRM *frame)
     var = FRAME_CONTEXT(frame);
 
     if (
-        !(IS_TYPESET(key) && (
-            VAL_TYPESET_SYM(key) == SYM_SELF
-            || VAL_TYPESET_SYM(key) == SYM_0
-        ))
-        && !IS_CLOSURE(key)
+        (IS_TYPESET(key) && VAL_TYPESET_SYM(key) == SYM_0)
+        || IS_CLOSURE(key)
     ) {
-        Debug_Fmt("First key slot in frame not SELF, SYM_0 or CLOSURE!");
+        // It's okay.  Note that in the future the rootkey for ordinary
+        // OBJECT!/ERROR!/PORT! etc. may be more interesting than SYM_0
+    }
+    else {
+        Debug_Fmt("First key slot in frame not SYM_0 or CLOSURE!");
         Panic_Frame(frame);
     }
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -428,7 +428,7 @@ void Make_Command(
     // Check that handle and extension are somewhat valid (not used)
     {
         REBEXT *rebext;
-        REBVAL *handle = VAL_CONTEXT_VAR(extension, 1);
+        REBVAL *handle = VAL_CONTEXT_VAR(extension, SELFISH(1));
         if (!IS_HANDLE(handle)) goto bad_func_def;
         rebext = &Ext_List[VAL_I32(handle)];
         if (!rebext || !rebext->call) goto bad_func_def;
@@ -446,7 +446,7 @@ void Make_Command(
         Copy_Array_At_Deep_Managed(VAL_ARRAY(spec), VAL_INDEX(spec));
 
     out->payload.any_function.func
-        = AS_FUNC(Check_Func_Spec(VAL_FUNC_SPEC(spec)));
+        = AS_FUNC(Make_Paramlist_Managed(VAL_FUNC_SPEC(spec)));
 
     // There is no "body", but we want to save `extension` and `command_num`
     // and the only place there is to put it is in the place where a function
@@ -509,7 +509,8 @@ REBFLG Do_Command_Throws(struct Reb_Call *call_)
 {
     // All of these were checked above on definition:
     REBVAL *val = ARRAY_HEAD(FUNC_BODY(D_FUNC));
-    REBEXT *ext = &Ext_List[VAL_I32(VAL_CONTEXT_VAR(val, 1))]; // Handler
+    // Handler
+    REBEXT *ext = &Ext_List[VAL_I32(VAL_CONTEXT_VAR(val, SELFISH(1)))];
     REBCNT cmd = cast(REBCNT, Int32(val + 1));
 
     REBCNT n;
@@ -676,7 +677,7 @@ void Do_Commands(REBVAL *out, REBARR *cmds, void *context)
         // Call the command (also supports different extension modules):
         func  = ARRAY_HEAD(VAL_FUNC_BODY(func));
         n = (REBCNT)VAL_INT64(func + 1);
-        ext = &Ext_List[VAL_I32(VAL_CONTEXT_VAR(func, 1))]; // Handler
+        ext = &Ext_List[VAL_I32(VAL_CONTEXT_VAR(func, SELFISH(1)))]; // Handler
         n = ext->call(n, &frm, ctx);
         val = out;
         switch (n) {

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -833,8 +833,6 @@ REBSER *Make_Series(REBCNT length, REBYTE wide, REBCNT flags)
 
     if (flags & MKS_LOCK) SERIES_SET_FLAG(series, SER_LOCK);
 
-    if (flags & MKS_FRAME) SERIES_SET_FLAG(series, SER_FRAME);
-
     if (flags & MKS_EXTERNAL) {
         // External series will poke in their own data pointer after the
         // REBSER header allocation is done

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -1012,7 +1012,7 @@ REBNATIVE(call)
     if (input_ser) DROP_GUARD_SERIES(input_ser);
 
     if (flag_info) {
-        REBFRM *frame = Alloc_Frame(2, TRUE);
+        REBFRM *frame = Alloc_Frame(2);
         REBVAL *val = Append_Frame(frame, NULL, SYM_ID);
         SET_INTEGER(val, pid);
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -104,7 +104,7 @@ static REBARR *Init_Loop(
     // Hand-make a FRAME (done for for speed):
     len = IS_BLOCK(spec) ? VAL_LEN_AT(spec) : 1;
     if (len == 0) fail (Error_Invalid_Arg(spec));
-    frame = Alloc_Frame(len, FALSE);
+    frame = Alloc_Frame(len);
     SET_ARRAY_LEN(FRAME_VARLIST(frame), len + 1);
     SET_ARRAY_LEN(FRAME_KEYLIST(frame), len + 1);
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -559,34 +559,3 @@ REBNATIVE(do_codec)
 
     return R_OUT;
 }
-
-
-//
-//  selfless?: native [
-//  
-//  "Returns true if the context doesn't bind 'self."
-//  
-//      value [any-word! any-context!]
-//          "Context or example word bound to the target context"
-//  ]
-//
-REBNATIVE(selfless_q)
-{
-    PARAM(1, value);
-
-    REBFRM *frame;
-
-    if (ANY_WORD(ARG(value))) {
-        if (VAL_WORD_INDEX(ARG(value)) < 0)
-            return R_TRUE;
-
-        frame = AS_FRAME(VAL_WORD_TARGET(ARG(value)));
-
-        if (!frame)
-            fail (Error(RE_NOT_BOUND, ARG(value)));
-    }
-    else
-        frame = VAL_FRAME(ARG(value));
-
-    return IS_SELFLESS(frame) ? R_TRUE : R_FALSE;
-}

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -45,7 +45,7 @@ static void update(REBREQ *req, REBINT len, REBVAL *arg)
     Extend_Series(VAL_SERIES(arg), len);
 
     for (i = 0; i < len; i ++) {
-        REBFRM *obj = Alloc_Frame(2, TRUE);
+        REBFRM *obj = Alloc_Frame(2);
         REBVAL *val = Append_Frame(
             obj, NULL, Make_Word(signal_no, LEN_BYTES(signal_no))
         );

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -499,7 +499,7 @@ REBFRM *Map_To_Object(REBMAP *map)
     }
 
     // See Alloc_Frame() - cannot use it directly because no Collect_Words
-    frame = Alloc_Frame(cnt, TRUE);
+    frame = Alloc_Frame(cnt);
     key = FRAME_KEY(frame, 1);
     var = FRAME_VAR(frame, 1);
 

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -134,15 +134,12 @@ static void Append_To_Context(REBFRM *frame, REBVAL *arg)
 {
     REBCNT i, len;
     REBVAL *word;
-    REBVAL *typeset;
+    REBVAL *key;
     REBINT *binds; // for binding table
 
     // Can be a word:
     if (ANY_WORD(arg)) {
         if (!Find_Word_Index(frame, VAL_WORD_SYM(arg), TRUE)) {
-            // bug fix, 'self is protected only in selfish frames
-            if ((VAL_WORD_CANON(arg) == SYM_SELF) && !IS_SELFLESS(frame))
-                fail (Error(RE_SELF_PROTECTED));
             Expand_Frame(frame, 1, 1); // copy word table also
             Append_Frame(frame, 0, VAL_WORD_SYM(arg));
             // val is UNSET
@@ -158,27 +155,27 @@ static void Append_To_Context(REBFRM *frame, REBVAL *arg)
     // Use binding table
     binds = WORDS_HEAD(Bind_Table);
 
-    // Handle selfless
-    Collect_Keys_Start(
-        IS_SELFLESS(frame) ? BIND_NO_SELF | BIND_ALL : BIND_ALL
-    );
+    Collect_Keys_Start(BIND_ALL);
 
-    // Setup binding table with obj words:
-    Collect_Context_Keys(frame);
+    // Setup binding table with obj words.  Binding table is empty so don't
+    // bother checking for duplicates.
+    //
+    Collect_Context_Keys(frame, FALSE);
 
     // Examine word/value argument block
     for (word = arg; NOT_END(word); word += 2) {
+        REBCNT canon;
 
         if (!IS_WORD(word) && !IS_SET_WORD(word))
             fail (Error_Invalid_Arg(word));
 
-        if ((i = binds[VAL_WORD_CANON(word)])) {
-            // bug fix, 'self is protected only in selfish frames:
-            if ((VAL_WORD_CANON(word) == SYM_SELF) && !IS_SELFLESS(frame))
-                fail (Error(RE_SELF_PROTECTED));
-        } else {
-            // collect the symbol
-            binds[VAL_WORD_CANON(word)] = ARRAY_LEN(BUF_COLLECT);
+        canon = VAL_WORD_CANON(word);
+
+        if (binds[canon] == 0) {
+            //
+            // Not already collected, so add it...
+            //
+            binds[canon] = ARRAY_LEN(BUF_COLLECT);
             EXPAND_SERIES_TAIL(ARRAY_SERIES(BUF_COLLECT), 1);
             Val_Init_Typeset(
                 ARRAY_LAST(BUF_COLLECT), ALL_64, VAL_WORD_SYM(word)
@@ -190,10 +187,13 @@ static void Append_To_Context(REBFRM *frame, REBVAL *arg)
     TERM_ARRAY(BUF_COLLECT);
 
     // Append new words to obj
+    //
     len = FRAME_LEN(frame) + 1;
     Expand_Frame(frame, ARRAY_LEN(BUF_COLLECT) - len, 1);
-    for (typeset = ARRAY_AT(BUF_COLLECT, len); NOT_END(typeset); typeset++)
-        Append_Frame(frame, NULL, VAL_TYPESET_SYM(typeset));
+    for (key = ARRAY_AT(BUF_COLLECT, len); NOT_END(key); key++) {
+        assert(IS_TYPESET(key));
+        Append_Frame(frame, NULL, VAL_TYPESET_SYM(key));
+    }
 
     // Set new values to obj words
     for (word = arg; NOT_END(word); word += 2) {
@@ -204,15 +204,11 @@ static void Append_To_Context(REBFRM *frame, REBVAL *arg)
         var = FRAME_VAR(frame, i);
         key = FRAME_KEY(frame, i);
 
-        if (VAL_GET_EXT(key, EXT_WORD_LOCK)) {
-            Collect_Keys_End(frame);
+        if (VAL_GET_EXT(key, EXT_WORD_LOCK))
             fail (Error_Protected_Key(key));
-        }
 
-        if (VAL_GET_EXT(key, EXT_WORD_HIDE)) {
-            Collect_Keys_End(frame);
+        if (VAL_GET_EXT(key, EXT_WORD_HIDE))
             fail (Error(RE_HIDDEN));
-        }
 
         if (IS_END(word + 1)) SET_NONE(var);
         else *var = word[1];
@@ -221,7 +217,7 @@ static void Append_To_Context(REBFRM *frame, REBVAL *arg)
     }
 
     // release binding table
-    Collect_Keys_End(frame);
+    Collect_Keys_End();
 }
 
 
@@ -246,7 +242,7 @@ static REBFRM *Trim_Frame(REBFRM *frame)
 
     // Create new frame based on the size found
     //
-    frame_new = Alloc_Frame(copy_count, TRUE);
+    frame_new = Alloc_Frame(copy_count);
     VAL_CONTEXT_SPEC(FRAME_CONTEXT(frame_new)) = NULL;
     VAL_CONTEXT_BODY(FRAME_CONTEXT(frame_new)) = NULL;
 
@@ -371,156 +367,124 @@ REBTYPE(Object)
     switch (action) {
 
     case A_MAKE:
-        // make object! | error! | module! | task!
+        //
+        // `make object! | error! | module!`; first parameter must be either
+        // a datatype or a type exemplar.
+        //
+        // !!! For objects historically, the "type exemplar" parameter was
+        // also the parent... this is not the long term answer.  For the
+        // future, `make (make object! [a: 10]) [b: 20]` will give the same
+        // result back as `make object! [b: 20]`, with parents specified to
+        // generators like `o: object [<parent> p] [...]`
+        //
+        if (!IS_DATATYPE(value) && !ANY_CONTEXT(value))
+            fail (Error_Bad_Make(VAL_TYPE(value), value));
+
         if (IS_DATATYPE(value)) {
-
             target = VAL_TYPE_KIND(value);
-
-            if (IS_BLOCK(arg)) {
-
-                // make object! [init]
-                //
-                if (target == REB_OBJECT) {
-                    //
-                    // First we scan the object for top-level set words in
-                    // order to make an appropriately sized frame.  Then
-                    // we put it into an object in D_OUT to GC protect it.
-                    //
-                    frame = Make_Frame_Detect(
-                        REB_OBJECT, // type
-                        NULL, // spec
-                        NULL, // body
-                        VAL_ARRAY_AT(arg), // scan for toplevel set-words
-                        NULL // parent
-                    );
-                    Val_Init_Object(D_OUT, frame);
-
-                    // !!! This binds the actual arg data, not a copy of it
-                    // (functions make a copy of the body they are passed to
-                    // be rebound).  This seems wrong.
-                    //
-                    Bind_Values_Deep(VAL_ARRAY_AT(arg), frame);
-
-                    // Do the block into scratch space (we ignore the result,
-                    // unless it is thrown in which case it must be returned.
-                    //
-                    if (DO_ARRAY_THROWS(D_CELL, arg)) {
-                        *D_OUT = *D_CELL;
-                        return R_OUT_IS_THROWN;
-                    }
-
-                    return R_OUT;
-                }
-
-                // make task! [init]
-                if (target == REB_TASK) {
-                    // !!! Tasks were never very well specified, though what
-                    // was intended should be studied.  Why were they objects,
-                    // and was that important?
-                    //
-                    fail (Error(RE_MISC));
-
-                    // Does it include a spec?
-                    /*
-                    if (IS_BLOCK(VAL_ARRAY_HEAD(arg))) {
-                        arg = VAL_ARRAY_HEAD(arg);
-                        if (!IS_BLOCK(arg + 1))
-                            fail (Error_Bad_Make(REB_TASK, value));
-                        frame = Make_Module_Spec(arg);
-                        VAL_MOD_BODY(value) = VAL_SERIES(arg+1);
-                    } else {
-                        frame = Make_Module_Spec(0);
-                        VAL_MOD_BODY(value) = VAL_SERIES(arg);
-                    }
-                    */
-                }
-            }
-
-            // make error! [....]
-            if (target == REB_ERROR) {
-                // arg is block/string
-                if (Make_Error_Object_Throws(D_OUT, arg))
-                    return R_OUT_IS_THROWN;
-                return R_OUT;
-            }
-
-            // make object! 10
-            if (IS_NUMBER(arg)) {
-                REBINT n = Int32s(arg, 0);
-                frame = Alloc_Frame(n, TRUE);
-                VAL_RESET_HEADER(FRAME_CONTEXT(frame), target);
-                FRAME_SPEC(frame) = NULL;
-                FRAME_BODY(frame) = NULL;
-                Val_Init_Context(D_OUT, target, frame, NULL, NULL);
-                return R_OUT;
-            }
-
-            // make object! map!
-            if (IS_MAP(arg)) {
-                frame = Map_To_Object(VAL_MAP(arg));
-                Val_Init_Context(D_OUT, target, frame, NULL, NULL);
-                return R_OUT;
-            }
-
-            fail (Error_Bad_Make(target, arg));
+            src_frame = NULL;
         }
-
-        // make parent-object ....
-        if (IS_OBJECT(value)) {
+        else {
+            target = VAL_TYPE(value);
             src_frame = VAL_FRAME(value);
-
-            // make parent none | []
-            if (IS_NONE(arg) || (IS_BLOCK(arg) && IS_EMPTY(arg))) {
-                frame = AS_FRAME(Copy_Array_Core_Managed(
-                    FRAME_VARLIST(src_frame),
-                    0, // at
-                    FRAME_LEN(src_frame) + 1, // tail (+1 for context/rootkey)
-                    0, // extra
-                    TRUE, // deep
-                    TS_CLONE // types
-                ));
-                ARRAY_SET_FLAG(FRAME_VARLIST(frame), SER_FRAME);
-                FRAME_KEYLIST(frame) = FRAME_KEYLIST(src_frame);
-                VAL_FRAME(FRAME_CONTEXT(frame)) = frame;
-                Rebind_Frame_Deep(src_frame, frame, REBIND_FUNC);
-                Val_Init_Object(D_OUT, frame);
-                return R_OUT;
-            }
-
-            // make parent [...]
-            if (IS_BLOCK(arg)) {
-                frame = Make_Frame_Detect(
-                    REB_OBJECT, // type
-                    NULL, // spec
-                    NULL, // body
-                    VAL_ARRAY_AT(arg), // values to scan for toplevel set-words
-                    src_frame // parent
-                );
-                Rebind_Frame_Deep(src_frame, frame, REBIND_FUNC);
-                Val_Init_Object(D_OUT, frame);
-                Bind_Values_Deep(VAL_ARRAY_AT(arg), frame);
-
-                // frame is GC safe, run the bound block body and put the
-                // output into a scratch cell.  We ignore the result unless
-                // it is thrown (in which case we return it)
-                //
-                if (DO_ARRAY_THROWS(D_CELL, arg)) {
-                    *D_OUT = *D_CELL;
-                    return R_OUT_IS_THROWN;
-                }
-
-                return R_OUT;
-            }
-
-            // make parent-object object
-            if (IS_OBJECT(arg)) {
-                frame = Merge_Frames(src_frame, VAL_FRAME(arg));
-                MANAGE_FRAME(frame);
-                Val_Init_Object(D_OUT, frame);
-                return R_OUT;
-            }
         }
-        fail (Error_Bad_Make(VAL_TYPE(value), value));
+
+        if (target == REB_OBJECT && (IS_BLOCK(arg) || IS_NONE(arg))) {
+            //
+            // make object! [init]
+            //
+            // First we scan the object for top-level set words in
+            // order to make an appropriately sized frame.  Then
+            // we put it into an object in D_OUT to GC protect it.
+            //
+            frame = Make_Selfish_Frame_Detect(
+                REB_OBJECT, // type
+                NULL, // spec
+                NULL, // body
+                // scan for toplevel set-words
+                IS_NONE(arg) ? EMPTY_BLOCK : VAL_ARRAY_AT(arg),
+                src_frame // parent
+            );
+            Val_Init_Object(D_OUT, frame);
+
+            // !!! This binds the actual arg data, not a copy of it
+            // (functions make a copy of the body they are passed to
+            // be rebound).  This seems wrong.
+            //
+            Bind_Values_Deep(VAL_ARRAY_AT(arg), frame);
+
+            // Do the block into scratch space (we ignore the result,
+            // unless it is thrown in which case it must be returned.
+            //
+            if (DO_ARRAY_THROWS(D_CELL, arg)) {
+                *D_OUT = *D_CELL;
+                return R_OUT_IS_THROWN;
+            }
+
+            return R_OUT;
+        }
+
+        // make parent-object object
+        //
+        if ((target == REB_OBJECT) && IS_OBJECT(value) && IS_OBJECT(arg)) {
+            //
+            // !!! Again, the presumption that the result of a merge is to
+            // be selfish should not be hardcoded in the C, but part of
+            // the generator choice by the person doing the derivation.
+            //
+            frame = Merge_Frames_Selfish(src_frame, VAL_FRAME(arg));
+            MANAGE_FRAME(frame);
+            Val_Init_Object(D_OUT, frame);
+            return R_OUT;
+        }
+
+        // make error! [....]
+        //
+        // arg is block/string, but let Make_Error_Object_Throws do the
+        // type checking.
+        //
+        if (target == REB_ERROR) {
+            if (Make_Error_Object_Throws(D_OUT, arg))
+                return R_OUT_IS_THROWN;
+            return R_OUT;
+        }
+
+        // `make object! 10` - currently not prohibited for any context type
+        //
+        if (IS_NUMBER(arg)) {
+            REBINT n = Int32s(arg, 0);
+
+            // !!! Temporary!  Ultimately SELF will be a user protocol.
+            // We use Make_Selfish_Frame while MAKE is filling in for
+            // what will be responsibility of the generators, just to
+            // get "completely fake SELF" out of index slot [0]
+            //
+            frame = Make_Selfish_Frame_Detect(
+                target, // type
+                NULL, // spec
+                NULL, // body
+                END_VALUE, // scan for toplevel set-words, empty
+                NULL // parent
+            );
+
+            // !!! Allocation when SELF is not the responsibility of MAKE
+            // will be more basic and look like this.
+            //
+            /* frame = Alloc_Frame(n);
+            VAL_RESET_HEADER(FRAME_CONTEXT(frame), target);
+            FRAME_SPEC(frame) = NULL;
+            FRAME_BODY(frame) = NULL; */
+            Val_Init_Context(D_OUT, target, frame, NULL, NULL);
+            return R_OUT;
+        }
+
+        // make object! map!
+        if (IS_MAP(arg)) {
+            frame = Map_To_Object(VAL_MAP(arg));
+            Val_Init_Context(D_OUT, target, frame, NULL, NULL);
+            return R_OUT;
+        }
+        fail (Error_Bad_Make(target, arg));
 
     case A_TO:
         target = IS_DATATYPE(value)
@@ -570,6 +534,18 @@ REBTYPE(Object)
             VAL_CONTEXT_SPEC(FRAME_CONTEXT(frame)) = VAL_FRAME(item);
             assert(VAL_CONTEXT_BODY(FRAME_CONTEXT(frame)) == NULL);
             VAL_RESET_HEADER(FRAME_CONTEXT(frame), REB_MODULE);
+
+            // !!! Again, not how this should be done but... if there is a
+            // self we set it to the module we just made.  (Here we tolerate
+            // it if there wasn't one in the object copied from.)
+            //
+            {
+                REBCNT self_index = Find_Word_Index(frame, SYM_SELF, TRUE);
+                if (self_index != 0) {
+                    assert(FRAME_KEY_CANON(frame, self_index) == SYM_SELF);
+                    *FRAME_VAR(frame, self_index) = *FRAME_CONTEXT(frame);
+                }
+            }
 
             Val_Init_Module(
                 D_OUT,

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -235,7 +235,7 @@ enum {
     BIND_GET = 8,       // Lookup :word and use its word value
     BIND_NO_DUP = 16,   // Do not allow dups during word collection (for specs)
     BIND_FUNC = 32,     // Recurse into functions.
-    BIND_NO_SELF = 64   // Do not bind SELF (in closures)
+    BIND_SELF = 64      // !!! Ensure SYM_SELF in context (transitional flag)
 };
 
 // Modes for Rebind_Values:

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -759,6 +759,7 @@ struct Reb_Frame {
     #define FRAME_VAR(f,n)      FRAME_VAR_Debug((f), (n))
 #endif
 #define FRAME_KEY_SYM(f,n)      VAL_TYPESET_SYM(FRAME_KEY((f), (n)))
+#define FRAME_KEY_CANON(f,n)    VAL_TYPESET_CANON(FRAME_KEY((f), (n)))
 
 // Navigate from frame series to context components.  Note that the frame's
 // "length" does not count the [0] cell of either the varlist or the keylist.

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1347,22 +1347,27 @@ struct Reb_Any_Context {
         Val_Init_Context_Core((o), (t), (f), (s), (b))
 #endif
 
-// Because information regarding reconstituting an object from a frame
-// existed (albeit partially) in a FRAME! in R3-Alpha, the choice was made
-// to have the keylist[0] hold a word that would let you refer to the
-// object itself.  This "SELF" keyword concept is deprecated, and the
-// slot will likely be used for another purpose after a "definitional self"
-// solution (like "definitional return") removes the need for it.
-//
-#define IS_SELFLESS(f) \
-    (IS_CLOSURE(FRAME_ROOTKEY(f)) \
-        || VAL_TYPESET_SYM(FRAME_ROOTKEY(f)) == SYM_0)
-
 // Convenience macros to speak in terms of object values instead of the frame
 //
 #define VAL_CONTEXT_VAR(v,n)        FRAME_VAR(VAL_FRAME(v), (n))
 #define VAL_CONTEXT_KEY(v,n)        FRAME_KEY(VAL_FRAME(v), (n))
 #define VAL_CONTEXT_KEY_SYM(v,n)    FRAME_KEY_SYM(VAL_FRAME(v), (n))
+
+// The movement of the SELF word into the domain of the object generators
+// means that an object may wind up having a hidden SELF key (and it may not).
+// Ultimately this key may well occur at any position.  While user code is
+// discouraged from accessing object members by integer index (`pick obj 1`
+// is an error), system code has historically relied upon this.
+//
+// During a transitional period where all MAKE OBJECT! constructs have a
+// "real" SELF key/var in the first position, there needs to be an adjustment
+// to the indexing of some of this system code.  Some of these will be
+// temporary, because not all objects will need a definitional SELF (just as
+// not all functions need a definitional RETURN).  Exactly which require it
+// and which do not remains to be seen, so this macro helps review the + 1
+// more easily than if it were left as just + 1.
+//
+#define SELFISH(n) (n + 1)
 
 #define Val_Init_Object(v,f) \
     Val_Init_Context((v), REB_OBJECT, (f), NULL, NULL)

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -190,6 +190,16 @@ bind-of: :bound?
 ;exists?
 
 
+; !!! Technically speaking all frames should be "selfless" in the sense that
+; the system does not have a particular interest in the word "self" as
+; applied to objects.  Generators like OBJECT may choose to establish a
+; self-bearing protocol.
+;
+selfless?: func [context [any-context!]] [
+    fail {selfless? no longer has meaning (all frames are "selfless")}
+]
+
+
 ; In word-space, TRY is very close to ATTEMPT, in having ambiguity about what
 ; is done with the error if one happens.  It also has historical baggage with
 ; TRY/CATCH constructs. TRAP does not have that, and better parallels CATCH

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -280,6 +280,11 @@ load-ext-module: function [
     ; Define default extension initialization if needed:
     ; It is overridden when extension provides it's own COMMAND func.
     unless :ext/command [
+        ;
+        ; This is appending raw material to a block that will be used to
+        ; make a MODULE!, so the function body will be bound first by the
+        ; module and then by the FUNC.
+        ;
         append tmp [
             cmd-index: 0
             command: func [
@@ -288,6 +293,11 @@ load-ext-module: function [
             ][
                 ; (contains module-local variables)
                 make command! reduce [
+                    ;
+                    ; `self` isn't the self in effect for load-ext-module
+                    ; (we're in the `sys` context, which doesn't have self).
+                    ; It will be bound in the context of the module.
+                    ;
                     args self also cmd-index (cmd-index: cmd-index + 1)
                 ]
             ]


### PR DESCRIPTION
While billing itself a "language with no keywords" (in the sense of
built-ins to the evaluator), Rebol had a hardcoded hack for the
handling of a feature trying to offer something similar to what languages
might consider a "this" pointer in objects.

The feature was called SELF.  As a hint of the hackishness, this is how
SYM_SELF (the symbol ID for the word "self") was hardcoded into the
binding process in R3-Alpha:

https://github.com/rebol/rebol/blob/25033f897b2bd466068d7663563cd3ff64740b94/src/core/c-frame.c#L825

Unlike all other words, SELF did not bind to a key in a context.  It bound
to a context but with a special "0" number, indicating no key...but a desire
to retrieve a value representing the context object itself that it was bound to.

Notably this meant it was not possible to assign SELF (specifically, because
var slot 0 was used for a system purpose, and it would crash the system).
It also meant there needed to be a distinction between "selfish" and "selfless"
frames, because not every creation of a new context should bind self.
Otherwise the following code would print out 2 4 6:

    for-each x [1 2 3] [print self/x + x]

This is because for-each needs to create a context "frame" containing just one
key and corresponding variable (for x), and then bind the body to that.  If this
context happened to have one of these "invisible self" bindings as well, then it
would also bind self and self/x would be the same meaning as x (instead of
leaving self bound however it was from the enclosing context).

The concept created a distinction that frames were either "selfish" or "selfless",
pushing further complexity into something that was already dubious due to
disrupting the no-keyword paradigm.

This commit contains several adaptations surrounding the elimination of the
SELF hack of R3-Alpha.  The end goal is to morph this into a solution that
strongly parallels the implementation strategy of Ren-C's "definitional RETURN",
where SELF is a word that uses the userspace concept of being hidden
(protect/hide) but is nevertheless present in the object as a key, and bound
using ordinary binding with no special symbolic exception or "0 index".

The idea is that `make object! [...]` as a primitive will necessarily make an
object with no SELF (just as in Ren-C a function declared via `make function!`
has no RETURN).  It will still be possible to get at the "self" by asking for the
`bind-of` any bound word inside of the object...and this precise mechanism
will be how generators like OBJECT, CONTEXT, MODULE and others will
implement a "userspace SELF" as protocol.

This first commit is a step toward that, because it starts with adding a hidden
key as being part of what `make object!` does.  This creates a significant
change for C code that used hardcoded indices into objects it created,
because formerly what was expected to be an index 1 will now be at index
2...because implementing a SELF now requires another key.  As things
evolve, it may be that these objects being indexed into by the system did
not actually need a SELF in the first place.  The macro SELFISH() is added
to add one to indices in places where this question can be reviewed.