### PR TITLE
Prefetching evaluator (full rewrite)

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -52,7 +52,12 @@ extern const REBRXT Reb_To_RXT[REB_MAX];
 extern RXIARG Value_To_RXI(const REBVAL *val); // f-extension.c
 extern void RXI_To_Value(REBVAL *val, RXIARG arg, REBCNT type); // f-extension.c
 extern void RXI_To_Block(RXIFRM *frm, REBVAL *out); // f-extension.c
-extern int Do_Callback(REBARR *obj, u32 name, RXIARG *args, RXIARG *result);
+extern int Do_Callback(
+    RXIARG *result,
+    REBFUN *func,
+    REBCNT label_sym,
+    RXIARG *args
+);
 
 
 //
@@ -1190,8 +1195,22 @@ RL_API int RL_Callback(RXICBI *cbi)
     REBEVT evt;
 
     // Synchronous callback?
+    //
     if (!GET_FLAG(cbi->flags, RXC_ASYNC)) {
-        return Do_Callback(cbi->obj, cbi->word, cbi->args, &(cbi->result));
+        //
+        // Find word in object, verify it is a function
+        //
+        REBVAL *val = Find_Word_Value(AS_CONTEXT(cbi->obj), cbi->word);
+        if (!val) {
+            SET_EXT_ERROR(&cbi->result, RXE_NO_WORD);
+            return 0;
+        }
+        if (!ANY_FUNC(val)) {
+            SET_EXT_ERROR(&cbi->result, RXE_NOT_FUNC);
+            return 0;
+        }
+
+        return Do_Callback(&cbi->result, VAL_FUNC(val), cbi->word, cbi->args);
     }
 
     CLEARS(&evt);

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -600,10 +600,10 @@ RL_API void RL_Do_Commands(REBARR *array, REBCNT flags, REBCEC *context)
 //
 RL_API void RL_Print(const REBYTE *fmt, ...)
 {
-    va_list args;
-    va_start(args, fmt);
-    Debug_Buf(cs_cast(fmt), &args);
-    va_end(args);
+    va_list varargs;
+    va_start(varargs, fmt);
+    Debug_Buf(cs_cast(fmt), &varargs);
+    va_end(varargs);
 }
 
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -237,7 +237,7 @@ RL_API int RL_Start(REBYTE *bin, REBINT len, REBYTE *script, REBINT script_len, 
         return ERR_NUM(error);
     }
 
