### PR TITLE
Change infix bitwise xor from XOR- to XOR+

### DIFF
--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -46,7 +46,7 @@ xor: to-infix :xor?
 
 and*: to-infix :and~
 or+: to-infix :or~
-xor-: to-infix :xor~
+xor+: to-infix :xor~
 
 ; !!! C-isms that are unlikely to be kept
 &: to-infix :and~

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -621,7 +621,7 @@ set 'r3-legacy* func [] [
 
         or: (:or+)
 
-        xor: (:xor-)
+        xor: (:xor+)
 
         apply: (:r3-alpha-apply)
 

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -884,7 +884,7 @@ prf: func [
         a: checksum/method/key a 'sha1 decode 'text s-2 ; A(n)
         append p-sha1 checksum/method/key rejoin [a seed] 'sha1 decode 'text s-2
     ]
-    return ((copy/part p-md5 output-length) xor- copy/part p-sha1 output-length)
+    return ((copy/part p-md5 output-length) xor+ copy/part p-sha1 output-length)
 ]
 
 make-key-block: func [

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -283,7 +283,7 @@ migrations: [
     or? <as> (func [a b] [true? any [:a :b]])
     or <as> :or ; see above
 
-    xor- <as> :xor
+    xor+ <as> :xor
     xor? <as> (func [a b] [true? any [all [:a (not :b)] all [(not :a) :b]]])
 ]
 


### PR DESCRIPTION
In Ren-C, infix AND OR and XOR are all logical operators.  (The prefix
logical forms are AND?, OR?, and XOR?)

The bitwise and "mathy" and-and-or use their boolean logic symbols
so infix operators are AND* and OR+.  Initial trials named the XOR
operator XOR- with a trailing minus sign.

But the exclusive-OR operation is symbolized by a + with a circle around
it.  Although there is some light parallel to subtraction (1 - 0 = 0,
1 - 1 = 0) the dangling hyphen on the end looks awkward and slight,
so it is probably better to just go ahead and make both OR+ and XOR+
use a plus symbol to denote they are bit math forms of the operations.