### PR TITLE
Literal blank for none

### DIFF
--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -557,18 +557,19 @@ ATTRIBUTE_NO_RETURN void Panic_Series_Debug(
     const char *file,
     int line
 ) {
-    if (TG_Pushing_Mold) { // cannot call Debug_Fmt !
-        Debug_String(
-            "Panic_Series() while pushing_mold",
-            33, // ^--- length of this!
-            FALSE, 1
-        );
-    }
-    else {
-        Debug_Fmt("Panic_Series() in %s at line %d", file, line);
-    }
+    // Note: Only use printf in debug builds (not a dependency of the main
+    // executable).  Here it's important because series panics can happen
+    // during mold and other times.
+    //
+    printf("\n\n*** Panic_Series() in %s at line %d\n", file, line);
+    fflush(stdout);
+
     if (*series->guard == 1020) // should make valgrind or asan alert
         panic (Error(RE_MISC));
+
+    printf("!!! *series->guard dereference didn't crash (not a REBSER?)\n");
+    fflush(stdout);
+
     panic (Error(RE_MISC)); // just in case it didn't crash
 }
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1136,7 +1136,7 @@ void Mold_Value(REB_MOLD *mold, const REBVAL *value, REBOOL molded)
         break;
 
     case REB_NONE:
-        Emit(mold, "+N", SYM_NONE);
+        Append_Unencoded(ser, "_");
         break;
 
     case REB_LOGIC:

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -51,6 +51,7 @@ enum Value_Types {
     TOKEN_NONE,     // not needed
     TOKEN_BAR,
     TOKEN_LIT_BAR,
+    TOKEN_BLANK,
     TOKEN_LOGIC,    // not needed
     TOKEN_INTEGER,
     TOKEN_DECIMAL,
@@ -162,6 +163,7 @@ enum LEX_SPECIAL_ENUM {             /* The order is important! */
     LEX_SPECIAL_MINUS,              /* 2D - - date, negative number */
     LEX_SPECIAL_TILDE,              /* 7E ~ - complement number */
     LEX_SPECIAL_BAR,                /* 7C | - expression barrier */
+    LEX_SPECIAL_BLANK,              /* 5F _ - blank */
 
                                     /** Any of these can follow - or ~ : */
     LEX_SPECIAL_PERIOD,             /* 2E . - decimal number */

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -145,3 +145,9 @@ ok?: func [
 ][
     not error? :value
 ]
+
+; Currently BLANK! is an alias for NONE!, but Ren-C's plan is that BLANK!
+; would be the official name, with NONE! the legacy alias.
+;
+blank?: :none?
+blank!: :none!

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -135,7 +135,7 @@ parse-asn: func [
                             (either constructed? ["constructed"] ["primitive"])
                             (index-of data)
                             (size)
-                            #[none]
+                            _
                         ]
                     ]
                     mode: 'type


### PR DESCRIPTION
This change makes a single _ equivalent to a literal NONE! value, and
is how a NONE! is molded to the display.  It establishes BLANK! as an
alias, and a test function BLANK?...but with no word BLANK to look
up to the value, as the underscore is intended to speak for itself.

WORD! with an underscore-only name would have to be done in construction
syntax.  (Note: #_ was seen in use in a very old copy of Red.)

The rationale for introducing this new literal form is due to an interest
in making it more useful in dialecting, and to remove it from the set of
things that the users might treat as a variable.  This will make it a
safer choice for dialects which just need to indicate a "slot", but do
not wish to establish their own keyword for slots.  Since NONE! needed
a literal form anyway, letting it do double duty as this shared idea
takes care of two things at once.

Notably, it is of use in the PRINT dialect for indicating a SPACE.
Attempts to come up with a satisfying solution for print which auto-spaces
has generally failed, as it is conceptually flawed to come up with ways
of putting in indicators to say "before there was something here, and now
there is nothing".  By making NONE!'s (blank's!) literal form a very
easy to type and regard symbol for indicating a space, it makes it less
painful, e.g.:

     print ["The value is" x] => print ["The value is" _ x]

While that reduced case may make it appear that the underscore is "ugly",
the "cleanliness" of the left case is generally an illusion.  More often
than not, code has to work its way out of the trap of the automatic
spacing.  Combined with the use of BAR! for newline, this presents
pleasing answers for PRINT.

Changes to PRINT will be in another commit.