-    if (Apply_Func_Throws(
+    if (Apply_Only_Throws(
         &result, Sys_Func(SYS_CTX_FINISH_RL_START), END_VALUE
     )) {
         #if !defined(NDEBUG)

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1580,7 +1580,7 @@ void Init_Core(REBARGS *rargs)
 
     assert(DSP == -1 && !DSF);
 
-    if (Apply_Func_Throws(
+    if (Apply_Only_Throws(
         &result, Sys_Func(SYS_CTX_FINISH_INIT_CORE), END_VALUE
     )) {
         // Note: You shouldn't be able to throw any uncaught values during

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1270,10 +1270,7 @@ reevaluate:
         *c->out = *GET_OPT_VAR_MAY_FAIL(c->value);
 
     do_retrieved_word:
-        if (IS_UNSET(c->out))
-            fail (Error(RE_NO_VALUE, c->value));
-
-        if (ANY_FUNC(c->out)) {
+        if (ANY_FUNC(c->out)) { // check before checking unset, for speed
             //
             // As mentioned in #1934, we only dispatch infix functions as
             // infix when they are looked up from words.  Yet that can only
@@ -1298,6 +1295,9 @@ reevaluate:
             FETCH_NEXT_ONLY_MAYBE_END(c);
             goto do_function_maybe_end_ok;
         }
+
+        if (IS_UNSET(c->out))
+            fail (Error(RE_NO_VALUE, c->value));
 
     #if !defined(NDEBUG)
         if (LEGACY(OPTIONS_LIT_WORD_DECAY) && IS_LIT_WORD(c->out)) {

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -2786,15 +2786,6 @@ REBOOL Redo_Func_Throws(struct Reb_Call *c, REBFUN *func_new)
     REBARR *code_array = Make_Array(FUNC_NUM_PARAMS(c->func));
     REBVAL *code = ARRAY_HEAD(code_array);
 
-    // The first element of our path will be the function, followed by its
-    // refinements.  It has an upper bound on length that is to consider the
-    // opposite case where it had only refinements and then the function
-    // at the head...
-    //
-    REBARR *path_array = Make_Array(FUNC_NUM_PARAMS(c->func) + 1);
-    REBVAL *path = ARRAY_HEAD(path_array);
-    REBVAL first;
-
     // We'll walk through the original functions param and arglist only, and
     // accept the error-checking the evaluator provides at this time (types,
     // refinement presence or absence matching).
@@ -2804,6 +2795,17 @@ REBOOL Redo_Func_Throws(struct Reb_Call *c, REBFUN *func_new)
     REBVAL *param = FUNC_PARAMS_HEAD(c->func);
     REBVAL *arg = DSF_ARGS_HEAD(c);
     REBOOL ignoring = FALSE;
+
+    // The first element of our path will be the function, followed by its
+    // refinements.  It has an upper bound on length that is to consider the
+    // opposite case where it had only refinements and then the function
+    // at the head...
+    //
+    REBARR *path_array = Make_Array(FUNC_NUM_PARAMS(c->func) + 1);
+    REBVAL *path = ARRAY_HEAD(path_array);
+
+    REBVAL first;
+    VAL_INIT_WRITABLE_DEBUG(&first);
 
     *path = *FUNC_VALUE(func_new);
     ++path;

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1158,11 +1158,28 @@ REBCON *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *args)
         }
         Val_Init_Block(&error_obj->where, backtrace);
 
-        // Nearby location of the error (in block being evaluated):
+        // Nearby location of the error...
         //
-        Val_Init_Block_Index(
-            &error_obj->nearest, DSF_ARRAY(DSF), DSF_EXPR_INDEX(DSF)
-        );
+        if (DSF_IS_VARARGS(DSF)) {
+            //
+            // !!! There should be a good logic for giving back errors if
+            // the call is originating from C, hence the position is in
+            // system code.  An empty block is not a good answer; what one
+            // could do is finish out the arg enumeration and on-demand
+            // mutate the varargs into a series which could be introspected.
+            //
+            // The assert is a reminder to investigate that mechanism if this
+            // kind of error happens vs. sweep under the rug.  (Will be common
+            // for Ren-C invocations as an API.)
+            //
+            assert(FALSE);
+            Val_Init_Block_Index(&error_obj->nearest, EMPTY_ARRAY, 0);
+        }
+        else {
+            Val_Init_Block_Index(
+                &error_obj->nearest, DSF_ARRAY(DSF), DSF_INDEX(DSF)
+            );
+        }
     }
 
     return error;

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -906,7 +906,7 @@ REBOOL Make_Error_Object_Throws(
 // return to the caller to properly call va_end with no longjmp
 // to skip it.
 //
-REBCON *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *args)
+REBCON *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *varargs_ptr)
 {
 #if !defined(NDEBUG)
     // The legacy error mechanism expects us to have exactly three fields
@@ -931,7 +931,7 @@ REBCON *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *args)
     assert(code != 0);
 
     if (PG_Boot_Phase < BOOT_ERRORS) {
-        Panic_Core(code, NULL, args);
+        Panic_Core(code, NULL, varargs_ptr);
         DEAD_END;
     }
 
@@ -1029,7 +1029,7 @@ REBCON *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *args)
 
         while (NOT_END(temp)) {
             if (IS_GET_WORD(temp)) {
-                REBVAL *arg = va_arg(*args, REBVAL*);
+                const REBVAL *arg = va_arg(*varargs_ptr, const REBVAL*);
 
                 if (!arg) {
                     // Terminating with a NULL is optional but can help
@@ -1224,12 +1224,16 @@ REBCON *Make_Error_Core(REBCNT code, REBOOL up_stack, va_list *args)
 //
 REBCON *Error(REBINT num, ... /* REBVAL *arg1, REBVAL *arg2, ... */)
 {
-    va_list args;
+    va_list varargs;
     REBCON *error;
 
-    va_start(args, num);
-    error = Make_Error_Core((num < 0 ? -num : num), LOGICAL(num < 0), &args);
-    va_end(args);
+    va_start(varargs, num);
+    error = Make_Error_Core(
+        (num < 0 ? -num : num),
+        LOGICAL(num < 0),
+        &varargs
+    );
+    va_end(varargs);
 
     return error;
 }

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -185,7 +185,7 @@ REBINT Awake_System(REBARR *ports, REBOOL only)
         //
         REBARR *array = Make_Array(2);
         Append_Value(array, awake);
-        Val_Init_Word_Unbound(Alloc_Tail_Array(array), REB_WORD, SYM_ONLY);
+        Val_Init_Word(Alloc_Tail_Array(array), REB_WORD, SYM_ONLY);
 
         Val_Init_Array(&awake_only, REB_PATH, array);
     }

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -48,7 +48,7 @@
 ATTRIBUTE_NO_RETURN void Panic_Core(
     REBCNT id,
     REBCON *opt_error,
-    va_list *args
+    va_list *varargs_ptr
 ) {
     char title[PANIC_TITLE_BUF_SIZE + 1]; // account for null terminator
     char message[PANIC_BUF_SIZE + 1]; // "
@@ -115,11 +115,11 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
 
         // !!! These strings currently do not heed arguments, so if they
         // use a format specifier it will be ignored.  Technically it
-        // *may* be possible at some levels of boot to use `args`.  If it
+        // *may* be possible at some levels of boot to use the args.  If it
         // becomes a priority then find a way to safely report them
         // (perhaps a subset like integer!, otherwise just print type #?)
         //
-        assert(args && !opt_error);
+        assert(varargs_ptr && !opt_error);
 
         strncat(
             message, "\n** Boot Error: ", PANIC_BUF_SIZE - strlen(message)
@@ -163,14 +163,14 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
         Push_Mold(&mo);
 
         if (opt_error) {
-            assert(!args);
+            assert(!varargs_ptr);
             Val_Init_Error(&error, opt_error);
         }
         else {
             // We aren't explicitly passed a Rebol ERROR! object, but we
             // consider it "safe" to make one since we're past BOOT_ERRORS
 
-            Val_Init_Error(&error, Make_Error_Core(id, FALSE, args));
+            Val_Init_Error(&error, Make_Error_Core(id, FALSE, varargs_ptr));
         }
 
         Mold_Value(&mo, &error, FALSE);

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -232,8 +232,14 @@ x*/ REBRXT Do_Callback(REBARR *obj, u32 name, RXIARG *rxis, RXIARG *out)
     SET_TRASH_SAFE(&result);
     c->flags = 0;
     c->out = &result;
-    c->array = DSF_ARRAY(PRIOR_DSF(DSF));
-    c->index = DSF_EXPR_INDEX(PRIOR_DSF(DSF));
+
+    //
+    // !!! This duplicates call frame building and type checking, and should
+    // be adapted to use one of the variations, perhaps Do_Values_At_Core()
+    //
+
+    c->source = PRIOR_DSF(DSF)->source;
+    c->indexor = PRIOR_DSF(DSF)->indexor;
     c->label_sym = name;
     c->func = VAL_FUNC(val);
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -598,7 +598,7 @@ bad_func_def:
 
 
 //
-//  Do_Command_Throws: C
+//  Do_Command_Core: C
 // 
 // Evaluates the arguments for a command function and creates
 // a resulting stack frame (struct or object) for command processing.
@@ -608,7 +608,7 @@ bad_func_def:
 //     spec - same as other funcs
 //     body - [ext-obj func-index]
 //
-REBOOL Do_Command_Throws(struct Reb_Call *call_)
+enum Reb_Call_Mode Do_Command_Core(struct Reb_Call *call_)
 {
     // All of these were checked above on definition:
     REBVAL *val = ARRAY_HEAD(FUNC_BODY(D_FUNC));
@@ -666,7 +666,7 @@ REBOOL Do_Command_Throws(struct Reb_Call *call_)
         SET_UNSET(D_OUT);
     }
 
-    return FALSE; // There is currently no interface for commands to "throw"
+    return CALL_MODE_0; // no interface to throw, and make CALL_MODE_THROWN
 }
 
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -269,7 +269,7 @@ x*/ REBRXT Do_Callback(RXIARG *out, REBFUN *func, REBCNT label_sym, RXIARG *rxis
             // In use--and used refinements must be added to the PATH!
             //
             ignoring = FALSE;
-            Val_Init_Word_Unbound(path, REB_WORD, VAL_TYPESET_SYM(param));
+            Val_Init_Word(path, REB_WORD, VAL_TYPESET_SYM(param));
             ++path;
             continue;
         }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -362,22 +362,22 @@ REBVAL *In_Object(REBCON *base, ...)
 {
     REBVAL *context = NULL;
     REBCNT n;
-    va_list args;
+    va_list varargs;
 
-    va_start(args, base);
-    while ((n = va_arg(args, REBCNT))) {
+    va_start(varargs, base);
+    while ((n = va_arg(varargs, REBCNT))) {
         if (n > CONTEXT_LEN(base)) {
-            va_end(args);
+            va_end(varargs);
             return NULL;
         }
         context = CONTEXT_VAR(base, n);
         if (!ANY_CONTEXT(context)) {
-            va_end(args);
+            va_end(varargs);
             return NULL;
         }
         base = VAL_CONTEXT(context);
     }
-    va_end(args);
+    va_end(varargs);
 
     return context;
 }

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -538,8 +538,10 @@ static void Mark_Devices_Deep(void)
 //
 static void Mark_Call_Frames_Deep(void)
 {
-    struct Reb_Call *c =
-        *SERIES_AT(struct Reb_Call*, TG_Do_Stack, SERIES_LEN(TG_Do_Stack) - 1);
+    // The GC must consider all entries, not just those that have been pushed
+    // into active evaluation.
+    //
+    struct Reb_Call *c = TG_Do_Stack;
 
     for (; c != NULL; c = c->prior) {
 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -83,13 +83,10 @@ void Init_Stacks(REBCNT size)
     //
     Set_Root_Series(TASK_STACK, ARRAY_SERIES(DS_Array));
 
-    // Call stack (includes pending functions, parens...)  We seed it with a
-    // NULL in the first spot so that pushes don't have to check for an
-    // empty array.
+    // Call stack (includes pending functions, parens...anything that sets
+    // up a `struct Reb_Call` and calls Do_Core())  Singly linked.
     //
-    TG_Do_Stack = Make_Series(128, sizeof(struct Reb_Call*), MKS_NONE);
-    *SERIES_HEAD(struct Reb_Call*, TG_Do_Stack) = NULL;
-    SET_SERIES_LEN(TG_Do_Stack, 1);
+    TG_Do_Stack = NULL;
 }
 
 
@@ -98,8 +95,7 @@ void Init_Stacks(REBCNT size)
 //
 void Shutdown_Stacks(void)
 {
-    assert(SERIES_LEN(TG_Do_Stack) == 1);
-    Free_Series(TG_Do_Stack);
+    assert(TG_Do_Stack == NULL);
 
     assert(TG_Top_Chunk == cast(struct Reb_Chunk*, &TG_Root_Chunker->payload));
 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -476,7 +476,22 @@ void Push_New_Arglist_For_Call(struct Reb_Call *c) {
     // args) or not.
     //
     while (--num_slots) {
+        //
+        // In Rebol2 and R3-Alpha, unused refinement arguments were set to
+        // NONE! (and refinements were TRUE as opposed to the WORD! of the
+        // refinement itself).  We captured the state of the legacy flag at
+        // the time of function creation, so that both kinds of functions
+        // can coexist at the same time.
+        //
+    #ifdef NDEBUG
         SET_UNSET(slot);
+    #else
+        if (VAL_GET_EXT(FUNC_VALUE(c->func), EXT_FUNC_LEGACY))
+            SET_NONE(slot);
+        else
+            SET_UNSET(slot);
+    #endif
+
         slot++;
     }
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -144,14 +144,15 @@ REBNATIVE(assert)
 
     if (!REF(type)) {
         REBARR *block = VAL_ARRAY(ARG(conditions));
-        REBCNT index = VAL_INDEX(ARG(conditions));
+        REBIXO indexor = VAL_INDEX(ARG(conditions));
         REBCNT i;
 
-        while (index < ARRAY_LEN(block)) {
-            i = index;
-            DO_NEXT_MAY_THROW(index, D_OUT, block, index);
+        while (indexor != END_FLAG) {
+            i = cast(REBCNT, indexor);
 
-            if (index == THROWN_FLAG) return R_OUT_IS_THROWN;
+            DO_NEXT_MAY_THROW(indexor, D_OUT, block, indexor);
+            if (indexor == THROWN_FLAG)
+                return R_OUT_IS_THROWN;
 
             if (IS_CONDITIONAL_FALSE(D_OUT)) {
                 // !!! Only copies 3 values (and flaky), see CC#2231

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -506,7 +506,7 @@ REBNATIVE(wake_up)
 
     value = CONTEXT_VAR(port, STD_PORT_AWAKE);
     if (ANY_FUNC(value)) {
-        if (Apply_Func_Throws(D_OUT, VAL_FUNC(value), ARG(event), END_VALUE))
+        if (Apply_Only_Throws(D_OUT, value, ARG(event), END_VALUE))
             fail (Error_No_Catch_For_Throw(D_OUT));
 
         if (!(IS_LOGIC(D_OUT) && VAL_LOGIC(D_OUT))) awakened = FALSE;

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -377,7 +377,7 @@ REBARR *Where_For_Call(struct Reb_Call *call)
     // WARNING: MIN is a C macro and repeats its arguments.
     //
     start = MIN(ARRAY_LEN(DSF_ARRAY(call)), DSF_INDEX(call));
-    end = MIN(ARRAY_LEN(DSF_ARRAY(call)), call->expr_index);
+    end = MIN(ARRAY_LEN(DSF_ARRAY(call)), cast(REBCNT, call->expr_index));
 
     assert(end >= start);
     assert(call->mode != CALL_MODE_0);

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -350,13 +350,34 @@ REBNATIVE(limit_usage)
 //
 REBARR *Where_For_Call(struct Reb_Call *call)
 {
-    // WARNING: MIN is a C macro and repeats its arguments.
-    //
-    REBCNT start = MIN(ARRAY_LEN(call->array), call->expr_index);
-    REBCNT end = MIN(ARRAY_LEN(call->array), call->index);
+    REBCNT start;
+    REBCNT end;
 
     REBARR *where;
     REBOOL pending;
+
+    if (DSF_IS_VARARGS(call)) {
+        //
+        // !!! Not yet implemented: the reporting of errors that occur when
+        // a C vararg list is used.  The historical instances of this were
+        // system calls that really would be difficult to know what was
+        // going wrong--and there wasn't much notice or tolerance of failure,
+        // but Ren-C is going to permit these calls everywhere and needs
+        // a better story.
+        //
+        // What needs to happen is that the args must be reified; it would
+        // make it impossible to continue evaluating after this point unless
+        // the varargs were transformed into an array.  This is similar to
+        // what needs to be done if there is a GC in the middle of an
+        // arbitrary varargs-based evaluation.
+        //
+        assert(FALSE);
+    }
+
+    // WARNING: MIN is a C macro and repeats its arguments.
+    //
+    start = MIN(ARRAY_LEN(DSF_ARRAY(call)), DSF_INDEX(call));
+    end = MIN(ARRAY_LEN(DSF_ARRAY(call)), call->expr_index);
 
     assert(end >= start);
     assert(call->mode != CALL_MODE_0);

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -75,50 +75,54 @@ enum {
 //
 REBSER *Emit(REB_MOLD *mold, const char *fmt, ...)
 {
-    va_list args;
+    va_list varargs;
     REBYTE ender = 0;
     REBSER *series = mold->series;
 
     assert(SERIES_WIDE(series) == 2);
 
-    va_start(args, fmt);
+    va_start(varargs, fmt);
 
     for (; *fmt; fmt++) {
         switch (*fmt) {
         case 'W':   // Word symbol
-            Append_UTF8(series, Get_Word_Name(va_arg(args, REBVAL*)), -1);
+            Append_UTF8(
+                series,
+                Get_Word_Name(va_arg(varargs, const REBVAL*)),
+                -1
+            );
             break;
         case 'V':   // Value
-            Mold_Value(mold, va_arg(args, REBVAL*), TRUE);
+            Mold_Value(mold, va_arg(varargs, const REBVAL*), TRUE);
             break;
         case 'S':   // String of bytes
-            Append_Unencoded(series, va_arg(args, const char *));
+            Append_Unencoded(series, va_arg(varargs, const char *));
             break;
         case 'C':   // Char
-            Append_Codepoint_Raw(series, va_arg(args, REBCNT));
+            Append_Codepoint_Raw(series, va_arg(varargs, REBCNT));
             break;
         case 'E': {  // Series (byte or uni)
-            REBSER *src = va_arg(args, REBSER*);
+            REBSER *src = va_arg(varargs, REBSER*);
             Insert_String(
                 series, SERIES_LEN(series), src, 0, SERIES_LEN(src), FALSE
             );
             break;
         }
         case 'I':   // Integer
-            Append_Int(series, va_arg(args, REBINT));
+            Append_Int(series, va_arg(varargs, REBINT));
             break;
         case 'i':
-            Append_Int_Pad(series, va_arg(args, REBINT), -9);
+            Append_Int_Pad(series, va_arg(varargs, REBINT), -9);
             Trim_Tail(mold->series, '0');
             break;
         case '2':   // 2 digit int (for time)
-            Append_Int_Pad(series, va_arg(args, REBINT), 2);
+            Append_Int_Pad(series, va_arg(varargs, REBINT), 2);
             break;
         case 'T':   // Type name
-            Append_UTF8(series, Get_Type_Name(va_arg(args, REBVAL*)), -1);
+            Append_UTF8(series, Get_Type_Name(va_arg(varargs, REBVAL*)), -1);
             break;
         case 'N':   // Symbol name
-            Append_UTF8(series, Get_Sym_Name(va_arg(args, REBCNT)), -1);
+            Append_UTF8(series, Get_Sym_Name(va_arg(varargs, REBCNT)), -1);
             break;
         case '+':   // Add #[ if mold/all
             if (GET_MOPT(mold, MOPT_MOLD_ALL)) {
@@ -128,18 +132,18 @@ REBSER *Emit(REB_MOLD *mold, const char *fmt, ...)
             break;
         case 'D':   // Datatype symbol: #[type
             if (ender) {
-                Append_UTF8(series, Get_Sym_Name(va_arg(args, REBCNT)), -1);
+                Append_UTF8(series, Get_Sym_Name(va_arg(varargs, REBCNT)), -1);
                 Append_Codepoint_Raw(series, ' ');
-            } else va_arg(args, REBCNT); // ignore it
+            } else va_arg(varargs, REBCNT); // ignore it
             break;
         case 'B':   // Boot string
-            Append_Boot_Str(series, va_arg(args, REBINT));
+            Append_Boot_Str(series, va_arg(varargs, REBINT));
             break;
         default:
             Append_Codepoint_Raw(series, *fmt);
         }
     }
-    va_end(args);
+    va_end(varargs);
 
     if (ender) Append_Codepoint_Raw(series, ender);
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1400,24 +1400,18 @@ REBSER *Copy_Mold_Value(const REBVAL *value, REBFLGS opts)
 //
 REBOOL Form_Reduce_Throws(REBVAL *out, REBARR *block, REBCNT index)
 {
-    REBINT start = DSP;
-    REBINT n;
+    REBIXO indexor = index;
 
     REB_MOLD mo;
     CLEARS(&mo);
 
     Push_Mold(&mo);
 
-    while (index < ARRAY_LEN(block)) {
-        DO_NEXT_MAY_THROW(index, out, block, index);
-        if (index == THROWN_FLAG)
+    while (indexor != END_FLAG) {
+        DO_NEXT_MAY_THROW(indexor, out, block, indexor);
+        if (indexor == THROWN_FLAG)
             return TRUE;
 
-        // Note: Form_Reduce was one of the motivators for a "mold stack"
-        // (as opposed to mold assuming it could write at the beginning of
-        // the UNI_BUF each time).  Without a mold stack, all the values
-        // had to be reduced into a side structure before any molding started.
-        //
         Mold_Value(&mo, out, FALSE);
     }
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -62,6 +62,7 @@ static void No_Nones(REBVAL *arg) {
     }
 }
 
+
 //
 //  MT_Array: C
 // 
@@ -79,8 +80,11 @@ REBOOL MT_Array(REBVAL *out, REBVAL *data, enum Reb_Kind type)
     REBCNT i;
 
     if (!ANY_ARRAY(data)) return FALSE;
-    if (type >= REB_PATH && type <= REB_LIT_PATH)
-        if (!ANY_WORD(VAL_ARRAY_HEAD(data))) return FALSE;
+    if (type >= REB_PATH && type <= REB_LIT_PATH) {
+        REBVAL *head = VAL_ARRAY_HEAD(data);
+        if (IS_END(head) || !ANY_WORD(head))
+            return FALSE;
+    }
 
     *out = *data++;
     VAL_RESET_HEADER(out, type);

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -358,9 +358,9 @@ static int Compare_Call(void *thunk, const void *v1, const void *v2)
         ));
     }
 
-    if (Apply_Func_Throws(
+    if (Apply_Only_Throws(
         &result,
-        VAL_FUNC(sort_flags.compare),
+        sort_flags.compare,
         v1,
         v2,
         END_VALUE

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1246,7 +1246,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
     MANAGE_SERIES(VAL_ROUTINE_EXTRA_MEM(out));
 
     if (type == REB_ROUTINE) {
-        REBCNT fn_idx = 0;
+        REBIXO indexor = 0;
 
         REBVAL lib;
         VAL_INIT_WRITABLE_DEBUG(&lib);
@@ -1254,13 +1254,13 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
         if (!IS_BLOCK(&blk[0]))
             fail (Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(&blk[0])));
 
-        DO_NEXT_MAY_THROW(fn_idx, &lib, VAL_ARRAY(data), 1);
-        if (fn_idx == THROWN_FLAG)
+        DO_NEXT_MAY_THROW(indexor, &lib, VAL_ARRAY(data), 1);
+        if (indexor == THROWN_FLAG)
             fail (Error_No_Catch_For_Throw(&lib));
 
         if (IS_INTEGER(&lib)) {
-            if (NOT_END(&blk[fn_idx]))
-                fail (Error_Invalid_Arg(&blk[fn_idx]));
+            if (indexor != END_FLAG)
+                fail (Error_Invalid_Arg(&blk[cast(REBCNT, indexor)]));
 
             //treated as a pointer to the function
             if (VAL_INT64(&lib) == 0)
@@ -1275,6 +1275,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
             REBSER *byte_sized;
             REBCNT b_index;
             REBCNT b_len;
+            REBCNT fn_idx = cast(REBCNT, indexor);
 
             if (!IS_LIBRARY(&lib))
                 fail (Error_Invalid_Arg(&lib));
@@ -1315,7 +1316,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
             }
         }
     } else if (type == REB_CALLBACK) {
-        REBCNT fn_idx = 0;
+        REBIXO indexor = 0;
 
         REBVAL fun;
         VAL_INIT_WRITABLE_DEBUG(&fun);
@@ -1323,16 +1324,16 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
         if (!IS_BLOCK(&blk[0]))
             fail (Error_Invalid_Arg(&blk[0]));
 
-        DO_NEXT_MAY_THROW(fn_idx, &fun, VAL_ARRAY(data), 1);
-        if (fn_idx == THROWN_FLAG)
+        DO_NEXT_MAY_THROW(indexor, &fun, VAL_ARRAY(data), 1);
+        if (indexor == THROWN_FLAG)
             fail (Error_No_Catch_For_Throw(&fun));
 
         if (!IS_FUNCTION(&fun))
             fail (Error_Invalid_Arg(&fun));
         VAL_CALLBACK_FUNC(out) = VAL_FUNC(&fun);
 
-        if (fn_idx != END_FLAG)
-            fail (Error_Invalid_Arg(&blk[fn_idx]));
+        if (indexor != END_FLAG)
+            fail (Error_Invalid_Arg(&blk[cast(REBCNT, indexor)]));
 
         //printf("RIN: %p, func: %p\n", VAL_ROUTINE_INFO(out), &blk[1]);
     }

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1330,7 +1330,8 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, enum Reb_Kind type)
         if (!IS_FUNCTION(&fun))
             fail (Error_Invalid_Arg(&fun));
         VAL_CALLBACK_FUNC(out) = VAL_FUNC(&fun);
-        if (NOT_END(&blk[fn_idx]))
+
+        if (fn_idx != END_FLAG)
             fail (Error_Invalid_Arg(&blk[fn_idx]));
 
         //printf("RIN: %p, func: %p\n", VAL_ROUTINE_INFO(out), &blk[1]);

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -724,7 +724,7 @@ REBOOL MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
         REBVAL *blk = VAL_ARRAY_AT(data);
         REBINT field_idx = 0; /* for field index */
         u64 offset = 0; /* offset in data */
-        REBCNT eval_idx = 0; /* for spec block evaluation */
+        REBIXO eval_idx = 0; /* for spec block evaluation */
         REBVAL *init = NULL; /* for result to save in data */
         REBOOL expect_init = FALSE;
         REBINT raw_size = -1;

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -822,7 +822,10 @@ REBOOL MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
                     if (eval_idx == THROWN_FLAG)
                         fail (Error_No_Catch_For_Throw(init));
 
-                    blk = VAL_ARRAY_AT_HEAD(data, eval_idx);
+                    if (eval_idx == END_FLAG)
+                        blk = VAL_ARRAY_TAIL(data);
+                    else
+                        blk = VAL_ARRAY_AT_HEAD(data, eval_idx);
                 }
 
                 if (field->array) {

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -129,7 +129,7 @@ REBCNT *VAL_TYPESET_SYM_Ptr_Debug(const REBVAL *typeset)
     assert(IS_TYPESET(typeset));
     // loses constness, but that's not the particular concern needed
     // to be caught in the wake of the UNWORD => TYPESET change...
-    return cast(REBCNT*, &typeset->payload.typeset.sym);
+    return (REBCNT*)(&typeset->payload.typeset.sym);
 }
 
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -777,6 +777,8 @@ static REBCNT Do_Eval_Rule(REBPARSE *p, REBCNT index, const REBVAL **rule)
     REBCNT n;
     REBPARSE newparse;
 
+    REBIXO indexor = index;
+
     REBVAL value;
     REBVAL save; // REVIEW: Could this just reuse value?
     VAL_INIT_WRITABLE_DEBUG(&value);
@@ -793,8 +795,8 @@ static REBCNT Do_Eval_Rule(REBPARSE *p, REBCNT index, const REBVAL **rule)
 
     // Evaluate next expression, stop processing if BREAK/RETURN/QUIT/THROW...
     //
-    DO_NEXT_MAY_THROW(index, &value, AS_ARRAY(p->series), index);
-    if (index == THROWN_FLAG) {
+    DO_NEXT_MAY_THROW(indexor, &value, AS_ARRAY(p->series), indexor);
+    if (indexor == THROWN_FLAG) {
         *p->out = value;
         return THROWN_FLAG;
     }

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -72,9 +72,9 @@
     // build, and give a hopefully informative error.
     //
     #if !defined(REN_C_STDIO_OK)
-        #define printf $dont_include_stdio_h$
-        #define fprintf $dont_include_stdio_h$
-        #define putc $dont_include_stdio_h$
+        #define printf dont_include_stdio_h
+        #define fprintf dont_include_stdio_h
+        #define putc dont_include_stdio_h
     #endif
 #else
     // Desire to not bake in <stdio.h> notwithstanding, in debug builds it

--- a/src/include/sys-do-cpp.h
+++ b/src/include/sys-do-cpp.h
@@ -1,0 +1,171 @@
+//
+// Rebol 3 Language Interpreter and Run-time Environment
+// "Ren-C" branch @ https://github.com/metaeducation/ren-c
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2016 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  Summary: Optional C++ Checking Classes
+//  File: %sys-cpp.h
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// R3-Alpha was designed to build under ANSI C89.  Though a seemingly archaic
+// requirement in 2016, the unique nature of the project and a desire to
+// build on as many platforms as possible has kept that a requirement.
+//
+// The Ren-C branch took the codebase forward to build in standard C99 and
+// C11, but also to build and run under C++98, C++11, C++14, and C++17.  At
+// the beginning this was just running in the lowest common denominator of
+// both C++ and C89 (which is C89 for any practical purposes in the project.)
+// Yet this was extended to use in both static and dynamic analysis, where
+// the C++ build had classes taking the place of plain values or structs and
+// to add more checking.
+//
+// No features are implemented using C++, and the classes are only used in a
+// debug build of the project.  They are strictly for additional checks.
+//
+// While the C89 feature strives for legacy support, the C++ build does not.
+// The build works under C++98 but adds no additional checking features to
+// the C89 version.  Additional classes are only enabled for C++11 and above.
+//
+
+//
+// Reb_Indexor
+//
+// R3-Alpha wished to encode "magic values" into the integer index which is
+// used for stepping through arrays.  Hence 0, 1, 2, etc. would be normal
+// indices, but 2,147,483,647 and 2,147,483,648 would be "magic" values
+// (for instance) to indicate a status result of THROWN or END of input.
+//
+// The risk of not having a separate type and methods to check for this is
+// that it's very easy to do math and turn a "magic value" into one that
+// is not magic, or otherwise pass a flag value unchecked to something that
+// only expects valid array indices.  To check this in the C++ build, a
+// class that encapsulates the legal operations checks to make sure that
+// a magic value never "escapes" or has math performed on it.
+//
+// Additionally, when the value changes a string is set to what the value
+// is supposed to represent.  This way when looking during the debug build
+// one can quickly see which magic value a strange number is supposed to
+// be representing.
+//
+class Reb_Indexor {
+    REBCNT bits;
+    const char* name;
+
+    static constexpr const char* array_index_name = "(array index)";
+    static constexpr const char* end_name = "END_FLAG";
+    static constexpr const char* thrown_name = "THROWN_FLAG";
+    static constexpr const char* varargs_name = "VARARGS_FLAG";
+    static constexpr const char* varargs_incomplete_name
+        = "VARARGS_INCOMPLETE";
+
+    void Update_Name() {
+        if (bits == END_FLAG)
+            name = end_name;
+        else if (bits == THROWN_FLAG)
+            name = thrown_name;
+        else if (bits == VARARGS_FLAG)
+            name = varargs_name;
+        else if (bits == VARARGS_INCOMPLETE_FLAG)
+            name = varargs_incomplete_name;
+        else
+            name = array_index_name;
+    }
+
+public:
+    Reb_Indexor() {} // simulate C uninitialization of bits
+    Reb_Indexor(REBCNT bits) : bits (bits) {
+        Update_Name();
+    }
+    void operator=(REBCNT rhs) {
+        bits = rhs;
+        Update_Name();
+    }
+    int operator==(Reb_Indexor const &rhs) {
+        return bits == rhs.bits;
+    }
+    int operator!=(Reb_Indexor const &rhs) {
+        return !((*this) == rhs);
+    }
+
+    // Basic check: whenever one tries to get an actual unset integer out of
+    // an indexor, it is asserted not to be a magic value.  This is called by
+    // the math operations, as well as any explicit `cast(REBCNT, indexor)`
+    //
+    explicit operator REBCNT() const {
+        assert(
+            bits != END_FLAG && bits != THROWN_FLAG &&
+            bits != VARARGS_FLAG && bits != VARARGS_INCOMPLETE_FLAG
+        );
+        return bits;
+    }
+
+    // Subset of operations that are exported to be legal to perform between
+    // an unsigned integer and an indexor.  Comparisons for equality and
+    // addition and subtraction are allowed.  While more operations could
+    // be added, the best course of action is generally that if one is going
+    // to do a lot of math on an indexor it is not a special value...so it
+    // should be extracted by casting to a REBCNT.
+    //
+    friend int operator==(REBCNT lhs, const Reb_Indexor &rhs) {
+        return lhs == rhs.bits;
+    }
+    friend int operator!=(REBCNT lhs, const Reb_Indexor &rhs) {
+        return !(lhs == rhs);
+    }
+    int operator<(REBCNT rhs) const {
+        return cast(REBCNT, *this) < rhs;
+    }
+    friend int operator<(REBCNT lhs, const Reb_Indexor &rhs) {
+        return lhs < rhs.bits;
+    }
+    int operator>(REBCNT rhs) const {
+        return cast(REBCNT, *this) > rhs;
+    }
+    friend int operator>(REBCNT lhs, const Reb_Indexor &rhs) {
+        return lhs > rhs.bits;
+    }
+    int operator<=(REBCNT rhs) const {
+        return cast(REBCNT, *this) <= rhs;
+    }
+    friend int operator<=(REBCNT lhs, const Reb_Indexor &rhs) {
+        return lhs <= rhs.bits;
+    }
+    REBCNT operator+(REBCNT rhs) const {
+        return cast(REBCNT, *this) + rhs;
+    }
+    friend REBCNT operator+(REBCNT lhs, const Reb_Indexor &rhs) {
+        return rhs + lhs;
+    }
+    REBCNT operator-(REBCNT rhs) const {
+        return cast(REBCNT, *this) - rhs;
+    }
+    friend REBCNT operator-(REBCNT lhs, const Reb_Indexor &rhs) {
+        return rhs - lhs;
+    }
+    REBCNT operator*(REBCNT rhs) const {
+        return cast(REBCNT, *this) * rhs;
+    }
+    friend REBCNT operator*(REBCNT lhs, const Reb_Indexor &rhs) {
+        return rhs * lhs;
+    }
+};

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -221,7 +221,7 @@ enum Reb_Call_Mode {
 
 union Reb_Call_Source {
     REBARR *array;
-    va_list *varargs;
+    va_list *varargs_ptr;
 };
 
 // NOTE: The ordering of the fields in `Reb_Call` are specifically done so
@@ -317,7 +317,7 @@ struct Reb_Call {
     //
     const REBVAL *eval_fetched;
 
-    // source.array, source.varargs [INPUT, READ-ONLY, GC-PROTECTED]
+    // source.array, source.varargs_ptr [INPUT, READ-ONLY, GC-PROTECTED]
     //
     // This is the source from which new values will be fetched.  The most
     // common dispatch of the evaluator is on values that live inside of a
@@ -615,7 +615,7 @@ struct Reb_Call {
             } \
         } \
         else { \
-            (c)->value = va_arg((c)->source.varargs, REBVAL*); \
+            (c)->value = va_arg(*(c)->source.varargs_ptr, const REBVAL*); \
             if (IS_END((c)->value)) { \
                 (c)->value = NULL; \
                 (c)->indexor = END_FLAG; \

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -215,7 +215,8 @@ enum Reb_Call_Mode {
     CALL_MODE_SCANNING, // looking for refinements (used out of order)
     CALL_MODE_SKIPPING, // in the process of skipping an unused refinement
     CALL_MODE_REVOKING, // found an unset and aiming to revoke refinement use
-    CALL_MODE_FUNCTION // running an ANY-FUNCTION!
+    CALL_MODE_FUNCTION, // running an ANY-FUNCTION!
+    CALL_MODE_THROWN    // a function has THROWN and call frame is ending
 };
 
 union Reb_Call_Source {
@@ -464,14 +465,23 @@ struct Reb_Call {
     //
     REBIXO expr_index;
 
+#if !defined(NDEBUG)
+    //
     // `do_count` [INTERNAL, DEBUG, READ-ONLY]
     //
     // The `do_count` represents the expression evaluation "tick" where the
     // Reb_Call is starting its processing.  This is helpful for setting
     // breakpoints on certain ticks in reproducible situations.
     //
-#if !defined(NDEBUG)
     REBCNT do_count;
+
+    // `label_str` [INTERNAL, DEBUG, READ-ONLY]
+    //
+    // Knowing the label symbol is not as handy as knowing the actual string
+    // of the function this call represents (if any).  It is in UTF8 format,
+    // and cast to `char*` to help debuggers that have trouble with REBYTE.
+    //
+    const char *label_str;
 #endif
 };
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -764,7 +764,7 @@ struct Reb_Call {
             assert((indexor_out) > 1); \
             --(indexor_out); \
         } \
-        cast(void, dummy); \
+        (void)dummy; \
     } while (0)
 
 // Note: It is safe for `out` and `array` to be the same variable.  The

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -153,7 +153,7 @@ TVAR REBUPT Stack_Limit;    // Limit address for CPU stack.
 // be filtered to get an understanding of something like a "backtrace of
 // currently running functions".
 //
-TVAR REBSER *TG_Do_Stack;
+TVAR struct Reb_Call *TG_Do_Stack;
 
 //-- Evaluation stack:
 TVAR REBARR *DS_Array;

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -379,9 +379,12 @@ struct Reb_Series {
 // Note that series indexing in C is zero based.  So as far as SERIES is
 // concerned, `SERIES_HEAD(t, s)` is the same as `SERIES_AT(t, s, 0)`
 //
+// !!! C++11 note: can't use cast helper here and have the const of an
+// incoming REBVAL be ignored... must use `(old_cast)casting_style`
+//
 
 #define SERIES_AT(t,s,i) \
-    (assert(SERIES_WIDE(s) == sizeof(t)), cast(t*, SERIES_AT_RAW((s), (i))))
+    (assert(SERIES_WIDE(s) == sizeof(t)), (t*)(SERIES_AT_RAW((s), (i))))
 
 #define SERIES_HEAD(t,s) \
     SERIES_AT(t, (s), 0)
@@ -764,9 +767,8 @@ struct Reb_Array {
 
 #define TERM_SERIES(s) \
     Is_Array_Series(s) \
-        ? cast(void, TERM_ARRAY(AS_ARRAY(s))) \
-        : cast( \
-            void, memset(SERIES_AT_RAW(s, SERIES_LEN(s)), 0, SERIES_WIDE(s)))
+        ? (void)TERM_ARRAY(AS_ARRAY(s)) \
+        : (void)memset(SERIES_AT_RAW(s, SERIES_LEN(s)), 0, SERIES_WIDE(s))
 
 // Setting and getting array flags is common enough to want a macro for it
 // vs. having to extract the ARRAY_SERIES to do it each time.

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -127,7 +127,7 @@ struct Reb_State {
     struct Reb_Call *call;
     REBCNT series_guard_len;
     REBCNT value_guard_len;
-    REBCNT do_stack_len;
+    struct Reb_Call *do_stack; // is it necessary to keep this *and* DSF?
     REBCON *error;
     REBINT gc_disable;      // Count of GC_Disables at time of Push
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1089,7 +1089,10 @@ struct Reb_Any_Series
 // These operations do not need to take the value's index position into
 // account; they strictly operate on the array series
 //
-#define VAL_ARRAY(v)            (*cast(REBARR**, &VAL_SERIES(v)))
+// Must use `(old_style)cast_here` because we may-or-may-not be casting away
+// constness in the process, e.g. a series extracted from a const REBVAL.
+//
+#define VAL_ARRAY(v)            (*(REBARR**)(&VAL_SERIES(v)))
 #define VAL_ARRAY_HEAD(v)       ARRAY_HEAD(VAL_ARRAY(v))
 #define VAL_ARRAY_TAIL(v)       ARRAY_AT(VAL_ARRAY(v), VAL_ARRAY_LEN_AT(v))
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1606,6 +1606,11 @@ enum {
     EXT_FUNC_INFIX = 0,     // called with "infix" protocol
     EXT_FUNC_HAS_RETURN,    // function "fakes" a definitionally scoped return
     EXT_FUNC_FRAMELESS,     // native hooks into DO state and does own arg eval
+
+#if !defined(NDEBUG)
+    EXT_FUNC_LEGACY,        // TRUE-valued refinements, NONE! for unused args
+#endif
+
     EXT_FUNC_MAX
 };
 

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -499,37 +499,37 @@ for-each-record-NO-RETURN type boot-types [
 ;
 emit {
 #define IS_SET(v) \
-    (VAL_TYPE(v) > REB_UNSET)
+    LOGICAL(VAL_TYPE(v) > REB_UNSET)
 
 #define IS_SCALAR(v) \
-    (VAL_TYPE(v) <= REB_DATE)
+    LOGICAL(VAL_TYPE(v) <= REB_DATE)
 
 #define ANY_SERIES(v) \
-    (VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_LIT_PATH)
+    LOGICAL(VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_LIT_PATH)
 
 #define ANY_STRING(v) \
-    (VAL_TYPE(v) >= REB_STRING && VAL_TYPE(v) <= REB_TAG)
+    LOGICAL(VAL_TYPE(v) >= REB_STRING && VAL_TYPE(v) <= REB_TAG)
 
 #define ANY_BINSTR(v) \
-    (VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_TAG)
+    LOGICAL(VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_TAG)
 
 #define ANY_ARRAY(v) \
-    (VAL_TYPE(v) >= REB_BLOCK && VAL_TYPE(v) <= REB_LIT_PATH)
+    LOGICAL(VAL_TYPE(v) >= REB_BLOCK && VAL_TYPE(v) <= REB_LIT_PATH)
 
 #define ANY_WORD(v) \
-    (VAL_TYPE(v) >= REB_WORD && VAL_TYPE(v) <= REB_ISSUE)
+    LOGICAL(VAL_TYPE(v) >= REB_WORD && VAL_TYPE(v) <= REB_ISSUE)
 
 #define ANY_PATH(v) \
-    (VAL_TYPE(v) >= REB_PATH && VAL_TYPE(v) <= REB_LIT_PATH)
+    LOGICAL(VAL_TYPE(v) >= REB_PATH && VAL_TYPE(v) <= REB_LIT_PATH)
 
 #define ANY_FUNC(v) \
-    (VAL_TYPE(v) >= REB_NATIVE && VAL_TYPE(v) <= REB_FUNCTION)
+    LOGICAL(VAL_TYPE(v) >= REB_NATIVE && VAL_TYPE(v) <= REB_FUNCTION)
 
 #define ANY_EVAL_BLOCK(v) \
-    (VAL_TYPE(v) >= REB_BLOCK  && VAL_TYPE(v) <= REB_GROUP)
+    LOGICAL(VAL_TYPE(v) >= REB_BLOCK  && VAL_TYPE(v) <= REB_GROUP)
 
 #define ANY_CONTEXT(v) \
-    (VAL_TYPE(v) >= REB_OBJECT && VAL_TYPE(v) <= REB_PORT)
+    LOGICAL(VAL_TYPE(v) >= REB_OBJECT && VAL_TYPE(v) <= REB_PORT)
 
 // If the type has evaluator behavior (vs. just passing through).  So like
 // WORD!, GROUP!, FUNCTION! (as opposed to BLOCK!, INTEGER!, OBJECT!).


### PR DESCRIPTION
*(Note: The changes in this commit in %c-do.c are longer than GitHub
will display.)*

This is a top-to-bottom rewrite of the evaluator, which hones its ways
of acquiring and updating values to process into a stylized API that
allows Do_Core to serve as the basis for all(*) evaluation requests.

(* - "extension" callbacks are not yet using the method, but will.)

This recasts the evaluator to build upon three basic primitives for
navigating the input data (really two, but three for clarity):

    - FETCH_NEXT_ONLY_MAYBE_END
    - DO_NEXT_REFETCH_MAY_THROW
    - DO_NEXT_REFETCH_QUOTED

By organizing the evaluation to not use arbitrary index math on the
input series, this opens the doors to using sources for the data to
evaluate which are not random access (such as C vararg lists).  By
extending the EVAL settings for the evaluator, things that could
previously only be achieved in standard evaluation by functions like
APPLY/ONLY can now be done by both system code using the vararg API
*and* user code in Rebol.

To truly generalize the approach so that it can do arbitrary evaluation
from C vararg calls, as well as to deliver meaningful WHERE positions
during an error in a vararg argument evaluation, more work will be
needed to convert the varargs on-demand into an array.  Also, some
sort of caching will be needed in a debug mode to "see back in time"
to before the varargs had been advanced.

Though that hasn't been done yet, this lays the majority of the
groundwork for the method.  Generally speaking one shouldn't notice a
difference in the behavior (modulo bugs), but this is a very significant
rewrite--so expect speedbumps here and there with it in the near term.

One user-visible change, however, is the treatment of infix literal
function values (such as `do compose [1 (:+) 2]`).  See CureCode
issue #1934 for why this literal form of function does not behave as
infix--it must be bound to a word to have infix behavior.  This may
be temporary or permanent, but it is a change that is needed for at
least the current moment.