### PR TITLE
CASE special handling of expression barriers

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -127,6 +127,7 @@ Script: [
     local-injection:    [{Attempt to inject value to local} :arg1 {in} :arg2]
 
     expression-barrier: {Expression barrier hit while processing arguments}
+    bar-hit-mid-case:   {Expression barrier hit in middle of CASE pairing}
 
     break-not-continue: {Use BREAK/WITH when body is the breaking condition}
 

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1156,6 +1156,16 @@ reevaluate:
 //
 // LIT-BAR! decays into an ordinary BAR! if seen here by the evaluator.
 //
+// Note that natives and dialects frequently do their own interpretation of
+// BAR!--rather than just evaluate it and let it mean something equivalent
+// to an unset.  For instance:
+//
+//     case [false [print "F"] | true [print ["T"]]
+//
+// If CASE did not specially recognize BAR!, it would complain that the
+// "second condition" was UNSET!.  So if you are looking for a BAR! behavior
+// and it's not passing through here, check the construct you are using.
+//
 //==//////////////////////////////////////////////////////////////////////==//
 
     case ET_BAR:

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -658,6 +658,31 @@ struct Reb_Call {
 // currently...this is an open question.
 //
 
+#define PUSH_CALL_UNLESS_END(c,v) \
+    do { \
+        (c)->value = VAL_ARRAY_AT(v); \
+        if (IS_END((c)->value)) { \
+            (c)->indexor = END_FLAG; \
+            break; \
+        } \
+        (c)->indexor = VAL_INDEX(v) + 1; \
+        (c)->source.array = VAL_ARRAY(v); \
+        (c)->eval_fetched = NULL; \
+        (c)->label_sym = SYM_0; \
+        (c)->mode = CALL_MODE_GUARD_ARRAY_ONLY; \
+        (c)->prior = TG_Do_Stack; \
+        TG_Do_Stack = c; \
+    } while (0)
+
+#define UPDATE_EXPRESSION_START(c) \
+    (assert((c)->indexor != VALIST_FLAG), (c)->expr_index = (c)->indexor)
+
+#define DROP_CALL(c) \
+    do { \
+        assert(TG_Do_Stack == (c)); \
+        TG_Do_Stack = c->prior; \
+    } while (0)
+
 #if 0
     // For detailed debugging of the fetching; coarse tool used only in very
     // deep debugging of the evaluator.


### PR DESCRIPTION
This modifies CASE to be more tightly integrated with the evaluator
(for improved performance and error reporting).  It also changes the
handling of expression barriers, so that they are only allowed between
the case pairs.

    >> case [false 1 | true 2]
    == 2

    >> case [false 1 true | 2]
    ** Script error: Expression barrier hit in middle of CASE pairing
    ** Where: case
    ** Near: false 1 true ?? | 2