### PR TITLE
Optimize stack indexing and expansion

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -430,7 +430,8 @@ RL_API int RL_Do_String(
 
     // assumes it can only be run at the topmost level where
     // the data stack is completely empty.
-    assert(DSP == -1);
+    //
+    assert(DSP == 0);
 
     PUSH_UNHALTABLE_TRAP(&error, &state);
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1595,7 +1595,7 @@ void Init_Core(REBARGS *rargs)
     Boot_Block = NULL;
     PG_Boot_Phase = BOOT_MEZZ;
 
-    assert(DSP == -1 && !DSF);
+    assert(DSP == 0 && !DSF);
 
     if (Apply_Only_Throws(
         &result, Sys_Func(SYS_CTX_FINISH_INIT_CORE), END_VALUE
@@ -1614,7 +1614,7 @@ void Init_Core(REBARGS *rargs)
         panic (Error(RE_MISC));
     }
 
-    assert(DSP == -1 && !DSF);
+    assert(DSP == 0 && !DSF);
 
     DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(&state);
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -278,7 +278,7 @@ struct Reb_Call {
     // something to compare against to find out how many is needed.  At this
     // position to sync alignment with same-sized `flags`.
     //
-    int dsp_orig; // type is REBDSP, but enforce alignment here
+    unsigned int dsp_orig; // type is REBDSP, but enforce alignment here
 
     // `flags` [INPUT, READ-ONLY (unless FRAMELESS signaling error)]
     //

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -157,6 +157,9 @@ TVAR struct Reb_Call *TG_Do_Stack;
 
 //-- Evaluation stack:
 TVAR REBARR *DS_Array;
+TVAR REBDSP DS_Index;
+TVAR REBVAL *DS_Movable_Base;
+
 TVAR struct Reb_Call *CS_Running;   // Call frame if *running* function
 
 // We store the head chunk of the current chunker even though it could be

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -205,7 +205,7 @@ struct Reb_State {
 //
 #define PUSH_TRAP_CORE(e,s,haltable) \
     do { \
-        assert(Saved_State || (DSP == -1 && !DSF)); \
+        assert(Saved_State || (DSP == 0 && !DSF)); \
         Snap_State_Core(s); \
         (s)->last_state = Saved_State; \
         Saved_State = (s); \


### PR DESCRIPTION
R3-Alpha used an ordinary "block" style series of values to represent
its stack, in order to leverage the existing mechanics for expansion
and access operations.  However, it did not want to pay the cost of
checking on each PUSH to see if it was out of bounds of the series to
see if it needed to expand, nor did it maintain termination with an
"END!" value the way a normal series did.

So instead of using typical series append operations, it would bump
the stack by an arbitrary amount in those routines that were known to
run out of space.  Most were given headroom of 20 slots to work in,
with the assumption that if it were not enough then that routine
would have to include the manual bumping as well.

That was somewhat failure-prone, and Ren-C sought to have a stack
"service layer" that would be able to check for the need for expansion
on each push.  Rather than do this efficiently, it just reverted to
the append operations for typical series while stability was reached.

This commit brings back the optimization in a new form that permits any
push to potentially expand.  The stack is maintained as a block of
elements that are *not* END markers, terminated by one END marker.
As END markers are never pushed to the stack, need for expansion can
be determined by bumping the data stack pointer and seeing if it's
an END or not...if not, the slot is safe to use.  Dropping the stack
will always leave a non-END behind, so that is legal too.

The garbage collector must handle this series specially, because though
it has "non-END" values going from after the data stack pointer to the
end of the array, these values should not be GC protected (as they
have been popped or dropped).  Consequently they are also potentially
invalid.  The GC must thus temporarily put an END marker in the data
stack after the DSP, and then restore it to a non-END marker (assuming
the DSP wasn't at the very end already).