### PR TITLE
Re-introduce legality of `x: ()` assignments

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -169,7 +169,7 @@ options: context [  ; Options supplied to REBOL during startup
     ; would mean adapting the mezzanine (or finding a way to mark a routine
     ; as not being in the mezzanine and following a different rule.)
 
-    ;--none at present--
+    set-word-void-is-error: false
 ]
 
 script: context [

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -382,8 +382,10 @@ reevaluate:
         else
             QUOTE_NEXT_REFETCH(f->out, f);
 
-        if (IS_UNSET(f->out))
+    #if !defined(NDEBUG)
+        if (LEGACY(OPTIONS_SET_WORD_VOID_IS_ERROR) && IS_UNSET(f->out))
             fail (Error(RE_NEED_VALUE, f->param)); // e.g. `foo: ()`
+    #endif
 
         *GET_MUTABLE_VAR_MAY_FAIL(f->param) = *(f->out);
         break;
@@ -507,10 +509,10 @@ reevaluate:
             FETCH_NEXT_ONLY_MAYBE_END(f);
         }
 
-        // `a/b/c: ()` is not legal (cannot assign path from unset)
-        //
-        if (IS_UNSET(f->out))
-            fail (Error(RE_NEED_VALUE, f->param));
+    #if !defined(NDEBUG)
+        if (LEGACY(OPTIONS_SET_WORD_VOID_IS_ERROR) && IS_UNSET(f->out))
+            fail (Error(RE_NEED_VALUE, f->param)); // e.g. `a/b/c: ()`
+    #endif
 
         // !!! The evaluation ordering of SET-PATH! evaluation seems to break
         // the "left-to-right" nature of the language:

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -135,7 +135,7 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
 
         if (Do_Signals_Throws(&result))
             fail (Error_No_Catch_For_Throw(&result));
-        if (IS_SET(&result))
+        if (IS_ANY_VALUE(&result))
             fail (Error(RE_MISC));
 
         // Used by verbatim terminal output, e.g. print of a BINARY!
@@ -161,7 +161,7 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
 
             if (Do_Signals_Throws(&result))
                 fail (Error_No_Catch_For_Throw(&result));
