### PR TITLE
New BACKTRACE native (replaces STACK)

### DIFF
--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -318,62 +318,255 @@ REBNATIVE(limit_usage)
 
 
 //
-//  stack: native [
+//  backtrace: native [
 //  
-//  "Returns stack backtrace or other values."
-//  
-//      offset [integer!] "Relative backward offset"
-//      /block "Block evaluation position"
-//      /word "Function or object name, if known"
-//      /func "Function value"
-//      /args "Block of args (may be modified)"
-//      /size "Current stack size (in value units)"
-//      /depth "Stack depth (frames)"
-//      /limit "Stack bounds (auto expanding)"
+//  "Returns backtrace with label symbols, include properties if requested"
+//
+//      /limit
+//          "Limit the length of the backtrace"
+//      depth [none! integer!]
+//          "Max stack levels to return, none for no limit"
+//      /at
+//          "Return only a single backtrace record"
+//      level [integer!]
+//          "Stack level to return properties for"
+//      /function
+//          "List function value in properties"
+//      /where
+//          "List block evaluation position in properties"
+//      /args
+//          "List args block in properties (may be modified since invocation)"
+//      /only
+//          "Do not list depths, only the selected properties"
 //  ]
 //
-REBNATIVE(stack)
+REBNATIVE(backtrace)
 {
-    REBINT index = VAL_INT32(D_ARG(1));
-    struct Reb_Call *call;
-    REBCNT len;
+    REFINE(1, limit);
+    PARAM(2, depth);
+    REFINE(3, at);
+    PARAM(4, level);
+    REFINE(5, function);
+    REFINE(6, where);
+    REFINE(7, args);
+    REFINE(8, only);
+
+    REBCNT n = 1;
+    REBCNT depth;
+    REBCNT level;
+
+    REBCNT index;
+
+    REBARR *backtrace;
+    struct Reb_Call *call = DSF->prior; // skip REBNATIVE(backtrace)
 
     Check_Security(SYM_DEBUG, POL_READ, 0);
 
-    call = Stack_Frame(index);
-    if (!call) return R_NONE;
+    if (REF(limit) && REF(at)) {
+        //
+        // /LIMIT assumes that you are returning a list of backtrace items,
+        // while /AT assumes exactly one.  They are mutually exclusive.
+        //
+        fail (Error(RE_BAD_REFINES));
+    }
 
-    if (D_REF(2)) {
-        Val_Init_Block_Index(D_OUT, DSF_ARRAY(call), DSF_EXPR_INDEX(call));
+    if (REF(limit)) {
+        if (IS_NONE(ARG(depth)))
+            depth = MAX_U32; // NONE is no limit--as many frames as possible
+        else {
+            if (VAL_INT32(ARG(depth)) < 0)
+                fail (Error_Invalid_Arg(ARG(depth)));
+            depth = VAL_INT32(ARG(depth));
+        }
     }
-    else if (D_REF(3)) {
-        Val_Init_Word_Unbound(D_OUT, REB_WORD, DSF_LABEL_SYM(call));
-    }
-    else if (D_REF(4)) *D_OUT = *FUNC_VALUE(DSF_FUNC(call));
-    else if (D_REF(5)) {
-        len = FUNC_NUM_PARAMS(DSF_FUNC(call));
-        Val_Init_Block(
-            D_OUT,
-            Copy_Values_Len_Shallow(DSF_ARGS_HEAD(call), len)
-        );
-    }
-    else if (D_REF(6)) {        // size
-        SET_INTEGER(D_OUT, DSP+1);
-    }
-    else if (D_REF(7)) {        // depth
-        SET_INTEGER(D_OUT, Stack_Depth());
-    }
-    else if (D_REF(8)) {        // limit
-        SET_INTEGER(
-            D_OUT,
-            SERIES_REST(ARRAY_SERIES(DS_Array))
-                + SERIES_BIAS(ARRAY_SERIES(DS_Array))
-        );
+    else
+        depth = 20; // On an 80x25 terminal leaves room to type...
+
+    if (REF(at)) {
+        if (VAL_INT32(ARG(level)) < 1)
+            fail (Error_Invalid_Arg(ARG(level)));
+        level = VAL_INT32(ARG(level));
     }
     else {
-        Val_Init_Block(D_OUT, Make_Backtrace(index));
+        // We're going to build our backtrace in reverse.  This is done so
+        // that the most recent stack frames are at the bottom, that way
+        // they don't scroll off the top.  But this is a little harder to
+        // get right, so get a count of how big it will be first.
+        //
+        // !!! This could also be done by over-allocating and then setting
+        // the series bias, though that reaches beneath the series layer
+        // and makes assumptions about the implementation.  And this isn't
+        // *that* complicated.
+        //
+        index = 1;
+        for (; call != NULL; call = PRIOR_DSF(call)) {
+            if (call->mode != CALL_MODE_FUNCTION) continue;
+
+            if (index > depth) {
+                ++index; break; // just one slot for ellipsis
+            }
+
+            // index and props for all other slots, unless /ONLY
+            //
+            index += REF(only) ? 1 : 2;
+        }
+
+        // Because our depth count started at 1 index started at 1 (so the
+        // check against the depth limit was right), but for the actual
+        // element count we need to decrement it.
+        //
+        --index;
+
+        // Reset the call for the second walk
+        //
+        call = DSF->prior;
+
+        // Worst case scenario in terms of size, the backtrace will be all
+        // pairs of integers with property blocks (Objects?).  The user
+        // should be able to pick from the result by integer with 1 being
+        // the topmost stack level.
+        //
+        // We never show backtrace itself (this currently running native)
+        // in the list, hence a (-1) * 2.  But we may add a SYM_ELLIPSIS to
+        // the start if output has been truncated, so that adds 1 element.
+        //
+        backtrace = Make_Array(index);
+        SET_ARRAY_LEN(backtrace, index);
+        TERM_ARRAY(backtrace);
     }
 
+    for (; call != NULL; call = PRIOR_DSF(call)) {
+        REBARR *props;
+        REBCNT len;
+        REBVAL *temp;
+
+        //
+        // Only consider invoked functions (not pending ones or parens)
+        //
+        if (call->mode != CALL_MODE_FUNCTION)
+            continue;
+
+        if (REF(at)) {
+            if (n != level) {
+                ++n;
+                continue;
+            }
+        }
+        else {
+            if (n > depth) {
+                //
+                // If there's more stack levels to be shown than we were asked
+                // to show, then put an ellipsis in the list and break.
+                //
+                temp = ARRAY_AT(backtrace, --index);
+                Val_Init_Word_Unbound(temp, REB_WORD, SYM_ELLIPSIS);
+                if (!REF(only))
+                    VAL_SET_OPT(temp, OPT_VALUE_LINE); // put on own line
+                break;
+            }
+        }
+
+        // The /ONLY case is bare bones and just gives a block of the label
+        // symbols (at this point in time).
+        //
+        if (REF(only)) {
+            if (REF(at)) {
+                Val_Init_Word_Unbound(temp, REB_WORD, DSF_LABEL_SYM(call));
+                return R_OUT;
+            }
+
+            temp = ARRAY_AT(backtrace, --index);
+            Val_Init_Word_Unbound(temp, REB_WORD, DSF_LABEL_SYM(call));
+            ++n;
+            continue;
+        }
+
+        // Make the properties list array the right size for the refinements
+        // that were requested.
+        //
+        len = (
+            1 // label always in the list
+            + REF(function) ? 1 : 0
+            + REF(where) ? 1 : 0
+            + REF(args) ? 1 : 0
+        );
+        props = Make_Array(len);
+
+        Val_Init_Word_Unbound(
+            Alloc_Tail_Array(props), REB_WORD, DSF_LABEL_SYM(call)
+        );
+
+        if (REF(function))
+            *Alloc_Tail_Array(props) = *FUNC_VALUE(DSF_FUNC(call));
+
+        if (REF(where))
+            Val_Init_Block_Index(
+                Alloc_Tail_Array(props), DSF_ARRAY(call), DSF_EXPR_INDEX(call)
+            );
+
+        if (REF(args)) {
+            //
+            // There may be "pure local" arguments that should be hidden (in
+            // definitional return there's at least RETURN:).  So the
+            // array could end up being larger than it needs to be.
+            //
+            // !!! Wouldn't this be perhaps more useful if it came back as an
+            // object, so you knew what the values corresponded to?
+            //
+            REBARR *array = Make_Array(FUNC_NUM_PARAMS(DSF_FUNC(call)));
+            REBVAL *param = FUNC_PARAMS_HEAD(DSF_FUNC(call));
+            REBVAL *arg = DSF_ARGS_HEAD(call);
+            REBVAL *dest = ARRAY_HEAD(array);
+
+            for (; NOT_END(param); param++, arg++, dest++) {
+                if (VAL_GET_EXT(param, EXT_TYPESET_HIDDEN))
+                    continue;
+                *dest = *arg;
+            }
+
+            SET_ARRAY_LEN(array, dest - ARRAY_HEAD(array));
+            TERM_ARRAY(array);
+
+            Val_Init_Block(Alloc_Tail_Array(props), array);
+        }
+
+        if (REF(at)) {
+            //
+            // If we were fetching a single stack level, then the props
+            // is our return result (if we found that level and got here)
+            //
+            Val_Init_Block(OUT, props);
+            return R_OUT;
+        }
+
+        // If building a backtrace, we just keep accumulating results as long
+        // as there are stack levels left and the limit hasn't been hit.
+        //
+        temp = ARRAY_AT(backtrace, --index);
+        Val_Init_Block(temp, props);
+
+        // The integer identifying the stack level (used to refer to it
+        // in other debugging commands).  Since we're going in reverse, we
+        // add it after the props so it will show up before, and give it
+        // the newline break marker.
+        //
+        temp = ARRAY_AT(backtrace, --index);
+        SET_INTEGER(temp, n);
+        VAL_SET_OPT(temp, OPT_VALUE_LINE);
+        ++n;
+    }
+
+    // If we ran out of stack levels before finding the single one requested
+    // via /AT, return a NONE!
+    //
+    if (REF(at))
+        return R_NONE;
+
+    // Return accumulated backtrace otherwise.  The reverse filling process
+    // should have exactly used up all the index slots, leaving index at 0.
+    //
+    assert(index == 0);
+    Val_Init_Block(OUT, backtrace);
     return R_OUT;
 }
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -479,6 +479,102 @@ set 'r3-legacy* func [] [
                 ]
             ]
         ])
