### PR TITLE
Experminental EVAL/ONLY, subvert argument eval

### DIFF
--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1049,7 +1049,9 @@ REBNATIVE(do)
 //  {(Special) Process received value *inline* as the evaluator loop would.}
 //  
 //      value [any-value!] 
-//      {BLOCK! passes-thru, FUNCTION! runs, SET-WORD! assigns...}
+//          {BLOCK! passes-thru, FUNCTION! runs, SET-WORD! assigns...}
+//      /only
+//          {Suppress evaluation on any ensuing arguments value consumes}
 //  ]
 //
 REBNATIVE(eval)

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -381,7 +381,7 @@ struct Reb_Call {
         c_.flags = DO_FLAG_DO | DO_FLAG_NEXT | (flags_); \
         Do_Core(&c_); \
         (index_out) = c_.index; \
-    } while (FALSE)
+    } while (0)
 
 #define DO_NEXT_MAY_THROW(index_out,out,array,index) \
     DO_NEXT_MAY_THROW_CORE( \
@@ -394,6 +394,22 @@ struct Reb_Call {
 //
 #define DO_ARRAY_THROWS(out,array) \
     Do_At_Throws((out), VAL_ARRAY(array), VAL_INDEX(array))
+
+// This macro is used internally to process from an unknown index a new item
+// without evaluation.  It is used to implement EVAL/ONLY and probably does
+// not have any other interesting use.
+//
+#define DO_NEXT_QUOTED(index_out,out_,array_,index_in) \
+    do { \
+        if ((index_in) >= ARRAY_LEN(array_)) { \
+            (index_out) = END_FLAG; \
+            SET_UNSET(out_); \
+        } \
+        else { \
+            *(out_) = *ARRAY_AT((array_), (index_in)); \
+            (index_out) = (index_in) + 1; \
+        } \
+    } while (0)
 
 
 //=////////////////////////////////////////////////////////////////////////=//


### PR DESCRIPTION
EVAL gives special access to "bounce" the evaluator, giving its
argument inline access to subsequent parameters.  It replaces DO of a
FUNCTION! but is more general:

    >> eval (quote x:) 1 + 2
    == 3
    >> print x
    3

(See notes: https://trello.com/c/YMAb89dv )

This enhances EVAL with an /ONLY refinement, somewhat in the spirit of
APPLY/ONLY.  This allows one to slip the ensuing values directly and
bypass any evaluation, regardless of quoted or unquoted status:

    >> bar: func [a b :c] [print [a b c]]
    >> eval/only :bar 1 + 2
    1 + 2

The implementation of this feature is a further step toward making
Do_Core() the sole piece of code that is responsible for building
call frames in the codebase (such as doing complete refinement and
error checking on calls to Rebol functions from C, through a single
optimized path).

It is designed for experimenting with that mode, as well as being a
potentially useful feature in its own right.