### PR TITLE
Back out legality of `x: ()`, CHECK-SET, SET+GET/OPT

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -163,7 +163,6 @@ options: context [  ; Options supplied to REBOL during startup
     ; would mean adapting the mezzanine (or finding a way to mark a routine
     ; as not being in the mezzanine and following a different rule.)
 
-    cant-unset-set-words: false
     arg1-arg2-arg3-error: false
 ]
 

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -154,6 +154,7 @@ options: context [  ; Options supplied to REBOL during startup
     none-instead-of-unsets: false
     dont-exit-natives: false
     paren-instead-of-group: false
+    get-will-get-anything: false
 
     ; Legacy Options that *cannot* be enabled (due to mezzanine dependency
     ; on the new behavior).  The points are retained in the code for purpose

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1268,21 +1268,10 @@ reevaluate:
 
         if (IS_UNSET(c->out)) {
             //
-            // Treat direct assignments of an unset as unsetting the word
+            // Assignments of unsets such as `x: ()` are not allowed, and SET
+            // has to be used to do it (with the /OPT refinement)
             //
-
-            REBVAL *var;
-
-        #if !defined(NDEBUG)
-            if (LEGACY(OPTIONS_CANT_UNSET_SET_WORDS))
-                fail (Error(RE_NEED_VALUE, c->value));
-        #endif
-
-            if (IS_WORD_UNBOUND(c->value))
-                fail (Error(RE_NOT_BOUND, c->value));
-
-            var = GET_MUTABLE_VAR(c->value);
-            SET_UNSET(var);
+            fail (Error(RE_NEED_VALUE, c->value));
         }
         else
             *GET_MUTABLE_VAR(c->value) = *c->out;

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -398,14 +398,14 @@ REBNATIVE(bound_q)
 
 
 //
-//  set?: native [
+//  any-value?: native [
 //  
-//  "Returns whether a value is set."
+//  "Returns whether a data cell contains a value."
 //  
 //      cell [unset! any-value!]
 //  ]
 //
-REBNATIVE(set_q)
+REBNATIVE(any_value_q)
 {
     return IS_UNSET(D_ARG(1)) ? R_FALSE : R_TRUE;
 }
@@ -1214,7 +1214,7 @@ REBNATIVE(nothing_q)
 //      value [unset! any-value!]
 //  ][
 //      all [
-//          set? :value
+//          any-value? :value
 //          not none? value
 //      ]
 //  ]

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -144,7 +144,7 @@ repend: func [
     /dup {Duplicates the insert a specified number of times}
     count [any-number! pair!]
 ][
-    either set? :value [
+    either any-value? :value [
         append/part/:only/dup series reduce :value :limit :count
     ][
         head series ;-- simulating result of appending () returns the head
@@ -156,7 +156,7 @@ join: func [
     value "Base value" [unset! any-value!]
     rest "Value or block of values" [unset! any-value!]
 ][
-    either set? :value [
+    either any-value? :value [
         value: either any-series? :value [copy value] [form :value]
         repend value :rest
     ][

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -36,5 +36,5 @@ check-set: func [
     'target [set-word! set-path!]
     value [unset! any-value!]
 ][
-    any-value? set/any target :value
+    any-value? set/opt target :value
 ]

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -29,3 +29,12 @@ wrap: func [
 ][
     do bind/copy/set body make object! 0
 ]
+
+check-set: func [
+    "Set optional value via set-word or set-path, TRUE unless UNSET!"
+
+    'target [set-word! set-path!]
+    value [unset! any-value!]
+][
+    any-value? set/any target :value
+]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -97,7 +97,7 @@ dump-obj: function [
     /doc "Open web browser to related documentation."
     /local value args item type-name types tmp print-args
 ][
-    if unset? get/any 'word [
+    unless value? 'word [
         print trim/auto {
             Use HELP or ? to see built-in info:
 
@@ -242,7 +242,7 @@ dump-obj: function [
     ; Get value (may be a function, so handle with ":")
     either path? :word [
         if any [
-            error? set/any 'value trap [get :word] ;trap reduce [to-get-path word]
+            error? set/opt 'value trap [get :word] ;trap reduce [to-get-path word]
             not value? 'value
         ][
             print ["No information on" word "(path has no value)"]
@@ -405,7 +405,7 @@ source: make function! [[
     case [
         any [word? :arg path? :arg] [
             name: arg
-            f: get/any arg
+            set/opt 'f get/opt arg
         ]
 
         integer? :arg [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -99,7 +99,7 @@ array: func [
 ][
     if block? size [
         if tail? rest: next size [rest: none]
-        unless integer? set/any 'size first size [
+        unless integer? set/opt 'size first size [
             cause-error 'script 'expect-arg reduce ['array 'size type-of :size]
         ]
     ]
@@ -262,7 +262,7 @@ reword: function [
         ] [
             while [not tail? values] [
                 w: first+ values  ; Keywords are not evaluated
-                set/any 'v do/next values 'values
+                set/opt 'v do/next values 'values
                 if any [set-word? :w lit-word? :w] [w: to word! :w]
                 case [
                     wtype = type-of :w none
@@ -305,7 +305,7 @@ reword: function [
     ; Convert keyword if the type doesn't match
     ;
     cword: pick [(w: to wtype w)] wtype <> type-of source
-    set/any [out: fout:] pick [
+    set/opt [out: fout:] pick [
         [   ; Convert to string if type combination needs it
             (output: insert output to string! copy/part a b)
             (output: insert output to string! a)
@@ -387,14 +387,14 @@ extract: func [
         if unset? :output [output: make series len * length pos]
         if all [not default any-string? output] [value: copy ""]
         for-skip series width [for-next pos [
-            if none? set/any 'val pick series pos/1 [set/any 'val value]
+            if none? set/opt 'val pick series pos/1 [set/opt 'val value]
             output: insert/only output :val
         ]]
     ][
         if unset? :output [output: make series len]
         if all [not default any-string? output] [value: copy ""]
         for-skip series width [
-            if none? set/any 'val pick series pos [set/any 'val value]
+            if none? set/opt 'val pick series pos [set/opt 'val value]
             output: insert/only output :val
         ]
     ]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -126,7 +126,7 @@ do*: function [
             header: hdr
             parent: :scr
             path: what-dir
-            args: :arg
+            args: to-value :arg
         ]
 
         ; Print out the script info

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -443,8 +443,8 @@ load: function [
             sftype: file-type? source
             ftype: case [
                 all [
-                    set? :ftype 'unbound = ftype
-                    set? :sftype 'extension = sftype
+                    any-value? :ftype 'unbound = ftype
+                    any-value? :sftype 'extension = sftype
                 ] [sftype]
                 type [ftype]
                 'default [sftype]
@@ -478,7 +478,7 @@ load: function [
 
         ;-- Bind code to user context:
         not any [
-            all [set? :ftype 'unbound = ftype]
+            all [any-value? :ftype 'unbound = ftype]
             'module = select hdr 'type
             find select hdr 'options 'unbound
         ][
@@ -585,7 +585,7 @@ do-needs: function [
         )
 
         ; Collect any mixins into the object (if we are doing that)
-        if all [set? :mixins mixin? mod] [
+        if all [any-value? :mixins mixin? mod] [
             resolve/extend/only mixins mod select spec-of mod 'exports
         ]
         mod
@@ -771,7 +771,7 @@ load-module: function [
         ]
 
         ; Unify hdr/name and /as name
-        set? :name [hdr/name: name] ; rename /as name
+        any-value? :name [hdr/name: name] ; rename /as name
         unset? :name [name: :hdr/name]
         all [not no-lib not word? :name] [ ; requires name for full import
             ; Unnamed module can't be imported to lib, so /no-lib here
@@ -871,7 +871,7 @@ load-module: function [
         ]
 
         all [not no-lib override?] [
-            unless set? :modsum [modsum: none]
+            unless any-value? :modsum [modsum: none]
             case/all [
                 pos [pos/2: mod pos/3: modsum] ; replace delayed module
 

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -130,7 +130,7 @@ load-header: function/with [
     ;    bad-checksum
     ;    bad-compress
     ;
-    ; Note: set/any and :var used - prevent malicious code errors.
+    ; Note: set/opt and :var used - prevent malicious code errors.
     ; Commented assert statements are for documentation and testing.
     ;
     end: none ;-- locals are now unset by default, added after that change
@@ -145,10 +145,10 @@ load-header: function/with [
         ]
 
         ; get 'rebol keyword
-        set/any [key: rest:] transcode/only data none
+        set/opt [key: rest:] transcode/only data none
 
         ; get header block
-        set/any [hdr: rest:] transcode/next/error rest none
+        set/opt [hdr: rest:] transcode/next/error rest none
 
         not block? :hdr [
             ; header block is incomplete
@@ -751,7 +751,7 @@ load-module: function [
             delay: no-share: none  hdr: spec-of mod
             assert/type [hdr/options [block! none!]]
         ]
-        block? mod [set/any [hdr: code:] mod]
+        block? mod [set/opt [hdr: code:] mod]
 
         ; module/block mod used later for override testing
 
@@ -782,7 +782,7 @@ load-module: function [
                 hdr/options: append any [hdr/options make block! 1] 'private
             ]
         ]
-        not tuple? set/any 'modver :hdr/version [
+        not tuple? set/opt 'modver :hdr/version [
             modver: 0.0.0 ; get version
         ]
 
@@ -798,7 +798,7 @@ load-module: function [
                 module? :mod0 [hdr0: spec-of mod0] ; final header
                 block? :mod0 [hdr0: first mod0] ; cached preparsed header
                 ;assert/type [name0 word! hdr0 object! sum0 [binary! none!]] none
-                not tuple? set/any 'ver0 :hdr0/version [ver0: 0.0.0]
+                not tuple? set/opt 'ver0 :hdr0/version [ver0: 0.0.0]
             ]
 
             ; Compare it to the module we want to load

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -218,7 +218,7 @@ for-each-record-NO-RETURN: func [
 
     table: next table
 
-    set/any quote result: while [not empty? table] [
+    set/opt quote result: while [not empty? table] [
         if (length headings) > (length table) [
             fail {Element count isn't even multiple of header count}
         ]

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -85,6 +85,34 @@ unless find words-of :set /opt [
     ]
 ]
 
+unless find words-of :get /opt [
+    ;
+    ; GET/OPT is the Ren-C replacement for GET/ANY, with /ANY supported
+    ; via <r3-legacy>.  But Rebol2 and R3-Alpha do not know /OPT.
+    ;
+    lib-get: :get
+    get: function [
+        {Gets the value of a word or path, or values of a context.}
+        source
+            "Word, path, context to get"
+        /opt
+            "The source may optionally have no value (allows returning UNSET!)"
+        /any
+            "Deprecated legacy synonym for /OPT"
+    ][
+        set_ANY: any
+        any: :lib/any ;-- in case it needs to be used
+        opt_ANY: opt
+        opt: none ;-- no OPT defined yet, but just in case, keep clear
+
+        apply :lib-get [source (any [opt_ANY set_ANY])]
+    ]
+]
+
+
+; === ABOVE ROUTINES NEEDED TO RUN BELOW ===
+
+
 migrations: [
     ;
     ; Note: EVERY cannot be written in R3-Alpha because there is no way
@@ -134,8 +162,8 @@ migrations: [
         {NONE! to unset, all other value types pass through.}
         value [any-type!]
     ][
-        either none? get/any 'value [()][
-            get/any 'value
+        either none? get/opt 'value [()][
+            get/opt 'value
         ]
     ])
 
@@ -143,7 +171,7 @@ migrations: [
         {Turns unset to NONE, with ANY-VALUE! passing through. (See: OPT)}
         value [any-type!]
     ][
-        either unset? get/any 'value [none][:value]
+        either unset? get/opt 'value [none][:value]
     ])
 
     something? <as> (func [value [any-type!]] [


### PR DESCRIPTION
This is a set of changes rolled up that were triggered by the idea from
@earl to make an operation designed to "set-and-test" a variable, which
came off as notationally pleasing without having to sacrifice the error
on plain get word assignments of unsets.

It makes the core operation where a value is optional named SET/OPT
and GET/OPT, which is just as short as GET/ANY and SET/ANY but more
in line with the present intentions for the connection between the unset
state and optional parameters and values.  The /ANY variations are
moved into user code for reasons that they were likely going to have to be
anyway...which will slow the primitives down some in the near term but
there should be ways of addressing it if it becomes a problem.

Due to hedging as a result of thoughts in chat, a previous decision to name
the opposite operation of UNSET? as SET? is revoked...before any more
cases of it get created.  It is not certain that this is the best use of the word,
or if it should be used at all, so the more conservative ANY-VALUE? was
chosen to match the existing typeset (which is still containing unsets for the
moment but about to change).