+
+        ; The name STACK is a noun that really suits a variable name, and
+        ; the interim choice for this functionality in Ren-C is "backtrace".
+        ; Because it is a debug-privilege API it might wind up under DEBUG
+        ; or some part of a REFLECT dialect over the long term.
+        ;
+        ; Several refinements have been renamed or are no longer relevant,
+        ; and it has a zero-arity default.  This wraps what functionality of
+        ; R3-Alpha's STACK corresponds in a terribly inefficient way, which
+        ; will likely never matter because odds are no one used it.
+        ;
+        ; !!! This routine would require review if anyone finds it of
+        ; actual interest, it's just here to show how it *could* be done.
+        ;
+        stack: (function [
+            "Returns stack backtrace or other values."
+            offset [integer!] "Relative backward offset"
+            /block "Block evaluation position"
+            /word "Function or object name, if known"
+            /func "Function value"
+            /args "Block of args (may be modified)"
+            /size "Current stack size (in value units)"
+            /depth "Stack depth (frames)"
+            /limit "Stack bounds (auto expanding)"
+        ][
+            func_STACK: :func
+            func: :lib/func
+
+            ; Get the full backtrace to start with because we need to filter
+            ;
+            bt: backtrace/limit/:args/(
+                either block 'where none
+            )/(
+                either func_STACK 'function none
+            ) none
+
+            ; The backtrace is going to have STACK in it, in slot number 1.
+            ; But the caller doesn't want to see STACK.  So remove it.
+            ;
+            take/part (find bt 1) 2
+
+            if depth [
+                count: 0
+                for-each item bt [
+                    if integer? item [count: count + 1]
+                ]
+                return count
+            ]
+
+            ; Now renumber all the stack entries to bump them down by 1,
+            ; accounting for the removal of stack.  If we find a number
+            ; that is less than the offset requested, strip the remainder.
+            ;
+            forall bt [
+                unless integer? bt/1 [continue]
+
+                bt/1: bt/1 - 1 ;; clears new-line marker, have to reset it
+                new-line bt true
+
+                if bt/1 < offset [
+                    clear bt
+                    break
+                ]
+            ]
+
+            ; If a singular property was requested, then select it out and
+            ; return it.
+            ;
+            case [
+                any [block func_STACK args] [
+                    prop: select bt offset
+                    return to-value if prop [
+                        second prop
+                    ]
+                ]
+
+                word [
+                    prop: select bt offset
+                    return to-value if prop [
+                        first prop
+                    ]
+                ]
+
+                size [fail "STACK/SIZE no longer supported"]
+
+                limit [fail "STACK/LIMIT no longer supported"]
+            ]
+
+            ; Or by default just return the backtrace/only minus the
+            ; last thing (the above is more a test for backtrace than
+            ; anything...hence very roundabout)
+            ;
+            bt: backtrace/only
+            take/last bt
+            bt
+        ])
     ]
 
     return none


### PR DESCRIPTION
The STACK routine that produced a backtrace was designed mainly for
reporting a block list of labels for an ERROR! to report its "where"
location.  The simple functionality and confusing interface wasn't
fitting for interactive stack exploration.

This implements a more featured version of BACKTRACE, which by default
is zero arity and gives numbered stack frames...suitable for an
interactive console that might be suspended in mid-stack (as in at a
debug break).  It attempts to also cover enough behaviors to implement
the previous STACK function's behavior, which is rewritten as
userspace code in `<r3-legacy>`.

For a version of the bare-bones functionality that just gives back
a list, BACKTRACE/ONLY provides that functionality at the moment.
Names and interface are very likely to change.