### PR TITLE
EXIT/FROM any stack level, natives

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -89,6 +89,8 @@ Internal: [
     codepoint-too-high: [{codepoint} :arg1 {too large for current interpreter}]
 
     debug-only:         {Feature available only in DEBUG builds}
+
+    invalid-exit:       {Frame does not exist on the stack to EXIT from}
 ]
 
 Syntax: [

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -152,6 +152,7 @@ options: context [  ; Options supplied to REBOL during startup
     print-forms-everything: false
     break-with-overrides: false
     none-instead-of-unsets: false
+    dont-exit-natives: false
 
     ; Legacy Options that *cannot* be enabled (due to mezzanine dependency
     ; on the new behavior).  The points are retained in the code for purpose
@@ -182,17 +183,15 @@ standard: context [
     ; (substituted in #BODY), this template is used to "lie" when asked what
     ; the BODY-OF the function is.
     ;
-    ; The substitution locations are hardcoded at index 5 (function! or
-    ; closure!) and index 8 in the block.  It does not "scan" to find #TYPE
-    ; or #BODY, just asserts the positions are ISSUE!.
+    ; The substitution location is hardcoded at index 5.  It does not "scan"
+    ; to find #BODY, just asserts the position is an ISSUE!.
     ;
     func-body: [
-        comment {boilerplate is equivalent user code (simulated, optimized)}
-        return: make #TYPE [
+        return: make function! [
             [{Returns a value from a function.} value [any-value!]]
-            [throw/name :value bind-of 'return]
+            [exit/at/with (bind-of 'return) :value]
         ]
-        catch/name #BODY bind-of 'return
+        #BODY
     ]
 
     error: context [ ; Template used for all errors:

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -249,9 +249,11 @@ REBOOL Trapped_Helper_Halted(struct Reb_State *s)
 // Sets a task-local value to be associated with the name and
 // mark it as the proxy value indicating a THROW().
 //
-void Convert_Name_To_Thrown_Debug(REBVAL *name, const REBVAL *arg)
+void Convert_Name_To_Thrown_Debug(REBVAL *name, const REBVAL *arg, REBOOL from)
 {
     assert(!THROWN(name));
+
+    if (from) VAL_SET_OPT((name), OPT_VALUE_EXIT_FROM);
     VAL_SET_OPT(name, OPT_VALUE_THROWN);
 
     assert(IS_TRASH_DEBUG(&TG_Thrown_Arg));
@@ -275,6 +277,7 @@ void Catch_Thrown_Debug(REBVAL *out, REBVAL *thrown)
 {
     assert(THROWN(thrown));
     VAL_CLR_OPT(thrown, OPT_VALUE_THROWN);
+    VAL_CLR_OPT(thrown, OPT_VALUE_EXIT_FROM);
 
     assert(!IS_TRASH_DEBUG(&TG_Thrown_Arg));
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -64,10 +64,10 @@ REBNATIVE(quit)
     *D_OUT = *FUNC_VALUE(D_FUNC);
 
     if (D_REF(1)) {
-        CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(2));
+        CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(2), FALSE);
     }
     else if (D_REF(3)) {
-        CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(4));
+        CONVERT_NAME_TO_THROWN(D_OUT, D_ARG(4), FALSE);
     }
     else {
         // Chosen to do it this way because returning to a calling script it
@@ -76,7 +76,7 @@ REBNATIVE(quit)
 
         // (UNSET! will be translated to 0 if it gets caught for the shell)
 
-        CONVERT_NAME_TO_THROWN(D_OUT, UNSET_VALUE);
+        CONVERT_NAME_TO_THROWN(D_OUT, UNSET_VALUE, FALSE);
     }
 
     return R_OUT_IS_THROWN;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -920,7 +920,9 @@ static REBCNT Parse_Rules_Loop(
                             }
 
                             *parse->out = *ROOT_PARSE_NATIVE;
-                            CONVERT_NAME_TO_THROWN(parse->out, &evaluated);
+                            CONVERT_NAME_TO_THROWN(
+                                parse->out, &evaluated, FALSE
+                            );
 
                             // Implicitly returns whatever's in parse->out
                             return THROWN_FLAG;
@@ -1320,7 +1322,7 @@ post:
                     );
 
                     *parse->out = *ROOT_PARSE_NATIVE;
-                    CONVERT_NAME_TO_THROWN(parse->out, &captured);
+                    CONVERT_NAME_TO_THROWN(parse->out, &captured, FALSE);
 
                     // Implicitly returns whatever's in parse->out
                     return THROWN_FLAG;

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -402,20 +402,22 @@ enum encoding_opts {
 // will occur exactly once (when it is caught).
 
 #ifdef NDEBUG
-    #define CONVERT_NAME_TO_THROWN(name,arg) \
+    #define CONVERT_NAME_TO_THROWN(name,arg,from) \
         do { \
+            if (from) VAL_SET_OPT((name), OPT_VALUE_EXIT_FROM); \
             VAL_SET_OPT((name), OPT_VALUE_THROWN); \
             (TG_Thrown_Arg = *(arg)); \
         } while (0)
 
     #define CATCH_THROWN(arg,thrown) \
         do { \
+            VAL_CLR_OPT((thrown), OPT_VALUE_EXIT_FROM); \
             VAL_CLR_OPT((thrown), OPT_VALUE_THROWN); \
             (*(arg) = TG_Thrown_Arg); \
         } while (0)
 #else
-    #define CONVERT_NAME_TO_THROWN(n,a) \
-        Convert_Name_To_Thrown_Debug(n, a)
+    #define CONVERT_NAME_TO_THROWN(name,arg,from) \
+        Convert_Name_To_Thrown_Debug(name, arg, from)
 
     #define CATCH_THROWN(a,t) \
         Catch_Thrown_Debug(a, t)

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -346,6 +346,21 @@ enum {
     //
     OPT_VALUE_THROWN,
 
+    // This is a bit used in conjunction with OPT_VALUE_THROWN, which could
+    // also be folded in to be a model of being in an "exiting state".  The
+    // usage is for definitionally scoped RETURN, RESUME/AT, and EXIT/FROM
+    // where the frame desired to be targeted is marked with this flag.
+    // Currently it is indicated by either the object of the FRAME! (for
+    // a CLOSURE!) or the paramlist for all other ANY-FUNCTION!.
+    //
+    // !!! WARNING - In the current scheme this will only jump up to the most
+    // recent instantiation of the function, as it does not have unique
+    // identity in relative binding.  When FUNCTION! and its kind are updated
+    // to use a new technique that brings it to parity with CLOSURE! in this
+    // regard, then that will fix this.
+    //
+    OPT_VALUE_EXIT_FROM,
+
     OPT_VALUE_MAX
 };
 
@@ -1557,7 +1572,7 @@ struct Reb_Any_Function {
 // actual FUNC.  (In the general case, the [0] element of the FUNC must be
 // consistent with the fields of the value holding it.)
 //
-#define VAL_FUNC_RETURN_TO(v) VAL_FUNC_BODY(v)
+#define VAL_FUNC_RETURN_FROM(v) VAL_FUNC_BODY(v)
 
 
 /***********************************************************************

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -328,7 +328,7 @@ dump-obj: function [
         print-args/extra "^/REFINEMENTS:" refl
     ]
 
-    exit ; return unset
+    () ; return unset
 ]
 
 about: func [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -359,6 +359,7 @@ set 'r3-legacy* func [] [
     system/options/break-with-overrides: true
     system/options/none-instead-of-unsets: true
     system/options/arg1-arg2-arg3-error: true
+    system/options/dont-exit-natives: true
 
     append system/contexts/user compose [
 


### PR DESCRIPTION
This alters the behavior of dynamically-scoped EXIT in two significant
ways.  One is that natives will be exited just like non-natives, so
if you were to write:

    foo: func [] [if 1 < 2 [exit print "no"] print "yes"]

Then calling foo would print "yes", because IF would respond to the
EXIT signal.

This is coupled with another change which is to allow the targeting of
a specific function or closure to exit via the /FROM refinement.  A
name of a function or the frame object of a closure can be used.  So
this exit will reach past the IF to WHILE to break the infinite loop.

    while [true] [if 1 < 2 [exit/from :while]]

Stronger contracts will be possible with FUNCTION! (as with CLOSURE!)
when each function frame is individually distinguishable.  In the
meantime, the most recent call on the stack will receive the exit
command.