### PR TITLE
Create Credits.md (restores some authorship information).

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,68 @@
+CREDITS
+=======================
+
+Creators of REBOL
+-----------------
+
+Carl Sassenrath, Rebol Technologies
+
+_REBOL is a trademark of REBOL Technologies_
+
+
+Code Contributors
+-----------------
+
+_The GitHub repository documents the significant code contributions by members of the REBOL language community - individuals
+and companies, following the release of REBOL to open source by Rebol Technologies in 2012._
+
+The project has also benefitted from significant supporting work outside this code repository by members of the commmunity--too numerous to list here!
+
+Contributors to this project are encouraged to add/edit their entries here.  Each entry identifies a contributor who may hold copyright in parts of the source,
+the rest of the entry identifies the author(s) of the contribution and any comments which may include a link to more information.
+
+Andreas Bolka
+* [@earl](https://github.com/earl)
+`; Keeper of rebol keys.`
+
+Atronix Engineering, Inc - [atronixengineering.com](http://www.atronixengineering.com/downloads)
+* [@zsx](https://github.com/zsx) Shixin Zeng
+`; Contributions include work upon %c-function.c %dev-signal.c %f-int.c %host-process.c %p-signal.c %reb-struct.h %t-library.c %t-struct.c %t-routine.c`
+
+Brett Handley
+* [@codebybrett](https://github.com/codebybrett)
+Long time Rebol user, using Rebol to modify Rebol C source.
+
+Brian Dickens - [hostilefork.com](http://www.hostilefork.com/)
+* [@hostilefork](https://github.com/hostilefork)
+"Ren-C" branch dev lead, core evaluator recoding and design
+
+Brian Hawley
+* [@BrianHawley](https://github.com/brianh)
+`; (Mezzanine, core patches, PARSE design, etc.)`
+
+Giulio Lunati
+* [@giuliolunati](https://github.com/giuliolunati)
+`; MAP! and hashing updates, Android branch, ...`
+
+Joshua Shireman
+* [@kealist](https://github.com/kealist)
+`; Contributions include work upon %dev-serial.c`
+
+Ladislav Mecir
+* [@ladislav](https://github.com/ladislav)
+`; Contributions include work upon f-math.c %m-gc.c reb-c.h`
+
+[Rebol Technologies](http://rebol.com/) ; Released source 12/12/2012.
+* [@carls](https://github.com/carls) Carl Sassenrath
+`; Creator of REBOL.`
+* [@ladislav](https://github.com/ladislav)
+`; Contributions include work upon %f-deci.c`
+
+Richard Smolak
+* `@???`
+`; Contributions include work upon %host-core.c %host-lib.c %host-process.c`
+
+Saphirion AG, Zug, Switzerland ; [See our Saphir Rebol work](http://development.saphirion.com/rebol/)
+* Robert M.Münch, CEO, Prototype sponsoring
+* [@earl](https://github.com/earl) Andreas Bolka
+* [@ladislav](https://github.com/ladislav) Ladislav Mecir `; Contributions include work upon @reb-dtoa.h`


### PR DESCRIPTION
During the bulk conversion of file headers some authorship information was removed from file headers on the basis that it would be contained in a Credits file instead. The Credits file should have been created during the conversion process but was not because it was seen to be in a draft form. So since the bulk conversion that authorship information has been missing from Ren-C.  While Credits.md may not be finished, the new file headers reference it, it therefore should exist.

The authorship information in question can be viewed at: https://github.com/metaeducation/ren-c/blob/91f0cff531d3bc6b664d83cd5b812d72c0812e92/source-tool.issues.txt

As the file header bulk conversion was from my PR, I feel it necessary to submit this Credits.md to honor the information that was affected during the conversion.