-            if (IS_SET(&result))
+            if (IS_ANY_VALUE(&result))
                 fail (Error(RE_MISC));
 
             Req_SIO->length = Encode_UTF8(

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -266,8 +266,8 @@ static void Rehash_Map(REBMAP *map)
 //
 //  Find_Map_Entry: C
 // 
-// Try to find the entry in the map. If not found and val IS_SET(), create the
-// entry and store the key and val.
+// Try to find the entry in the map. If not found and val isn't void, create
+// the entry and store the key and val.
 //
 // RETURNS: the index to the VALUE or zero if there is none.
 //

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -869,7 +869,7 @@ static REBCNT Do_Eval_Rule(struct Reb_Frame *f)
         n = VAL_CMD(item);
 
         if (n == SYM_SKIP)
-            return (IS_SET(&value)) ? P_POS : NOT_FOUND;
+            return IS_UNSET(&value) ? NOT_FOUND : P_POS;
 
         if (n == SYM_QUOTE) {
             item = item + 1;
@@ -1036,7 +1036,7 @@ static REBCNT Parse_Rules_Loop(struct Reb_Frame *f, REBCNT depth) {
             if (Do_Signals_Throws(&result))
                 fail (Error_No_Catch_For_Throw(&result));
 
-            if (IS_SET(&result))
+            if (IS_ANY_VALUE(&result))
                 fail (Error(RE_MISC));
         }
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -258,7 +258,7 @@ default: func [
     'word [word! set-word! lit-word!] "The word (use :var for word! values)"
     value "The value" ; unset! not allowed on purpose
 ][
-    unless all [value? word not none? get word] [set word :value] :value
+    unless all [set? word | not none? get word] [set word :value] :value
 ]
 
 

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -29,12 +29,3 @@ wrap: func [
 ][
     do bind/copy/set body make object! 0
 ]
-
-check-set: func [
-    "Set optional value via set-word or set-path, TRUE unless UNSET!"
-
-    'target [set-word! set-path!]
-    value [opt-any-value!]
-][
-    any-value? set/opt target :value
-]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -48,7 +48,7 @@ dump-obj: function [
 
     ; Search for matching strings:
     out: copy []
-    wild: all [value? 'pat string? pat  find pat "*"]
+    wild: all [set? 'pat | string? pat | find pat "*"]
 
     for-each [word val] obj [
         ; !!! to-word necessary as long as OPTIONS_DATATYPE_WORD_STRICT exists
@@ -132,7 +132,7 @@ title-of: function [
     /doc "Open web browser to related documentation."
     /local value args item type-name types tmp print-args
 ][
-    unless value? 'word [
+    unless set? 'word [
         print trim/auto {
             Use HELP or ? to see built-in info:
 
@@ -208,7 +208,7 @@ title-of: function [
 ;           More information: http://www.rebol.com/docs.html
 
     ; If arg is an undefined word, just make it into a string:
-    if all [word? :word not value? :word] [word: mold :word]
+    if all [word? :word | not set? :word] [word: mold :word]
 
     ; Open the web page for it?
     if all [
@@ -246,7 +246,7 @@ title-of: function [
                 "It is of the general type" value/type newline
             ]
         ]
-        if any [:word = 'unset! not value? :word] [return ()]
+        if all [any-word? :word | not set? :word] [return ()]
         types: dump-obj/match lib :word
         sort types
         if not empty? types [
@@ -278,7 +278,7 @@ title-of: function [
     either path? :word [
         if any [
             error? set/opt 'value trap [get :word] ;trap reduce [to-get-path word]
-            not value? 'value
+            not set? 'value
         ][
             print ["No information on" word "(path has no value)"]
             return ()

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -99,7 +99,7 @@ array: func [
 ][
     if block? size [
         if tail? rest: next size [rest: none]
-        unless integer? set/opt 'size first size [
+        unless integer? size: first size [
             cause-error 'script 'expect-arg reduce ['array 'size type-of :size]
         ]
     ]
@@ -262,7 +262,7 @@ reword: function [
         ] [
             while [not tail? values] [
                 w: first+ values  ; Keywords are not evaluated
-                set/opt 'v do/next values 'values
+                v: do/next values 'values
                 if any [set-word? :w lit-word? :w] [w: to word! :w]
                 case [
                     wtype = type-of :w none
@@ -387,14 +387,14 @@ extract: func [
         if unset? :output [output: make series len * length pos]
         if all [not default any-string? output] [value: copy ""]
         for-skip series width [for-next pos [
-            if none? set/opt 'val pick series pos/1 [set/opt 'val value]
+            if none? val: pick series pos/1 [val: value]
             output: insert/only output :val
         ]]
     ][
         if unset? :output [output: make series len]
         if all [not default any-string? output] [value: copy ""]
         for-skip series width [
-            if none? set/opt 'val pick series pos [set/opt 'val value]
+            if none? val: pick series pos [val: value]
             output: insert/only output :val
         ]
     ]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -798,7 +798,7 @@ load-module: function [
                 module? :mod0 [hdr0: spec-of mod0] ; final header
                 block? :mod0 [hdr0: first mod0] ; cached preparsed header
                 ;assert/type [name0 word! hdr0 object! sum0 [binary! none!]] none
-                not tuple? set/opt 'ver0 :hdr0/version [ver0: 0.0.0]
+                not tuple? ver0: :hdr0/version [ver0: 0.0.0]
             ]
 
             ; Compare it to the module we want to load

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -218,7 +218,10 @@ for-each-record-NO-RETURN: func [
 
     table: next table
 
-    set/opt quote result: while [not empty? table] [
+    ; Note: this code must run in R3-Alpha, so can't just use `result:`
+    ; like in Ren-C (which will unset the variable if VOID? argument)
+    ;
+    set/opt (quote result:) while [not empty? table] [
         if (length headings) > (length table) [
             fail {Element count isn't even multiple of header count}
         ]

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -561,6 +561,9 @@ emit {
 #define IS_SET(v) \
     LOGICAL(VAL_TYPE(v) > REB_UNSET)
 
+#define IS_ANY_VALUE(v) \
+    LOGICAL(VAL_TYPE(v) != REB_UNSET)
+
 #define IS_SCALAR(v) \
     LOGICAL(VAL_TYPE(v) <= REB_DATE)
 


### PR DESCRIPTION
*(NOTE: This commit is from late March, and was tied up as part of the specific binding branch.  It is being extracted as part of the `pre-specific-binding` "frozen" branch, since the decision is now firmed up, after experimenting with alternatives like `check-set`.)*

---

With the demise of "reified unsets", the role of the non-reified unset
(a "void" or "no expression result") is being reconsidered.  Its
advantage as a return value from routines that need an "out of band"
result, such as to distinguish `first []` from `first [_]`...is high.

Historically Rebol has sought to be ergonomic by conflating "no result"
with a "NONE! result", because of the hot-potato nature of handling an
UNSET! value.  A non-negotiable aspect of the hot-potato is on typical
GET, because otherwise a typo like `my-3-arg-funtcion 1 2 3` would
evaluate to 3 without an error.

However, the advantage of a "hot potato" on writes is less obvious.  It
provides locality of errors when an assignment would wind up clearing
a variable instead of setting it.  However, this often needs to be
subverted via SET/OPT (a.k.a. set/any), and with locals gathering
has to be `set/opt (quote item:) ...` instead of just `item: ...`

Given the hot-potato nature of reads, it's also one of the least helpful
cases.  Consider:

    str: some-function a b c
    if str = "something" [...]

In this case, should some-function return no value and str: accept that
as unsetting the str, it would still generate an error on the `str`
access.  Yet if some-function returned another "good" type like an
integer!, then it would not error and just fail quietly in the
comparison.

The ENSURE primitive exists to make sure a value is acquired:

    str: ensure some-function a b c

And there are perhaps other type-based constraints that could be
developed, so that only variables marked as legally optional would
allow an assignment from voids.  Such a feature could also be used to
constrain to other types, catching INTEGER! to STRING! for instance.

But for the general ergonomics of handling the soon-to-be-more-common
VOID? return results, being able to assign them easily is too important
with the concrete advantages of stopping the assignments too limited
in the scheme of things.