### PR TITLE
PARSE returns input on success, PARSE? variant

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -196,6 +196,7 @@ Script: [
     parse-variable:     [{PARSE - expected a variable, not:} :arg1]
     parse-command:      [{PARSE - command cannot be used as variable:} :arg1]
     parse-series:       [{PARSE - input must be a series:} :arg1]
+    parse-non-logic:    [{Non-logic PARSE? result:} :arg1 {use PARSE instead}]
 
     not-ffi-build:      {This Rebol build wasn't linked with libffi features}
     bad-library:        {bad library (already closed?)}


### PR DESCRIPTION
This implements #2165 where PARSE is to return the input series on
success, and NONE on false, unless a RETURN is used to override it
(in the future, COLLECT would override it as well).

It also implements a twist, with a PARSE? variation that can only
return TRUE or FALSE.  Since it ends in a question mark, the idea that
it act exactly like the old PARSE isn't a precise match...as the rule
is that functions ending in question mark return *only* true or false.
As one possible way of pushing that rule through, the PARSE? variant
does not tolerate RETURN (unless it is a return of a LOGIC!) and
will error.

This makes PARSE? suitable for use in practically every case where the
previous desire to return a TRUE or a FALSE was desired.  In the cases
where it was not, the PARSE variant makes more sense.

Legacy support uses a heuristic to make a good guess about what the
original PARSE output would have been, but can be tripped up if a
RETURN happened to return the series at the input position.

This is an experiment to see how it goes and if it turns out to be
of benefit.