### PR TITLE
Codebase-wide boolean audit

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -428,7 +428,7 @@ RL_API int RL_Do_String(int *exit_status, const REBYTE *text, REBCNT flags, RXIA
         len = FRAME_LEN(user) + 1;
         Bind_Values_All_Deep(ARRAY_HEAD(code), user);
         SET_INTEGER(&vali, len);
-        Resolve_Context(user, Lib_Context, &vali, FALSE, 0);
+        Resolve_Context(user, Lib_Context, &vali, FALSE, FALSE);
     }
 
     if (Do_At_Throws(&out, code, 0)) {
@@ -480,8 +480,14 @@ RL_API int RL_Do_String(int *exit_status, const REBYTE *text, REBCNT flags, RXIA
 //     As of A104, only compressed scripts are supported, however,
 //     rebin, cloaked, signed, and encrypted formats will be supported.
 //
-RL_API int RL_Do_Binary(int *exit_status, const REBYTE *bin, REBINT length, REBCNT flags, REBCNT key, RXIARG *result)
-{
+RL_API int RL_Do_Binary(
+    int *exit_status,
+    const REBYTE *bin,
+    REBINT length,
+    REBCNT flags,
+    REBCNT key,
+    RXIARG *result
+) {
     REBSER *text;
 #ifdef DUMP_INIT_SCRIPT
     int f;
@@ -489,7 +495,7 @@ RL_API int RL_Do_Binary(int *exit_status, const REBYTE *bin, REBINT length, REBC
     int do_result;
 
     text = Decompress(bin, length, -1, FALSE, FALSE);
-    if (!text) return FALSE;
+    if (!text) return 0;
     Append_Codepoint_Raw(text, 0);
 
 #ifdef DUMP_INIT_SCRIPT
@@ -1071,7 +1077,7 @@ RL_API int RL_Get_Value(REBARR *array, u32 index, RXIARG *result)
 //     val  - new value for field
 //     type - datatype of value
 //
-RL_API int RL_Set_Value(REBARR *array, u32 index, RXIARG val, int type)
+RL_API REBOOL RL_Set_Value(REBARR *array, u32 index, RXIARG val, int type)
 {
     REBVAL value;
     CLEARS(&value);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -95,7 +95,7 @@ REBOOL Trapped_Helper_Halted(REBOL_STATE *state)
     ASSERT_FRAME(state->error);
     assert(FRAME_TYPE(state->error) == REB_ERROR);
 
-    halted = (ERR_NUM(state->error) == RE_HALT);
+    halted = LOGICAL(ERR_NUM(state->error) == RE_HALT);
 
     // Restore Rebol call stack frame at time of Push_Trap.  Also, our
     // topmost call state (which may have been pushed but not put into
@@ -481,7 +481,7 @@ static REBFRM *Make_Guarded_Arg123_Error_Frame(void)
 // maps out the existing landscape so that if it is to be changed
 // then it can be seen exactly what is changing.
 //
-REBFLG Make_Error_Object_Throws(
+REBOOL Make_Error_Object_Throws(
     REBVAL *out, // output location **MUST BE GC SAFE**!
     REBVAL *arg
 ) {
@@ -786,7 +786,7 @@ REBFLG Make_Error_Object_Throws(
 // return to the caller to properly call va_end with no longjmp
 // to skip it.
 //
-REBFRM *Make_Error_Core(REBCNT code, REBFLG up_stack, va_list *args)
+REBFRM *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *args)
 {
     REBFRM *root_frame;
 
@@ -1064,7 +1064,7 @@ REBFRM *Error(REBINT num, ... /* REBVAL *arg1, REBVAL *arg2, ... */)
     REBFRM *frame;
 
     va_start(args, num);
-    frame = Make_Error_Core((num < 0 ? -num : num), num < 0, &args);
+    frame = Make_Error_Core((num < 0 ? -num : num), LOGICAL(num < 0), &args);
     va_end(args);
 
     return frame;

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -390,7 +390,7 @@ void Collect_Keys_End(void)
 // there is a check for duplciates, otherwise the keys are assumed to
 // be unique and copied in using `memcpy` as an optimization.
 //
-void Collect_Context_Keys(REBFRM *frame, REBFLG check_dups)
+void Collect_Context_Keys(REBFRM *frame, REBOOL check_dups)
 {
     REBVAL *key = FRAME_KEYS_HEAD(frame);
     REBINT *binds = WORDS_HEAD(Bind_Table);
@@ -655,7 +655,7 @@ REBARR *Collect_Words(REBVAL value[], REBVAL prior_value[], REBCNT modes)
 // Clone old src_frame to new dst_frame knowing
 // which types of values need to be copied, deep copied, and rebound.
 //
-void Rebind_Frame_Deep(REBFRM *src_frame, REBFRM *dst_frame, REBFLG modes)
+void Rebind_Frame_Deep(REBFRM *src_frame, REBFRM *dst_frame, REBFLGS modes)
 {
     Rebind_Values_Deep(
         FRAME_VARLIST(src_frame),
@@ -859,7 +859,7 @@ REBFRM *Make_Selfish_Frame_Detect(
 REBFRM *Construct_Frame(
     enum Reb_Kind kind,
     REBVAL value[],
-    REBFLG as_is,
+    REBOOL as_is,
     REBFRM *opt_parent
 ) {
     REBFRM *frame = Make_Selfish_Frame_Detect(
@@ -1051,8 +1051,8 @@ void Resolve_Context(
     REBFRM *target,
     REBFRM *source,
     REBVAL *only_words,
-    REBFLG all,
-    REBFLG expand
+    REBOOL all,
+    REBOOL expand
 ) {
     REBINT *binds  = WORDS_HEAD(Bind_Table); // GC safe to do here
     REBVAL *key;
@@ -1108,7 +1108,7 @@ void Resolve_Context(
 
         // Expand frame by the amount required:
         if (n > 0) Expand_Frame(target, n, 0);
-        else expand = 0;
+        else expand = FALSE;
     }
 
     // Maps a word to its value index in the source context.
@@ -1405,7 +1405,7 @@ void Rebind_Values_Deep(
     REBARR *src_target,
     REBARR *dst_target,
     REBVAL value[],
-    REBFLG modes
+    REBFLGS modes
 ) {
     REBINT *binds = WORDS_HEAD(Bind_Table);
 
@@ -1496,7 +1496,7 @@ REBCNT Find_Param_Index(REBARR *paramlist, REBCNT sym)
 // Return the frame index for a word. Locate it by matching
 // the canon word identifiers. Return 0 if not found.
 //
-REBCNT Find_Word_Index(REBFRM *frame, REBCNT sym, REBFLG always)
+REBCNT Find_Word_Index(REBFRM *frame, REBCNT sym, REBOOL always)
 {
     REBVAL *key = FRAME_KEYS_HEAD(frame);
     REBCNT len = FRAME_LEN(frame);

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -187,7 +187,7 @@ REBARR *Make_Paramlist_Managed(REBARR *spec)
                 // Turn block into typeset for parameter at current index
                 // Note: Make_Typeset leaves VAL_TYPESET_SYM as-is
                 //
-                Make_Typeset(VAL_ARRAY_HEAD(item), typeset, 0);
+                Make_Typeset(VAL_ARRAY_HEAD(item), typeset, FALSE);
                 continue;
             }
 
@@ -296,7 +296,7 @@ void Make_Native(
     REBARR *spec,
     REBNAT code,
     enum Reb_Kind type,
-    REBFLG frameless
+    REBOOL frameless
 ) {
     REBARR *paramlist;
 
@@ -361,7 +361,7 @@ void Make_Native(
 // Free_Series.  This means that the body must currently be shallow
 // copied, and the splicing slot must be in the topmost series.
 //
-REBARR *Get_Maybe_Fake_Func_Body(REBFLG *is_fake, const REBVAL *func)
+REBARR *Get_Maybe_Fake_Func_Body(REBOOL *is_fake, const REBVAL *func)
 {
     REBARR *fake_body;
 
@@ -458,7 +458,7 @@ void Make_Function(
     enum Reb_Kind type,
     const REBVAL *spec,
     const REBVAL *body,
-    REBFLG has_return
+    REBOOL has_return
 ) {
     REBYTE func_flags = 0; // 8-bits in header, reserved type-specific flags
 
@@ -489,7 +489,7 @@ void Make_Function(
 
         REBVAL *item = VAL_ARRAY_HEAD(spec);
         REBCNT index = 0;
-        REBFLG convert_local = FALSE;
+        REBOOL convert_local = FALSE;
 
         for (; NOT_END(item); index++, item++) {
             if (IS_SET_WORD(item)) {
@@ -796,7 +796,7 @@ void Clonify_Function(REBVAL *value)
 //
 //  Do_Native_Throws: C
 //
-REBFLG Do_Native_Throws(struct Reb_Call *call_)
+REBOOL Do_Native_Throws(struct Reb_Call *call_)
 {
     REB_R ret;
 
@@ -837,15 +837,15 @@ REBFLG Do_Native_Throws(struct Reb_Call *call_)
 
     // The VAL_OPT_THROWN bit is being eliminated, but used temporarily to
     // check the actions and natives are returning the correct thing.
-    assert(THROWN(D_OUT) == (ret == R_OUT_IS_THROWN));
-    return ret == R_OUT_IS_THROWN;
+    assert(THROWN(D_OUT) == LOGICAL(ret == R_OUT_IS_THROWN));
+    return LOGICAL(ret == R_OUT_IS_THROWN);
 }
 
 
 //
 //  Do_Action_Throws: C
 //
-REBFLG Do_Action_Throws(struct Reb_Call *call_)
+REBOOL Do_Action_Throws(struct Reb_Call *call_)
 {
     REBCNT type = VAL_TYPE(D_ARG(1));
     REBACT action;
@@ -904,15 +904,15 @@ REBFLG Do_Action_Throws(struct Reb_Call *call_)
 
     // The VAL_OPT_THROWN bit is being eliminated, but used temporarily to
     // check the actions and natives are returning the correct thing.
-    assert(THROWN(D_OUT) == (ret == R_OUT_IS_THROWN));
-    return ret == R_OUT_IS_THROWN;
+    assert(THROWN(D_OUT) == LOGICAL(ret == R_OUT_IS_THROWN));
+    return LOGICAL(ret == R_OUT_IS_THROWN);
 }
 
 
 //
 //  Do_Function_Throws: C
 //
-REBFLG Do_Function_Throws(struct Reb_Call *call_)
+REBOOL Do_Function_Throws(struct Reb_Call *call_)
 {
     Eval_Functions++;
 
@@ -959,7 +959,7 @@ REBFLG Do_Function_Throws(struct Reb_Call *call_)
 // Do a closure by cloning its body and rebinding it to
 // a new frame of words/values.
 //
-REBFLG Do_Closure_Throws(struct Reb_Call *call_)
+REBOOL Do_Closure_Throws(struct Reb_Call *call_)
 {
     REBARR *body;
     REBFRM *frame;
@@ -1077,7 +1077,7 @@ REBFLG Do_Closure_Throws(struct Reb_Call *call_)
 //
 //  Do_Routine_Throws: C
 //
-REBFLG Do_Routine_Throws(struct Reb_Call *call_)
+REBOOL Do_Routine_Throws(struct Reb_Call *call_)
 {
     REBARR *args = Copy_Values_Len_Shallow(
         D_ARGC > 0 ? D_ARG(1) : NULL,
@@ -1114,7 +1114,7 @@ REBNATIVE(func)
     PARAM(1, spec);
     PARAM(2, body);
 
-    const REBFLG has_return = TRUE;
+    const REBOOL has_return = TRUE;
 
     Make_Function(D_OUT, REB_FUNCTION, ARG(spec), ARG(body), has_return);
 
@@ -1153,7 +1153,7 @@ REBNATIVE(clos)
     PARAM(1, spec);
     PARAM(2, body);
 
-    const REBFLG has_return = TRUE;
+    const REBOOL has_return = TRUE;
 
     Make_Function(D_OUT, REB_CLOSURE, ARG(spec), ARG(body), has_return);
 
@@ -1249,12 +1249,12 @@ REBFUN *VAL_FUNC_Debug(const REBVAL *v) {
 
     if (v_header.all != func_header.all) {
         REBVAL *func_value = FUNC_VALUE(func);
-        REBFLG frameless_value = VAL_GET_EXT(v, EXT_FUNC_FRAMELESS);
-        REBFLG frameless_func = VAL_GET_EXT(func_value, EXT_FUNC_FRAMELESS);
-        REBFLG has_return_value = VAL_GET_EXT(v, EXT_FUNC_HAS_RETURN);
-        REBFLG has_return_func = VAL_GET_EXT(func_value, EXT_FUNC_HAS_RETURN);
-        REBFLG infix_value = VAL_GET_EXT(v, EXT_FUNC_INFIX);
-        REBFLG infix_func = VAL_GET_EXT(func_value, EXT_FUNC_INFIX);
+        REBOOL frameless_value = VAL_GET_EXT(v, EXT_FUNC_FRAMELESS);
+        REBOOL frameless_func = VAL_GET_EXT(func_value, EXT_FUNC_FRAMELESS);
+        REBOOL has_return_value = VAL_GET_EXT(v, EXT_FUNC_HAS_RETURN);
+        REBOOL has_return_func = VAL_GET_EXT(func_value, EXT_FUNC_HAS_RETURN);
+        REBOOL infix_value = VAL_GET_EXT(v, EXT_FUNC_INFIX);
+        REBOOL infix_func = VAL_GET_EXT(func_value, EXT_FUNC_INFIX);
 
         Debug_Fmt("Mismatch header bits found in FUNC_VALUE from payload");
         Debug_Array(v->payload.any_function.spec);

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -57,7 +57,7 @@ void Make_Port(REBVAL *out, const REBVAL *spec)
 // Standard method for checking if port is open.
 // A convention. Not all ports use this method.
 //
-REBFLG Is_Port_Open(REBFRM *port)
+REBOOL Is_Port_Open(REBFRM *port)
 {
     REBVAL *state = FRAME_VAR(port, STD_PORT_STATE);
     if (!IS_BINARY(state)) return FALSE;
@@ -71,11 +71,11 @@ REBFLG Is_Port_Open(REBFRM *port)
 // Standard method for setting a port open/closed.
 // A convention. Not all ports use this method.
 //
-void Set_Port_Open(REBFRM *port, REBFLG flag)
+void Set_Port_Open(REBFRM *port, REBOOL open)
 {
     REBVAL *state = FRAME_VAR(port, STD_PORT_STATE);
     if (IS_BINARY(state)) {
-        if (flag) SET_OPEN(VAL_BIN_AT(state));
+        if (open) SET_OPEN(VAL_BIN_AT(state));
         else SET_CLOSED(VAL_BIN_AT(state));
     }
 }
@@ -115,7 +115,7 @@ void *Use_Port_State(REBFRM *port, REBCNT device, REBCNT size)
 // Return TRUE if port value is pending a signal.
 // Not valid for all ports - requires request struct!!!
 //
-REBFLG Pending_Port(REBVAL *port)
+REBOOL Pending_Port(REBVAL *port)
 {
     REBVAL *state;
     REBREQ *req;
@@ -139,7 +139,7 @@ REBFLG Pending_Port(REBVAL *port)
 //      0 for nothing to do
 //      1 for wait is satisifed
 //
-REBINT Awake_System(REBARR *ports, REBINT only)
+REBINT Awake_System(REBARR *ports, REBOOL only)
 {
     REBVAL *port;
     REBVAL *state;
@@ -196,7 +196,7 @@ REBINT Awake_System(REBARR *ports, REBINT only)
 // Returns:
 //     TRUE when port action happened, or FALSE for timeout.
 //
-REBINT Wait_Ports(REBARR *ports, REBCNT timeout, REBINT only)
+REBOOL Wait_Ports(REBARR *ports, REBCNT timeout, REBOOL only)
 {
     REBI64 base = OS_DELTA_TIME(0, 0);
     REBCNT time;

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -375,7 +375,7 @@ const REBYTE *Get_Type_Name(const REBVAL *value)
 // Note that words are kept UTF8 encoded.
 // Positive result if s > t and negative if s < t.
 //
-REBINT Compare_Word(const REBVAL *s, const REBVAL *t, REBFLG is_case)
+REBINT Compare_Word(const REBVAL *s, const REBVAL *t, REBOOL is_case)
 {
     REBYTE *sp = VAL_WORD_NAME(s);
     REBYTE *tp = VAL_WORD_NAME(t);
@@ -396,7 +396,7 @@ REBINT Compare_Word(const REBVAL *s, const REBVAL *t, REBFLG is_case)
 // 
 // Only flags BIND_Table creation only (for threads).
 //
-void Init_Words(REBFLG only)
+void Init_Words(REBOOL only)
 {
     REBCNT n = Get_Hash_Prime(WORD_TABLE_SIZE * 4); // extra to reduce rehashing
 

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -100,13 +100,13 @@ void Print_OS_Line(void)
 // 
 // The encoding options are OPT_ENC_XXX flags OR'd together.
 //
-void Prin_OS_String(const void *p, REBCNT len, REBFLG opts)
+void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
 {
     #define BUF_SIZE 1024
     REBYTE buffer[BUF_SIZE]; // on stack
     REBYTE *buf = &buffer[0];
     REBCNT len2;
-    const REBOOL unicode = (opts & OPT_ENC_UNISRC) != 0;
+    const REBOOL unicode = LOGICAL(opts & OPT_ENC_UNISRC);
 
     const REBYTE *bp = unicode ? NULL : cast(const REBYTE *, p);
     const REBUNI *up = unicode ? cast(const REBUNI *, p) : NULL;
@@ -191,7 +191,7 @@ void Out_Str(const REBYTE *bp, REBINT lines)
 //
 //  Enable_Backtrace: C
 //
-void Enable_Backtrace(REBFLG on)
+void Enable_Backtrace(REBOOL on)
 {
     if (on) {
         if (Trace_Limit == 0) {
@@ -280,7 +280,7 @@ void Debug_String(const void *p, REBCNT len, REBOOL unicode, REBINT lines)
 //
 void Debug_Line(void)
 {
-    Debug_String(cb_cast(""), UNKNOWN, 0, 1);
+    Debug_String(cb_cast(""), UNKNOWN, FALSE, 1);
 }
 
 
@@ -291,7 +291,7 @@ void Debug_Line(void)
 //
 void Debug_Str(const char *str)
 {
-    Debug_String(cb_cast(str), UNKNOWN, 0, 1);
+    Debug_String(cb_cast(str), UNKNOWN, FALSE, 1);
 }
 
 
@@ -302,7 +302,7 @@ void Debug_Str(const char *str)
 //
 void Debug_Uni(const REBSER *ser)
 {
-    const REBFLG encopts = OPT_ENC_UNISRC | OPT_ENC_CRLF_MAYBE;
+    const REBFLGS encopts = OPT_ENC_UNISRC | OPT_ENC_CRLF_MAYBE;
     REBCNT ul;
     REBCNT bl;
     REBYTE buf[1024];
@@ -315,7 +315,7 @@ void Debug_Uni(const REBSER *ser)
     while (size > 0) {
         ul = size;
         bl = Encode_UTF8(buf, 1020, up, &ul, encopts);
-        Debug_String(buf, bl, 0, 0);
+        Debug_String(buf, bl, FALSE, 0);
         size -= ul;
         up += ul;
     }
@@ -394,8 +394,8 @@ void Debug_Num(const REBYTE *str, REBINT num)
 {
     REBYTE buf[40];
 
-    Debug_String(str, UNKNOWN, 0, 0);
-    Debug_String(cb_cast(" "), 1, 0, 0);
+    Debug_String(str, UNKNOWN, FALSE, 0);
+    Debug_String(cb_cast(" "), 1, FALSE, 0);
     Form_Hex_Pad(buf, num, 8);
     Debug_Str(s_cast(buf));
 }
@@ -412,7 +412,7 @@ void Debug_Chars(REBYTE chr, REBCNT num)
 
     memset(spaces, chr, MIN(num, 99));
     spaces[num] = 0;
-    Debug_String(spaces, num, 0, 0);
+    Debug_String(spaces, num, FALSE, 0);
 }
 
 
@@ -530,7 +530,7 @@ void Debug_Buf(const char *fmt, va_list *args)
     for (n = 0; n < tail; n += len) {
         len = LEN_BYTES(BIN_AT(buf, n));
         if (len > 1024) len = 1024;
-        Debug_String(BIN_AT(buf, n), len, 0, 0);
+        Debug_String(BIN_AT(buf, n), len, FALSE, 0);
     }
 
     assert(GC_Disabled == 1);
@@ -600,10 +600,10 @@ void Probe_Core_Debug(const char *msg, const char *file, int line, const REBVAL 
 //
 //  Echo_File: C
 //
-REBFLG Echo_File(REBCHR *file)
+REBOOL Echo_File(REBCHR *file)
 {
     Req_SIO->special.file.path = file;
-    return (DR_ERROR != OS_DO_DEVICE(Req_SIO, RDC_CREATE));
+    return LOGICAL(DR_ERROR != OS_DO_DEVICE(Req_SIO, RDC_CREATE));
 }
 
 
@@ -814,7 +814,7 @@ pick:
             vp = va_arg(*args, REBVAL *);
 mold_value:
             // Form the REBOL value into a reused buffer:
-            ser = Mold_Print_Value(vp, 0, desc != 'v');
+            ser = Mold_Print_Value(vp, 0, LOGICAL(desc != 'v'));
 
             l = max - len - 1;
             if (pad != 1 && l > pad) l = pad;

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -328,7 +328,7 @@ void Copy_Stack_Values(REBINT start, REBVAL *into)
             // the operation?
 
             REBCNT i;
-            REBCNT flags = 0;
+            REBFLGS flags = 0;
             // you get weird behavior if you don't do this
             if (IS_BINARY(into)) SET_FLAG(flags, AN_SERIES);
             for (i = 0; i < len; i++) {

--- a/src/core/f-enbase.c
+++ b/src/core/f-enbase.c
@@ -38,7 +38,7 @@ static const REBYTE Debase64[128] =
     #define BIN_ERROR   (REBYTE)0x80
     #define BIN_SPACE   (REBYTE)0x40
     #define BIN_VALUE   (REBYTE)0x3f
-    #define IS_BIN_SPACE(c) (Debase64[c] & BIN_SPACE)
+    #define IS_BIN_SPACE(c) LOGICAL(Debase64[c] & BIN_SPACE)
 
     /* Control Chars */
     BIN_ERROR,BIN_ERROR,BIN_ERROR,BIN_ERROR,    /* 80 */
@@ -375,7 +375,7 @@ const REBYTE *Decode_Binary(REBVAL *value, const REBYTE *src, REBCNT len, REBINT
 // 
 // Base2 encode a given series. Must be BYTES, not UNICODE.
 //
-REBSER *Encode_Base2(const REBVAL *value, REBSER *series, REBFLG brk)
+REBSER *Encode_Base2(const REBVAL *value, REBSER *series, REBOOL brk)
 {
     REBYTE *p;  // ?? should it be REBYTE? Same with below functions?
     REBYTE *src;
@@ -424,7 +424,7 @@ REBSER *Encode_Base2(const REBVAL *value, REBSER *series, REBFLG brk)
 // 
 // Base16 encode a given series. Must be BYTES, not UNICODE.
 //
-REBSER *Encode_Base16(const REBVAL *value, REBSER *series, REBFLG brk)
+REBSER *Encode_Base16(const REBVAL *value, REBSER *series, REBOOL brk)
 {
     REBCNT count;
     REBCNT len;
@@ -465,7 +465,7 @@ REBSER *Encode_Base16(const REBVAL *value, REBSER *series, REBFLG brk)
 // 
 // Base64 encode a given series. Must be BYTES, not UNICODE.
 //
-REBSER *Encode_Base64(const REBVAL *value, REBSER *series, REBFLG brk)
+REBSER *Encode_Base64(const REBVAL *value, REBSER *series, REBOOL brk)
 {
     REBYTE *p;
     REBYTE *src;

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -524,7 +524,7 @@ bad_func_def:
 //     spec - same as other funcs
 //     body - [ext-obj func-index]
 //
-REBFLG Do_Command_Throws(struct Reb_Call *call_)
+REBOOL Do_Command_Throws(struct Reb_Call *call_)
 {
     // All of these were checked above on definition:
     REBVAL *val = ARRAY_HEAD(FUNC_BODY(D_FUNC));

--- a/src/core/f-int.c
+++ b/src/core/f-int.c
@@ -95,7 +95,7 @@ REBOOL reb_u32_mul_overflow(u32 x, u32 y, u32 *prod)
 
 REBOOL reb_i64_mul_overflow(i64 x, i64 y, i64 *prod)
 {
-    REBFLG sgn;
+    REBOOL sgn;
     u64 p = 0;
 
     if (!x || !y) {
@@ -103,38 +103,38 @@ REBOOL reb_i64_mul_overflow(i64 x, i64 y, i64 *prod)
         return FALSE;
     }
 
-    sgn = (x < 0);
+    sgn = LOGICAL(x < 0);
     if (sgn) {
         if (x == MIN_I64) {
             switch (y) {
                 case 0:
                     *prod = 0;
-                    return 0;
+                    return FALSE;
                 case 1:
                     *prod = x;
-                    return 0;
+                    return FALSE;
                 default:
-                    return 1;
+                    return TRUE;
             }
         }
         x = -x; /* undefined when x == MIN_I64 */
     }
     if (y < 0) {
-        sgn = !sgn;
+        sgn = NOT(sgn);
         if (y == MIN_I64) {
             switch (x) {
                 case 0:
                     *prod = 0;
-                    return 0;
+                    return FALSE;
                 case 1:
                     if (!sgn) {
-                        return 1;
+                        return TRUE;
                     } else {
                         *prod = y;
-                        return 0;
+                        return FALSE;
                     }
                 default:
-                    return 1;
+                    return TRUE;
             }
         }
         y = -y; /* undefined when y == MIN_I64 */

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -129,7 +129,7 @@ REBCNT Modify_String(
     REBSER *dst_ser,        // target
     REBCNT dst_idx,         // position
     const REBVAL *src_val,  // source
-    REBCNT flags,           // AN_PART
+    REBFLGS flags,          // AN_PART
     REBINT dst_len,         // length to remove
     REBINT dups             // dup count
 ) {

--- a/src/core/f-random.c
+++ b/src/core/f-random.c
@@ -129,7 +129,7 @@ static REBI64 ran_arr_cycle()
 // 
 // Return random integer. Secure uses SHA1 for better safety.
 //
-REBI64 Random_Int(REBFLG secure)
+REBI64 Random_Int(REBOOL secure)
 {
     REBI64 tmp;
     tmp = ran_arr_next();
@@ -150,7 +150,7 @@ REBI64 Random_Int(REBFLG secure)
 //
 //  Random_Range: C
 //
-REBI64 Random_Range(REBI64 r, REBFLG secure)
+REBI64 Random_Range(REBI64 r, REBOOL secure)
 {
     REBU64 s, m, u;
     if (r == 0) return 0;
@@ -165,7 +165,7 @@ REBI64 Random_Range(REBI64 r, REBFLG secure)
 //
 //  Random_Dec: C
 //
-REBDEC Random_Dec(REBDEC r, REBFLG secure)
+REBDEC Random_Dec(REBDEC r, REBOOL secure)
 {
     REBDEC t, s;
     t = secure ? 5.4210108624275222e-20 /* 2^-64 */ :  2.1684043449710089e-19 /* 2^-62 */;

--- a/src/core/f-round.c
+++ b/src/core/f-round.c
@@ -85,7 +85,7 @@ REBDEC Round_Dec(REBDEC dec, REBCNT flags, REBDEC scale)
 {
     REBDEC r;
     int e;
-    REBFLG v;
+    REBOOL v;
     union {REBDEC d; REBI64 i;} m;
     REBI64 j;
 
@@ -97,7 +97,7 @@ REBDEC Round_Dec(REBDEC dec, REBCNT flags, REBDEC scale)
     /* is scale negligible? */
     if (scale < ldexp(fabs(dec), -53)) return dec;
 
-    if ((v = scale >= 1.0)) dec = dec / scale;
+    if ((v = LOGICAL(scale >= 1.0))) dec = dec / scale;
     else {
         r = frexp(scale, &e);
         if (e <= -1022) {

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -151,7 +151,7 @@ is_true:
 // Compare two blocks and return the difference of the first
 // non-matching value.
 //
-REBINT Cmp_Block(const REBVAL *sval, const REBVAL *tval, REBFLG is_case)
+REBINT Cmp_Block(const REBVAL *sval, const REBVAL *tval, REBOOL is_case)
 {
     REBVAL  *s = VAL_ARRAY_AT(sval);
     REBVAL  *t = VAL_ARRAY_AT(tval);
@@ -199,7 +199,7 @@ diff_of_ends:
 // 
 // is_case TRUE for case sensitive compare
 //
-REBINT Cmp_Value(const REBVAL *s, const REBVAL *t, REBFLG is_case)
+REBINT Cmp_Value(const REBVAL *s, const REBVAL *t, REBOOL is_case)
 {
     REBDEC  d1, d2;
 
@@ -271,7 +271,7 @@ chkDecimal:
     case REB_EMAIL:
     case REB_URL:
     case REB_TAG:
-        return Compare_String_Vals(s, t, (REBOOL)!is_case);
+        return Compare_String_Vals(s, t, NOT(is_case));
 
     case REB_BITSET:
     case REB_BINARY:

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1525,8 +1525,12 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
         case TOKEN_PERCENT:
             // Do not allow 1.2/abc:
             VAL_RESET_HEADER(value, REB_DECIMAL);
-            if (*ep == '/' || !Scan_Decimal(&VAL_DECIMAL(value), bp, len, 0))
+            if (
+                *ep == '/'
+                || !Scan_Decimal(&VAL_DECIMAL(value), bp, len, FALSE)
+            ) {
                 goto syntax_error;
+            }
             if (bp[len-1] == '%') {
                 VAL_RESET_HEADER(value, REB_PERCENT);
                 VAL_DECIMAL(value) /= 100.0;
@@ -1737,7 +1741,7 @@ exit_block:
 //
 static REBARR *Scan_Full_Block(SCAN_STATE *scan_state, REBYTE mode_char)
 {
-    REBFLG only = GET_FLAG(scan_state->opts, SCAN_ONLY);
+    REBOOL only = GET_FLAG(scan_state->opts, SCAN_ONLY);
     REBARR *array;
     CLR_FLAG(scan_state->opts, SCAN_ONLY);
     array = Scan_Block(scan_state, mode_char);

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -32,7 +32,7 @@
 #include "sys-dec-to-char.h"
 #include <errno.h>
 
-typedef REBFLG (*MAKE_FUNC)(REBVAL *, REBVAL *, enum Reb_Kind);
+typedef REBOOL (*MAKE_FUNC)(REBVAL *, REBVAL *, enum Reb_Kind);
 #include "tmp-maketypes.h"
 
 
@@ -201,7 +201,7 @@ const REBYTE *Scan_Dec_Buf(const REBYTE *cp, REBCNT len, REBYTE *buf)
         if (*cp != '\'') {
             *bp++ = *cp++;
             if (bp >= be) return 0;
-            dig=1;
+            dig = TRUE;
         }
         else cp++;
     if (*cp == ',' || *cp == '.') cp++;
@@ -211,14 +211,14 @@ const REBYTE *Scan_Dec_Buf(const REBYTE *cp, REBCNT len, REBYTE *buf)
         if (*cp != '\'') {
             *bp++ = *cp++;
             if (bp >= be) return 0;
-            dig=1;
+            dig = TRUE;
         }
         else cp++;
     if (!dig) return 0;
     if (*cp == 'E' || *cp == 'e') {
             *bp++ = *cp++;
             if (bp >= be) return 0;
-            dig = 0;
+            dig = FALSE;
             if (*cp == '-' || *cp == '+') {
                 *bp++ = *cp++;
                 if (bp >= be) return 0;
@@ -226,7 +226,7 @@ const REBYTE *Scan_Dec_Buf(const REBYTE *cp, REBCNT len, REBYTE *buf)
             while (IS_LEX_NUMBER(*cp)) {
                 *bp++ = *cp++;
                 if (bp >= be) return 0;
-                dig=1;
+                dig = TRUE;
             }
             if (!dig) return 0;
     }
@@ -240,7 +240,7 @@ const REBYTE *Scan_Dec_Buf(const REBYTE *cp, REBCNT len, REBYTE *buf)
 // 
 // Scan and convert a decimal value.  Return zero if error.
 //
-const REBYTE *Scan_Decimal(REBDEC *out, const REBYTE *cp, REBCNT len, REBFLG dec_only)
+const REBYTE *Scan_Decimal(REBDEC *out, const REBYTE *cp, REBCNT len, REBOOL dec_only)
 {
     const REBYTE *bp = cp;
     REBYTE buf[MAX_NUM_LEN+4];
@@ -252,19 +252,29 @@ const REBYTE *Scan_Decimal(REBDEC *out, const REBYTE *cp, REBCNT len, REBFLG dec
 
     if (*cp == '+' || *cp == '-') *ep++ = *cp++;
     while (IS_LEX_NUMBER(*cp) || *cp == '\'')
-        if (*cp != '\'') *ep++ = *cp++, dig=1;
+        if (*cp != '\'') {
+            *ep++ = *cp++;
+            dig = TRUE;
+        }
         else cp++;
     if (*cp == ',' || *cp == '.') cp++;
     *ep++ = '.';
     while (IS_LEX_NUMBER(*cp) || *cp == '\'')
-        if (*cp != '\'') *ep++ = *cp++, dig=1;
+        if (*cp != '\'') {
+            *ep++ = *cp++;
+            dig = TRUE;
+        }
         else cp++;
     if (!dig) return 0;
     if (*cp == 'E' || *cp == 'e') {
             *ep++ = *cp++;
-            dig = 0;
-            if (*cp == '-' || *cp == '+') *ep++ = *cp++;
-            while (IS_LEX_NUMBER(*cp)) *ep++ = *cp++, dig=1;
+            dig = FALSE;
+            if (*cp == '-' || *cp == '+')
+                *ep++ = *cp++;
+            while (IS_LEX_NUMBER(*cp)) {
+                *ep++ = *cp++;
+                dig= TRUE;
+            }
             if (!dig) return 0;
     }
     if (*cp == '%') {
@@ -866,7 +876,7 @@ REBARR *Load_Markup(const REBYTE *cp, REBINT len)
 // Keep in mind that this function is being called as part of the
 // scanner, so optimal performance is critical.
 //
-REBFLG Construct_Value(REBVAL *out, REBARR *spec)
+REBOOL Construct_Value(REBVAL *out, REBARR *spec)
 {
     REBVAL *val;
     REBCNT sym;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1313,8 +1313,17 @@ void Guard_Value_Core(const REBVAL *value)
 //
 void Init_GC(void)
 {
-    GC_Active = 0;          // TRUE when recycle is enabled (set by RECYCLE func)
-    GC_Disabled = 0;        // GC disabled counter for critical sections.
+    // TRUE when recycle is enabled (set by RECYCLE func)
+    //
+    GC_Active = FALSE;
+
+    // GC disabled counter for critical sections.  Used liberally in R3-Alpha.
+    // But with Ren-C's introduction of the idea that an allocated series is
+    // not seen by the GC until such time as it gets the SER_MANAGED flag
+    // set, there are fewer legitimate justifications to disabling the GC.
+    //
+    GC_Disabled = 0;
+
     GC_Ballast = MEM_BALLAST;
 
     // Temporary series protected from GC. Holds series pointers.

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1484,7 +1484,7 @@ void Manuals_Leak_Check_Debug(REBCNT manuals_len, const char *label_str)
 // with either managed or unmanaged value states for variables w/o needing
 // this test to know which it has.)
 //
-REBFLG Is_Value_Managed(const REBVAL *value, REBFLG thrown_or_end_ok)
+REBOOL Is_Value_Managed(const REBVAL *value, REBOOL thrown_or_end_ok)
 {
     if (IS_END(value))
         return thrown_or_end_ok;
@@ -1547,7 +1547,7 @@ void Free_Gob(REBGOB *gob)
 // 
 // Confirm that the series value is in the series pool.
 //
-REBFLG Series_In_Pool(REBSER *series)
+REBOOL Series_In_Pool(REBSER *series)
 {
     REBSEG  *seg;
     REBSER *start;
@@ -1765,7 +1765,7 @@ REBU64 Inspect_Series(REBCNT flags)
     REBSER  *series;
     REBCNT  segs, n, tot, blks, strs, unis, nons, odds, fre;
     REBCNT  str_size, uni_size, blk_size, odd_size, seg_size, fre_size;
-    REBFLG  f = 0;
+    REBOOL  f = FALSE;
     REBINT  pool_num;
 #ifdef SERIES_LABELS
     REBYTE  *kind;
@@ -1788,7 +1788,7 @@ REBU64 Inspect_Series(REBCNT flags)
             if (SERIES_WIDE(series)) {
                 tot++;
                 tot_size += SERIES_TOTAL(series);
-                f = 0;
+                f = FALSE;
             } else {
                 fre++;
             }
@@ -1798,10 +1798,10 @@ REBU64 Inspect_Series(REBCNT flags)
             //if (Find_Root(series)) kind = "ROOT";
             if (!SERIES_FREED(series) && series->label) {
                 Debug_Fmt_("%08x: %16s %s ", series, series->label, kind);
-                f = 1;
+                f = TRUE;
             } else if (!SERIES_FREED(series) && (flags & 0x100)) {
                 Debug_Fmt_("%08x: %s ", series, kind);
-                f = 1;
+                f = TRUE;
             }
 #endif
             if (Is_Array_Series(series)) {

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -411,7 +411,7 @@ REBNATIVE(case)
     REBCNT index = VAL_INDEX(D_ARG(1));
 
     // Save refinement to boolean to free up GC protected call frame slot
-    REBFLG all = D_REF(2);
+    REBOOL all = D_REF(2);
 
     // reuse refinement slot for GC safety (const pointer optimized out)
     REBVAL * const safe_temp = D_ARG(2);
@@ -419,7 +419,7 @@ REBNATIVE(case)
     // condition result must survive across potential GC evaluations of
     // the body evaluation re-using `safe-temp`, but can be collapsed to a
     // flag as the full value of the condition is never returned.
-    REBFLG matched;
+    REBOOL matched;
 
     // CASE is in the same family as IF/UNLESS/EITHER, so if there is no
     // matching condition it will return UNSET!.  Set that as default.
@@ -1166,7 +1166,7 @@ REBNATIVE(fail)
 }
 
 
-static REB_R If_Unless_Core(struct Reb_Call *call_, REBFLG trigger) {
+static REB_R If_Unless_Core(struct Reb_Call *call_, REBOOL trigger) {
     PARAM(1, condition);
     PARAM(2, branch);
     REFINE(3, only);

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -100,13 +100,11 @@ static REBOOL Is_Type_Of(const REBVAL *value, REBVAL *types)
 
     val = IS_WORD(types) ? GET_VAR(types) : types;
 
-    if (IS_DATATYPE(val)) {
-        return (VAL_TYPE_KIND(val) == VAL_TYPE(value));
-    }
+    if (IS_DATATYPE(val))
+        return LOGICAL(VAL_TYPE_KIND(val) == VAL_TYPE(value));
 
-    if (IS_TYPESET(val)) {
-        return (TYPE_CHECK(val, VAL_TYPE(value)));
-    }
+    if (IS_TYPESET(val))
+        return LOGICAL(TYPE_CHECK(val, VAL_TYPE(value)));
 
     if (IS_BLOCK(val)) {
         for (types = VAL_ARRAY_AT(val); NOT_END(types); types++) {
@@ -259,7 +257,7 @@ REBNATIVE(bind)
     REBARR *target_series;
     REBARR *array;
     REBCNT flags;
-    REBFLG is_relative;
+    REBOOL is_relative;
 
     flags = REF(only) ? 0 : BIND_DEEP;
     if (REF(new)) flags |= BIND_ALL;
@@ -281,7 +279,7 @@ REBNATIVE(bind)
         // frame is just an object frame (at the moment).
         //
         assert(ANY_WORD(ARG(target)));
-        is_relative = (VAL_WORD_INDEX(ARG(target)) < 0);
+        is_relative = LOGICAL(VAL_WORD_INDEX(ARG(target)) < 0);
         target_series = VAL_WORD_TARGET(ARG(target));
         if (!target_series) fail (Error(RE_NOT_BOUND, ARG(target)));
     }
@@ -1291,7 +1289,7 @@ REBFRM **VAL_FRAME_Ptr_Debug(const REBVAL *v)
 // Variant of IS_CONDITIONAL_FALSE() macro for the debug build which checks to
 // ensure you never call it on an UNSET!
 //
-REBFLG IS_CONDITIONAL_FALSE_Debug(const REBVAL *v)
+REBOOL IS_CONDITIONAL_FALSE_Debug(const REBVAL *v)
 {
     assert(!IS_UNSET(v));
     if (VAL_GET_OPT(v, OPT_VALUE_FALSE)) {

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -108,7 +108,7 @@ REBNATIVE(mold)
 }
 
 
-static REBFLG Print_Native_Modifying_Throws(
+static REBOOL Print_Native_Modifying_Throws(
     REBVAL *value, // Value may be modified.  Contents must be GC-safe!
     REBOOL newline
 ) {
@@ -169,7 +169,7 @@ static REBFLG Print_Native_Modifying_Throws(
             return TRUE;
         }
 
-        Prin_Value(value, 0, 0);
+        Prin_Value(value, 0, FALSE);
         if (newline)
             Print_OS_Line();
     }
@@ -179,7 +179,7 @@ static REBFLG Print_Native_Modifying_Throws(
 #endif
         // !!! Full behavior review needed for all types.
 
-        Prin_Value(value, 0, 0);
+        Prin_Value(value, 0, FALSE);
         if (newline)
             Print_OS_Line();
     }
@@ -524,7 +524,7 @@ REBNATIVE(to_rebol_file)
     REBVAL *arg = D_ARG(1);
     REBSER *ser;
 
-    ser = Value_To_REBOL_Path(arg, 0);
+    ser = Value_To_REBOL_Path(arg, FALSE);
     if (!ser) fail (Error_Invalid_Arg(arg));
     Val_Init_File(D_OUT, ser);
 
@@ -613,7 +613,6 @@ REBNATIVE(change_dir)
 {
     REBVAL *arg = D_ARG(1);
     REBSER *ser;
-    REBINT n;
     REBVAL val;
 
     REBVAL *current_path = Get_System(SYS_OPTIONS, OPTIONS_CURRENT_PATH);
@@ -635,9 +634,7 @@ REBNATIVE(change_dir)
         Val_Init_String(&val, ser); // may be unicode or utf-8
         Check_Security(SYM_FILE, POL_EXEC, &val);
 
-        n = OS_SET_CURRENT_DIR(cast(REBCHR*, SERIES_DATA(ser)));
-
-        if (n == 0)
+        if (!OS_SET_CURRENT_DIR(cast(REBCHR*, SERIES_DATA(ser))))
             fail (Error_Invalid_Arg(arg)); // !!! ERROR MSG
     }
 
@@ -1107,7 +1104,7 @@ REBSER *Block_To_String_List(REBVAL *blk)
     Reset_Mold(&mo);
 
     for (value = VAL_ARRAY_AT(blk); NOT_END(value); value++) {
-        Mold_Value(&mo, value, 0);
+        Mold_Value(&mo, value, FALSE);
         Append_Codepoint_Raw(mo.series, 0);
     }
     Append_Codepoint_Raw(mo.series, 0);

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -48,7 +48,7 @@ typedef enum {
 // If FALSE is returned then the throw name `val` was not a break
 // or continue, and needs to be bubbled up or handled another way.
 //
-REBFLG Catching_Break_Or_Continue(REBVAL *val, REBFLG *stop)
+REBOOL Catching_Break_Or_Continue(REBVAL *val, REBOOL *stop)
 {
     assert(THROWN(val));
 
@@ -153,7 +153,7 @@ static REBARR *Init_Loop(
 //
 //  Loop_Series_Throws: C
 //
-static REBFLG Loop_Series_Throws(
+static REBOOL Loop_Series_Throws(
     REBVAL *out,
     REBVAL *var,
     REBARR *body,
@@ -177,7 +177,7 @@ static REBFLG Loop_Series_Throws(
         VAL_INDEX(var) = si;
 
         if (Do_At_Throws(out, body, 0)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(out, &stop)) {
                 if (stop) break;
                 goto next_iteration;
@@ -197,7 +197,7 @@ static REBFLG Loop_Series_Throws(
 //
 //  Loop_Integer_Throws: C
 //
-static REBFLG Loop_Integer_Throws(
+static REBOOL Loop_Integer_Throws(
     REBVAL *out,
     REBVAL *var,
     REBARR *body,
@@ -213,7 +213,7 @@ static REBFLG Loop_Integer_Throws(
         VAL_INT64(var) = start;
 
         if (Do_At_Throws(out, body, 0)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(out, &stop)) {
                 if (stop) break;
                 goto next_iteration;
@@ -236,7 +236,7 @@ static REBFLG Loop_Integer_Throws(
 //
 //  Loop_Number_Throws: C
 //
-static REBFLG Loop_Number_Throws(
+static REBOOL Loop_Number_Throws(
     REBVAL *out,
     REBVAL *var,
     REBARR *body,
@@ -277,7 +277,7 @@ static REBFLG Loop_Number_Throws(
         VAL_DECIMAL(var) = s;
 
         if (Do_At_Throws(out, body, 0)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(out, &stop)) {
                 if (stop) break;
                 goto next_iteration;
@@ -348,7 +348,7 @@ static REB_R Loop_All(struct Reb_Call *call_, REBINT mode)
             }
 
             if (Do_At_Throws(D_OUT, body, bodi)) {
-                REBFLG stop;
+                REBOOL stop;
                 if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                     if (stop) {
                         // Return value has been set in D_OUT, but we need
@@ -411,8 +411,8 @@ static REB_R Loop_Each(struct Reb_Call *call_, LOOP_MODE mode)
     REBINT rindex;  // read
     REBVAL *ds;
 
-    REBFLG stop = FALSE;
-    REBFLG every_true = TRUE; // need due to OPTIONS_NONE_INSTEAD_OF_UNSETS
+    REBOOL stop = FALSE;
+    REBOOL every_true = TRUE; // need due to OPTIONS_NONE_INSTEAD_OF_UNSETS
     REBOOL threw = FALSE; // did a non-BREAK or non-CONTINUE throw occur
 
     if (mode == LOOP_EVERY)
@@ -614,7 +614,7 @@ static REB_R Loop_Each(struct Reb_Call *call_, LOOP_MODE mode)
                 // Unsets "opt out" of the vote, as with ANY and ALL
             }
             else
-                every_true = every_true && IS_CONDITIONAL_TRUE(D_OUT);
+                every_true = LOGICAL(every_true && IS_CONDITIONAL_TRUE(D_OUT));
             break;
         default:
             assert(FALSE);
@@ -826,7 +826,7 @@ REBNATIVE(forever)
 
     do {
         if (DO_ARRAY_THROWS(D_OUT, block)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop) return R_OUT;
                 continue;
@@ -928,7 +928,7 @@ REBNATIVE(loop)
 
     for (; count > 0; count--) {
         if (DO_ARRAY_THROWS(D_OUT, block)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop) return R_OUT;
                 continue;
@@ -1010,7 +1010,7 @@ REBNATIVE(until)
     do {
     skip_check:
         if (DO_ARRAY_THROWS(D_OUT, block)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop) return R_OUT;
 
@@ -1080,7 +1080,7 @@ REBNATIVE(while)
         }
 
         if (DO_ARRAY_THROWS(D_OUT, body)) {
-            REBFLG stop;
+            REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop) return R_OUT;
                 continue;

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -386,7 +386,7 @@ REBINT Compare_Modify_Values(REBVAL *a, REBVAL *b, REBINT strictness)
     REBINT result;
 
     if (ta != tb) {
-        if (strictness > 1) return FALSE;
+        if (strictness > 1) return 0;
 
         switch (ta) {
         case REB_INTEGER:
@@ -443,14 +443,14 @@ REBINT Compare_Modify_Values(REBVAL *a, REBVAL *b, REBINT strictness)
             break;
         }
 
-        if (strictness == 0 || strictness == 1) return FALSE;
+        if (strictness == 0 || strictness == 1) return 0;
         //if (strictness >= 2)
         fail (Error(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b)));
     }
 
 compare:
     // At this point, both args are of the same datatype.
-    if (!(code = Compare_Types[VAL_TYPE(a)])) return FALSE;
+    if (!(code = Compare_Types[VAL_TYPE(a)])) return 0;
     result = code(a, b, strictness);
     if (result < 0) fail (Error(RE_INVALID_COMPARE, Type_Of(a), Type_Of(b)));
     return result;
@@ -645,7 +645,7 @@ REBNATIVE(maximum)
     REBVAL a, b;
 
     if (IS_PAIR(D_ARG(1)) || IS_PAIR(D_ARG(2))) {
-        Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), 1);
+        Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), TRUE);
         return R_OUT;
     }
 
@@ -670,7 +670,7 @@ REBNATIVE(minimum)
     REBVAL a, b;
 
     if (IS_PAIR(D_ARG(1)) || IS_PAIR(D_ARG(2))) {
-        Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), 0);
+        Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), FALSE);
         return R_OUT;
     }
 

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -46,14 +46,14 @@ enum {
 static REBSER *Make_Set_Operation_Series(
     const REBVAL *val1,
     const REBVAL *val2,
-    REBCNT flags,
-    REBCNT cased,
+    REBFLGS flags,
+    REBOOL cased,
     REBCNT skip
 ) {
     REBSER *buffer;     // buffer for building the return series
     REBCNT i;
-    REBINT h = TRUE;
-    REBFLG first_pass = TRUE; // are we in the first pass over the series?
+    REBINT h = 1; // used for both logic true/false and hash check
+    REBOOL first_pass = TRUE; // are we in the first pass over the series?
     REBSER *out_ser;
 
     assert(ANY_SERIES(val1));

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -169,7 +169,7 @@ REBNATIVE(spelling_of)
         // during the FORMing process
 
         VAL_RESET_HEADER(value, REB_WORD);
-        series = Copy_Mold_Value(value, TRUE);
+        series = Copy_Mold_Value(value, 0 /* opts... MOPT_0? */);
     }
 
     Val_Init_String(D_OUT, series);
@@ -239,7 +239,7 @@ REBNATIVE(checksum)
 
             if (digests[i].index == sym) {
                 REBSER *digest = Make_Series(
-                    digests[i].len + 1, sizeof(char), FALSE
+                    digests[i].len + 1, sizeof(char), MKS_NONE
                 );
 
                 LABEL_SERIES(digest, "checksum digest");

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -252,10 +252,10 @@ REBNATIVE(evoke)
                 Reb_Opts->crash_dump = TRUE;
                 break;
             case SYM_WATCH_RECYCLE:
-                Reb_Opts->watch_recycle = !Reb_Opts->watch_recycle;
+                Reb_Opts->watch_recycle = NOT(Reb_Opts->watch_recycle);
                 break;
             case SYM_WATCH_OBJ_COPY:
-                Reb_Opts->watch_obj_copy = !Reb_Opts->watch_obj_copy;
+                Reb_Opts->watch_obj_copy = NOT(Reb_Opts->watch_obj_copy);
                 break;
             case SYM_STACK_SIZE:
                 arg++;
@@ -477,7 +477,7 @@ REBNATIVE(do_codec)
             codi.extra.bits = VAL_IMAGE_BITS(val);
             codi.w = VAL_IMAGE_WIDE(val);
             codi.h = VAL_IMAGE_HIGH(val);
-            codi.alpha = Image_Has_Alpha(val, 0);
+            codi.has_alpha = Image_Has_Alpha(val, FALSE) ? 1 : 0;
         }
         else if (IS_STRING(val)) {
             codi.w = VAL_SERIES_WIDTH(val);

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -247,7 +247,7 @@ static void Write_File_Port(REBREQ *file, REBVAL *data, REBCNT len, REBCNT args)
         if (args & AM_WRITE_LINES) {
             mo.opts = 1 << MOPT_LINES;
         }
-        Mold_Value(&mo, data, 0);
+        Mold_Value(&mo, data, FALSE);
         Val_Init_String(data, mo.series); // fall into next section
         len = SERIES_LEN(mo.series);
     }

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -333,7 +333,7 @@ void Val_Init_Map(REBVAL *out, REBMAP *map)
 // 
 // Note: hash array contents (indexes) are 1-based!
 //
-REBSER *Hash_Block(const REBVAL *block, REBCNT skip, REBCNT cased)
+REBSER *Hash_Block(const REBVAL *block, REBCNT skip, REBOOL cased)
 {
     REBCNT n;
     REBSER *hashlist;

--- a/src/core/s-file.c
+++ b/src/core/s-file.c
@@ -49,7 +49,7 @@
 // REBDIFF: No longer appends current dir to volume when no
 // root slash is provided (that odd MSDOS c:file case).
 //
-REBSER *To_REBOL_Path(const void *p, REBCNT len, REBFLG flags)
+REBSER *To_REBOL_Path(const void *p, REBCNT len, REBFLGS flags)
 {
     REBOOL saw_colon = FALSE;  // have we hit a ':' yet?
     REBOOL saw_slash = FALSE; // have we hit a '/' yet?
@@ -74,7 +74,9 @@ REBSER *To_REBOL_Path(const void *p, REBCNT len, REBFLG flags)
     // instance) the target is going to be used as a Win32 native string.
     //
     assert(
-        (flags & PATH_OPT_FORCE_UNI_DEST) ? (flags & PATH_OPT_UNI_SRC) : TRUE
+        (flags & PATH_OPT_FORCE_UNI_DEST)
+            ? LOGICAL(flags & PATH_OPT_UNI_SRC)
+            : TRUE
     );
     dst = ((flags & PATH_OPT_FORCE_UNI_DEST) || (unicode && Is_Wide(up, len)))
         ? Make_Unicode(len + FN_PAD)
@@ -273,7 +275,7 @@ REBSER *Value_To_Local_Path(REBVAL *val, REBOOL full)
 {
     assert(ANY_BINSTR(val));
     return To_Local_Path(
-        VAL_DATA_AT(val), VAL_LEN_AT(val), !VAL_BYTE_SIZE(val), full
+        VAL_DATA_AT(val), VAL_LEN_AT(val), NOT(VAL_BYTE_SIZE(val)), full
     );
 }
 
@@ -283,7 +285,7 @@ REBSER *Value_To_Local_Path(REBVAL *val, REBOOL full)
 // 
 // Helper to above function.
 //
-REBSER *Value_To_OS_Path(REBVAL *val, REBFLG full)
+REBSER *Value_To_OS_Path(REBVAL *val, REBOOL full)
 {
     REBSER *ser; // will be unicode size
 #ifndef TO_WINDOWS
@@ -293,7 +295,7 @@ REBSER *Value_To_OS_Path(REBVAL *val, REBFLG full)
     assert(ANY_BINSTR(val));
 
     ser = To_Local_Path(
-        VAL_DATA_AT(val), VAL_LEN_AT(val), (REBOOL)!VAL_BYTE_SIZE(val), full
+        VAL_DATA_AT(val), VAL_LEN_AT(val), NOT(VAL_BYTE_SIZE(val)), full
     );
 
 #ifndef TO_WINDOWS

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -106,7 +106,7 @@ const REBYTE *Match_Bytes(const REBYTE *src, const REBYTE *pat)
 // Return TRUE if s1 is a subpath of s2.
 // Case insensitive.
 //
-REBFLG Match_Sub_Path(REBSER *s1, REBSER *s2)
+REBOOL Match_Sub_Path(REBSER *s1, REBSER *s2)
 {
     REBCNT len = SERIES_LEN(s1);
     REBCNT n;
@@ -132,7 +132,7 @@ REBFLG Match_Sub_Path(REBSER *s1, REBSER *s2)
 
     // a/b matches: a/b, a/b/, a/b/c
     c2 = GET_ANY_CHAR(s2, n);
-    return (
+    return LOGICAL(
             n >= len  // all chars matched
             &&  // Must be at end or at dir sep:
             (c1 == '/' || c1 == '\\'
@@ -300,7 +300,7 @@ REBINT Compare_UTF8(const REBYTE *s1, const REBYTE *s2, REBCNT l2)
 // 
 // NOTE: Series tail must be > index.
 //
-REBCNT Find_Byte_Str(REBSER *series, REBCNT index, REBYTE *b2, REBCNT l2, REBFLG uncase, REBFLG match)
+REBCNT Find_Byte_Str(REBSER *series, REBCNT index, REBYTE *b2, REBCNT l2, REBOOL uncase, REBOOL match)
 {
     REBYTE *b1;
     REBYTE *e1;
@@ -367,7 +367,7 @@ REBCNT Find_Str_Str(REBSER *ser1, REBCNT head, REBCNT index, REBCNT tail, REBINT
     REBUNI c2;
     REBUNI c3;
     REBCNT n = 0;
-    REBOOL uncase = !(flags & AM_FIND_CASE); // uncase = case insenstive
+    REBOOL uncase = NOT(flags & AM_FIND_CASE); // case insenstive
 
     c2 = GET_ANY_CHAR(ser2, index2); // starting char
     if (uncase && c2 < UNICODE_CASES) c2 = LO_CASE(c2);
@@ -413,7 +413,7 @@ REBCNT Find_Str_Str(REBSER *ser1, REBCNT head, REBCNT index, REBCNT tail, REBINT
 REBCNT Find_Str_Char(REBSER *ser, REBCNT head, REBCNT index, REBCNT tail, REBINT skip, REBUNI c2, REBCNT flags)
 {
     REBUNI c1;
-    REBOOL uncase = !GET_FLAG(flags, ARG_FIND_CASE-1); // uncase = case insenstive
+    REBOOL uncase = NOT(GET_FLAG(flags, ARG_FIND_CASE - 1)); // case insensitive
 
     if (uncase && c2 < UNICODE_CASES) c2 = LO_CASE(c2);
 
@@ -445,7 +445,7 @@ REBCNT Find_Str_Char(REBSER *ser, REBCNT head, REBCNT index, REBCNT tail, REBINT
 REBCNT Find_Str_Bitset(REBSER *ser, REBCNT head, REBCNT index, REBCNT tail, REBINT skip, REBSER *bset, REBCNT flags)
 {
     REBUNI c1;
-    REBOOL uncase = !GET_FLAG(flags, ARG_FIND_CASE-1); // uncase = case insenstive
+    REBOOL uncase = NOT(GET_FLAG(flags, ARG_FIND_CASE - 1)); // case insensitive
 
     for (; index >= head && index < tail; index += skip) {
 

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -191,7 +191,7 @@ void Insert_Char(REBSER *dst, REBCNT index, REBCNT chr)
 // Source and/or destination can be 1 or 2 bytes wide.
 // If destination is not wide enough, it will be widened.
 //
-void Insert_String(REBSER *dst, REBCNT idx, const REBSER *src, REBCNT pos, REBCNT len, REBFLG no_expand)
+void Insert_String(REBSER *dst, REBCNT idx, const REBSER *src, REBCNT pos, REBCNT len, REBOOL no_expand)
 {
     REBUNI *up;
     REBYTE *bp;
@@ -489,7 +489,7 @@ void Append_Uni_Uni(REBSER *dst, const REBUNI *src, REBCNT len)
 //
 void Append_String(REBSER *dst, const REBSER *src, REBCNT i, REBCNT len)
 {
-    Insert_String(dst, SERIES_LEN(dst), src, i, len, 0);
+    Insert_String(dst, SERIES_LEN(dst), src, i, len, FALSE);
 }
 
 

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -299,7 +299,7 @@ REBSER *Complement_Binary(REBVAL *value)
 // Randomize a string. Return a new string series.
 // Handles both BYTE and UNICODE strings.
 //
-void Shuffle_String(REBVAL *value, REBFLG secure)
+void Shuffle_String(REBVAL *value, REBOOL secure)
 {
     REBCNT n;
     REBCNT k;
@@ -334,7 +334,7 @@ static REBYTE seed_str[SEED_LEN] = {
 // 
 // The key (kp) is passed as a REBVAL or REBYTE (when klen is !0).
 //
-REBOOL Cloak(REBOOL decode, REBYTE *cp, REBCNT dlen, REBYTE *kp, REBCNT klen, REBFLG as_is)
+REBOOL Cloak(REBOOL decode, REBYTE *cp, REBCNT dlen, REBYTE *kp, REBCNT klen, REBOOL as_is)
 {
     REBCNT i, n;
     REBYTE src[20];
@@ -395,7 +395,7 @@ REBOOL Cloak(REBOOL decode, REBYTE *cp, REBCNT dlen, REBYTE *kp, REBCNT klen, RE
 //
 void Trim_Tail(REBSER *src, REBYTE chr)
 {
-    REBOOL unicode = !BYTE_SIZE(src);
+    REBOOL unicode = NOT(BYTE_SIZE(src));
     REBCNT tail;
     REBUNI c;
 

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -29,7 +29,7 @@
 
 #include "sys-core.h"
 
-static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
+static REBOOL find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 {
     while (len-- > 0) if (*up++ == c) return TRUE;
     return FALSE;
@@ -199,7 +199,7 @@ static void trim_lines(REBSER *ser, REBCNT index, REBCNT tail)
 // Trim from head and tail of each line, trim any leading or
 // trailing lines as well, leaving one at the end if present
 //
-static void trim_head_tail(REBSER *ser, REBCNT index, REBCNT tail, REBFLG h, REBFLG t)
+static void trim_head_tail(REBSER *ser, REBCNT index, REBCNT tail, REBOOL h, REBOOL t)
 {
     REBCNT out = index;
     REBOOL append_line_feed = FALSE;
@@ -289,6 +289,12 @@ void Trim_String(REBSER *ser, REBCNT index, REBCNT len, REBCNT flags, REBVAL *wi
         trim_lines(ser, index, tail);
     }
     else {
-        trim_head_tail(ser, index, tail, flags & AM_TRIM_HEAD, flags & AM_TRIM_TAIL);
+        trim_head_tail(
+            ser,
+            index,
+            tail,
+            LOGICAL(flags & AM_TRIM_HEAD),
+            LOGICAL(flags & AM_TRIM_TAIL)
+        );
     }
 }

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -738,9 +738,9 @@ REBINT What_UTF(REBYTE *bp, REBCNT len)
 // 
 // Returns TRUE if char is legal.
 //
-REBFLG Legal_UTF8_Char(const REBYTE *str, REBCNT len)
+REBOOL Legal_UTF8_Char(const REBYTE *str, REBCNT len)
 {
-    return isLegalUTF8Sequence(str, str + len);
+    return LOGICAL(isLegalUTF8Sequence(str, str + len));
 }
 
 
@@ -982,10 +982,18 @@ REBSER *Decode_UTF_String(REBYTE *bp, REBCNT len, REBINT utf)
     }
 
     if (utf == 0 || utf == 8) {
-        size = Decode_UTF8((REBUNI*)Reset_Buffer(ser, len), bp, len, TRUE);
+        size = Decode_UTF8(
+            cast(REBUNI*, Reset_Buffer(ser, len)), bp, len, TRUE
+        );
     }
     else if (utf == -16 || utf == 16) {
-        size = Decode_UTF16((REBUNI*)Reset_Buffer(ser, len/2 + 1), bp, len, utf < 0, TRUE);
+        size = Decode_UTF16(
+            cast(REBUNI*, Reset_Buffer(ser, (len / 2) + 1)),
+            bp,
+            len,
+            LOGICAL(utf < 0),
+            TRUE
+        );
     }
     else {
         // Encoding is unsupported or not yet implemented.
@@ -1011,7 +1019,7 @@ REBSER *Decode_UTF_String(REBYTE *bp, REBCNT len, REBINT utf)
 // 
 // Returns how long the UTF8 encoded string would be.
 //
-REBCNT Length_As_UTF8(const void *p, REBCNT len, REBFLG opts)
+REBCNT Length_As_UTF8(const void *p, REBCNT len, REBFLGS opts)
 {
     REBCNT size = 0;
     REBCNT c;
@@ -1089,7 +1097,7 @@ REBCNT Encode_UTF8(
     REBCNT max,
     const void *src,
     REBCNT *len,
-    REBFLG opts
+    REBFLGS opts
 ) {
     REBUNI c;
     REBINT n;
@@ -1183,8 +1191,12 @@ int Encode_UTF8_Line(REBSER *dst, REBSER *src, REBCNT idx)
 // null-terminated series. Can reserve extra bytes of space.
 // Resulting series must be either freed or handed to the GC.
 //
-REBSER *Make_UTF8_Binary(const void *data, REBCNT len, REBCNT extra, REBFLG opts)
-{
+REBSER *Make_UTF8_Binary(
+    const void *data,
+    REBCNT len,
+    REBCNT extra,
+    REBFLGS opts
+) {
     REBCNT size = Length_As_UTF8(data, len, opts);
     REBSER *series = Make_Binary(size + extra);
     SET_SERIES_LEN(series, Encode_UTF8(
@@ -1203,8 +1215,11 @@ REBSER *Make_UTF8_Binary(const void *data, REBCNT len, REBCNT extra, REBFLG opts
 // size ANY-STRING! value to a UTF8-encoded series.  Resulting
 // series must be either freed or handed to the GC.
 //
-REBSER *Make_UTF8_From_Any_String(const REBVAL *value, REBCNT len, REBFLG opts)
-{
+REBSER *Make_UTF8_From_Any_String(
+    const REBVAL *value,
+    REBCNT len,
+    REBFLGS opts
+) {
     assert(ANY_STR(value));
 
     if (!(opts & OPT_ENC_CRLF) && VAL_STR_IS_ASCII(value)) {

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -49,7 +49,7 @@ REBINT CT_Array(REBVAL *a, REBVAL *b, REBINT mode)
     if (mode == 3)
         return VAL_SERIES(a) == VAL_SERIES(b) && VAL_INDEX(a) == VAL_INDEX(b);
 
-    num = Cmp_Block(a, b, mode > 1);
+    num = Cmp_Block(a, b, LOGICAL(mode > 1));
     if (mode >= 0) return (num == 0);
     if (mode == -1) return (num >= 0);
     return (num > 0);
@@ -74,7 +74,7 @@ static void No_Nones(REBVAL *arg) {
 //     MT_Get_Path
 //     MT_Lit_Path
 //
-REBFLG MT_Array(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Array(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     REBCNT i;
 
@@ -163,7 +163,8 @@ REBCNT Find_In_Array(
             cnt = 0;
             value = ARRAY_AT(array, index);
             for (val = VAL_ARRAY_AT(target); NOT_END(val); val++, value++) {
-                if (0 != Cmp_Value(value, val, (REBOOL)(flags & AM_FIND_CASE))) break;
+                if (0 != Cmp_Value(value, val, LOGICAL(flags & AM_FIND_CASE)))
+                    break;
                 if (++cnt >= len) {
                     return index;
                 }
@@ -194,7 +195,8 @@ REBCNT Find_In_Array(
     else {
         for (; index >= start && index < end; index += skip) {
             value = ARRAY_AT(array, index);
-            if (0 == Cmp_Value(value, target, (REBOOL)(flags & AM_FIND_CASE))) return index;
+            if (0 == Cmp_Value(value, target, LOGICAL(flags & AM_FIND_CASE)))
+                return index;
             if (flags & AM_FIND_MATCH) break;
         }
         return NOT_FOUND;
@@ -283,8 +285,8 @@ done:
 // WARNING! Not re-entrant. !!!  Must find a way to push it on stack?
 // Fields initialized to zero due to global scope
 static struct {
-    REBFLG cased;
-    REBFLG reverse;
+    REBOOL cased;
+    REBOOL reverse;
     REBCNT offset;
     REBVAL *compare;
 } sort_flags;
@@ -392,12 +394,12 @@ static int Compare_Call(void *thunk, const void *v1, const void *v2)
 //
 static void Sort_Block(
     REBVAL *block,
-    REBFLG ccase,
+    REBOOL ccase,
     REBVAL *skipv,
     REBVAL *compv,
     REBVAL *part,
-    REBFLG all,
-    REBFLG rev
+    REBOOL all,
+    REBOOL rev
 ) {
     REBCNT len;
     REBCNT skip = 1;
@@ -475,7 +477,7 @@ static void Trim_Array(REBARR *array, REBCNT index, REBCNT flags)
 //
 //  Shuffle_Block: C
 //
-void Shuffle_Block(REBVAL *value, REBFLG secure)
+void Shuffle_Block(REBVAL *value, REBOOL secure)
 {
     REBCNT n;
     REBCNT k;

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -43,7 +43,7 @@ REBINT CT_Datatype(REBVAL *a, REBVAL *b, REBINT mode)
 //
 //  MT_Datatype: C
 //
-REBFLG MT_Datatype(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Datatype(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     REBCNT sym;
     if (!IS_WORD(data)) return FALSE;

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -68,7 +68,7 @@ REBINT Cmp_Event(const REBVAL *t1, const REBVAL *t2)
 //
 //  Set_Event_Var: C
 //
-static REBFLG Set_Event_Var(REBVAL *value, const REBVAL *word, const REBVAL *val)
+static REBOOL Set_Event_Var(REBVAL *value, const REBVAL *word, const REBVAL *val)
 {
     REBVAL *arg;
     REBINT n;
@@ -207,7 +207,7 @@ static void Set_Event_Vars(REBVAL *evt, REBVAL *blk)
 //
 //  Get_Event_Var: C
 //
-static REBFLG Get_Event_Var(const REBVAL *value, REBCNT sym, REBVAL *val)
+static REBOOL Get_Event_Var(const REBVAL *value, REBCNT sym, REBVAL *val)
 {
     REBVAL *arg;
     REBREQ *req;
@@ -359,7 +359,7 @@ is_none:
 //
 //  MT_Event: C
 //
-REBFLG MT_Event(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Event(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     if (IS_BLOCK(data)) {
         CLEARS(out);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -44,7 +44,7 @@ static REBOOL Same_Func(REBVAL *val, REBVAL *arg)
 //
 REBINT CT_Function(REBVAL *a, REBVAL *b, REBINT mode)
 {
-    if (mode >= 0) return Same_Func(a, b);
+    if (mode >= 0) return Same_Func(a, b) ? 1 : 0;
     return -1;
 }
 
@@ -65,7 +65,7 @@ REBINT CT_Function(REBVAL *a, REBVAL *b, REBINT mode)
 // 
 // See notes in Make_Command() regarding that mechanism and meaning.
 //
-REBFLG MT_Function(REBVAL *out, REBVAL *def, enum Reb_Kind type)
+REBOOL MT_Function(REBVAL *out, REBVAL *def, enum Reb_Kind type)
 {
     REBVAL *spec;
     REBCNT len;
@@ -94,7 +94,7 @@ REBFLG MT_Function(REBVAL *out, REBVAL *def, enum Reb_Kind type)
         // Spec-constructed functions do *not* have definitional returns
         // added automatically.  They are part of the generators.
 
-        REBFLG has_return = FALSE;
+        REBOOL has_return = FALSE;
 
         if (len != 2) return FALSE;
 
@@ -155,7 +155,7 @@ REBTYPE(Function)
                 // complicit in the "lie" about the effective bodies of the
                 // functions made by the optimized generators FUNC and CLOS...
 
-                REBFLG is_fake;
+                REBOOL is_fake;
                 REBARR *body = Get_Maybe_Fake_Func_Body(&is_fake, value);
                 Val_Init_Block(D_OUT, Copy_Array_Deep_Managed(body));
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -94,7 +94,7 @@ REBINT Cmp_Gob(const REBVAL *g1, const REBVAL *g2)
 //
 //  Set_Pair: C
 //
-static REBFLG Set_Pair(REBXYF *pair, const REBVAL *val)
+static REBOOL Set_Pair(REBXYF *pair, const REBVAL *val)
 {
     if (IS_PAIR(val)) {
         pair->x = VAL_PAIR_X(val);
@@ -161,7 +161,7 @@ static void Detach_Gob(REBGOB *gob)
 // If index >= tail, an append occurs. Each gob has its parent
 // gob field set. (Call Detach_Gobs() before inserting.)
 //
-static void Insert_Gobs(REBGOB *gob, const REBVAL *arg, REBCNT index, REBCNT len, REBFLG change)
+static void Insert_Gobs(REBGOB *gob, const REBVAL *arg, REBCNT index, REBCNT len, REBOOL change)
 {
     REBGOB **ptr;
     REBCNT n, count;
@@ -341,7 +341,7 @@ static void Set_Gob_Flag(REBGOB *gob, const REBVAL *word)
 //
 //  Set_GOB_Var: C
 //
-static REBFLG Set_GOB_Var(REBGOB *gob, const REBVAL *word, const REBVAL *val)
+static REBOOL Set_GOB_Var(REBGOB *gob, const REBVAL *word, const REBVAL *val)
 {
     switch (VAL_WORD_CANON(word)) {
     case SYM_OFFSET:
@@ -411,9 +411,11 @@ static REBFLG Set_GOB_Var(REBGOB *gob, const REBVAL *word, const REBVAL *val)
     case SYM_PANE:
         if (GOB_PANE(gob)) Clear_Series(GOB_PANE(gob));
         if (IS_BLOCK(val))
-            Insert_Gobs(gob, VAL_ARRAY_AT(val), 0, VAL_ARRAY_LEN_AT(val), 0);
+            Insert_Gobs(
+                gob, VAL_ARRAY_AT(val), 0, VAL_ARRAY_LEN_AT(val), FALSE
+            );
         else if (IS_GOB(val))
-            Insert_Gobs(gob, val, 0, 1, 0);
+            Insert_Gobs(gob, val, 0, 1, FALSE);
         else if (IS_NONE(val))
             gob->pane = 0;
         else
@@ -481,7 +483,7 @@ static REBFLG Set_GOB_Var(REBGOB *gob, const REBVAL *word, const REBVAL *val)
 //
 //  Get_GOB_Var: C
 //
-static REBFLG Get_GOB_Var(REBGOB *gob, const REBVAL *word, REBVAL *val)
+static REBOOL Get_GOB_Var(REBGOB *gob, const REBVAL *word, REBVAL *val)
 {
     switch (VAL_WORD_CANON(word)) {
 
@@ -666,7 +668,7 @@ REBARR *Gob_To_Array(REBGOB *gob)
 //
 //  MT_Gob: C
 //
-REBFLG MT_Gob(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Gob(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     REBGOB *ngob;
 
@@ -810,7 +812,7 @@ REBTYPE(Gob)
         ) {
             fail (Error(RE_NOT_DONE));
         }
-        Insert_Gobs(gob, arg, index, 1, 0);
+        Insert_Gobs(gob, arg, index, 1, FALSE);
         //ngob = *GOB_AT(gob, index);
         //GOB_PARENT(ngob) = 0;
         //*GOB_AT(gob, index) = VAL_GOB(arg);
@@ -832,7 +834,7 @@ REBTYPE(Gob)
             arg = VAL_ARRAY_AT(arg);
         }
         else goto is_arg_error;;
-        Insert_Gobs(gob, arg, index, len, 0);
+        Insert_Gobs(gob, arg, index, len, FALSE);
         break;
 
     case A_CLEAR:

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -131,7 +131,7 @@ void Value_To_Int64(REBI64 *out, const REBVAL *value, REBOOL no_sign)
 
         // default signedness interpretation to high-bit of first byte, but
         // override if the function was called with `no_sign`
-        negative = no_sign ? FALSE : *bp >= 0x80;
+        negative = no_sign ? FALSE : LOGICAL(*bp >= 0x80);
 
         // Consume any leading 0x00 bytes (or 0xFF if negative)
         while (n != 0 && *bp == (negative ? 0xFF : 0x00)) {
@@ -293,7 +293,7 @@ REBTYPE(Integer)
     REBI64 p;
     REBU64 a, b; // for overflow detection
     REBCNT a1, a0, b1, b0;
-    REBFLG sgn;
+    REBOOL sgn;
     REBI64 anum;
 
     num = VAL_INT64(val);
@@ -322,7 +322,7 @@ REBTYPE(Integer)
             case A_DIVIDE:
             case A_REMAINDER:
             case A_POWER:
-                if (IS_DECIMAL(val2) | IS_PERCENT(val2)) {
+                if (IS_DECIMAL(val2) || IS_PERCENT(val2)) {
                     SET_DECIMAL(val, (REBDEC)num); // convert main arg
                     return T_Decimal(call_, action);
                 }
@@ -444,7 +444,7 @@ REBTYPE(Integer)
             return R_UNSET;
         }
         if (num == 0) break;
-        num = Random_Range(num, (REBOOL)D_REF(3));  //!!! 64 bits
+        num = Random_Range(num, D_REF(3));  //!!! 64 bits
 #ifdef OLD_METHOD
         if (num < 0)  num = -(1 + (REBI64)(arg % -num));
         else          num =   1 + (REBI64)(arg % num);

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -42,7 +42,7 @@ REBINT CT_None(REBVAL *a, REBVAL *b, REBINT mode)
 //
 //  MT_None: C
 //
-REBFLG MT_None(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_None(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     VAL_RESET_HEADER(out, type);
     return TRUE;

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -276,8 +276,8 @@ static REBFRM *Trim_Frame(REBFRM *frame)
 REBINT CT_Object(REBVAL *a, REBVAL *b, REBINT mode)
 {
     if (mode < 0) return -1;
-    if (mode == 3) return Same_Object(a, b);
-    return Equal_Object(a, b);
+    if (mode == 3) return Same_Object(a, b) ? 1 : 0;
+    return Equal_Object(a, b) ? 1 : 0;
 }
 
 
@@ -295,7 +295,7 @@ REBINT CT_Frame(REBVAL *a, REBVAL *b, REBINT mode)
 //
 //  MT_Object: C
 //
-REBFLG MT_Object(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Object(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     REBFRM *frame;
     if (!IS_BLOCK(data)) return FALSE;

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -48,7 +48,7 @@ REBINT CT_Pair(REBVAL *a, REBVAL *b, REBINT mode)
 //
 //  MT_Pair: C
 //
-REBFLG MT_Pair(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Pair(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     REBD32 x;
     REBD32 y;
@@ -99,7 +99,7 @@ REBINT Cmp_Pair(const REBVAL *t1, const REBVAL *t2)
 //
 //  Min_Max_Pair: C
 //
-void Min_Max_Pair(REBVAL *out, const REBVAL *a, const REBVAL *b, REBFLG maxed)
+void Min_Max_Pair(REBVAL *out, const REBVAL *a, const REBVAL *b, REBOOL maxed)
 {
     REBXYF aa;
     REBXYF bb;
@@ -283,8 +283,8 @@ REBTYPE(Pair)
 
         case A_RANDOM:
             if (D_REF(2)) fail (Error(RE_BAD_REFINES)); // seed
-            x1 = (REBD32)Random_Range((REBINT)x1, (REBOOL)D_REF(3));
-            y1 = (REBD32)Random_Range((REBINT)y1, (REBOOL)D_REF(3));
+            x1 = cast(REBD32, Random_Range(cast(REBINT, x1), D_REF(3)));
+            y1 = cast(REBD32, Random_Range(cast(REBINT, y1), D_REF(3)));
             goto setPair;
 
         case A_PICK:

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -43,7 +43,7 @@ REBINT CT_Port(REBVAL *a, REBVAL *b, REBINT mode)
 //
 //  MT_Port: C
 //
-REBFLG MT_Port(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Port(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     return FALSE;
 }

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1117,14 +1117,14 @@ static void callback_dispatcher(
 //     abi: word "note"
 // ] lib "name"]
 //
-REBFLG MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     //RL_Print("%s, %d\n", __func__, __LINE__);
     ffi_type ** args = NULL;
     REBVAL *blk = NULL;
     REBCNT eval_idx = 0; /* for spec block evaluation */
     REBSER *extra_mem = NULL;
-    REBFLG ret = TRUE;
+    REBOOL ret = TRUE;
     CFUNC *func = NULL;
     REBCNT n = 1; /* arguments start with the index 1 (return type has a index of 0) */
     REBCNT has_return = 0;

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -126,7 +126,7 @@ static REBOOL get_scalar(const REBSTU *stu,
 //
 //  Get_Struct_Var: C
 //
-static REBFLG Get_Struct_Var(REBSTU *stu, REBVAL *word, REBVAL *val)
+static REBOOL Get_Struct_Var(REBSTU *stu, REBVAL *word, REBVAL *val)
 {
     struct Struct_Field *field = NULL;
     REBCNT i = 0;
@@ -360,7 +360,7 @@ static REBOOL assign_scalar(REBSTU *stu,
 //
 //  Set_Struct_Var: C
 //
-static REBFLG Set_Struct_Var(REBSTU *stu, REBVAL *word, REBVAL *elem, REBVAL *val)
+static REBOOL Set_Struct_Var(REBSTU *stu, REBVAL *word, REBVAL *elem, REBVAL *val)
 {
     struct Struct_Field *field = NULL;
     REBCNT i = 0;
@@ -570,7 +570,7 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
             case SYM_STRUCT_TYPE:
                 ++ val;
                 if (IS_BLOCK(val)) {
-                    REBFLG res;
+                    REBOOL res;
 
                     res = MT_Struct(inner, val, REB_STRUCT);
 
@@ -620,11 +620,11 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
             fail (Error_Unexpected_Type(REB_INTEGER, VAL_TYPE(val)));
 
         field->dimension = cast(REBCNT, VAL_INT64(&ret));
-        field->array = TRUE;
+        field->array = 1; // TRUE, but bitfield must be integer
         ++ val;
     } else {
         field->dimension = 1; /* scalar */
-        field->array = FALSE;
+        field->array = 0; // FALSE, but bitfield must be integer
     }
 
     if (NOT_END(val))
@@ -644,7 +644,7 @@ static REBOOL parse_field_type(struct Struct_Field *field, REBVAL *spec, REBVAL 
 //         field4: [type1[3]]
 //         ...
 //     ]
-REBFLG MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     //RL_Print("%s\n", __func__);
     REBINT max_fields = 16;
@@ -814,7 +814,7 @@ REBFLG MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
             if (offset > VAL_STRUCT_LIMIT)
                 fail (Error(RE_SIZE_LIMIT, out));
 
-            field->done = TRUE;
+            field->done = 1; // TRUE, but bitfields must be integer
 
             ++ field_idx;
 

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -46,7 +46,7 @@ REBINT CT_Tuple(REBVAL *a, REBVAL *b, REBINT mode)
 //
 //  MT_Tuple: C
 //
-REBFLG MT_Tuple(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Tuple(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     REBYTE  *vp;
     REBINT len = 0;
@@ -379,7 +379,8 @@ REBTYPE(Tuple)
             if (len > MAX_TUPLE) goto bad_arg; // valid even for UTF-8
             VAL_TUPLE_LEN(value) = len;
             for (alen = 0; alen < len; alen++) {
-                if (!Scan_Hex2(ap, &c, 0)) goto bad_arg;
+                const REBOOL unicode = FALSE;
+                if (!Scan_Hex2(ap, &c, unicode)) goto bad_arg;
                 *vp++ = (REBYTE)c;
                 ap += 2;
             }

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -135,7 +135,7 @@ REBCNT *VAL_TYPESET_SYM_Ptr_Debug(const REBVAL *typeset)
 // block - block of datatypes (datatype words ok too)
 // value - value to hold result (can be word-spec type too)
 //
-REBFLG Make_Typeset(REBVAL *block, REBVAL *value, REBFLG load)
+REBOOL Make_Typeset(REBVAL *block, REBVAL *value, REBOOL load)
 {
     const REBVAL *val;
     REBCNT sym;
@@ -175,7 +175,7 @@ REBFLG Make_Typeset(REBVAL *block, REBVAL *value, REBFLG load)
 //
 //  MT_Typeset: C
 //
-REBFLG MT_Typeset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Typeset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     if (!IS_BLOCK(data)) return FALSE;
 
@@ -196,7 +196,7 @@ REBINT Find_Typeset(REBVAL *block)
     REBINT n;
 
     VAL_RESET_HEADER(&value, REB_TYPESET);
-    Make_Typeset(block, &value, 0);
+    Make_Typeset(block, &value, FALSE);
 
     val = VAL_ARRAY_AT_HEAD(ROOT_TYPESETS, 1);
 
@@ -263,7 +263,7 @@ REBTYPE(Typeset)
     case A_TO:
         if (IS_BLOCK(arg)) {
             VAL_RESET_HEADER(D_OUT, REB_TYPESET);
-            Make_Typeset(VAL_ARRAY_AT(arg), D_OUT, 0);
+            Make_Typeset(VAL_ARRAY_AT(arg), D_OUT, FALSE);
             return R_OUT;
         }
     //  if (IS_NONE(arg)) {

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -259,7 +259,7 @@ REBINT Compare_Vector(const REBVAL *v1, const REBVAL *v2)
 //
 //  Shuffle_Vector: C
 //
-void Shuffle_Vector(REBVAL *vect, REBFLG secure)
+void Shuffle_Vector(REBVAL *vect, REBOOL secure)
 {
     REBCNT n;
     REBCNT k;
@@ -433,7 +433,7 @@ REBVAL *Make_Vector_Spec(REBVAL *bp, REBVAL *value)
 //
 //  MT_Vector: C
 //
-REBFLG MT_Vector(REBVAL *out, REBVAL *data, enum Reb_Kind type)
+REBOOL MT_Vector(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 {
     if (Make_Vector_Spec(data, out)) return TRUE;
     return FALSE;
@@ -608,7 +608,7 @@ bad_make:
 //
 //  Mold_Vector: C
 //
-void Mold_Vector(const REBVAL *value, REB_MOLD *mold, REBFLG molded)
+void Mold_Vector(const REBVAL *value, REB_MOLD *mold, REBOOL molded)
 {
     REBSER *vect = VAL_SERIES(value);
     REBYTE *data = SERIES_DATA(vect);

--- a/src/core/u-bmp.c
+++ b/src/core/u-bmp.c
@@ -143,7 +143,7 @@ typedef RGBQUAD *RGBQUADPTR;
 
 //**********************************************************************
 
-static int longaligned(void) {
+static REBOOL longaligned(void) {
     static char filldata[] = {0,0,1,1,1,1};
     struct {
         unsigned short a;

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -95,7 +95,7 @@ static REBFRM *Error_Compression(const z_stream *strm, int ret)
 // 
 // !!! Does not expose the "streaming" ability of zlib.
 //
-REBSER *Compress(REBSER *input, REBINT index, REBCNT len, REBFLG gzip, REBFLG raw)
+REBSER *Compress(REBSER *input, REBINT index, REBCNT len, REBOOL gzip, REBOOL raw)
 {
     REBCNT buf_size;
     REBSER *output;
@@ -192,8 +192,8 @@ REBSER *Decompress(
     const REBYTE *input,
     REBCNT len,
     REBINT max,
-    REBFLG gzip,
-    REBFLG raw
+    REBOOL gzip,
+    REBOOL raw
 ) {
     REBOL_STATE state;
     REBFRM *error;

--- a/src/core/u-gif.c
+++ b/src/core/u-gif.c
@@ -271,7 +271,7 @@ void Decode_GIF_Image(REBCDI *codi)
         if (c != ',') continue;
 
         image_count++;
-        interlaced = (cp[8] & 0x40) != 0;
+        interlaced = LOGICAL(cp[8] & 0x40);
         local_colormap = cp[8] & 0x80;
 
         w = LSBFirstOrder(cp[4],cp[5]);

--- a/src/core/u-jpg.c
+++ b/src/core/u-jpg.c
@@ -5,6 +5,19 @@
 #include <setjmp.h>
 #include "sys-jpg.h"
 
+#ifdef STRICT_BOOL_COMPILER_TEST
+    //
+    // This is third party code that is not written to use REBOOL, and hence
+    // the definitions of TRUE and FALSE used in the "fake" build will trip
+    // it up.  We substitute in normal definitions for this file.  See
+    // the explanations of this test in %reb-c.h for more information.
+    //
+    #undef TRUE
+    #undef FALSE
+    #define TRUE 1
+    #define FALSE 0
+#endif
+
 /*
  * jdatasrc.c
  *

--- a/src/core/u-png.c
+++ b/src/core/u-png.c
@@ -32,6 +32,19 @@
 #include "sys-zlib.h"
 #include <ctype.h> // remove this later !!!!
 
+#ifdef STRICT_BOOL_COMPILER_TEST
+    //
+    // This is third party code that is not written to use REBOOL, and hence
+    // the definitions of TRUE and FALSE used in the "fake" build will trip
+    // it up.  We substitute in normal definitions for this file.  See
+    // the explanations of this test in %reb-c.h for more information.
+    //
+    #undef TRUE
+    #undef FALSE
+    #define TRUE 1
+    #define FALSE 0
+#endif
+
 #if defined(ENDIAN_LITTLE)
 #define CVT_END_L(a) a=(a<<24)|(((a>>8)&255)<<16)|(((a>>16)&255)<<8)|(a>>24)
 #elif defined(ENDIAN_BIG)
@@ -560,7 +573,7 @@ int png_info(unsigned char *buffer, int nbytes, int *w, int *h) {
     return 1;
 }
 
-void png_load(unsigned char *buffer, int nbytes, char *output, REBOOL *alpha) {
+void png_load(unsigned char *buffer, int nbytes, char *output, BOOL *alpha) {
     unsigned char *p;
     int length,ret,adam7pass;
     int awidth,aheight,r,comp_awidth;
@@ -715,12 +728,12 @@ void Encode_PNG_Image(REBCDI *codi)
     unsigned char *linebuf,*cp;
     int x,y,imgsize,ret;
     REBCNT *dp,cv;
-    REBOOL hasalpha;
+    int hasalpha;
 //  z_stream zstream={0}; // Ren/C: changed for -Wmissing-field-initializers
     z_stream zstream;
     memset(&zstream, '\0', sizeof(zstream));
 
-    hasalpha = codi->alpha;
+    hasalpha = codi->has_alpha;
 
     ihdr.width=w;
     CVT_END_L(ihdr.width);
@@ -823,7 +836,7 @@ error:
 void Decode_PNG_Image(REBCDI *codi)
 {
     int w, h;
-    REBOOL alpha = 0;
+    BOOL alpha = 0;
 
     if (!png_info(codi->data, codi->len, &w, &h )) trap_png();
     codi->w = w;

--- a/src/include/reb-args.h
+++ b/src/include/reb-args.h
@@ -29,7 +29,7 @@
 
 // REBOL startup option structure:
 typedef struct rebol_args {
-    REBCNT options;
+    REBFLGS options;
     REBCHR *script;
     REBCHR **args;
     REBCHR *do_arg;

--- a/src/include/reb-codec.h
+++ b/src/include/reb-codec.h
@@ -50,7 +50,7 @@ typedef struct reb_codec_image {
     int w;
     int h;
     unsigned int len;
-    int alpha;
+    int has_alpha; // files referring to this are third party (no REBOOL)
     unsigned char *data;
     union {
         u32 *bits;

--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -146,7 +146,7 @@ Special internal defines used by RT, not Host-Kit developers:
     #define WIN32_LEAN_AND_MEAN     // trim down the Win32 headers
 #else
     #define OS_DIR_SEP '/'          // rest of the world uses it
-    #define OS_CRLF FALSE           // just LF in strings
+    #define OS_CRLF 0               // just LF in strings
 
     #define API_IMPORT
     // Note: Unsupported by gcc 2.95.3-haiku-121101

--- a/src/include/reb-gob.h
+++ b/src/include/reb-gob.h
@@ -212,10 +212,10 @@ enum {
     GOB_USED = 1<<1     // Gob is used (not free).
 };
 
-#define IS_GOB_MARK(g)  ((g)->resv & GOB_MARK)
+#define IS_GOB_MARK(g)  LOGICAL((g)->resv & GOB_MARK)
 #define MARK_GOB(g)     ((g)->resv |= GOB_MARK)
 #define UNMARK_GOB(g)   ((g)->resv &= ~GOB_MARK)
-#define IS_GOB_USED(g)  ((g)->resv & GOB_USED)
+#define IS_GOB_USED(g)  LOGICAL((g)->resv & GOB_USED)
 #define USE_GOB(g)      ((g)->resv |= GOB_USED)
 #define FREE_GOB(g)     ((g)->resv &= ~GOB_USED)
 

--- a/src/include/reb-struct.h
+++ b/src/include/reb-struct.h
@@ -75,7 +75,7 @@ struct Struct_Data {
     REBSER *data;
     REBCNT offset;
     REBCNT len;
-    REBFLG flags;
+    REBFLGS flags;
 };
 
 #define STRUCT_DATA_BIN(v) (((struct Struct_Data*)SERIES_DATA((v)->data))->data)

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -147,7 +147,7 @@ typedef struct rebol_port_action_map {
 
 typedef struct rebol_mold {
     REBSER *series;     // destination series (uni)
-    REBCNT opts;        // special option flags
+    REBFLGS opts;        // special option flags
     REBINT indent;      // indentation amount
 //  REBYTE space;       // ?
     REBYTE period;      // for decimal point
@@ -263,8 +263,10 @@ enum REB_Mold_Opts {
 #define GET_MOPT(v, f) GET_FLAG(v->opts, f)
 
 // Special flags for decimal formatting:
-#define DEC_MOLD_PERCENT 1  // follow num with %
-#define DEC_MOLD_MINIMAL 2  // allow decimal to be integer
+enum {
+    DEC_MOLD_PERCENT = 1 << 0,      // follow num with %
+    DEC_MOLD_MINIMAL = 1 << 1       // allow decimal to be integer
+};
 
 // Temporary:
 #define MOPT_NON_ANSI_PARENED MOPT_MOLD_ALL // Non ANSI chars are ^() escaped
@@ -419,7 +421,8 @@ enum encoding_opts {
         Catch_Thrown_Debug(a, t)
 #endif
 
-#define THROWN(v)           (VAL_GET_OPT((v), OPT_VALUE_THROWN))
+#define THROWN(v) \
+    VAL_GET_OPT((v), OPT_VALUE_THROWN)
 
 
 /***********************************************************************
@@ -691,11 +694,11 @@ typedef struct rebol_stats {
 
 //-- Options of various kinds:
 typedef struct rebol_opts {
-    REBFLG  watch_obj_copy;
-    REBFLG  watch_recycle;
-    REBFLG  watch_series;
-    REBFLG  watch_expand;
-    REBFLG  crash_dump;
+    REBOOL  watch_obj_copy;
+    REBOOL  watch_recycle;
+    REBOOL  watch_series;
+    REBOOL  watch_expand;
+    REBOOL  crash_dump;
 } REB_OPTS;
 
 typedef struct rebol_time_fields {

--- a/src/include/sys-deci-funcs.h
+++ b/src/include/sys-deci-funcs.h
@@ -26,16 +26,16 @@
 ***********************************************************************/
 
 /* unary operators - logic */
-REBFLG deci_is_zero (const deci a);
+REBOOL deci_is_zero (const deci a);
 
 /* unary operators - deci */
 deci deci_abs (deci a);
 deci deci_negate (deci a);
 
 /* binary operators - logic */
-REBFLG deci_is_equal (deci a, deci b);
-REBFLG deci_is_lesser_or_equal (deci a, deci b);
-REBFLG deci_is_same (deci a, deci b);
+REBOOL deci_is_equal (deci a, deci b);
+REBOOL deci_is_lesser_or_equal (deci a, deci b);
+REBOOL deci_is_same (deci a, deci b);
 
 /* binary operators - deci */
 deci deci_add (deci a, deci b);

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -196,7 +196,7 @@ typedef struct rebol_scan_state {
     const REBYTE *limit;    /* no chars after this point */
     REBCNT line_count;
     const REBYTE *head_line;        // head of current line (used for errors)
-    REBCNT opts;
+    REBFLGS opts;
     REBCNT errors;
 } SCAN_STATE;
 

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -187,7 +187,7 @@ struct Reb_Series {
             REBCNT wide:16;
             REBCNT high:16;
         } area;
-        REBFLG negated; // for bitsets (can't be EXT flag on just one value)
+        REBOOL negated; // for bitsets (can't be EXT flag on just one value)
     } misc;
 
     //
@@ -317,7 +317,7 @@ struct Reb_Series {
     cast(void, (SERIES_FLAGS(s) &= ~((f) << 8)))
 
 #define SERIES_GET_FLAG(s, f) \
-    (0 != (SERIES_FLAGS(s) & ((f) << 8)))
+    LOGICAL(SERIES_FLAGS(s) & ((f) << 8))
 
 #define Is_Array_Series(s) SERIES_GET_FLAG((s), SER_ARRAY)
 
@@ -530,7 +530,7 @@ struct Reb_Series {
 // size is not odd was added to Make_Series; reconsider if this becomes an
 // issue at some point.
 //
-#define BYTE_SIZE(s) (((s)->info) & 1)
+#define BYTE_SIZE(s) LOGICAL(((s)->info) & 1)
 
 //
 // Arg is a unicode series:

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -353,7 +353,7 @@ enum {
 // 8 bits.  (They need to be lowest for the OPT_NOT_END trick to work.)
 //
 #define VAL_SET_OPT(v,n)    ((v)->header.all |= ((1 << (n)) << 8))
-#define VAL_GET_OPT(v,n)    (((v)->header.all & ((1 << (n)) << 8)) != 0)
+#define VAL_GET_OPT(v,n)    LOGICAL((v)->header.all & ((1 << (n)) << 8))
 #define VAL_CLR_OPT(v,n) \
     ((v)->header.all &= ~cast(REBUPT, (1 << (n)) << 8))
 
@@ -419,8 +419,10 @@ enum {
 // Reading/writing routines for the 8 "EXTS" flags that are interpreted
 // differently depending on the VAL_TYPE() of the value.
 //
-#define VAL_SET_EXT(v,n)    ((v)->header.all |= (1 << ((n) + 16)))
-#define VAL_GET_EXT(v,n)    (((v)->header.all & (1 << ((n) + 16))) != 0)
+#define VAL_SET_EXT(v,n) \
+    ((v)->header.all |= (1 << ((n) + 16)))
+#define VAL_GET_EXT(v,n) \
+    LOGICAL((v)->header.all & (1 << ((n) + 16)))
 #define VAL_CLR_EXT(v,n) \
     ((v)->header.all &= ~cast(REBUPT, 1 << ((n) + 16)))
 
@@ -672,7 +674,7 @@ enum {
 #endif
 
 #define SET_LOGIC(v,n)  ((n) ? SET_TRUE(v) : SET_FALSE(v))
-#define VAL_LOGIC(v)    !VAL_GET_OPT((v), OPT_VALUE_FALSE)
+#define VAL_LOGIC(v)    NOT(VAL_GET_OPT((v), OPT_VALUE_FALSE))
 
 #ifdef NDEBUG
     #define IS_CONDITIONAL_FALSE(v) \
@@ -685,7 +687,7 @@ enum {
         IS_CONDITIONAL_FALSE_Debug(v)
 #endif
 
-#define IS_CONDITIONAL_TRUE(v) !IS_CONDITIONAL_FALSE(v)
+#define IS_CONDITIONAL_TRUE(v) NOT(IS_CONDITIONAL_FALSE(v))
 
 
 /***********************************************************************
@@ -1085,7 +1087,7 @@ struct Reb_Any_Series
 
 #define SET_BIT(d,n)    ((d)[(n) >> 3] |= (1 << ((n) & 7)))
 #define CLR_BIT(d,n)    ((d)[(n) >> 3] &= ~(1 << ((n) & 7)))
-#define IS_BIT(d,n)     ((d)[(n) >> 3] & (1 << ((n) & 7)))
+#define IS_BIT(d,n)     LOGICAL((d)[(n) >> 3] & (1 << ((n) & 7)))
 
 #define Val_Init_Bitset(v,s) \
     Val_Init_Series((v), REB_BITSET, (s))
@@ -1333,7 +1335,7 @@ struct Reb_Any_Context {
 // someone who thinks they are initializing a REB_OBJECT from a FRAME does
 // not accidentally get a REB_ERROR, for instance.)
 //
-#if FALSE && defined(NDEBUG)
+#if 0 && defined(NDEBUG)
     //
     // !!! Currently Val_Init_Context_Core does not require the passed in
     // frame to already be managed.  If it did, then it could be this
@@ -1603,7 +1605,7 @@ struct Reb_Handle {
 
 typedef struct Reb_Library_Handle {
     void * fd;
-    REBFLG flags;
+    REBFLGS flags;
 } REBLHL;
 
 struct Reb_Library {
@@ -1684,8 +1686,8 @@ struct Reb_Routine_Info {
     REBARR  *all_args;
     REBARR  *arg_structs; /* for struct arguments */
     REBSER  *extra_mem; /* extra memory that needs to be free'ed */
+    REBCNT  flags; // !!! 32-bit...should it use REBFLGS for 64-bit on 64-bit?
     REBINT  abi;
-    REBFLG  flags;
 };
 
 typedef REBFUN REBROT;
@@ -1728,7 +1730,7 @@ enum {
 #define ROUTINE_FLAGS(s)       ((s)->flags)
 #define ROUTINE_SET_FLAG(s, f) (ROUTINE_FLAGS(s) |= (f))
 #define ROUTINE_CLR_FLAG(s, f) (ROUTINE_FLAGS(s) &= ~(f))
-#define ROUTINE_GET_FLAG(s, f) (ROUTINE_FLAGS(s) &  (f))
+#define ROUTINE_GET_FLAG(s, f) LOGICAL(ROUTINE_FLAGS(s) & (f))
 
 #define IS_CALLBACK_ROUTINE(s) ROUTINE_GET_FLAG(s, ROUTINE_CALLBACK)
 

--- a/src/os/dev-dns.c
+++ b/src/os/dev-dns.c
@@ -187,7 +187,7 @@ DEVICE_CMD Poll_DNS(REBREQ *dr)
         else prior = &req->next;
     }
 
-    return change;
+    return change ? 1 : 0; // DEVICE_CMD implicitly returns i32
 }
 
 

--- a/src/os/dev-net.c
+++ b/src/os/dev-net.c
@@ -93,13 +93,13 @@ static REBOOL Nonblocking_Mode(SOCKET sock)
     // Set non-blocking mode. Return TRUE if no error.
 #ifdef FIONBIO
     unsigned long mode = 1;
-    return !IOCTL(sock, FIONBIO, &mode);
+    return NOT(IOCTL(sock, FIONBIO, &mode));
 #else
     int flags;
     flags = fcntl(sock, F_GETFL, 0);
     flags |= O_NONBLOCK;
     //else flags &= ~O_NONBLOCK;
-    return fcntl(sock, F_SETFL, flags) >= 0;
+    return LOGICAL(fcntl(sock, F_SETFL, flags) >= 0);
 #endif
 }
 

--- a/src/os/host-core.c
+++ b/src/os/host-core.c
@@ -474,7 +474,13 @@ RXIEXT int RXD_Core(int cmd, RXIFRM *frm, REBCEC *data)
             if (RXA_WORD(frm, 3)) // decrypt refinement
             {
 
-                binary_len = RSA_decrypt(rsa_ctx, dataBuffer, binaryBuffer, RXA_WORD(frm, 4), padding);
+                binary_len = RSA_decrypt(
+                    rsa_ctx,
+                    dataBuffer,
+                    binaryBuffer,
+                    RXA_WORD(frm, 4),
+                    padding ? 1 : 0
+                );
 
                 if (binary_len == -1) {
                     bi_free(rsa_ctx->bi_ctx, data_bi);
@@ -482,7 +488,16 @@ RXIEXT int RXD_Core(int cmd, RXIFRM *frm, REBCEC *data)
                     return RXR_NONE;
                 }
             } else {
-                if (-1 == RSA_encrypt(rsa_ctx, dataBuffer, data_len, binaryBuffer, RXA_WORD(frm, 4), padding)) {
+                if (
+                    -1 == RSA_encrypt(
+                        rsa_ctx,
+                        dataBuffer,
+                        data_len,
+                        binaryBuffer,
+                        RXA_WORD(frm, 4),
+                        padding ? 1 : 0
+                    )
+                ) {
                     bi_free(rsa_ctx->bi_ctx, data_bi);
                     RSA_free(rsa_ctx);
                     return RXR_NONE;

--- a/src/os/host-device.c
+++ b/src/os/host-device.c
@@ -146,7 +146,7 @@ static int Poll_Default(REBDEV *dev)
         }
     }
 
-    return change;
+    return change ? 1 : 0;
 }
 
 

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -323,7 +323,7 @@ void Host_Repl(int *exit_status) {
     int line_len;
 
     REBYTE *utf8byte;
-    BOOL inside_short_str = FALSE;
+    REBOOL inside_short_str = FALSE;
     int long_str_level = 0;
 
     while (TRUE) {
@@ -358,7 +358,7 @@ void Host_Repl(int *exit_status) {
             switch (*utf8byte) {
                 case '"':
                     if (long_str_level == 0) {
-                        inside_short_str = !inside_short_str;
+                        inside_short_str = NOT(inside_short_str);
                     }
                     break;
                 case '[':

--- a/src/os/host-stdio.c
+++ b/src/os/host-stdio.c
@@ -75,7 +75,7 @@ static REBYTE *Get_Next_Line()
     return 0; // more input needed
 }
 
-static int Fetch_Buf()
+static REBOOL Fetch_Buf()
 {
     REBCNT len = LEN_BYTES(inbuf);
 
@@ -86,7 +86,7 @@ static int Fetch_Buf()
     OS_Do_Device(&Std_IO_Req, RDC_READ);
 
     // If error, don't crash, just ignore it:
-    if (Std_IO_Req.error) return 0; //Host_Crash("stdio read");
+    if (Std_IO_Req.error) return FALSE; //Host_Crash("stdio read");
 
     // Terminate (LF) last line?
     if (len > 0 && Std_IO_Req.actual == 0) {
@@ -98,7 +98,7 @@ static int Fetch_Buf()
     // Null terminate buffer:
     len = Std_IO_Req.actual;
     Std_IO_Req.common.data[len] = 0;
-    return len > 0;
+    return LOGICAL(len > 0);
 }
 
 

--- a/src/os/linux/host-browse.c
+++ b/src/os/linux/host-browse.c
@@ -92,7 +92,7 @@ int OS_Get_Current_Dir(REBCHR **path)
 //
 REBOOL OS_Set_Current_Dir(REBCHR *path)
 {
-    return chdir(path) == 0;
+    return LOGICAL(chdir(path) == 0);
 }
 
 

--- a/src/os/linux/host-event.c
+++ b/src/os/linux/host-event.c
@@ -636,7 +636,7 @@ static void handle_configure_notify(XEvent *ev, REBGOB *gob)
 static void handle_key(XEvent *ev, REBGOB *gob)
 {
     KeySym keysym;
-    REBFLG flags = Check_Modifiers(0, ev->xkey.state);
+    REBINT flags = Check_Modifiers(0, ev->xkey.state);
     char key_string[8];
     XComposeStatus compose_status;
     int i = 0, key = -1;

--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -139,13 +139,14 @@ static REBOOL Seek_File_64(REBREQ *file)
 
     if (result < 0) {
         file->error = -RFE_NO_SEEK;
-        return 0;
+        return FALSE;
     }
 
     file->special.file.index = result;
 
-    return 1;
+    return TRUE;
 }
+
 
 static int Get_File_Info(REBREQ *file)
 {
@@ -255,7 +256,7 @@ static int Read_Directory(REBREQ *dir, REBREQ *file)
     file->modes = 0;
     strncpy(file->special.file.path, cp, MAX_FILE_NAME);
 
-#if FALSE
+#if 0
     // NOTE: we do not use d_type even if DT_DIR is #define-d.  First of all,
     // it's not a POSIX requirement and not all operating systems support it.
     // (Linux/BSD have it defined in their structs, but Haiku doesn't--for

--- a/src/os/posix/host-process.c
+++ b/src/os/posix/host-process.c
@@ -287,12 +287,27 @@ REBINT OS_Kill(REBINT pid)
 // POSIX previous simple version was just 'return system(call);'
 // This uses 'execvp' which is "POSIX.1 conforming, UNIX compatible"
 //
-int OS_Create_Process(const REBCHR *call, int argc, const REBCHR* argv[], u32 flags, u64 *pid, int *exit_code, u32 input_type, char *input, u32 input_len, u32 output_type, char **output, u32 *output_len, u32 err_type, char **err, u32 *err_len)
-{
-    unsigned char flag_wait = FALSE;
-    unsigned char flag_console = FALSE;
-    unsigned char flag_shell = FALSE;
-    unsigned char flag_info = FALSE;
+int OS_Create_Process(
+    const REBCHR *call,
+    int argc,
+    const REBCHR* argv[],
+    u32 flags,
+    u64 *pid,
+    int *exit_code,
+    u32 input_type,
+    char *input,
+    u32 input_len,
+    u32 output_type,
+    char **output,
+    u32 *output_len,
+    u32 err_type,
+    char **err,
+    u32 *err_len
+) {
+    REBOOL flag_wait = FALSE;
+    REBOOL flag_console = FALSE;
+    REBOOL flag_shell = FALSE;
+    REBOOL flag_info = FALSE;
     int stdin_pipe[] = {-1, -1};
     int stdout_pipe[] = {-1, -1};
     int stderr_pipe[] = {-1, -1};

--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -100,9 +100,9 @@ typedef struct term_data {
 } STD_TERM;
 
 // Globals:
-static int  Term_Init = 0;          // Terminal init was successful
-static char **Line_History;     // Prior input lines
-static int Line_Count;          // Number of prior lines
+static REBOOL Term_Initialized = FALSE;     // Terminal init was successful
+static char **Line_History;                 // Prior input lines
+static int Line_Count;                      // Number of prior lines
 
 #ifndef NO_TTY_ATTRIBUTES
 static struct termios Term_Attrs;   // Initial settings, restored on exit
@@ -125,7 +125,7 @@ STD_TERM *Init_Terminal(void)
 #ifndef NO_TTY_ATTRIBUTES
     struct termios attrs;
 
-    if (Term_Init || tcgetattr(0, &Term_Attrs)) return FALSE;
+    if (Term_Initialized || tcgetattr(0, &Term_Attrs)) return NULL;
 
     attrs = Term_Attrs;
 
@@ -157,7 +157,7 @@ STD_TERM *Init_Terminal(void)
     term->residue = OS_ALLOC_N(char, TERM_BUF_LEN);
     term->residue[0] = 0;
 
-    Term_Init = TRUE;
+    Term_Initialized = TRUE;
 
     return term;
 }
@@ -175,7 +175,7 @@ void Quit_Terminal(STD_TERM *term)
 {
     int n;
 
-    if (Term_Init) {
+    if (Term_Initialized) {
 #ifndef NO_TTY_ATTRIBUTES
         tcsetattr(0, TCSADRAIN, &Term_Attrs);
 #endif
@@ -186,7 +186,7 @@ void Quit_Terminal(STD_TERM *term)
         OS_FREE(Line_History);
     }
 
-    Term_Init = FALSE;
+    Term_Initialized = FALSE;
 }
 
 
@@ -368,7 +368,7 @@ static char *Insert_Char(STD_TERM *term, char *cp)
 // Redisplay the line. Blank out extra char at end.
 // Unicode: not yet supported!
 //
-static void Delete_Char(STD_TERM *term, int back)
+static void Delete_Char(STD_TERM *term, REBOOL back)
 {
     int len;
 

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -207,7 +207,7 @@ emit {
 
 /***********************************************************************
 **
-*/  const REBFLG Eval_Table[REB_MAX] =
+*/  const REBOOL Eval_Table[REB_MAX] =
 /*
 ** This table is used to bypass a Do_Core evaluation for certain types.  So
 ** if you have `foo [x] [y]`, the DO_NEXT_MAY_THROW macro checks the table
@@ -286,7 +286,7 @@ for-each-record-NO-RETURN type boot-types [
         ; taken care of by make-headers.r, no need to re-emit
         comment [
             emit-line/up1/decl
-                "extern REBFLG MT_" type/class "(REBVAL *, REBVAL *, REBCNT);"
+                "extern REBOOL MT_" type/class "(REBVAL *, REBVAL *, REBCNT);"
         ]
         append types-used type/class
     ]
@@ -485,10 +485,8 @@ for-each-record-NO-RETURN type boot-types [
 
     str: uppercase form type/name
     replace/all str #"-" #"_"
-    def: join {#define IS_} [str "(v)"]
-    len: 31 - length def
-    loop to-integer len / 4 [append def tab]
-    emit [def "(VAL_TYPE(v)==REB_" str ")" newline]
+    def: join {#define IS_} [str "(v)" space]
+    emit [def "LOGICAL(VAL_TYPE(v)==REB_" str ")" newline]
 
     n: n + 1
 ]
@@ -539,7 +537,7 @@ emit {
 // (though perhaps someday it could be tweaked so that all the evaluated types
 // had a certain bit set?) hence use a small fixed table.
 
-extern const REBFLG Eval_Table[REB_MAX];
+extern const REBOOL Eval_Table[REB_MAX];
 
 #define ANY_EVAL(v) Eval_Table[VAL_TYPE(v)]
 }


### PR DESCRIPTION
This commit represents the mostly mechanical remainder of a
compiler-assisted check over the codebase for usages of REBOOL
that were misinterpreted as integers.  Bugs or solutions to confusing
usages have been committed separately.

To directly read and comment on the new definitions, go directly to the
new "Boolean" section of %reb-c.h:

https://github.com/metaeducation/ren-c/pull/189/files#diff-6ef5cfafbcfde94617f41a68573fbe68R246

The previous separation between the 8-bit "REBOOL" for efficient
structure packing and the platform-optimal "REBFLG" for CPU
convenience is eliminated, favoring REBOOL for the common type
due to its similarity to `bool` as the C99 and C++ standard term for
a boolean value.  In practice there actually were no REBOOL cases
used for efficient structure packing anyway, but this defines the type
REBOOL8 just in case.

REBFLG is renamed to REBFLGS and reclaimed as a platform
efficient carrier for several bitflags--not to be confused with the singular
REBOOL.

Though testing booleans using any ordinary integer-bearing operators
one likes is still legal, the changes make it so that it is not legal to
directly assign integers to REBOOL.  This means for instance that you
cannot write `REBOOL b = 2;`, and confines them to being the values
1 and 0 only.  The inconvenience of this is that given the way C works,
this also rules out `REBOOL b = (1 < 2);` as that also is an integer
assignment.  The macro LOGICAL is introduced to do the conversion,
as is the macro NOT for the inverse.

*(Note: This is a complete replacement for casting macros such as
`(REBOOL)some_expression`...which did not do what whoever wrote that
thought it did (e.g. it would not coerce arbitrary bitmasks into 0 or 1.
in C++ `(bool)some_expression` would do that, but in C with REBOOL
was an 8-bit integer in C, so you'd just clip it to 8 bits.)*

Two different tests were used to vet the codebase for bugs.  One is kept
under the conditional STRICT_BOOL_COMPILER_TEST, which will make
REBOOL a pointer type to a dummy struct and then use bogus pointer
values to catch mixtures with integers.  This does not catch the case of
literal assignment of "0" as a subtitute for FALSE, so that is addressed by
a different check which makes REBOOL an enumerated type.  As this
is not compatible with the Windows definitions, the approach is not used
on Windows.

By its nature, the STRICT_BOOL_COMPILER_TEST does not use a 0
value to represent false...hence the produced executable is garbage...and
the only use is to locate potential bugs in offending usages.