### PR TITLE
PRINT/FAIL new design, recursion, |, BINARY! UTF8

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -42,6 +42,12 @@ return-native
 leave-native
 parse-native
 
+;; PRINT takes a /DELIMIT which can be a block specifying delimiters at each
+;; level of depth in the recursion of blocks.  The default is [#" " |], which
+;; is a signal to put spaces at the first level and then after that nothing.
+;;
+default-print-delimiter
+
 ;; The BREAKPOINT instruction needs to be able to re-transmit a RESUME
 ;; instruction in the case that it wants to leapfrog another breakpoint
 ;; sandbox on the stack, and needs access to the resume native for the label

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -787,6 +787,18 @@ static void Init_Root_Context(void)
     SET_ARR_FLAG(VAL_ARRAY(ROOT_LEAVE_BLOCK), SERIES_FLAG_LOCKED);
     SET_ARR_FLAG(VAL_ARRAY(ROOT_LEAVE_BLOCK), SERIES_FLAG_FIXED_SIZE);
 
+    // Used by REBNATIVE(print)
+    //
+    Val_Init_Block(ROOT_DEFAULT_PRINT_DELIMITER, Make_Array(2));
+    SET_CHAR(VAL_ARRAY_HEAD(ROOT_DEFAULT_PRINT_DELIMITER), ' ');
+    SET_BAR(VAL_ARRAY_AT_HEAD(ROOT_DEFAULT_PRINT_DELIMITER, 1));
+    SET_END(VAL_ARRAY_AT_HEAD(ROOT_DEFAULT_PRINT_DELIMITER, 2));
+    SET_ARRAY_LEN(VAL_ARRAY(ROOT_DEFAULT_PRINT_DELIMITER), 2);
+    SET_ARR_FLAG(VAL_ARRAY(ROOT_DEFAULT_PRINT_DELIMITER), SERIES_FLAG_LOCKED);
+    SET_ARR_FLAG(
+        VAL_ARRAY(ROOT_DEFAULT_PRINT_DELIMITER), SERIES_FLAG_FIXED_SIZE
+    );
+
     // We can't actually put an end value in the middle of a block, so we poke
     // this one into a program global.  We also dynamically allocate it in
     // order to get uninitialized memory for everything but the header (if

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -814,8 +814,9 @@ REBNATIVE(backtrace)
 
     // If they didn't use /ONLY we assume they want it printed out.
     //
-    Prin_Value(D_OUT, 0, TRUE); // TRUE = mold
-    Print_OS_Line();
+    // TRUE = mold
+    //
+    Print_Value(D_OUT, 0, TRUE);
     return R_UNSET;
 }
 


### PR DESCRIPTION
This adds features to PRINT and FAIL, and offers the functionality to
make a string via FORM/NEW (because there is speculation that FORM may
wind up being the word taken for this behavior, despite breaking legacy
compatibility with the quoted-vs-non-quoting default).

Largely this is folding a native implementation of what was called
"COMBINE" into the basic behavior of PRINT.  Changes are:

BINARY! is not molded as a Rebol constant, rather interpreted as UTF8;
if Rebol molding is desired that must be requested explicitly:

    >> print ["Hello" #{52656E2D43} "World"]
    Hello Ren-C World

    >> print ["Hello" mold #{52656E2D43} "World"]
    Hello #{52656E2D43} World

Blocks can be used as in PARSE for grouping or recursion.  Also as in
PARSE, this creates the opportunity for stack overflows (but if one
is running a general evaluation anyway, you could have already done
that if you wanted).

    >> x-rule: ["The value of x is" space x]
    == ["The value of x is" space x]

    >> print [(x: 10 |) x-rule newline (x: 20 |) x-rule]
    The value of x is 10
    The value of x is 20

By default, the top level of the block is separated by spaces while
nested blocks are not:

    >> print ["Part" "One" ["Part" "Two"]]
    Part One PartTwo

This may be overridden by /DELIMIT, which is able to take either a
single delimiter or a block of delimiters--with each element of the
block corresponding to a depth:

    >> print/delimit [
            "Level" ["Level" ["Level" "Three"] "Two"] "One"
        ] ["1" "2" "3"]

    Level1Level2Level3Three2Two1One

When the block runs out of delimiters but there is an extra level of
depth, it will repeat the last delimiter.  NONE! or BAR! may be used
to suppress this.  Hence the default delimiter is [#" " |].

The behavior of BAR! is not yet customizable, but follows the same
logic--to insert different characters at different depths, but to also
suppress other delimiting.  At the outermost level it acts as a newline
while inner levels it acts as a space, by default:

    >> print [["a" "b"] | "c" "d" | ["e" | "f"]]
    ab
    c d
    e f

Included in the design is the suppression of delimiting when content
does not add to the output (which is open for discussion on how to 
best do this--perhaps empty string content should still delimit and
people be responsible for turning that to UNSET!?  NONE! behavior
is also still not completely finalized.)

    >> print/delimit ["the" {} ["brown" () "fox"]] "; "
    the; brown; fox

A quoted version is also provided:

    >> print/quote [a b | [1 + 2]]
    a b
    1+2