### PR TITLE
Change termination trick to not break aliasing

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -168,16 +168,11 @@ static void Assert_Basics(void)
         panic (Error(RE_MISC));
     }
 
-    // The REBSER is designed to place the `info` bits exactly after a
-    // REBVAL and a pointer that can do double-duty as also a terminator
-    // for that REBVAL when viewed as an array of data.
+    // The REBSER is designed to place the `info` bits exactly after a REBVAL
+    // so they can do double-duty as also a terminator for that REBVAL when
+    // enumerated as an ARRAY.
     //
-    // !!! The info bits actually are going to go at the very head, to
-    // permit REBSER node sizes in multiples of REBVAL.  But this will
-    // require some technical adjustments to how freeness indicator
-    // interacts with the memory pool.
-    //
-    if (offsetof(struct Reb_Series, info) != sizeof(REBVAL) + sizeof(void*))
+    if (offsetof(struct Reb_Series, info) != sizeof(REBVAL))
         panic (Error(RE_MISC));
 
     // Check special return values used "in-band" in an unsigned integer that


### PR DESCRIPTION
(Hopeful fix for #208, #211)

The idea of using the lowest bit in the header of a REBVAL to indicate
termination, and making it the size of a REBUPT (Rebol's uintptr_t
abstraction), led to the idea of allowing pointers in data structures
do this termination job as they were a sunk cost--and this would add
little complexity to those structures.

Though a bit sketchy in principle, suggestion that it worked on most
all platforms made it seem like something that could be used and
then disabled on those rare architectures upon which it would not work
in practice:

http://stackoverflow.com/questions/19991506

But in addition to being overall a questionable idea to allow *any*
builds purposefully break undefined behavior, reports were submitted
of conventional platforms (Windows7 Intel w/MinGW, Linux 64-Bit w/gcc)
having trouble.

The existing deployment of the technique was only a test before a
larger application.  This rethinks it in a way that is believed to be
in line with the standard requirements of the compiler, and not
invoke undefined behavior.

The change is to not alias the REBUPT* to pointers to pointer-sized
things.  (That pointer cast is not legal, while -value- casting a
uintptr_t to and from a pointer is...these are different things.)
Instead the header bits of REBUPT are only interpreted out of
structures which layout a REBUPT at the tail position of the values
they wish to bound.