### PR TITLE
Add a series flag OPT_SER_ACCESSIBLE

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -271,6 +271,9 @@ Access: [
     process-not-found:  [{process not found:} :arg1]
 
     symbol-not-found:   [{symbol not found:} :arg1]
+    bad-memory:         [{non-accessible memory at} :arg1 {in} :arg2]
+    no-external-storage: [{no external storage in the series}]
+    already-destroyed:  [{storage at} :arg1 {already destroyed}]
 ]
 
 Command: [

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1271,3 +1271,22 @@ REBTYPE(Struct)
 is_arg_error:
     fail (Error_Unexpected_Type(REB_STRUCT, VAL_TYPE(arg)));
 }
+
+//
+//  destroy-struct-storage: native [
+//
+//  {Destroy the external memory associated the struct}
+//      s   [struct!]
+//      /free func [routine!] {Specify the function to free the memory}
+//  ]
+//
+REBNATIVE(destroy_struct_storage)
+{
+    PARAM(1, val);
+    REFINE(2, free_q);
+    PARAM(3, free_func);
+
+    return Destroy_External_Storage(D_OUT,
+                                    VAL_STRUCT_DATA_BIN(ARG(val)),
+                                    REF(free_q)? ARG(free_func) : NULL);
+}

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -238,7 +238,14 @@ enum {
     // Ren-Cpp, but by relatively old extensions...so there may be no good
     // answer in the case of those clients (likely either leaks or crashes).
     //
-    OPT_SER_EXTERNAL = 1 << 8
+    OPT_SER_EXTERNAL = 1 << 8,
+
+    // `OPT_SER_ACCESSIBLE` indicates that the external memory pointed by `->data`
+    // is accessible. This is not check at every access to the `->data` for the
+    // performance consideration, only on those that are known to have possible
+    // external memory storage (currently only struct! could have such serieses)
+    //
+    OPT_SER_ACCESSIBLE = 1 << 9
 };
 
 struct Reb_Series_Dynamic {
@@ -416,6 +423,12 @@ struct Reb_Series {
 #define FAIL_IF_LOCKED_SERIES(s) \
     if (SERIES_GET_FLAG(s, OPT_SER_LOCKED)) fail (Error(RE_LOCKED))
 
+//
+// Series external data accessible
+//
+#define SERIES_DATA_NOT_ACCESSIBLE(s) \
+    (SERIES_GET_FLAG(s, OPT_SER_EXTERNAL) \
+     && !SERIES_GET_FLAG(s, OPT_SER_ACCESSIBLE))
 //
 // Optimized expand when at tail (but, does not reterminate)
 //


### PR DESCRIPTION
When the series has an external data storage, the life cycle of the data storage is not managed by the core. The core needs to know when the data can not be accessed any more, or the core could crash.
`OPT_SER_ACCESSIBLE` is for this purpose.

A new native is added for destroying the data storage and mark it non-accessible.

This is the testing script:
```
REBOL []

libc: make library! %libc.so.6

malloc: make routine! compose [
	[
		size [uint64]
		return: [pointer]
	]
	(libc) "malloc"
]

free: make routine! compose [
	[
		mem [pointer]
		return: [void]
	]
	(libc) "free"
]

m: malloc 4

s0: make struct! compose/deep [
	[raw-memory: (m)]
	i [int32]
]

;normal access
s0/i: 10
print mold values-of s0

print length? s0

;free the external storage
destroy-struct-storage/free s0 :free

err: try [destroy-struct-storage/free s0 :free]
assert [
	all [
		err/type = 'Access
		err/id = 'already-destroyed
	]
]

err: try [s0/i: 1]
assert [
	all [
		err/type = 'Access
		err/id = 'bad-memory
	]
]

err: try [
	print ["10, values-of:" values-of s0]
]
assert [
	all [
		err/type = 'Access
		err/id = 'bad-memory
	]
]

s1: make struct! []
err: try [destroy-struct-storage s1]
assert [
	all [
		err/type = 'Access
		err/id = 'no-external-storage
	]
]
```