### PR TITLE
Retire varless ("frameless") native optimization

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -187,9 +187,6 @@ Script: [
     hidden:             {not allowed - would expose or modify hidden values}
     bad-bad:            [:arg1 {error:} :arg2]
 
-    varless-word:       [{variable} :arg1 {optimized out, run with DEBUG ON}]
-    varless-call:       {arguments optimized out, run with DEBUG ON}
-
     bad-make-arg:       [{cannot MAKE/TO} :arg1 {from:} :arg2]
 ;   no-decode:          [{cannot decode} :arg1 {encoding}]
     wrong-denom:        [:arg1 {not same denomination as} :arg2]

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -251,7 +251,7 @@ static void Do_Global_Block(
     if (rebind > 1) Bind_Values_Deep(item, Sys_Context);
 
     // !!! The words NATIVE and ACTION were bound but paths would not bind.
-    // So you could do `native [spec]` but not `native/varless [spec]`
+    // So you could do `native [spec]` but not `native/xxx [spec]`
     // because in the later case, it wouldn't have descended into the path
     // to bind `native`.  This is apparently intentional to avoid binding
     // deeply in the system context.
@@ -420,8 +420,6 @@ static void Init_Constants(void)
 //      /body
 //          {Equivalent body of Rebol code matching native's implementation}
 //      code [block!]
-//      /varless
-//          {Native wants delegation to eval its own args and extend DO state}
 //  ]
 //
 REBNATIVE(native)
@@ -438,7 +436,6 @@ REBNATIVE(native)
     PARAM(1, spec);
     REFINE(2, body);
     PARAM(3, code);
-    REFINE(4, varless);
 
     if (
         (Native_Limit != 0 || !*Native_Functions)
@@ -451,8 +448,7 @@ REBNATIVE(native)
         D_OUT,
         VAL_ARRAY(ARG(spec)),
         *Native_Functions++,
-        FUNC_CLASS_NATIVE,
-        REF(varless)
+        FUNC_CLASS_NATIVE
     );
 
     Native_Count++;
@@ -511,8 +507,7 @@ REBNATIVE(action)
         D_OUT,
         VAL_ARRAY(ARG(spec)),
         cast(REBNAT, cast(REBUPT, Action_Count)),
-        FUNC_CLASS_ACTION,
-        REF(typecheck) // varless? (all typechecks run "varlessly")
+        FUNC_CLASS_ACTION
     );
 
     Action_Count++;
@@ -620,7 +615,7 @@ static void Init_Natives(void)
     assert(IS_WORD(item) && VAL_WORD_SYM(item) == SYM_NATIVE);
     item++; // skip `native` so we're on the `[spec [block!]]`
     Make_Native(
-        val, VAL_ARRAY(item), *Native_Functions++, FUNC_CLASS_NATIVE, FALSE
+        val, VAL_ARRAY(item), *Native_Functions++, FUNC_CLASS_NATIVE
     );
     Native_Count++;
     item++; // skip spec
@@ -639,7 +634,7 @@ static void Init_Natives(void)
     assert(IS_WORD(item) && VAL_WORD_SYM(item) == SYM_NATIVE);
     item++; // skip `native`
     Make_Native(
-        val, VAL_ARRAY(item), *Native_Functions++, FUNC_CLASS_NATIVE, FALSE
+        val, VAL_ARRAY(item), *Native_Functions++, FUNC_CLASS_NATIVE
     );
     Native_Count++;
     item++; // skip spec

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -393,10 +393,6 @@ void Bind_Relative_Deep(REBFUN *func, REBVAL *head, REBU64 bind_types)
     // interesting case.  While this avenue is explored, relative bindings
     // for all function types are being permitted.
     //
-    // NOTE: This cannot work if the native is invoked framelessly.  A
-    // debug mode must be enabled that prohibits the native from being
-    // varless if it's to be introspected.
-    //
     /*assert(
         IS_FUNCTION(FUNC_VALUE(func))
         && VAL_FUNC_CLASS(FUNC_VALUE(func)) == FUNC_CLASS_USER

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -226,8 +226,7 @@ REBIXO Do_Va_Core(
         //
         // Infix lookahead causes a fetch that cannot be undone.  Hence
         // va_list DO/NEXT can't be resumed -- see VALIST_INCOMPLETE_FLAG.
-        // For a resumable interface on va_list, see the lower level
-        // varless API.
+        // For a resumable interface on va_list, see the lower level API.
         //
         // Note that the va_list may be reified during the call, so the
         // index may not be VALIST_FLAG at this point.

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1372,21 +1372,6 @@ struct Reb_Frame *Frame_For_Relative_Word(
             continue;
         }
 
-        if (FRM_IS_VARLESS(frame)) {
-            //
-            // !!! Trying to get a variable from a varless native is a
-            // little bit different and probably shouldn't be willing to
-            // fail in an "oh it's unbound but that's okay" way.  Because
-            // the data should be there, it's just been "optimized out"
-            //
-            // We ignore the `trap` setting for this unusual case, which
-            // generally should only be possible in debugging scenarios
-            // (how else would one get access to a binding to a native's
-            // locals and args??)
-            //
-            fail (Error(RE_VARLESS_WORD, any_word));
-        }
-
         // Currently the only `mode` in which a frame should be
         // considered as a legitimate match is CALL_MODE_FUNCTION.
         // Other call types include a GROUP! being recursed or

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -379,8 +379,7 @@ void Make_Native(
     REBVAL *out,
     REBARR *spec,
     REBNAT code,
-    enum Reb_Func_Class fclass,
-    REBOOL varless
+    enum Reb_Func_Class fclass
 ) {
     //Print("Make_Native: %s spec %d", Get_Sym_Name(type+1), SER_LEN(spec));
 
@@ -388,9 +387,6 @@ void Make_Native(
 
     VAL_RESET_HEADER(out, REB_FUNCTION);
     INIT_VAL_FUNC_CLASS(out, fclass);
-
-    if (varless)
-        SET_VAL_FLAG(out, FUNC_FLAG_VARLESS);
 
     VAL_FUNC_CODE(out) = code;
     VAL_FUNC_SPEC(out) = spec;
@@ -1242,10 +1238,7 @@ void Do_Action_Core(struct Reb_Frame *f)
 
     assert(type < REB_MAX);
 
-    // Handle special datatype test cases (eg. integer?).  Note that this
-    // has a varless implementation which is the one that typically runs
-    // when a frame is not required (such as when running under trace, where
-    // the values need to be inspectable)
+    // Handle special datatype test cases (eg. integer?).
     //
     if (FUNC_ACT(f->func) < REB_MAX_0) {
         if (TO_0_FROM_KIND(type) == FUNC_ACT(f->func))
@@ -1783,10 +1776,6 @@ REBFUN *VAL_FUNC_Debug(const REBVAL *v) {
         // If this happens, these help with debugging if stopped at breakpoint.
         //
         REBVAL *func_value = FUNC_VALUE(func);
-        REBOOL varless_value
-            = GET_VAL_FLAG(v, FUNC_FLAG_VARLESS);
-        REBOOL varless_func
-            = GET_VAL_FLAG(func_value, FUNC_FLAG_VARLESS);
         REBOOL has_return_value
             = GET_VAL_FLAG(v, FUNC_FLAG_LEAVE_OR_RETURN);
         REBOOL has_return_func

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -745,8 +745,7 @@ REBNATIVE(set_scheme)
                 Obj_Value(actor, n), // function,
                 VAL_FUNC_SPEC(act),
                 cast(REBNAT, map->func),
-                FUNC_CLASS_NATIVE,
-                FALSE
+                FUNC_CLASS_NATIVE
             );
         }
     }

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -170,7 +170,7 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
             // We aren't explicitly passed a Rebol ERROR! object, but we
             // consider it "safe" to make one since we're past BOOT_ERRORS
 
-            Val_Init_Error(&error, Make_Error_Core(id, FALSE, vaptr));
+            Val_Init_Error(&error, Make_Error_Core(id, vaptr));
         }
 
         Mold_Value(&mo, &error, FALSE);

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -621,15 +621,7 @@ static void Mark_Frame_Stack_Deep(void)
         // the arglist is under construction, but guaranteed to have all
         // cells be safe for garbage collection.
         //
-        if (GET_VAL_FLAG(FUNC_VALUE(f->func), FUNC_FLAG_VARLESS)) {
-            //
-            // Optimized native: it didn't need a variable-sized chunk
-            // allocated for its args and locals because it was able to do
-            // its work just processing the block input directly.  So nothing
-            // in `f->frame` to GC protect.
-            //
-        }
-        else if (f->flags & DO_FLAG_FRAME_CONTEXT) {
+        if (f->flags & DO_FLAG_FRAME_CONTEXT) {
             //
             // Though a Reb_Frame starts off with just a chunk of memory, it
             // may be promoted to a context (backed by a data pointer of
@@ -657,7 +649,7 @@ static void Mark_Frame_Stack_Deep(void)
         }
 
         // `param`, and `refine` may both be NULL
-        // (`arg` is a cache of the head of the arglist or NULL if varless)
+        // (`arg` is a cache of the head of the arglist)
 
         if (f->param && Is_Value_Managed(f->param, FALSE))
             Queue_Mark_Value_Deep(f->param);

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -476,9 +476,9 @@ void Drop_Chunk(REBVAL *opt_head)
 //
 //  Push_Or_Alloc_Vars_For_Call: C
 //
-// Allocate the series of REBVALs inspected by a non-varless function when
-// executed (the values behind D_ARG(1), D_REF(2), etc.)  Since the call
-// contains the function, it is known how many parameters are needed.
+// Allocate the series of REBVALs inspected by a function when executed (the
+// values behind D_ARG(1), D_REF(2), etc.)  Since the call contains the
+// REBFUN pointer, it is known how many parameters are needed.
 //
 // The call frame will be pushed onto the call stack, and hence its fields
 // will be seen by the GC and protected.
@@ -651,15 +651,6 @@ REBCTX *Context_For_Frame_May_Reify(
     }
     else {
         assert(f->mode != CALL_MODE_GUARD_ARRAY_ONLY);
-        if (FRM_IS_VARLESS(f)) {
-            //
-            // After-the-fact attempt to create a frame for a varless native.
-            // Suggest running in debug mode.
-            //
-            // !!! Debug mode disabling optimizations not yet written.
-            //
-            fail (Error(RE_VARLESS_CALL));
-        }
         context = AS_CONTEXT(Make_Series(
             1, // length report will not come from this, but from end marker
             sizeof(REBVAL),

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1205,8 +1205,6 @@ REBNATIVE(true_q)
 //  ]
 //
 REBNATIVE(false_q)
-//
-// TBD: Make varless
 {
     PARAM(1, value);
 
@@ -1225,8 +1223,6 @@ REBNATIVE(false_q)
 //  ]
 //
 REBNATIVE(quote)
-//
-// TBD: Make varless
 {
     PARAM(1, value);
 
@@ -1249,8 +1245,6 @@ REBNATIVE(quote)
 //  ]
 //
 REBNATIVE(nothing_q)
-//
-// TBD: Make varless
 {
     PARAM(1, value);
 
@@ -1272,8 +1266,6 @@ REBNATIVE(nothing_q)
 //  ]
 //
 REBNATIVE(something_q)
-//
-// TBD: Make varless
 {
     PARAM(1, value);
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -574,18 +574,13 @@ enum Reb_Vararg_Op {
 // to GET_OPT_VAR_MAY_FAIL() on an unbound variable will raise an error.
 //
 // TRY_GET_OPT_VAR() also provides const access.  But it will return NULL
-// instead of fail on unbound variables.  (One uncommon exception to this is
-// if a word somehow becomes bound to a PARAM of a NATIVE!, which can happen
-// during debugging inspection.  Because it's possible for natives to be
-// "varless" and optimize out the need to store arguments, a bound variable
-// into a varless native may nevertheless fail during TRY_GET_OPT_VAR().)
+// instead of fail on unbound variables.
 //
 // GET_MUTABLE_VAR_MAY_FAIL() and TRY_GET_MUTABLE_VAR() offer parallel
 // facilities for getting a non-const REBVAL back.  They will fail if the
 // variable is either unbound -or- marked with OPT_TYPESET_LOCKED to protect
 // them against modification.  The TRY variation will fail quietly by
-// returning NULL (with the same caveat about varless natives mentioned
-// above.)
+// returning NULL.
 //
 
 #define GET_OPT_VAR_MAY_FAIL(w) \

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1994,15 +1994,11 @@ enum {
     //
     FUNC_FLAG_LEAVE_OR_RETURN = (1 << (TYPE_SPECIFIC_BIT + 4)) | FUNC_FLAG_X,
 
-    // native hooks into DO state and does own arg eval
-    //
-    FUNC_FLAG_VARLESS = (1 << (TYPE_SPECIFIC_BIT + 5)) | FUNC_FLAG_X,
-
 #if !defined(NDEBUG)
     //
     // TRUE-valued refinements, NONE! for unused args
     //
-    FUNC_FLAG_LEGACY = (1 << (TYPE_SPECIFIC_BIT + 6)) | FUNC_FLAG_X,
+    FUNC_FLAG_LEGACY = (1 << (TYPE_SPECIFIC_BIT + 5)) | FUNC_FLAG_X,
 #endif
 
     FUNC_FLAG_NO_COMMA // needed for proper comma termination of this list

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -543,7 +543,7 @@ REBOOL Host_Start_Exiting(int *exit_status, int argc, REBCHR **argv) {
         REBVAL debug_native;
         VAL_INIT_WRITABLE_DEBUG(&debug_native);
 
-        Make_Native(&debug_native, spec, &N_debug, FUNC_CLASS_NATIVE, FALSE);
+        Make_Native(&debug_native, spec, &N_debug, FUNC_CLASS_NATIVE);
 
         *Append_Context(Lib_Context, 0, debug_sym) = debug_native;
         *Append_Context(user_context, 0, debug_sym) = debug_native;


### PR DESCRIPTION
The concept of the "frameless" optimization was that pushing stack
space, iterating argument lists, and type-checking could be foregone
or simplified in certain foundational operations (IF, EITHER, QUOTE,
CASE) by having those routines operate directly on the input series--
as if those natives were part of the Do_Core() function itself.

Between the time of the initial idea and today, some changes made the
idea less of a win.  The evaluator had its state turned "inside out"
such that all functions had frame objects, and it was merely that these
routines were becoming "varless".  Also, the number of conditions under
which varlessness could be exercised were reduced, so several checks
were needed to decide whether to put it into effect--creating cost for
both varless and non-varless routines.

The debugger in particular exposed complexities, because a varless
native could not have its parameters introspected in the stack.  Error
reporting had to take varlessness into account, in terms of whether
the error should be reported in the caller (in the case of a failed
type check) or in the varless native (if the code was part of the
implementation post-parameter gathering.

In order to better face irreducible complexities (such as specific
binding), this eliminates the setting for natives.  However, the API
which was developed to support them has been renamed from the "varless"
API, and is now the "low-level DO API"--which is still in use, and
helped in the design of other features.