### PR TITLE
FRAME! represents specific function instance+args, Debug Features

### DIFF
--- a/src/boot/ops.r
+++ b/src/boot/ops.r
@@ -18,7 +18,7 @@ REBOL [
 
         and:
 
-            set (bind/new first [<>] bind? 'func) func [...] [...]
+            set (bind/new first [<>] context-of 'func) func [...] [...]
 
         You may be able to get an assignment with the second.  BUT
         it could be too late for references that have already been

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -190,7 +190,7 @@ standard: context [
     func-body: [
         return: make function! [
             [{Returns a value from a function.} value [opt-any-value!]]
-            [exit/at/with (bind-of 'return) :value]
+            [exit/from/with (context-of 'return) :value]
         ]
         #BODY
     ]

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -694,7 +694,11 @@ static void Init_Root_Context(void)
     // (You can't ASSERT_CONTEXT(PG_Root_Context) until that happens.)  The
     // new keylist will be managed so we manage the varlist to match.
     //
-    Free_Array(CONTEXT_KEYLIST(root));
+    // !!! We let it get GC'd, which is a bit wasteful, but the interface
+    // for Alloc_Context() wants to manage the keylist in general.  This
+    // is done for convenience.
+    //
+    /*Free_Array(CONTEXT_KEYLIST(root));*/
     INIT_CONTEXT_KEYLIST(root, NULL);
     MANAGE_ARRAY(CONTEXT_VARLIST(root));
 
@@ -818,7 +822,11 @@ static void Init_Task_Context(void)
     // (You can't ASSERT_CONTEXT(TG_Task_Context) until that happens.)  The
     // new keylist will be managed so we manage the varlist to match.
     //
-    Free_Array(CONTEXT_KEYLIST(task));
+    // !!! We let it get GC'd, which is a bit wasteful, but the interface
+    // for Alloc_Context() wants to manage the keylist in general.  This
+    // is done for convenience.
+    //
+    /*Free_Array(CONTEXT_KEYLIST(task));*/
     INIT_CONTEXT_KEYLIST(task, NULL);
     MANAGE_ARRAY(CONTEXT_VARLIST(task));
 
@@ -949,7 +957,6 @@ static void Init_System_Object(void)
 static void Init_Contexts_Object(void)
 {
     REBVAL *value;
-//  REBCON *context;
 
     value = Get_System(SYS_CONTEXTS, CTX_SYS);
     Val_Init_Object(value, Sys_Context);
@@ -959,12 +966,6 @@ static void Init_Contexts_Object(void)
 
     value = Get_System(SYS_CONTEXTS, CTX_USER);  // default for new code evaluation
     Val_Init_Object(value, Lib_Context);
-
-    // Make the boot context - used to store values created
-    // during boot, but processed in REBOL code (e.g. codecs)
-//  value = Get_System(SYS_CONTEXTS, CTX_BOOT);
-//  context = Alloc_Context(4, TRUE);
-//  Val_Init_Object(value, context);
 }
 
 //
@@ -1446,7 +1447,6 @@ void Init_Core(REBARGS *rargs)
     //
     Lib_Context = Alloc_Context(600);
     MANAGE_ARRAY(CONTEXT_VARLIST(Lib_Context));
-    MANAGE_ARRAY(CONTEXT_KEYLIST(Lib_Context));
 
     VAL_RESET_HEADER(CONTEXT_VALUE(Lib_Context), REB_OBJECT);
     CONTEXT_SPEC(Lib_Context) = NULL;
@@ -1456,7 +1456,6 @@ void Init_Core(REBARGS *rargs)
     //
     Sys_Context = Alloc_Context(50);
     MANAGE_ARRAY(CONTEXT_VARLIST(Sys_Context));
-    MANAGE_ARRAY(CONTEXT_KEYLIST(Sys_Context));
 
     VAL_RESET_HEADER(CONTEXT_VALUE(Sys_Context), REB_OBJECT);
     CONTEXT_SPEC(Sys_Context) = NULL;

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -944,7 +944,7 @@ static void Init_System_Object(void)
 
         value = Get_System(SYS_CODECS, 0);
         VAL_RESET_HEADER(CONTEXT_VALUE(codecs), REB_OBJECT);
-        CONTEXT_SPEC(codecs) = NULL;
+        INIT_CONTEXT_SPEC(codecs, NULL);
         CONTEXT_STACKVARS(codecs) = NULL;
         Val_Init_Object(value, codecs);
     }
@@ -1449,7 +1449,7 @@ void Init_Core(REBARGS *rargs)
     MANAGE_ARRAY(CONTEXT_VARLIST(Lib_Context));
 
     VAL_RESET_HEADER(CONTEXT_VALUE(Lib_Context), REB_OBJECT);
-    CONTEXT_SPEC(Lib_Context) = NULL;
+    INIT_CONTEXT_SPEC(Lib_Context, NULL);
     CONTEXT_STACKVARS(Lib_Context) = NULL;
 
     // Must manage, else Expand_Context() looks like a leak
@@ -1458,7 +1458,7 @@ void Init_Core(REBARGS *rargs)
     MANAGE_ARRAY(CONTEXT_VARLIST(Sys_Context));
 
     VAL_RESET_HEADER(CONTEXT_VALUE(Sys_Context), REB_OBJECT);
-    CONTEXT_SPEC(Sys_Context) = NULL;
+    INIT_CONTEXT_SPEC(Sys_Context, NULL);
     CONTEXT_STACKVARS(Sys_Context) = NULL;
 
     DOUT("Level 2");

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -778,7 +778,7 @@ static void Init_Root_Context(void)
     // in the debug build for good measure.
     //
     PG_End_Val = cast(REBVAL*, malloc(sizeof(REBVAL)));
-    PG_End_Val->header.all = 0; // read-only end
+    PG_End_Val->header.bits = 0; // read-only end
     assert(IS_END(END_VALUE));
 
     // Can't ASSERT_CONTEXT here; no keylist yet...

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1442,13 +1442,22 @@ void Init_Core(REBARGS *rargs)
 
     // !!! Have MAKE-BOOT compute # of words
     //
+    // Must manage, else Expand_Context() looks like a leak
+    //
     Lib_Context = Alloc_Context(600);
-    MANAGE_CONTEXT(Lib_Context); // Expand_Context() looks like a leak otherwise
+    MANAGE_ARRAY(CONTEXT_VARLIST(Lib_Context));
+    MANAGE_ARRAY(CONTEXT_KEYLIST(Lib_Context));
+
     VAL_RESET_HEADER(CONTEXT_VALUE(Lib_Context), REB_OBJECT);
     CONTEXT_SPEC(Lib_Context) = NULL;
     CONTEXT_BODY(Lib_Context) = NULL;
+
+    // Must manage, else Expand_Context() looks like a leak
+    //
     Sys_Context = Alloc_Context(50);
-    MANAGE_CONTEXT(Sys_Context); // Expand_Context() looks like a leak otherwise
+    MANAGE_ARRAY(CONTEXT_VARLIST(Sys_Context));
+    MANAGE_ARRAY(CONTEXT_KEYLIST(Sys_Context));
+
     VAL_RESET_HEADER(CONTEXT_VALUE(Sys_Context), REB_OBJECT);
     CONTEXT_SPEC(Sys_Context) = NULL;
     CONTEXT_BODY(Sys_Context) = NULL;

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -702,11 +702,11 @@ static void Init_Root_Context(void)
     INIT_CONTEXT_KEYLIST(root, NULL);
     MANAGE_ARRAY(CONTEXT_VARLIST(root));
 
-    // !!! Also no `body` (or `spec`, not yet implemented); revisit
+    // !!! Also no `stackvars` (or `spec`, not yet implemented); revisit
     //
     VAL_RESET_HEADER(CONTEXT_VALUE(root), REB_OBJECT);
     VAL_CONTEXT_SPEC(CONTEXT_VALUE(root)) = NULL;
-    VAL_CONTEXT_BODY(CONTEXT_VALUE(root)) = NULL;
+    VAL_CONTEXT_STACKVARS(CONTEXT_VALUE(root)) = NULL;
 
     // Set all other values to NONE:
     {
@@ -834,7 +834,7 @@ static void Init_Task_Context(void)
     //
     VAL_RESET_HEADER(CONTEXT_VALUE(task), REB_OBJECT);
     VAL_CONTEXT_SPEC(CONTEXT_VALUE(task)) = NULL;
-    VAL_CONTEXT_BODY(CONTEXT_VALUE(task)) = NULL;
+    VAL_CONTEXT_STACKVARS(CONTEXT_VALUE(task)) = NULL;
 
     // Set all other values to NONE:
     {
@@ -945,7 +945,7 @@ static void Init_System_Object(void)
         value = Get_System(SYS_CODECS, 0);
         VAL_RESET_HEADER(CONTEXT_VALUE(codecs), REB_OBJECT);
         CONTEXT_SPEC(codecs) = NULL;
-        CONTEXT_BODY(codecs) = NULL;
+        CONTEXT_STACKVARS(codecs) = NULL;
         Val_Init_Object(value, codecs);
     }
 }
@@ -1450,7 +1450,7 @@ void Init_Core(REBARGS *rargs)
 
     VAL_RESET_HEADER(CONTEXT_VALUE(Lib_Context), REB_OBJECT);
     CONTEXT_SPEC(Lib_Context) = NULL;
-    CONTEXT_BODY(Lib_Context) = NULL;
+    CONTEXT_STACKVARS(Lib_Context) = NULL;
 
     // Must manage, else Expand_Context() looks like a leak
     //
@@ -1459,7 +1459,7 @@ void Init_Core(REBARGS *rargs)
 
     VAL_RESET_HEADER(CONTEXT_VALUE(Sys_Context), REB_OBJECT);
     CONTEXT_SPEC(Sys_Context) = NULL;
-    CONTEXT_BODY(Sys_Context) = NULL;
+    CONTEXT_STACKVARS(Sys_Context) = NULL;
 
     DOUT("Level 2");
     Load_Boot();            // Protected strings now available

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1846,34 +1846,32 @@ reevaluate:
 
                 #if !defined(NDEBUG)
                     //
-                    // We captured the "true-valued-refinements" legacy switch
-                    // and decided whether to make the refinement true or the
-                    // word value of the refinement.  We use the same switch
-                    // to cover whether the unused args are NONE or UNSET...
-                    // but decide which it is by looking at what was filled
-                    // in for the refinement.  UNSET is the default.
+                    // Sanity check that the refinement revoking type is good,
+                    // whether legacy (true/false) or Ren-C (WORD! of the
+                    // refinement itself).
                     //
-                    if (!IS_WORD(c->refine)) {
+                    if (VAL_GET_EXT(FUNC_VALUE(c->func), EXT_FUNC_LEGACY)) {
                         assert(IS_LOGIC(c->refine));
-                        SET_NONE(c->arg);
+                        assert(IS_NONE(c->arg)); // is actually already none
+                    }
+                    else {
+                        assert(IS_WORD(c->refine));
+                        assert(IS_UNSET(c->arg));
                     }
                 #endif
 
                     SET_NONE(c->refine); // ...revoke the refinement.
                 }
                 else if (c->mode == CALL_MODE_REVOKING) {
-                #ifdef NDEBUG
                     //
-                    // Don't have to do anything, it's unset
+                    // We are revoking arguments to a refinement that have
+                    // never been filled, so they should be vacant.
                     //
-                #else
-                    //
-                    // We have overwritten the refinement so we don't know if
-                    // it was LOGIC! or WORD!, but we don't need to know that
-                    // because we can just copy whatever the previous arg
-                    // was set to...
-                    //
-                    *c->arg = *(c->arg - 1);
+                #if !defined(NDEBUG)
+                    if (VAL_GET_EXT(FUNC_VALUE(c->func), EXT_FUNC_LEGACY))
+                        assert(IS_NONE(c->arg));
+                    else
+                        assert(IS_UNSET(c->arg));
                 #endif
                 }
             }

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1974,13 +1974,12 @@ reevaluate:
         #if !defined(NDEBUG)
             if (ARRAY_GET_FLAG(exit_from, OPT_SER_CONTEXT)) {
                 //
-                // The function was actually a CLOSURE!, so "when it took
-                // BIND-OF on 'RETURN" it "would have gotten back an OBJECT!".
+                // Request to exit from a specific FRAME!
                 //
-                assert(IS_OBJECT(CONTEXT_VALUE(AS_CONTEXT(exit_from))));
+                assert(IS_FRAME(CONTEXT_VALUE(AS_CONTEXT(exit_from))));
             }
             else {
-                // It was a stack-relative FUNCTION!
+                // Request to dynamically exit from first ANY-FUNCTION! found
                 //
                 assert(IS_FUNCTION(FUNC_VALUE(AS_FUNC(exit_from))));
                 assert(FUNC_PARAMLIST(AS_FUNC(exit_from)) == exit_from);
@@ -2095,7 +2094,7 @@ reevaluate:
             c->mode == CALL_MODE_THROWN
             && VAL_GET_OPT(c->out, OPT_VALUE_EXIT_FROM)
         ) {
-            if (IS_OBJECT(c->out)) {
+            if (IS_FRAME(c->out)) {
                 //
                 // This identifies an exit from a *specific* functiion
                 // invocation.  We can only match it if we have a reified

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1977,7 +1977,6 @@ reevaluate:
                 //
                 *c->out = *CONTEXT_VALUE(AS_CONTEXT(exit_from));
                 assert(IS_FRAME(c->out));
-                PROBE_MSG(c->out, "exit_from frame");
             }
             else {
                 // Request to dynamically exit from first ANY-FUNCTION! found
@@ -2153,9 +2152,6 @@ reevaluate:
                 ) {
                     CATCH_THROWN(c->out, c->out);
                     c->mode = CALL_MODE_0;
-                }
-                else {
-                    PROBE_MSG(c->out, "passing on exit_from");
                 }
             }
             else if (ANY_FUNC(c->out)) {

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -2098,7 +2098,8 @@ reevaluate:
         // which happens depends on whether eval_fetched is NULL or not
         //
         if (c->flags & DO_FLAG_FRAME_CONTEXT) {
-            Drop_Chunk(ARRAY_HEAD(CONTEXT_VARLIST(c->frame.context)));
+            if (CONTEXT_STACKVARS(c->frame.context) != NULL)
+                Drop_Chunk(CONTEXT_STACKVARS(c->frame.context));
 
             if (ARRAY_GET_FLAG(
                 CONTEXT_VARLIST(c->frame.context), OPT_SER_MANAGED

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -546,7 +546,7 @@ static REBCON *Make_Guarded_Arg123_Error(void)
     REBVAL *key;
     REBVAL *var;
     REBCNT n;
-    REBCNT root_len = CONTEXT_LEN(root_error);
+    REBCNT root_len = ARRAY_LEN(CONTEXT_VARLIST(root_error));
 
     // Update the length to suppress out of bounds assert from CONTEXT_KEY/VAL
     //
@@ -554,7 +554,7 @@ static REBCON *Make_Guarded_Arg123_Error(void)
     SET_ARRAY_LEN(CONTEXT_KEYLIST(error), root_len + 3);
 
     key = CONTEXT_KEY(error, CONTEXT_LEN(root_error) + 1);
-    var = CONTEXT_KEY(error, CONTEXT_LEN(root_error) + 1);
+    var = CONTEXT_VAR(error, CONTEXT_LEN(root_error) + 1);
 
     for (n = 0; n < 3; n++, key++, var++) {
         Val_Init_Typeset(key, ALL_64, SYM_ARG1 + n);

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -150,7 +150,7 @@ REBCON *Alloc_Context(REBCNT len)
 
     // Allowed to be set to NULL, but must be done so explicitly
     //
-    CONTEXT_BODY(context) = cast(REBARR*, 0xBAADF00D);
+    CONTEXT_STACKVARS(context) = cast(REBVAL*, 0xBAADF00D);
 #endif
 
     SET_END(CONTEXT_VARS_HEAD(context));
@@ -700,7 +700,7 @@ void Rebind_Context_Deep(REBCON *src, REBCON *dst, REBINT *opt_binds)
 REBCON *Make_Selfish_Context_Detect(
     enum Reb_Kind kind,
     REBCON *spec,
-    REBARR *body,
+    REBVAL *stackvars,
     REBVAL value[],
     REBCON *opt_parent
 ) {
@@ -788,7 +788,7 @@ REBCON *Make_Selfish_Context_Detect(
         //
         CONTEXT_VALUE(context)->payload.any_context.context = context;
         VAL_CONTEXT_SPEC(CONTEXT_VALUE(context)) = NULL;
-        VAL_CONTEXT_BODY(CONTEXT_VALUE(context)) = NULL;
+        VAL_CONTEXT_STACKVARS(CONTEXT_VALUE(context)) = NULL;
 
         // !!! This code was inlined from Create_Frame() because it was only
         // used once here, and it filled the context vars with NONE!.  For
@@ -830,7 +830,7 @@ REBCON *Make_Selfish_Context_Detect(
     assert(CONTEXT_TYPE(context) == kind);
 
     CONTEXT_SPEC(context) = spec;
-    CONTEXT_BODY(context) = body;
+    CONTEXT_STACKVARS(context) = stackvars;
 
     // We should have a SELF key in all cases here.  Set it to be a copy of
     // the object we just created.  (It is indeed a copy of the [0] element,
@@ -993,7 +993,7 @@ REBCON *Merge_Contexts_Selfish(REBCON *parent1, REBCON *parent2)
     INIT_CONTEXT_KEYLIST(child, keylist);
     INIT_VAL_CONTEXT(value, child);
     VAL_CONTEXT_SPEC(value) = NULL;
-    VAL_CONTEXT_BODY(value) = NULL;
+    VAL_CONTEXT_STACKVARS(value) = NULL;
 
     // Copy parent1 values:
     memcpy(

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1975,8 +1975,6 @@ void Assert_Context_Core(REBCON *context)
         Panic_Context(context);
     }
 
-    assert(!IS_FRAME(var)); // !!! these don't actually exist just yet...
-
     if (var->payload.any_context.context != context) {
         Debug_Fmt("Embedded ANY-CONTEXT!'s context doesn't match context");
         Panic_Context(context);

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -146,7 +146,10 @@ REBCON *Alloc_Context(REBCNT len)
     // an object spec will wind up looking like, and may end up being the
     // "meta" information.
     //
-    CONTEXT_SPEC(context) = cast(REBCON*, 0xBAADF00D);
+    // !!! This should likely corrupt the data for the CONTEXT_FUNC as well
+    //
+    CONTEXT_VALUE(context)->payload.any_context.more.spec
+        =  cast(REBCON*, 0xBAADF00D);
 
     // Allowed to be set to NULL, but must be done so explicitly
     //
@@ -829,7 +832,7 @@ REBCON *Make_Selfish_Context_Detect(
     VAL_RESET_HEADER(CONTEXT_VALUE(context), kind);
     assert(CONTEXT_TYPE(context) == kind);
 
-    CONTEXT_SPEC(context) = spec;
+    INIT_CONTEXT_SPEC(context, spec);
     CONTEXT_STACKVARS(context) = stackvars;
 
     // We should have a SELF key in all cases here.  Set it to be a copy of
@@ -1899,7 +1902,7 @@ void Init_Collector(void)
 //  CONTEXT_KEY_Debug: C
 //
 REBVAL *CONTEXT_KEY_Debug(REBCON *c, REBCNT n) {
-    assert(n != 0 && n < ARRAY_LEN(CONTEXT_KEYLIST(c)));
+    assert(n != 0 && n <= CONTEXT_LEN(c));
     return CONTEXT_KEYS_HEAD(c) + (n) - 1;
 }
 
@@ -1908,7 +1911,7 @@ REBVAL *CONTEXT_KEY_Debug(REBCON *c, REBCNT n) {
 //  CONTEXT_VAR_Debug: C
 //
 REBVAL *CONTEXT_VAR_Debug(REBCON *c, REBCNT n) {
-    assert(n != 0 && n < ARRAY_LEN(CONTEXT_VARLIST(c)));
+    assert(n != 0 && n <= CONTEXT_LEN(c));
     return CONTEXT_VARS_HEAD(c) + (n) - 1;
 }
 

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -280,7 +280,7 @@ REBCON *Copy_Context_Shallow_Extra(REBCON *src, REBCNT extra) {
 
 
 //
-//  Copy_Context_Shallow_Managed: C
+//  Copy_Context_Shallow: C
 //
 // !!! Make this a macro when there's a place to put it.
 //
@@ -1364,7 +1364,6 @@ static void Bind_Relative_Inner_Loop(
                 VAL_SET_EXT(value, EXT_WORD_BOUND_RELATIVE);
                 INIT_WORD_RELATIVE(value, func);
                 INIT_WORD_INDEX(value, n);
-
             }
         }
         else if (ANY_ARRAY(value))

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -995,7 +995,7 @@ void Do_Function_Core(struct Reb_Call *c)
         // return, the local for this return should so far have just been
         // ensured in last slot...and left unset by any arg filling process.
         //
-        REBVAL *last_arg = &c->arg[FUNC_NUM_PARAMS(c->func)];
+        REBVAL *last_arg = DSF_ARG(c, FUNC_NUM_PARAMS(c->func));
 
     #if !defined(NDEBUG)
         REBVAL *last_param = FUNC_PARAM(c->func, FUNC_NUM_PARAMS(c->func));
@@ -1031,7 +1031,7 @@ void Do_Function_Core(struct Reb_Call *c)
 void Do_Closure_Core(struct Reb_Call *c)
 {
     REBARR *body;
-    REBCON *context = Frame_For_Call_May_Reify(c, FALSE);
+    REBCON *context = Frame_For_Call_May_Reify(c, NULL, FALSE);
 
     Eval_Functions++;
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -480,9 +480,9 @@ REBARR *Get_Maybe_Fake_Func_Body(REBOOL *is_fake, const REBVAL *func)
 // 
 //     return: make function! [
 //         [{Returns a value from a function.} value [opt-any-value!]]
-//         [throw/name :value bind-of 'return]
+//         [exit/from/with (context-of 'return) :value]
 //     ]
-//     catch/name (body) bind-of 'return
+//     (body goes here)
 // 
 // This pattern addresses "Definitional Return" in a way that does not
 // technically require building RETURN in as a language keyword in any

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -153,7 +153,6 @@ REBARR *Make_Paramlist_Managed(REBARR *spec, REBCNT opt_sym_last)
     paramlist = Collect_Keylist_Managed(
         NULL, ARRAY_HEAD(spec), NULL, BIND_ALL | BIND_NO_DUP
     );
-    ARRAY_SET_FLAG(paramlist, OPT_SER_PARAMLIST);
 
     // Whatever function is being made, it must fill in the paramlist slot 0
     // with an ANY-FUNCTION! value corresponding to the function that it is
@@ -857,8 +856,6 @@ void Clonify_Function(REBVAL *value)
     func_orig = VAL_FUNC(value);
     paramlist_copy = Copy_Array_Shallow(FUNC_PARAMLIST(func_orig));
 
-    ARRAY_SET_FLAG(paramlist_copy, OPT_SER_PARAMLIST);
-
     value->payload.any_function.func = AS_FUNC(paramlist_copy);
 
     VAL_FUNC_BODY(value) = Copy_Array_Deep_Managed(VAL_FUNC_BODY(value));
@@ -1267,18 +1264,18 @@ REBFUN *VAL_FUNC_Debug(const REBVAL *v) {
     // however, for many of the same reasons it's a nuisance here.  The
     // OPT_VALUE_EXIT_FROM needs to be handled in the same way.
     //
-    v_header.all |= (
+    v_header.bits |= (
         (1 << OPT_VALUE_EXIT_FROM)
         | (1 << OPT_VALUE_LINE)
         | (1 << OPT_VALUE_THROWN)
     ) << 8;
-    func_header.all |= (
+    func_header.bits |= (
         (1 << OPT_VALUE_EXIT_FROM)
         | (1 << OPT_VALUE_LINE)
         | (1 << OPT_VALUE_THROWN)
     ) << 8;
 
-    if (v_header.all != func_header.all) {
+    if (v_header.bits != func_header.bits) {
         REBVAL *func_value = FUNC_VALUE(func);
         REBOOL frameless_value = VAL_GET_EXT(v, EXT_FUNC_FRAMELESS);
         REBOOL frameless_func = VAL_GET_EXT(func_value, EXT_FUNC_FRAMELESS);

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -570,7 +570,6 @@ REBNATIVE(set_scheme)
             ALL_64,
             SYM_FROM_KIND(REB_PORT)
         );
-        ARRAY_SET_FLAG(paramlist, OPT_SER_PARAMLIST);
         MANAGE_ARRAY(paramlist);
 
         // !!! Review: If this spec ever got leaked then it would be leaking

--- a/src/core/c-task.c
+++ b/src/core/c-task.c
@@ -62,8 +62,21 @@
 //
 //  Launch_Task: C
 //
+// !!! TASK! was an unfinished feature of R3-Alpha.  While the code had been
+// reigned in from what was apparently a large number of global variables,
+// there was no articulated story of how different threads of execution
+// would interact safely with the same data.  Because synchronization was
+// not accounted for in the memory pools or otherwise, these tasks would
+// have to lock down large parts of the system to run and not risk crashing
+// another thread.
+//
+// Ren-C has moved along without it but not quite yet deleted the code due
+// to wanting to understand what the original goal was.  Over time what code
+// there was has been commented out entirely, so it will likely be removed.
+//
 static void Launch_Task(void *task_rebval)
 {
+/*
     REBVAL *task = cast(REBVAL*, task_rebval);
     REBARR *body;
 
@@ -80,6 +93,7 @@ static void Launch_Task(void *task_rebval)
         fail (Error_No_Catch_For_Throw(&ignored));
 
     Debug_Str("End Task");
+*/
 }
 
 

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -297,9 +297,9 @@ void Val_Init_Word_Bound(
     assert(context);
 
     VAL_RESET_HEADER(out, type);
-    VAL_SET_EXT(out, EXT_WORD_BOUND_NORMAL);
+    VAL_SET_EXT(out, EXT_WORD_BOUND_SPECIFIC);
     INIT_WORD_SYM(out, sym);
-    INIT_WORD_CONTEXT(out, context);
+    INIT_WORD_SPECIFIC(out, context);
     INIT_WORD_INDEX(out, index);
 
     assert(ANY_WORD(out));

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -323,7 +323,7 @@ void Val_Init_Word(REBVAL *out, enum Reb_Kind type, REBCNT sym)
     INIT_WORD_SYM(out, sym);
 
 #if !defined(NDEBUG)
-    INIT_WORD_INDEX(out, 0);
+    out->payload.any_word.index = 0;
 #endif
 
     assert(ANY_WORD(out));

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -54,7 +54,7 @@ void Dump_Series(REBSER *series, const char *memo)
         SERIES_BIAS(series),
         SERIES_LEN(series),
         SERIES_REST(series),
-        SERIES_FLAGS(series)
+        series->info.bits // flags + width
     );
     if (Is_Array_Series(series)) {
         Dump_Values(ARRAY_HEAD(AS_ARRAY(series)), SERIES_LEN(series));

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -166,7 +166,7 @@ void Clonify_Values_Len_Managed(
                 assert(!IS_FRAME(value)); // !!! Don't exist yet...
                 INIT_VAL_CONTEXT(
                     value,
-                    Copy_Context_Shallow_Managed(VAL_CONTEXT(value))
+                    Copy_Context_Shallow(VAL_CONTEXT(value))
                 );
                 series = ARRAY_SERIES(CONTEXT_VARLIST(VAL_CONTEXT(value)));
             }

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -608,7 +608,7 @@ bad_func_def:
 //     spec - same as other funcs
 //     body - [ext-obj func-index]
 //
-enum Reb_Call_Mode Do_Command_Core(struct Reb_Call *call_)
+void Do_Command_Core(struct Reb_Call *call_)
 {
     // All of these were checked above on definition:
     REBVAL *val = ARRAY_HEAD(FUNC_BODY(D_FUNC));
@@ -666,7 +666,9 @@ enum Reb_Call_Mode Do_Command_Core(struct Reb_Call *call_)
         SET_UNSET(D_OUT);
     }
 
-    return CALL_MODE_0; // no interface to throw, and make CALL_MODE_THROWN
+    // Note: no current interface for Rebol "commands" to throw (to the extent
+    // that REB_COMMAND has a future in Ren-C).  If it could throw, then
+    // this would set `c->mode = CALL_MODE_THROW_PENDING` in that case.
 }
 
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -473,7 +473,7 @@ REBNATIVE(load_extension)
     ext->index = Ext_Next++;
 
     // Extension return: dll, info, filename
-    context = Copy_Context_Shallow_Managed(
+    context = Copy_Context_Shallow(
         VAL_CONTEXT(Get_System(SYS_STANDARD, STD_EXTENSION))
     );
     Val_Init_Object(D_OUT, context);

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -498,7 +498,7 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 
 
 //
-//  Val_Init_Context_Core: C
+//  Val_Init_Context: C
 //
 // Common routine for initializing OBJECT, MODULE!, PORT!, and ERROR!
 //

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -516,9 +516,20 @@ void Val_Init_Context_Core(
     }
 #endif
 
-    ENSURE_CONTEXT_MANAGED(context);
-
+    // Some contexts (stack frames in particular) start out unmanaged, and
+    // then check to see if an operation like Val_Init_Context set them to
+    // managed.  If not, they will free the context.  This avoids the need
+    // for the garbage collector to have to deal with the series if there's
+    // no reason too.  (See also INIT_WORD_SPECIFIC() for how a word set
+    // up with a binding ensures what it's bound to becomes managed.)
+    //
+    ENSURE_ARRAY_MANAGED(CONTEXT_VARLIST(context));
     assert(ARRAY_GET_FLAG(CONTEXT_VARLIST(context), OPT_SER_CONTEXT));
+
+    // Should we assume or assert that all context keylists are "pre-managed"?
+    //
+    /*assert(ARRAY_GET_FLAG(CONTEXT_KEYLIST(context), OPT_SER_MANAGED));*/
+    ENSURE_ARRAY_MANAGED(CONTEXT_KEYLIST(context));
 
 #if !defined(NDEBUG)
     {

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -533,11 +533,11 @@ void Val_Init_Context(REBVAL *out, enum Reb_Kind kind, REBCON *context) {
     // may want to use another word of that and make a block "spec"
     //
     assert(
-        !CONTEXT_SPEC(context)
-        || ARRAY_GET_FLAG(
-            CONTEXT_VARLIST(CONTEXT_SPEC(context)),
-            OPT_SER_CONTEXT
-        )
+        IS_FRAME(CONTEXT_VALUE(context))
+            ? ANY_FUNC(FUNC_VALUE(CONTEXT_FUNC(context)))
+            : (!CONTEXT_SPEC(context)
+                || ANY_CONTEXT(CONTEXT_VALUE(CONTEXT_SPEC(context)))
+            )
     );
 #endif
 

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -755,7 +755,10 @@ void Queue_Mark_Value_Deep(const REBVAL *val)
             {
                 REBVAL *value = CONTEXT_VALUE(context);
                 assert(VAL_CONTEXT(value) == context);
-                assert(VAL_CONTEXT_SPEC(val) == VAL_CONTEXT_SPEC(value));
+                if (IS_FRAME(val))
+                    assert(VAL_CONTEXT_FUNC(val) == VAL_CONTEXT_FUNC(value));
+                else
+                    assert(VAL_CONTEXT_SPEC(val) == VAL_CONTEXT_SPEC(value));
 
                 // Though the general rule is that canon values should match
                 // the bits of any instance, an exception is made in the
@@ -775,16 +778,21 @@ void Queue_Mark_Value_Deep(const REBVAL *val)
 
             QUEUE_MARK_CONTEXT_DEEP(context);
 
-            if (VAL_CONTEXT_SPEC(val)) {
-                //
-                // !!! Under the module system, the spec is actually another
-                // context of an object constructed with the various pieces
-                // of module information.  This idea is being reviewed to
-                // see if what is called the "object spec" should be
-                // something more like a function spec, with the module
-                // information going in something called a "meta"
-                //
-                QUEUE_MARK_CONTEXT_DEEP(VAL_CONTEXT_SPEC(val));
+            if (IS_FRAME(val)) {
+                QUEUE_MARK_ARRAY_DEEP(AS_ARRAY(VAL_CONTEXT_FUNC(val)));
+            }
+            else {
+                if (VAL_CONTEXT_SPEC(val)) {
+                    //
+                    // !!! Under the module system, the spec is another
+                    // context of an object constructed with the various pieces
+                    // of module information.  This idea is being reviewed to
+                    // see if what is called the "object spec" should be
+                    // something more like a function spec, with the module
+                    // information going in something called a "meta"
+                    //
+                    QUEUE_MARK_CONTEXT_DEEP(VAL_CONTEXT_SPEC(val));
+                }
             }
 
             // If CONTEXT_STACKVARS is not NULL, the marking will be taken

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -734,6 +734,7 @@ void Queue_Mark_Value_Deep(const REBVAL *val)
         case REB_OBJECT:
         case REB_MODULE:
         case REB_PORT:
+        case REB_FRAME:
         case REB_ERROR: {
             REBCON *context = VAL_CONTEXT(val);
             assert(CONTEXT_TYPE(context) == VAL_TYPE(val));

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -777,7 +777,6 @@ void Queue_Mark_Value_Deep(const REBVAL *val)
             QUEUE_MARK_ARRAY_DEEP(VAL_FUNC_BODY(val));
         case REB_NATIVE:
         case REB_ACTION:
-            assert(ARRAY_GET_FLAG(VAL_FUNC_PARAMLIST(val), OPT_SER_PARAMLIST));
             assert(VAL_FUNC_SPEC(val) == FUNC_SPEC(VAL_FUNC(val)));
             assert(VAL_FUNC_PARAMLIST(val) == FUNC_PARAMLIST(VAL_FUNC(val)));
 
@@ -1232,7 +1231,7 @@ REBCNT Recycle_Core(REBOOL shutdown)
                 REBVAL *chunk_value = &chunk->values[0];
                 while (
                     cast(REBYTE*, chunk_value)
-                    < cast(REBYTE*, chunk) + chunk->size
+                    < cast(REBYTE*, chunk) + chunk->size.bits
                 ) {
                     if (NOT_END(chunk_value))
                         Queue_Mark_Value_Deep(chunk_value);

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1536,33 +1536,6 @@ void Manage_Series(REBSER *series)
 }
 
 
-#if !defined(NDEBUG)
-
-//
-//  Manage_Context_Debug: C
-// 
-// Special handler for making sure contexts are managed by the GC,
-// specifically.  If you've poked in a wordlist from somewhere
-// else you might not be able to use this.
-//
-void Manage_Context_Debug(REBCON *context)
-{
-    if (
-        ARRAY_GET_FLAG(CONTEXT_VARLIST(context), OPT_SER_MANAGED)
-        != ARRAY_GET_FLAG(CONTEXT_KEYLIST(context), OPT_SER_MANAGED)
-    ) {
-        // Only one of these will trip...
-        ASSERT_ARRAY_MANAGED(CONTEXT_VARLIST(context));
-        ASSERT_ARRAY_MANAGED(CONTEXT_KEYLIST(context));
-    }
-
-    MANAGE_ARRAY(CONTEXT_KEYLIST(context));
-    MANAGE_ARRAY(CONTEXT_VARLIST(context));
-}
-
-#endif
-
-
 //
 //  Is_Value_Managed: C
 // 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -628,7 +628,7 @@ REBCON *Frame_For_Call_May_Reify(
     //
     VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_FRAME);
     INIT_VAL_CONTEXT(CONTEXT_VALUE(context), context);
-    CONTEXT_SPEC(context) = NULL;
+    INIT_CONTEXT_FUNC(context, c->func);
 
     // Give this series the data from what was in the chunk, and make note
     // of the series in the chunk so that it can be marked as "gone bad"

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -578,10 +578,7 @@ REBCON *Frame_For_Call_May_Reify(struct Reb_Call *c, REBOOL ensure_managed)
     // able to access this information.  GC protection for pending
     // frames could be issued on demand by the debugger, however.
     //
-    // Formerly the arglist's 0 slot had a CLOSURE! value in it, but we now
-    // are going to be switching it to an OBJECT!.
-    //
-    VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_OBJECT);
+    VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_FRAME);
     INIT_VAL_CONTEXT(CONTEXT_VALUE(context), context);
     CONTEXT_SPEC(context) = NULL;
     CONTEXT_BODY(context) = NULL;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -127,11 +127,7 @@ static void Protect_Word_Value(REBVAL *word, REBCNT flags)
     REBVAL *key;
     REBVAL *val;
 
-    if (
-        ANY_WORD(word)
-        && IS_WORD_BOUND(word)
-        && !IS_FRAME_CONTEXT(VAL_WORD_CONTEXT(word))
-    ) {
+    if (ANY_WORD(word) && IS_WORD_BOUND(word)) {
         key = CONTEXT_KEY(VAL_WORD_CONTEXT(word), VAL_WORD_INDEX(word));
         Protect_Key(key, flags);
         if (GET_FLAG(flags, PROT_DEEP)) {

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1434,9 +1434,9 @@ REBNATIVE(map_gob_offset)
 //
 void Assert_REBVAL_Writable(REBVAL *v, const char *file, int line)
 {
-    if (NOT((v)->header.all & WRITABLE_MASK_DEBUG)) {
+    if (NOT((v)->header.bits & WRITABLE_MASK_DEBUG)) {
         Debug_Fmt("Non-writable value found at %s:%d", file, line);
-        assert((v)->header.all & WRITABLE_MASK_DEBUG); // for message
+        assert((v)->header.bits & WRITABLE_MASK_DEBUG); // for message
     }
 }
 
@@ -1457,7 +1457,7 @@ enum Reb_Kind VAL_TYPE_Debug(const REBVAL *v, const char *file, int line)
         Debug_Fmt("Unexpected TRASH in VAL_TYPE(), %s:%d", file, line);
         assert(!IS_TRASH_DEBUG(v)); // for message
     }
-    return cast(enum Reb_Kind, ((v)->header.all & HEADER_TYPE_MASK) >> 2);
+    return cast(enum Reb_Kind, ((v)->header.bits & HEADER_TYPE_MASK) >> 2);
 }
 
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -366,27 +366,27 @@ REBNATIVE(bind)
 
 
 //
-//  bound?: native [
+//  context-of: native [
 //  
 //  "Returns the context in which a word is bound."
 //  
 //      word [any-word!]
 //  ]
 //
-REBNATIVE(bound_q)
+REBNATIVE(context_of)
 {
-    REBVAL *word = D_ARG(1);
+    PARAM(1, word);
 
-    if (IS_WORD_UNBOUND(word)) return R_NONE;
+    if (IS_WORD_UNBOUND(ARG(word))) return R_NONE;
 
-    // The canon value for a non-frame context lives in the [0] cell, and
-    // right now the value used for a frame context is the value of the
-    // function paramlist itself.  This is also found in the [0] cell.
+    // Requesting the context of a word that is relatively bound may result
+    // in that word having a FRAME! incarnated as a REBSER node (if it
+    // was not already reified.)
     //
-    // !!! The decoding will become trickier :-/  A function paramlist is
-    // not sufficient to be a FRAME! and identify a specific call...
+    // !!! Mechanically it is likely that in the future, all FRAME!s for
+    // user functions will be reified from the moment of invocation.
     //
-    *D_OUT = *CONTEXT_VALUE(VAL_WORD_CONTEXT_MAY_REIFY(word));
+    *D_OUT = *CONTEXT_VALUE(VAL_WORD_CONTEXT_MAY_REIFY(ARG(word)));
 
     return R_OUT;
 }

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -291,7 +291,8 @@ REBNATIVE(new_line)
         if (skip == 0) break;
     }
 
-    return R_ARG1;
+    *D_OUT = *ARG(position);
+    return R_OUT;
 }
 
 
@@ -617,7 +618,9 @@ REBNATIVE(what_dir)
 //
 REBNATIVE(change_dir)
 {
-    REBVAL *arg = D_ARG(1);
+    PARAM(1, path);
+
+    REBVAL *arg = ARG(path);
     REBVAL *current_path = Get_System(SYS_OPTIONS, OPTIONS_CURRENT_PATH);
 
     if (IS_URL(arg)) {
@@ -648,7 +651,8 @@ REBNATIVE(change_dir)
 
     *current_path = *arg;
 
-    return R_ARG1;
+    *D_OUT = *ARG(path);
+    return R_OUT;
 }
 
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -111,7 +111,7 @@ static REBARR *Init_Loop(
 
     VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_OBJECT);
     CONTEXT_SPEC(context) = NULL;
-    CONTEXT_BODY(context) = NULL;
+    CONTEXT_STACKVARS(context) = NULL;
 
     // Setup for loop:
     key = CONTEXT_KEYS_HEAD(context);

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -110,7 +110,7 @@ static REBARR *Init_Loop(
     SET_ARRAY_LEN(CONTEXT_KEYLIST(context), len + 1);
 
     VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_OBJECT);
-    CONTEXT_SPEC(context) = NULL;
+    INIT_CONTEXT_SPEC(context, NULL);
     CONTEXT_STACKVARS(context) = NULL;
 
     // Setup for loop:

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -318,26 +318,30 @@ REBNATIVE(square_root)
 //
 REBNATIVE(shift)
 {
-    REBI64 b = VAL_INT64(D_ARG(2));
-    REBVAL *a = D_ARG(1);
+    PARAM(1, value);
+    PARAM(2, bits);
+    REFINE(3, logical);
+
+    REBI64 b = VAL_INT64(ARG(bits));
+    REBVAL *a = ARG(value);
     REBU64 c, d;
 
     if (b < 0) {
         // this is defined:
         c = -(REBU64)b;
         if (c >= 64) {
-            if (D_REF(3)) VAL_INT64(a) = 0;
+            if (REF(logical)) VAL_INT64(a) = 0;
             else VAL_INT64(a) >>= 63;
         } else {
-            if (D_REF(3)) VAL_UNT64(a) >>= c;
+            if (REF(logical)) VAL_UNT64(a) >>= c;
             else VAL_INT64(a) >>= (REBI64)c;
         }
     } else {
         if (b >= 64) {
-            if (D_REF(3)) VAL_INT64(a) = 0;
+            if (REF(logical)) VAL_INT64(a) = 0;
             else if (VAL_INT64(a)) fail (Error(RE_OVERFLOW));
         } else
-            if (D_REF(3)) VAL_UNT64(a) <<= b;
+            if (REF(logical)) VAL_UNT64(a) <<= b;
             else {
                 c = (REBU64)MIN_I64 >> b;
                 d = VAL_INT64(a) < 0 ? -VAL_UNT64(a) : VAL_UNT64(a);
@@ -351,7 +355,9 @@ REBNATIVE(shift)
                     VAL_INT64(a) <<= b;
             }
     }
-    return R_ARG1;
+
+    *D_OUT = *ARG(value);
+    return R_OUT;
 }
 
 
@@ -644,14 +650,16 @@ REBNATIVE(maximum)
 {
     if (IS_PAIR(D_ARG(1)) || IS_PAIR(D_ARG(2))) {
         Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), TRUE);
-        return R_OUT;
     }
     else {
         REBVAL a = *D_ARG(1);
         REBVAL b = *D_ARG(2);
-        if (Compare_Modify_Values(&a, &b, -1)) return R_ARG1;
-        return R_ARG2;
+        if (Compare_Modify_Values(&a, &b, -1))
+            *D_OUT = *D_ARG(1);
+        else
+            *D_OUT = *D_ARG(2);
     }
+    return R_OUT;
 }
 
 
@@ -668,15 +676,17 @@ REBNATIVE(minimum)
 {
     if (IS_PAIR(D_ARG(1)) || IS_PAIR(D_ARG(2))) {
         Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), FALSE);
-        return R_OUT;
     }
     else {
         REBVAL a = *D_ARG(1);
         REBVAL b = *D_ARG(2);
 
-        if (Compare_Modify_Values(&a, &b, -1)) return R_ARG2;
-        return R_ARG1;
+        if (Compare_Modify_Values(&a, &b, -1))
+            *D_OUT = *D_ARG(2);
+        else
+            *D_OUT = *D_ARG(1);
     }
+    return R_OUT;
 }
 
 

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -522,7 +522,8 @@ REBNATIVE(unique)
         //
         // Bitsets and typesets already unique (by definition)
         //
-        return R_ARG1;
+        *D_OUT = *ARG(series);
+        return R_OUT;
     }
 
     Val_Init_Series(

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -523,13 +523,23 @@ REBNATIVE(enbase)
 //
 REBNATIVE(decloak)
 {
-    REBVAL *data = D_ARG(1);
-    REBVAL *key  = D_ARG(2);
+    PARAM(1, data);
+    PARAM(2, key);
+    REFINE(3, with);
 
-    if (!Cloak(TRUE, VAL_BIN_AT(data), VAL_LEN_AT(data), (REBYTE*)key, 0, D_REF(3)))
-        fail (Error_Invalid_Arg(key));
+    if (!Cloak(
+        TRUE,
+        VAL_BIN_AT(ARG(data)),
+        VAL_LEN_AT(ARG(data)),
+        cast(REBYTE*, ARG(key)),
+        0,
+        REF(with)
+    )) {
+        fail (Error_Invalid_Arg(ARG(key)));
+    }
 
-    return R_ARG1;
+    *D_OUT = *ARG(data);
+    return R_OUT;
 }
 
 
@@ -545,13 +555,23 @@ REBNATIVE(decloak)
 //
 REBNATIVE(encloak)
 {
-    REBVAL *data = D_ARG(1);
-    REBVAL *key  = D_ARG(2);
+    PARAM(1, data);
+    PARAM(2, key);
+    REFINE(3, with);
 
-    if (!Cloak(FALSE, VAL_BIN_AT(data), VAL_LEN_AT(data), (REBYTE*)key, 0, D_REF(3)))
-        fail (Error_Invalid_Arg(key));
+    if (!Cloak(
+        FALSE,
+        VAL_BIN_AT(ARG(data)),
+        VAL_LEN_AT(ARG(data)),
+        cast(REBYTE*, ARG(key)),
+        0,
+        REF(with))
+    ) {
+        fail (Error_Invalid_Arg(ARG(key)));
+    }
 
-    return R_ARG1;
+    *D_OUT = *ARG(data);
+    return R_OUT;
 }
 
 
@@ -643,11 +663,14 @@ REBNATIVE(dehex)
 //
 REBNATIVE(deline)
 {
-    REBVAL *val = D_ARG(1);
+    PARAM(1, string);
+    REFINE(2, lines);
+
+    REBVAL *val = ARG(string);
     REBINT len = VAL_LEN_AT(val);
     REBINT n;
 
-    if (D_REF(2)) { //lines
+    if (REF(lines)) {
         Val_Init_Block(D_OUT, Split_Lines(val));
         return R_OUT;
     }
@@ -662,7 +685,8 @@ REBNATIVE(deline)
 
     SET_SERIES_LEN(VAL_SERIES(val), VAL_LEN_HEAD(val) - (len - n));
 
-    return R_ARG1;
+    *D_OUT = *ARG(string);
+    return R_OUT;
 }
 
 
@@ -678,7 +702,9 @@ REBNATIVE(enline)
 //
 // Convert LF to CRLF or native format.
 {
-    REBVAL *val = D_ARG(1);
+    PARAM(1, series);
+
+    REBVAL *val = ARG(series);
     REBSER *ser = VAL_SERIES(val);
 
     if (SERIES_LEN(ser)) {
@@ -688,7 +714,8 @@ REBNATIVE(enline)
             Enline_Uni(ser, VAL_INDEX(val), VAL_LEN_AT(val));
     }
 
-    return R_ARG1;
+    *D_OUT = *ARG(series);
+    return R_OUT;
 }
 
 
@@ -850,7 +877,9 @@ REBNATIVE(to_hex)
 //
 REBNATIVE(find_script)
 {
-    REBVAL *arg = D_ARG(1);
+    PARAM(1, script);
+
+    REBVAL *arg = ARG(script);
     REBINT n;
 
     n = What_UTF(VAL_BIN_AT(arg), VAL_LEN_AT(arg));
@@ -865,7 +894,8 @@ REBNATIVE(find_script)
 
     VAL_INDEX(arg) += n;
 
-    return R_ARG1;
+    *D_OUT = *ARG(script);
+    return R_OUT;
 }
 
 
@@ -897,14 +927,20 @@ REBNATIVE(utf_q)
 //
 REBNATIVE(invalid_utf_q)
 {
-    REBVAL *arg = D_ARG(1);
+    PARAM(1, data);
+    REFINE(2, utf);
+    PARAM(3, num);
+
+    REBVAL *arg = ARG(data);
     REBYTE *bp;
 
     bp = Check_UTF8(VAL_BIN_AT(arg), VAL_LEN_AT(arg));
     if (bp == 0) return R_NONE;
 
     VAL_INDEX(arg) = bp - VAL_BIN_HEAD(arg);
-    return R_ARG1;
+
+    *D_OUT = *arg;
+    return R_OUT;
 }
 
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -729,7 +729,7 @@ REBNATIVE(backtrace)
             // `where-of`, `label-of`, `function-of`, etc.)
             //
             Val_Init_Context(
-                D_OUT, REB_FRAME, Frame_For_Call_May_Reify(call, FALSE)
+                D_OUT, REB_FRAME, Frame_For_Call_May_Reify(call, NULL, FALSE)
             );
             return R_OUT;
         }

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -992,7 +992,8 @@ REBOOL Do_Breakpoint_Throws(
                         if (VAL_TYPE(FUNC_VALUE(call->func)) != REB_CLOSURE)
                             continue;
                         if (
-                            VAL_CONTEXT(target) == AS_CONTEXT(call->arglist.array)
+                            VAL_CONTEXT(target)
+                            == AS_CONTEXT(call->frame.context)
                         ) {
                             // Found a closure matching the target before we
                             // reached a breakpoint, no need to retransmit.
@@ -1241,20 +1242,18 @@ REBNATIVE(resume)
 
         if (IS_OBJECT(FUNC_VALUE(target->func))) {
             //
-            // !!! A CLOSURE! instantiation can be successfully identified
-            // by its frame, as it is a unique object.  Which is good, but
-            // the associated costs suggest another approach which would be
-            // cheaper and applicable to all functions...hence closure is
-            // scheduled to be removed from Ren-C
+            // !!! A CLOSURE! or FUNCTION! instantiation can be successfully
+            // identified by its frame, as it is a unique object.
             //
             Val_Init_Object(
                 ARRAY_AT(instruction, RESUME_INST_TARGET),
-                AS_CONTEXT(target->arglist.array)
+                AS_CONTEXT(target->frame.context)
             );
         }
         else {
-            // See notes on OPT_VALUE_EXIT_FROM regarding non-CLOSURE!s and
-            // their present inability to target arbitrary frames.
+            // See notes on OPT_VALUE_EXIT_FROM regarding non-FUNCTION! and
+            // non-CLOSURE!s and their present inability to target arbitrary
+            // frames.
             //
             *ARRAY_AT(instruction, RESUME_INST_TARGET)
                 = *FUNC_VALUE(target->func);

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -495,13 +495,22 @@ REBNATIVE(function_of)
 {
     PARAM(1, level);
 
-    struct Reb_Call *call = Call_For_Stack_Level(NULL, ARG(level), TRUE);
-    if (!call)
-        fail (Error_Invalid_Arg(ARG(level)));
+    REBVAL *level = ARG(level);
 
-    *D_OUT = *FUNC_VALUE(call->func);
+    if (IS_FRAME(level)) {
+        *D_OUT = *FUNC_VALUE(VAL_CONTEXT_FUNC(level));
+    }
+    else {
+        struct Reb_Call *call = Call_For_Stack_Level(NULL, level, TRUE);
+        if (!call)
+            fail (Error_Invalid_Arg(level));
+
+        *D_OUT = *FUNC_VALUE(call->func);
+    }
+
     return R_OUT;
 }
+
 
 //
 //  backtrace: native [

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -191,7 +191,8 @@ static REB_R Clipboard_Actor(struct Reb_Call *call_, REBCON *port, REBCNT action
         fail (Error_Illegal_Action(REB_PORT, action));
     }
 
-    return R_ARG1; // port
+    *D_OUT = *D_ARG(1); // port
+    return R_OUT;
 }
 
 

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -239,8 +239,9 @@ create:
         ///OS_FREE(dir.file.path);
         if (result < 0) fail (Error(RE_NO_CREATE, path));
         if (action == A_CREATE) {
-            // !!! Used to return R_ARG2, but create is single arity.  :-/
-            return R_ARG1;
+            // !!! Used to return D_ARG(2), but create is single arity.  :-/
+            *D_OUT = *D_ARG(1);
+            return R_OUT;
         }
         SET_NONE(state);
         break;
@@ -270,8 +271,9 @@ create:
         result = OS_DO_DEVICE(&dir, RDC_DELETE);
         ///OS_FREE(dir.file.path);
         if (result < 0) fail (Error(RE_NO_DELETE, path));
-        // !!! Returned R_ARG2 before, but there is no second argument :-/
-        return R_ARG1;
+        // !!! Returned D_ARG(2) before, but there is no second argument :-/
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     case A_OPEN:
         // !! If open fails, what if user does a READ w/o checking for error?

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -570,7 +570,8 @@ static REB_R File_Actor(struct Reb_Call *call_, REBCON *port, REBCNT action)
 
 seeked:
     SET_FLAG(file->modes, RFM_RESEEK);
-    return R_ARG1;
+    *D_OUT = *D_ARG(1);
+    return R_OUT;
 
 is_true:
     return R_TRUE;

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -118,7 +118,7 @@ void Ret_Query_File(REBCON *port, REBREQ *file, REBVAL *ret)
     if (!info || !IS_OBJECT(info))
         fail (Error_On_Port(RE_INVALID_SPEC, port, -10));
 
-    context = Copy_Context_Shallow_Managed(VAL_CONTEXT(info));
+    context = Copy_Context_Shallow(VAL_CONTEXT(info));
 
     Val_Init_Object(ret, context);
     Val_Init_Word(

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -50,7 +50,7 @@ static void Ret_Query_Net(REBCON *port, REBREQ *sock, REBVAL *out)
     if (!std_info || !IS_OBJECT(std_info))
         fail (Error_On_Port(RE_INVALID_SPEC, port, -10));
 
-    info = Copy_Context_Shallow_Managed(VAL_CONTEXT(std_info));
+    info = Copy_Context_Shallow(VAL_CONTEXT(std_info));
 
     Set_Tuple(
         CONTEXT_VAR(info, STD_NET_INFO_LOCAL_IP),
@@ -93,7 +93,7 @@ static void Accept_New_Port(REBVAL *out, REBCON *port, REBREQ *sock)
     nsock->next = 0;
 
     // Create a new port using ACCEPT request passed by sock->common.sock:
-    port = Copy_Context_Shallow_Managed(port);
+    port = Copy_Context_Shallow(port);
     Val_Init_Port(out, port); // Also for GC protect
 
     SET_NONE(CONTEXT_VAR(port, STD_PORT_DATA)); // just to be sure.

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -189,7 +189,8 @@ static REB_R Signal_Actor(struct Reb_Call *call_, REBCON *port, REBCNT action)
                 if (OS_DO_DEVICE(req, RDC_OPEN))
                     fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
                 if (action == A_OPEN) {
-                    return R_ARG1; //port
+                    *D_OUT = *D_ARG(1); // port
+                    return R_OUT;
                 }
                 break;
 
@@ -248,7 +249,8 @@ static REB_R Signal_Actor(struct Reb_Call *call_, REBCON *port, REBCNT action)
 
         case A_CLOSE:
             OS_DO_DEVICE(req, RDC_CLOSE);
-            return R_ARG1;
+            *D_OUT = *D_ARG(1);
+            return R_OUT;
 
         case A_OPEN_Q:
             return R_TRUE;

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1300,6 +1300,7 @@ void Mold_Value(REB_MOLD *mold, const REBVAL *value, REBOOL molded)
     case REB_OBJECT:
     case REB_MODULE:
     case REB_PORT:
+    case REB_FRAME:
         if (!molded) Form_Object(value, mold);
         else Mold_Object(value, mold);
         break;

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -882,8 +882,10 @@ zero_blk:
         fail (Error_Illegal_Action(VAL_TYPE(value), action));
     }
 
-    if (!value)
-        return R_ARG1;
+    if (!value) {
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
+    }
 
     *D_OUT = *value;
     return R_OUT;

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -761,7 +761,8 @@ REBTYPE(Date)
 
 ///     case A_POKE:
 ///         Pick_Path(D_OUT, val, arg, D_ARG(3));
-///         return R_ARG3;
+///         *D_OUT = *D_ARG(3);
+///         return R_OUT;
 
         case A_MAKE:
         case A_TO:

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -399,9 +399,15 @@ REBTYPE(Event)
 
     if (action == A_MAKE) {
         // Clone an existing event?
-        if (IS_EVENT(value)) return R_ARG1;
+        if (IS_EVENT(value)) {
+            *D_OUT = *D_ARG(1);
+            return R_OUT;
+        }
         else if (IS_DATATYPE(value)) {
-            if (IS_EVENT(arg)) return R_ARG2;
+            if (IS_EVENT(arg)) {
+                *D_OUT = *D_ARG(2);
+                return R_OUT;
+            }
             //fail (Error_Bad_Make(REB_EVENT, value));
             VAL_RESET_HEADER(D_OUT, REB_EVENT);
             CLEARS(&(D_OUT->payload.event));

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -925,7 +925,8 @@ REBTYPE(Gob)
             *GOB_AT(gob, tail-index-1) = *GOB_AT(gob, index);
             *GOB_AT(gob, index) = ngob;
         }
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     default:
         fail (Error_Illegal_Action(REB_GOB, action));

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -906,7 +906,8 @@ REBTYPE(Image)
 
     case A_POKE:
         Pick_Path(D_OUT, value, arg, D_ARG(3));
-        return R_ARG3;
+        *D_OUT = *D_ARG(3);
+        return R_OUT;
 
     case A_SKIP:
     case A_AT:

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -137,6 +137,5 @@ REBTYPE(Logic)
         fail (Error_Illegal_Action(REB_LOGIC, action));
     }
 
-    SET_LOGIC(D_ARG(1), val1);
-    return R_ARG1;
+    return val1 ? R_TRUE : R_FALSE;
 }

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -172,11 +172,13 @@ REBTYPE(Money)
     switch(action) {
     case A_NEGATE:
         VAL_MONEY_AMOUNT(val).s = !VAL_MONEY_AMOUNT(val).s;
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     case A_ABSOLUTE:
         VAL_MONEY_AMOUNT(val).s = 0;
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     case A_ROUND:
         arg = D_ARG(3);
@@ -229,7 +231,8 @@ REBTYPE(Money)
             break;
 
         case REB_MONEY:
-            return R_ARG2;
+            *D_OUT = *D_ARG(2);
+            return R_OUT;
 
         case REB_STRING:
         {

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -549,7 +549,8 @@ REBTYPE(Context)
         if (!IS_OBJECT(value))
             fail (Error_Illegal_Action(VAL_TYPE(value), action));
         Append_To_Context(VAL_CONTEXT(value), arg);
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     case A_LENGTH:
         if (!IS_OBJECT(value))

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -291,7 +291,7 @@ REBOOL MT_Context(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 
     context = Construct_Context(type, VAL_ARRAY_AT(data), FALSE, NULL);
 
-    Val_Init_Context(out, type, context, NULL, NULL);
+    Val_Init_Context(out, type, context);
 
     if (type == REB_ERROR) {
         REBVAL result;
@@ -466,14 +466,14 @@ REBTYPE(Context)
             VAL_RESET_HEADER(CONTEXT_VALUE(context), target);
             CONTEXT_SPEC(context) = NULL;
             CONTEXT_BODY(context) = NULL; */
-            Val_Init_Context(D_OUT, target, context, NULL, NULL);
+            Val_Init_Context(D_OUT, target, context);
             return R_OUT;
         }
 
         // make object! map!
         if (IS_MAP(arg)) {
             context = Alloc_Context_From_Map(VAL_MAP(arg));
-            Val_Init_Context(D_OUT, target, context, NULL, NULL);
+            Val_Init_Context(D_OUT, target, context);
             return R_OUT;
         }
         fail (Error_Bad_Make(target, arg));
@@ -522,7 +522,7 @@ REBTYPE(Context)
             // is no way to change the context type to module without wrecking
             // the object passed in.
 
-            context = Copy_Context_Shallow_Managed(VAL_CONTEXT(item + 1));
+            context = Copy_Context_Shallow(VAL_CONTEXT(item + 1));
             VAL_CONTEXT_SPEC(CONTEXT_VALUE(context)) = VAL_CONTEXT(item);
             assert(VAL_CONTEXT_BODY(CONTEXT_VALUE(context)) == NULL);
             VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_MODULE);
@@ -539,12 +539,7 @@ REBTYPE(Context)
                 }
             }
 
-            Val_Init_Module(
-                D_OUT,
-                context,
-                VAL_CONTEXT(item),
-                NULL
-            );
+            Val_Init_Module(D_OUT, context);
             return R_OUT;
         }
         fail (Error_Bad_Make(target, arg));
@@ -589,13 +584,7 @@ REBTYPE(Context)
                 types
             );
         }
-        Val_Init_Context(
-            D_OUT,
-            VAL_TYPE(value),
-            context,
-            VAL_CONTEXT_SPEC(value),
-            VAL_CONTEXT_BODY(value)
-        );
+        Val_Init_Context(D_OUT, VAL_TYPE(value), context);
         return R_OUT;
     }
 
@@ -652,9 +641,7 @@ REBTYPE(Context)
         Val_Init_Context(
             D_OUT,
             VAL_TYPE(value),
-            Trim_Context(VAL_CONTEXT(value)),
-            VAL_CONTEXT_SPEC(value),
-            VAL_CONTEXT_BODY(value)
+            Trim_Context(VAL_CONTEXT(value))
         );
         return R_OUT;
 

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -244,7 +244,7 @@ static REBCON *Trim_Context(REBCON *context)
     //
     context_new = Alloc_Context(copy_count);
     VAL_CONTEXT_SPEC(CONTEXT_VALUE(context_new)) = NULL;
-    VAL_CONTEXT_BODY(CONTEXT_VALUE(context_new)) = NULL;
+    VAL_CONTEXT_STACKVARS(CONTEXT_VALUE(context_new)) = NULL;
 
     // Second pass: copy the values that were not skipped in the first pass
     //
@@ -524,7 +524,7 @@ REBTYPE(Context)
 
             context = Copy_Context_Shallow(VAL_CONTEXT(item + 1));
             VAL_CONTEXT_SPEC(CONTEXT_VALUE(context)) = VAL_CONTEXT(item);
-            assert(VAL_CONTEXT_BODY(CONTEXT_VALUE(context)) == NULL);
+            assert(VAL_CONTEXT_STACKVARS(CONTEXT_VALUE(context)) == NULL);
             VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_MODULE);
 
             // !!! Again, not how this should be done but... if there is a

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -426,7 +426,6 @@ REBTYPE(Context)
             // the generator choice by the person doing the derivation.
             //
             context = Merge_Contexts_Selfish(src_context, VAL_CONTEXT(arg));
-            MANAGE_CONTEXT(context);
             Val_Init_Object(D_OUT, context);
             return R_OUT;
         }
@@ -580,7 +579,6 @@ REBTYPE(Context)
             Copy_Array_Shallow(CONTEXT_VARLIST(VAL_CONTEXT(value)))
         );
         INIT_CONTEXT_KEYLIST(context, CONTEXT_KEYLIST(VAL_CONTEXT(value)));
-        MANAGE_ARRAY(CONTEXT_VARLIST(context));
         ARRAY_SET_FLAG(CONTEXT_VARLIST(context), OPT_SER_CONTEXT);
         INIT_VAL_CONTEXT(CONTEXT_VALUE(context), context);
         if (types != 0) {

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -98,7 +98,7 @@ REBTYPE(Port)
         // vs. making it as a port to begin with (?)  Look into why
         // system/standard/port is made with CONTEXT and not with MAKE PORT!
         //
-        context = Copy_Context_Shallow_Managed(VAL_CONTEXT(arg));
+        context = Copy_Context_Shallow(VAL_CONTEXT(arg));
         VAL_RESET_HEADER(CONTEXT_VALUE(context), REB_PORT);
         Val_Init_Port(D_OUT, context);
         return R_OUT;

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -506,12 +506,14 @@ REBTYPE(Time)
                     );
                     VAL_DECIMAL(arg) /= SEC_SEC;
                     VAL_RESET_HEADER(arg, REB_DECIMAL);
-                    return R_ARG3;
+                    *D_OUT = *D_ARG(3);
+                    return R_OUT;
                 }
                 else if (IS_INTEGER(arg)) {
                     VAL_INT64(arg) = Round_Int(secs, 1, Int32(arg) * SEC_SEC) / SEC_SEC;
                     VAL_RESET_HEADER(arg, REB_INTEGER);
-                    return R_ARG3;
+                    *D_OUT = *D_ARG(3);
+                    return R_OUT;
                 }
                 else fail (Error_Invalid_Arg(arg));
             }
@@ -536,7 +538,8 @@ REBTYPE(Time)
 
 ///     case A_POKE:
 ///         Pick_Path(D_OUT, val, arg, D_ARG(3));
-///         return R_ARG3;
+///         *D_OUT = *D_ARG(3);
+///         return R_OUT;
 
         case A_MAKE:
         case A_TO:

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -301,7 +301,8 @@ REBTYPE(Tuple)
 
 /// case A_POKE:
 ///     Pick_Path(D_OUT, value, arg, D_ARG(3));
-///     return R_ARG3;
+///     *D_OUT = *D_ARG(3);
+///     return R_OUT;
 
     case A_REVERSE:
         if (D_REF(2)) {
@@ -343,7 +344,8 @@ REBTYPE(Tuple)
     case A_MAKE:
     case A_TO:
         if (IS_TUPLE(arg)) {
-            return R_ARG2;
+            *D_OUT = *D_ARG(2);
+            return R_OUT;
         }
 
         // !!! Net lookup parses IP addresses out of `tcp://93.184.216.34` or

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -272,9 +272,13 @@ REBTYPE(Typeset)
     //  if (IS_NONE(arg)) {
     //      VAL_RESET_HEADER(arg, REB_TYPESET);
     //      VAL_TYPESET_BITS(arg) = 0L;
-    //      return R_ARG2;
+    //      *D_OUT = *D_ARG(2);
+    //      return R_OUT;
     //  }
-        if (IS_TYPESET(arg)) return R_ARG2;
+        if (IS_TYPESET(arg)) {
+            *D_OUT = *D_ARG(2);
+            return R_OUT;
+        }
         fail (Error_Bad_Make(REB_TYPESET, arg));
 
     case A_AND_T:
@@ -291,11 +295,13 @@ REBTYPE(Typeset)
             VAL_TYPESET_BITS(val) &= VAL_TYPESET_BITS(arg);
         else
             VAL_TYPESET_BITS(val) ^= VAL_TYPESET_BITS(arg);
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     case A_COMPLEMENT:
         VAL_TYPESET_BITS(val) = ~VAL_TYPESET_BITS(val);
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     default:
         fail (Error_Illegal_Action(REB_TYPESET, action));

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -552,7 +552,8 @@ REBTYPE(Vector)
     case A_POKE:
         // Third argument to pick path is the
         Pick_Path(D_OUT, value, arg, D_ARG(3));
-        return R_ARG3;
+        *D_OUT = *D_ARG(3);
+        return R_OUT;
 
     case A_MAKE:
         // We only allow MAKE VECTOR! ...
@@ -592,7 +593,8 @@ REBTYPE(Vector)
     case A_RANDOM:
         if (D_REF(2) || D_REF(4)) fail (Error(RE_BAD_REFINES)); // /seed /only
         Shuffle_Vector(value, D_REF(3));
-        return R_ARG1;
+        *D_OUT = *D_ARG(1);
+        return R_OUT;
 
     default:
         fail (Error_Illegal_Action(VAL_TYPE(value), action));

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -63,8 +63,8 @@ REBINT CT_Word(const REBVAL *a, const REBVAL *b, REBINT mode)
             if (VAL_WORD_INDEX(a) != VAL_WORD_INDEX(b))
                 return 0;
 
-            if (VAL_GET_EXT(a, EXT_WORD_BOUND_NORMAL)) {
-                if (!VAL_GET_EXT(b, EXT_WORD_BOUND_NORMAL))
+            if (VAL_GET_EXT(a, EXT_WORD_BOUND_SPECIFIC)) {
+                if (!VAL_GET_EXT(b, EXT_WORD_BOUND_SPECIFIC))
                     return 0;
 
                 return (VAL_WORD_CONTEXT(a) == VAL_WORD_CONTEXT(b)) ? 1 : 0;
@@ -74,21 +74,17 @@ REBINT CT_Word(const REBVAL *a, const REBVAL *b, REBINT mode)
                 if (!VAL_GET_EXT(b, EXT_WORD_BOUND_RELATIVE)) {
                     //
                     // !!! We'll need to be able to compare a relative bound
-                    // word to a frame bound word, but frame bound words do
-                    // not yet exist (at time of writing).
+                    // word to a frame bound word... but for the moment
+                    // the only guesstimation of equality would be if the
+                    // word were equal when considered in the current
+                    // stack level, e.g. a stack-relative comparison...and
+                    // that broken dependency isn't worth hacking in here.
                     //
-                    assert(!VAL_GET_EXT(b, EXT_WORD_BOUND_FRAME));
                     return 0;
                 }
 
-                return (VAL_WORD_FUNC(a) == VAL_WORD_FUNC(b)) ? 1 : 0;
-            }
-
-            if (VAL_GET_EXT(a, EXT_WORD_BOUND_FRAME)) {
-                //
-                // !!! These don't exist yet!
-                //
-                assert(FALSE);
+                return (a->payload.any_word.binding.relative
+                    == b->payload.any_word.binding.relative) ? 1 : 0;
             }
 
             // `a` isn't bound, so it matches if `b` is unbound too.

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -127,7 +127,8 @@ REBTYPE(Word)
             // stay in sync with the binding state)
             //
             VAL_SET_TYPE_BITS(arg, type);
-            return R_ARG2;
+            *D_OUT = *D_ARG(2);
+            return R_OUT;
         }
         else {
             if (IS_STRING(arg)) {

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -640,7 +640,8 @@ REBNATIVE(delect)
 
     if (err < 0) fail (Error_Invalid_Arg(ARG(input))); // !!! make better error
 
-    return R_ARG2;
+    *D_OUT = *ARG(input);
+    return R_OUT;
 }
 
 

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -106,8 +106,8 @@ static int Find_Command(REBCON *dialect, REBVAL *word)
         n = VAL_WORD_INDEX(word);
     else {
         if ((n = Find_Word_In_Context(dialect, VAL_WORD_SYM(word), FALSE))) {
-            VAL_SET_EXT(word, EXT_WORD_BOUND_NORMAL);
-            INIT_WORD_CONTEXT(word, dialect);
+            VAL_SET_EXT(word, EXT_WORD_BOUND_SPECIFIC);
+            INIT_WORD_SPECIFIC(word, dialect);
             INIT_WORD_INDEX(word, n);
         }
         else return 0;

--- a/src/include/mem-series.h
+++ b/src/include/mem-series.h
@@ -46,6 +46,21 @@
 #define SERIES_FREED(s)  (0 == SERIES_WIDE(s))
 
 //
+// Non-series-internal code needs to read SERIES_WIDE but should not be
+// needing to set it directly.
+//
+// !!! Can't `assert((w) < MAX_SERIES_WIDE)` without triggering "range of
+// type makes this always false" warning; C++ build could sense if it's a
+// REBYTE and dodge the comparison if so.
+//
+
+#define MAX_SERIES_WIDE 0x100 \
+
+#define SERIES_SET_WIDE(s,w) \
+    ((s)->info.bits = ((s)->info.bits & 0xffff) | (w << 16))
+
+
+//
 // Bias is empty space in front of head:
 //
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -949,8 +949,8 @@ struct Native_Refine {
     //
     #define PARAM(n,name) \
         const struct Native_Param p_##name = { \
-            call_->arg ? VAL_TYPE(call_->arg + (n)) : REB_TRASH, \
-            call_->arg ? call_->arg + (n) : NULL, \
+            call_->arg ? VAL_TYPE(call_->arg + (n) - 1) : REB_TRASH, \
+            call_->arg ? call_->arg + (n) - 1 : NULL, \
             (n) \
         }
 
@@ -962,8 +962,8 @@ struct Native_Refine {
     //
     #define REFINE(n,name) \
         const struct Native_Refine p_##name = { \
-            call_->arg ? NOT(IS_NONE(call_->arg + (n))) : TRUE, \
-            call_->arg ? call_->arg + (n) : NULL, \
+            call_->arg ? NOT(IS_NONE(call_->arg + (n) - 1)) : TRUE, \
+            call_->arg ? call_->arg + (n) - 1 : NULL, \
             (n) \
         }
 #endif
@@ -972,7 +972,7 @@ struct Native_Refine {
 // with either.
 //
 #define ARG(name) \
-    (call_->arg + (p_##name).num)
+    (call_->arg + (p_##name).num - 1)
 
 #define PAR(name) \
     FUNC_PARAM(call_->func, (p_##name).num) // a TYPESET!
@@ -1036,12 +1036,12 @@ struct Native_Refine {
 #define DSF_ARGS_HEAD(c) \
     (((c)->flags & DO_FLAG_FRAME_CONTEXT) \
         ? CONTEXT_VARS_HEAD((c)->frame.context) \
-        : &(c)->frame.stackvars[1])
+        : &(c)->frame.stackvars[0])
 
 // ARGS is the parameters and refinements
 // 1-based indexing into the arglist (0 slot is for object/function value)
 #ifdef NDEBUG
-    #define DSF_ARG(c,n)    ((c)->arg + (n))
+    #define DSF_ARG(c,n)    ((c)->arg + (n) - 1)
 #else
     #define DSF_ARG(c,n)    DSF_ARG_Debug((c), (n)) // checks arg index bound
 #endif

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -233,7 +233,7 @@ enum Reb_Call_Mode {
     CALL_MODE_SKIPPING, // in the process of skipping an unused refinement
     CALL_MODE_REVOKING, // found an unset and aiming to revoke refinement use
     CALL_MODE_FUNCTION, // running an ANY-FUNCTION!
-    CALL_MODE_THROWN    // a function has THROWN and call frame is ending
+    CALL_MODE_THROWN // function threw (sometimes may be intercepted)
 };
 
 union Reb_Call_Source {

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -233,7 +233,7 @@ enum Reb_Call_Mode {
     CALL_MODE_SKIPPING, // in the process of skipping an unused refinement
     CALL_MODE_REVOKING, // found an unset and aiming to revoke refinement use
     CALL_MODE_FUNCTION, // running an ANY-FUNCTION!
-    CALL_MODE_THROWN // function threw (sometimes may be intercepted)
+    CALL_MODE_THROW_PENDING // function threw (sometimes may be intercepted)
 };
 
 union Reb_Call_Source {
@@ -1067,7 +1067,7 @@ struct Native_Refine {
 #define D_OUT       DSF_OUT(call_)          // GC-safe slot for output value
 #define D_ARGC      DSF_ARGC(call_)         // count of args+refinements/args
 #define D_ARG(n)    DSF_ARG(call_, (n))     // pass 1 for first arg
-#define D_REF(n)    LOGICAL(!IS_NONE(D_ARG(n)))    // D_REFinement (not D_REFerence)
+#define D_REF(n)    NOT(IS_NONE(D_ARG(n)))  // D_REFinement (not D_REFerence)
 #define D_FUNC      DSF_FUNC(call_)         // REBVAL* of running function
 #define D_LABEL_SYM DSF_LABEL_SYM(call_)    // symbol or placeholder for call
 #define D_CELL      DSF_CELL(call_)         // GC-safe extra value
@@ -1075,9 +1075,13 @@ struct Native_Refine {
 
 #define D_FRAMELESS DSF_FRAMELESS(call_)    // Native running w/no call frame
 
-// !!! frameless stuff broken completely by prefetch, but will be easier now
+// Frameless native access
+//
+// !!! Should `call_` just be renamed to `c_` to make this briefer and be used
+// directly?  It is helpful to have macros to find the usages, however.
+//
 #define D_CALL      call_
 #define D_ARRAY     (call_->source.array)
 #define D_INDEXOR   (call_->indexor)
 #define D_VALUE     (call_->value)
-
+#define D_MODE      (call_->mode)

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -1015,7 +1015,21 @@ struct Reb_Context {
 #define CONTEXT_LEN(c)          (ARRAY_LEN(CONTEXT_KEYLIST(c)) - 1)
 #define CONTEXT_ROOTKEY(c)      ARRAY_HEAD(CONTEXT_KEYLIST(c))
 #define CONTEXT_TYPE(c)         VAL_TYPE(CONTEXT_VALUE(c))
-#define CONTEXT_SPEC(c)         VAL_CONTEXT_SPEC(CONTEXT_VALUE(c))
+
+#define INIT_CONTEXT_SPEC(c,s) \
+    (assert(!IS_FRAME(CONTEXT_VALUE(c))), \
+        VAL_CONTEXT_SPEC(CONTEXT_VALUE(c)) = (s))
+
+#define CONTEXT_SPEC(c) \
+    (VAL_CONTEXT_SPEC(CONTEXT_VALUE(c)) + 0)
+
+#define INIT_CONTEXT_FUNC(c,f) \
+    (assert(IS_FRAME(CONTEXT_VALUE(c))), \
+        VAL_CONTEXT_FUNC(CONTEXT_VALUE(c)) = (f))
+
+#define CONTEXT_FUNC(c) \
+    (VAL_CONTEXT_FUNC(CONTEXT_VALUE(c)) + 0)
+
 #define CONTEXT_STACKVARS(c)    VAL_CONTEXT_STACKVARS(CONTEXT_VALUE(c))
 
 #define FAIL_IF_LOCKED_CONTEXT(c) \

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -889,31 +889,16 @@ struct Reb_Context {
     #define AS_CONTEXT(s)       cast(REBCON*, (s))
 #endif
 
-// In the gradual shift to where FRAME! can be an ANY-CONTEXT (even though
-// it's only one series with its data coming out of the stack) we can
-// discern it based on whether the type in the first slot is an
-// ANY-FUNCTION!.  Should never be a closure.
-//
-#define IS_FRAME_CONTEXT(c) \
-    ARRAY_GET_FLAG(AS_ARRAY(c), OPT_SER_PARAMLIST)
-
 // Special property: keylist pointer is stored in the misc field of REBSER
 //
 #define CONTEXT_VARLIST(c) \
-    (IS_FRAME_CONTEXT(c) \
-        ? NULL /* won't ever have a series...lives in chunk stack */ \
-        : &(c)->varlist)
+    (&(c)->varlist)
 
 #define CONTEXT_KEYLIST(c) \
-    (IS_FRAME_CONTEXT(c) \
-        ? AS_ARRAY(c) \
-        : ARRAY_SERIES(CONTEXT_VARLIST(c))->misc.keylist)
+    (ARRAY_SERIES(CONTEXT_VARLIST(c))->misc.keylist)
 
 #define INIT_CONTEXT_KEYLIST(c,k) \
-    do { \
-        assert(!IS_FRAME_CONTEXT(c)); \
-        ARRAY_SERIES(CONTEXT_VARLIST(c))->misc.keylist = (k); \
-    } while (0)
+    (ARRAY_SERIES(CONTEXT_VARLIST(c))->misc.keylist = (k))
 
 // The keys and vars are accessed by positive integers starting at 1.  If
 // indexed access is used then the debug build will check to be sure that

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -255,17 +255,22 @@ struct Reb_Chunk {
     //
 #endif
 
+    // If this serves as the backing memory for a REBSER array of REBVALs,
+    // then when the data goes away it is necessary to mark that array as
+    // not having its memory any more.  This cannot be managed purely by the
+    // client, because a fail() can longjmp...and the chunk stack needs enough
+    // information stored to find that series to mark.
     //
-    // Pointer to the previous chunk.  We rely upon the fact that the low
-    // bit of this pointer is always 0 in order for it to be an implicit END
-    // for the value array of the previous chunk.
+    REBARR *opt_holder;
+
+    // Pointer to the previous chunk.
     //
     struct Reb_Chunk *prev;
 
     // The `values` is an array whose real size exceeds the struct.  (It is
-    // set to a size of one because it cannot be [0] in C++.)  When the
-    // value pointer is given back to the user, this is how they speak about
-    // the chunk itself.
+    // set to a size of one because it cannot be [0] if the sources wind
+    // up being built as C++.)  When the value pointer is given back to the
+    // user, this is how they speak about the chunk itself.
     //
     // See note above about how the next chunk's `prev` pointer serves as
     // an END marker for this array (which may or may not be necessary for

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -259,13 +259,13 @@ struct Reb_Chunk {
     //
 #endif
 
-    // If this serves as the backing memory for a REBSER array of REBVALs,
-    // then when the data goes away it is necessary to mark that array as
+    // If this serves as the backing memory for a context's stackvars then
+    // when the data goes away it is necessary to mark that context as
     // not having its memory any more.  This cannot be managed purely by the
     // client, because a fail() can longjmp...and the chunk stack needs enough
     // information stored to find that series to mark.
     //
-    REBARR *opt_holder;
+    REBCON *opt_context;
 
     // Pointer to the previous chunk.
     //
@@ -287,6 +287,14 @@ struct Reb_Chunk {
 // generally don't want for our math, due to C++ "no zero element array" rule
 //
 #define BASE_CHUNK_SIZE (sizeof(struct Reb_Chunk) - sizeof(REBVAL))
+
+#define CHUNK_FROM_VALUES(v) \
+    cast(struct Reb_Chunk *, cast(REBYTE*, (v)) \
+        - offsetof(struct Reb_Chunk, values))
+
+#define CHUNK_LEN_FROM_VALUES(v) \
+    ((CHUNK_FROM_VALUES(v)->size.bits - offsetof(struct Reb_Chunk, values)) \
+        / sizeof(REBVAL))
 
 
 //=////////////////////////////////////////////////////////////////////////=//

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -228,12 +228,16 @@ struct Reb_Chunk;
 
 struct Reb_Chunk {
     //
-    // We start the chunk with a REBUPT (unsigned integer size of a pointer)
-    // because we are relying upon the fact that the low bit of this value
-    // is always 0 in order for it to be an implicit END for the value array
-    // of the previous chunk.  We know sizes are even so we leverage that.
+    // We start the chunk with a Reb_Value_Header, which has as its `bits`
+    // field a REBUPT (unsigned integer size of a pointer).  We are relying
+    // on the fact that the low 2 bits of this value is always 0 in order
+    // for it to be an implicit END for the value array of the previous chunk.
     //
-    REBUPT size;
+    // (REBVALs are multiples of 4 bytes in size on all platforms Rebol
+    // will run on, hence the low two bits of a byte size of N REBVALs will
+    // always have the two lowest bits clear.)
+    //
+    struct Reb_Value_Header size;
 
     // How many bytes are left in the memory chunker this chunk lives in
     // (its own size has already been subtracted from the amount)

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1312,7 +1312,7 @@ struct Reb_Any_Word {
 #define INIT_WORD_SPECIFIC(v,context) \
     (assert(VAL_GET_EXT((v), EXT_WORD_BOUND_SPECIFIC) \
         && !VAL_GET_EXT((v), EXT_WORD_BOUND_RELATIVE)), \
-        ENSURE_ARRAY_MANAGED(CONTEXT_VARLIST(context)), \
+        ENSURE_SERIES_MANAGED(CONTEXT_SERIES(context)), \
         assert(ARRAY_GET_FLAG(CONTEXT_KEYLIST(context), OPT_SER_MANAGED)), \
         (v)->payload.any_word.binding.specific = (context))
 
@@ -1467,7 +1467,7 @@ struct Reb_Typeset {
 struct Reb_Any_Context {
     REBCON *context;
     REBCON *spec; // optional (currently only used by modules)
-    REBARR *body; // optional (currently not used at all)
+    REBVAL *stackvars;
 };
 
 #define VAL_CONTEXT(v) \
@@ -1477,7 +1477,12 @@ struct Reb_Any_Context {
     ((v)->payload.any_context.context = (c))
 
 #define VAL_CONTEXT_SPEC(v)         ((v)->payload.any_context.spec)
-#define VAL_CONTEXT_BODY(v)         ((v)->payload.any_context.body)
+
+#define VAL_CONTEXT_STACKVARS(v)    ((v)->payload.any_context.stackvars)
+
+#define VAL_CONTEXT_STACKVARS_LEN(v) \
+    (assert(ANY_CONTEXT(v)), \
+        CHUNK_LEN_FROM_VALUES((v)->payload.any_context.stackvars))
 
 // Convenience macros to speak in terms of object values instead of the context
 //

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1479,8 +1479,12 @@ struct Reb_Typeset {
 
 struct Reb_Any_Context {
     REBCON *context;
-    REBCON *spec; // optional (currently only used by modules)
     REBVAL *stackvars;
+
+    union {
+        REBCON *spec; // used by REB_MODULE
+        REBFUN *func; // used by REB_FRAME
+    } more;
 };
 
 #define VAL_CONTEXT(v) \
@@ -1489,7 +1493,9 @@ struct Reb_Any_Context {
 #define INIT_VAL_CONTEXT(v,c) \
     ((v)->payload.any_context.context = (c))
 
-#define VAL_CONTEXT_SPEC(v)         ((v)->payload.any_context.spec)
+#define VAL_CONTEXT_SPEC(v)         ((v)->payload.any_context.more.spec)
+
+#define VAL_CONTEXT_FUNC(v)         ((v)->payload.any_context.more.func)
 
 #define VAL_CONTEXT_STACKVARS(v)    ((v)->payload.any_context.stackvars)
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1313,6 +1313,7 @@ struct Reb_Any_Word {
     (assert(VAL_GET_EXT((v), EXT_WORD_BOUND_SPECIFIC) \
         && !VAL_GET_EXT((v), EXT_WORD_BOUND_RELATIVE)), \
         ENSURE_ARRAY_MANAGED(CONTEXT_VARLIST(context)), \
+        assert(ARRAY_GET_FLAG(CONTEXT_KEYLIST(context), OPT_SER_MANAGED)), \
         (v)->payload.any_word.binding.specific = (context))
 
 #define INIT_WORD_RELATIVE(v,func) \
@@ -1478,27 +1479,6 @@ struct Reb_Any_Context {
 #define VAL_CONTEXT_SPEC(v)         ((v)->payload.any_context.spec)
 #define VAL_CONTEXT_BODY(v)         ((v)->payload.any_context.body)
 
-// A fully constructed context can reconstitute the ANY-CONTEXT! REBVAL that is
-// its canon form from a single pointer...the REBVAL sitting in the 0 slot
-// of the context's varlist.  In a debug build we check to make sure the
-// type of the embedded value matches the type of what is intended (so
-// someone who thinks they are initializing a REB_OBJECT from a CONTEXT does
-// not accidentally get a REB_ERROR, for instance.)
-//
-#if 0 && defined(NDEBUG)
-    //
-    // !!! Currently Val_Init_Context_Core does not require the passed in
-    // context to already be managed.  If it did, then it could be this
-    // simple and not be a "bad macro".  Review if it's worthwhile to change
-    // the prerequisite that this is only called on managed contexts.
-    //
-    #define Val_Init_Context(o,t,f,s,b) \
-        (*(o) = *CONTEXT_VALUE(f))
-#else
-    #define Val_Init_Context(o,t,f,s,b) \
-        Val_Init_Context_Core((o), (t), (f), (s), (b))
-#endif
-
 // Convenience macros to speak in terms of object values instead of the context
 //
 #define VAL_CONTEXT_VAR(v,n)        CONTEXT_VAR(VAL_CONTEXT(v), (n))
@@ -1521,8 +1501,8 @@ struct Reb_Any_Context {
 //
 #define SELFISH(n) (n + 1)
 
-#define Val_Init_Object(v,f) \
-    Val_Init_Context((v), REB_OBJECT, (f), NULL, NULL)
+#define Val_Init_Object(v,c) \
+    Val_Init_Context((v), REB_OBJECT, (c))
 
 
 /***********************************************************************
@@ -1536,8 +1516,8 @@ struct Reb_Any_Context {
 #define VAL_MOD_SPEC(v)     VAL_CONTEXT_SPEC(v)
 #define VAL_MOD_BODY(v)     VAL_CONTEXT_BODY(v)
 
-#define Val_Init_Module(v,f,s,b) \
-    Val_Init_Context((v), REB_MODULE, (f), (s), (b))
+#define Val_Init_Module(v,c) \
+    Val_Init_Context((v), REB_MODULE, (c))
 
 
 /***********************************************************************
@@ -1546,8 +1526,8 @@ struct Reb_Any_Context {
 **
 ***********************************************************************/
 
-#define Val_Init_Port(v,f) \
-    Val_Init_Context((v), REB_PORT, (f), NULL, NULL)
+#define Val_Init_Port(v,c) \
+    Val_Init_Context((v), REB_PORT, (c))
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -1577,8 +1557,8 @@ struct Reb_Any_Context {
 #define VAL_ERR_VALUES(v)   ERR_VALUES(VAL_CONTEXT(v))
 #define VAL_ERR_NUM(v)      ERR_NUM(VAL_CONTEXT(v))
 
-#define Val_Init_Error(o,f) \
-    Val_Init_Context((o), REB_ERROR, (f), NULL, NULL)
+#define Val_Init_Error(v,c) \
+    Val_Init_Context((v), REB_ERROR, (c))
 
 
 /***********************************************************************

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1614,10 +1614,7 @@ enum {
     R_UNSET, // => SET_UNSET(D_OUT); return R_OUT;
     R_NONE, // => SET_NONE(D_OUT); return R_OUT;
     R_TRUE, // => SET_TRUE(D_OUT); return R_OUT;
-    R_FALSE, // => SET_FALSE(D_OUT); return R_OUT;
-    R_ARG1, // => *D_OUT = *D_ARG(1); return R_OUT;
-    R_ARG2, // => *D_OUT = *D_ARG(2); return R_OUT;
-    R_ARG3 // => *D_OUT = *D_ARG(3); return R_OUT;
+    R_FALSE // => SET_FALSE(D_OUT); return R_OUT;
 };
 typedef REBCNT REB_R;
 

--- a/src/mezz/base-constants.r
+++ b/src/mezz/base-constants.r
@@ -56,6 +56,5 @@ max: :maximum
 abs: :absolute
 empty?: :tail?
 ---: :comment
-bind?: :bound?
 
 rebol.com: http://www.rebol.com

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -210,16 +210,13 @@ series?: :any-series?
 ;
 any-type!: :opt-any-value!
 
-; !!! BIND? and BOUND? will have to go, but it's not clear exactly if
-; BIND-OF or CONTEXT-OF or what is the right term.  So a mass renaming
-; effort has not been undertaken, especially given the number of bootstrap
-; references.  When the new name final decision comes, then BIND? and BOUND?
-; will be the ones with their home in the legacy module...
-
-bind-of: :bound?
-;bind?
-;bound?
-
+; BIND? and BOUND? didn't fit the naming convention of returning LOGIC! if
+; they end in a question mark.  Also, CONTEXT-OF is more explicit about the
+; type of the return result, which makes it more useful than BINDING-OF or
+; BIND-OF as a name.  (Result can be an ANY-CONTEXT!, including FRAME!)
+;
+bound?: :context-of
+bind?: :context-of
 
 ; !!! These less common cases still linger as question mark routines that
 ; don't return LOGIC!, and they seem like they need greater rethinking in

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -348,6 +348,7 @@ int Do_String(
         //
         if (at_breakpoint) {
             struct Reb_Call *call;
+            REBCON *frame;
 
             REBVAL level;
             VAL_INIT_WRITABLE_DEBUG(&level);
@@ -355,7 +356,14 @@ int Do_String(
 
             call = Call_For_Stack_Level(NULL, &level, FALSE);
             assert(call);
-            Bind_Relative_Deep(call->func, code);
+
+            // Need to manage because it may be no words get bound into it,
+            // and we're not putting it into a FRAME! value, so it might leak
+            // otherwise if it's reified.
+            //
+            frame = Frame_For_Call_May_Reify(call, NULL, TRUE);
+
+            Bind_Values_Deep(ARRAY_HEAD(code), frame);
         }
 
         // !!! This was unused code that used to be in Do_String from


### PR DESCRIPTION
This is a significant change which creates an abstraction for referring specifically to a function instance and its arguments called FRAME!.

Like an OBJECT!, a FRAME! is an ANY-CONTEXT!.  It may be bound into and its fields may be accessed.  Unlike historical OBJECT!, depending on the function type (CLOSURE! vs. FUNCTION!) the fields may "disappear" when the call is no longer on the stack.  A CLOSURE!'s frame fields will be persistent, while a FUNCTION!s will only last for the function's lifetime.

*(Note: This all-or-nothing distinction is hoped to eventually be replaced by a per-argument notion of "durability", so any arg or local could be marked as lasting or not.  It is also a goal to bring this feature to OBJECT! and other ANY-CONTEXT! types as well, to have some portion of their fields marked as lasting only during their construction and unavailable outside the body.  These "hybrid" frames have much of the groundwork laid to make them feasible, but won't be scheduled until the feature is truly needed.)*

To get a FRAME! one can use CONTEXT-OF (the replacement for BOUND?).  Also in the debugger, BACKTRACE permits querying for frames from the stack, via stack index or by an ANY-FUNCTION!  value (the most recent invocation of the function is picked in that case).  It is possible to get frames not only for user functions, but for NATIVE!s as well...and to bind into them.

*(Note: "Frameless" natives will require running in a special debug mode to ask them not to run framelessly in order to have their arguments inspected.)*

The debugger's BACKTRACE has been enhanced, as has the ability to pick a stack frame and bind code specifically to that stack frame in recursive contexts.

On the mechanical side, this change has been careful to reduce memory requirements and to defer the creation of the FRAME! until it is asked for.  More advancements in the usage of FRAME! are planned shortly.