### PR TITLE
POKE on BITSET! only pokes LOGIC! values

### DIFF
--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -565,24 +565,6 @@ REBCNT Val_Byte_Len(const REBVAL *value)
 
 
 //
-//  Get_Logic_Arg: C
-//
-REBFLG Get_Logic_Arg(REBVAL *arg)
-{
-    if (IS_NONE(arg))
-        return 0;
-    if (IS_INTEGER(arg))
-        return VAL_INT64(arg) != 0;
-    if (IS_LOGIC(arg))
-        return VAL_LOGIC(arg) != 0;
-    if (IS_DECIMAL(arg) || IS_PERCENT(arg))
-        return VAL_DECIMAL(arg) != 0.0;
-
-    fail (Error_Invalid_Arg(arg));
-}
-
-
-//
 //  Partial1: C
 // 
 // Process the /part (or /skip) and other length modifying

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -523,7 +523,7 @@ REBTYPE(Bitset)
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
     REBSER *ser;
     REBINT len;
-    REBINT diff;
+    REBOOL diff;
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= A_TAKE && action <= A_SORT)
@@ -542,7 +542,7 @@ REBTYPE(Bitset)
     case A_COMPLEMENT:
     case A_NEGATE:
         ser = Copy_Sequence(VAL_SERIES(value));
-        BITS_NOT(ser) = !BITS_NOT(VAL_SERIES(value));
+        BITS_NOT(ser) = NOT(BITS_NOT(VAL_SERIES(value)));
         Val_Init_Bitset(value, ser);
         break;
 
@@ -570,10 +570,12 @@ REBTYPE(Bitset)
         goto set_bits;
 
     case A_POKE:
-        diff = Get_Logic_Arg(D_ARG(3));
+        if (!IS_LOGIC(D_ARG(3)))
+            fail (Error_Invalid_Arg(D_ARG(3)));
+        diff = VAL_LOGIC(D_ARG(3));
 set_bits:
-        if (BITS_NOT(VAL_SERIES(value))) diff = !diff;
-        if (Set_Bits(VAL_SERIES(value), arg, (REBOOL)diff)) break;
+        if (BITS_NOT(VAL_SERIES(value))) diff = NOT(diff);
+        if (Set_Bits(VAL_SERIES(value), arg, diff)) break;
         fail (Error_Invalid_Arg(arg));
 
     case A_REMOVE:  // #"a" "abc"  remove/part bs "abcd"  yuk: /part ?


### PR DESCRIPTION
R3-Alpha would allow you to poke numbers into bitsets, and checked
to see if those numbers were zero or not (where zero is false).  This
behavior of zero-detection as logic is used no other place in the code,
confuses the type handling, and isn't consistent with Rebol's "zero is
not false" belief.

    >> foo: make bitset! 1
    == make bitset! #{00}

    >> poke foo 0 0.000000000000001
    == make bitset! #{80}

    >> bar: make bitset! 1
    == make bitset! #{00}

    >> poke foo 0 0.000000000000000
    == make bitset! #{00}

It makes more sense to constrain to logic true and false than it does
to open the field to anything conditionally true by default.  (It's easy
enough to say TRUE? xxx or NOT ZERO? xxx to get a LOGIC!.)

So this reigns in the feature and makes anything poked into a bitset
that isn't a LOGIC! an error.