### PR TITLE
Add PRINT/ONLY, only dialect nested PRINTs if literal

### DIFF
--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -240,6 +240,18 @@ selfless?: func [context [any-context!]] [
 ]
 
 
+; The legacy PRIN construct is equivalent to PRINT/ONLY of a reduced value
+; (since PRIN of a block would historically execute it).
+;
+prin: function [
+    "Print value, no line break, reducing blocks.  <r3-legacy>, use PRINT/ONLY"
+
+    value [opt-any-value!]
+][
+    print/only either block? :value [reduce value] [:value]
+]
+
+
 ; BREAK/RETURN was supplanted by BREAK/WITH.  The confusing idea of involving
 ; the word RETURN in the refinement (return from where, who?) became only
 ; more confusing with the introduction of definitional return.


### PR DESCRIPTION
This adds an /ONLY switch to PRINT in order to have it print a value
without adding a newline, nor reducing it if it's a block.  PRIN is
then rewritten in terms of PRINT/ONLY (reducing blocks first).

It also changes the nesting logic so that a block will only be
reduced and handled in the "print dialect" if it appears literally.
Hence `print ["a" [reverse "hello"] "b"]` will run the reverse, while
`foo: [reverse "hello"] print ["a" foo "b"]` will not.  This is a
step toward avoiding accidental reducing, although further changes to
the "print dialect" will likely be needed.