### PR TITLE
Add ENSURE mezzanine (with ENSURE/TYPE)

### DIFF
--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -252,5 +252,25 @@ default: func [
     unless all [value? word not none? get word] [set word :value] :value
 ]
 
+
+ensure: func [
+    {Pass through a value that isn't NONE! or UNSET!, but FAIL on all else.}
+    value [opt-any-value!]
+    /type
+    types [block! datatype! typeset!]
+        {FAIL only if not one of these types (block converts to TYPESET!)}
+][
+    unless find (case [
+        unset? :types [any-something!]
+        block? :types [make typeset! types]
+        typeset? :types [types]
+        datatype? :types [reduce [types]] ;-- we'll find DATATYPE! in a block
+    ]) type-of :value [
+        fail ["ENSURE did not expect value to have type" (type-of :value)]
+    ]
+    :value
+]
+
+
 secure: func ['d] [boot-print "SECURE is disabled"]
 


### PR DESCRIPTION
This adds a construct designed to pass through a value, assuming it
is not NONE! or UNSET!... e.g. that it is a SOMETHING?.  If it is a
NOTHING? then it will fail with an error message.

There is also a refinement that is able to take a data type or types
to check.  If types are provided to the ENSURE then they override the
checking for set and unset--only those types will match, and NONE!
or UNSET! will be fair game.

    >> ensure 1020
    == 1020

    >> ensure none
    ** user error: ENSURE did not expect value to have type none!

    ** Note: use WHY? for more error information

    >> ensure if 304 > 1020 [print "unsets aren't taken"]
    ** user error: ENSURE did not expect value to have type unset!

    >> ensure/type 1020 string!
    ** user error: ENSURE did not expect value to have type integer!

    >> ensure/type 1020 [string! integer!]
    == 1020

    >> ensure/type none none!
    == none