### PR TITLE
not TRUE/NONE, not WORD/NONE but TRUE/FALSE refinements

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -155,7 +155,9 @@ Script: [
     no-refine:          [:arg1 {has no refinement called} :arg2]
     bad-refines:        {incompatible or invalid refinements}
     bad-refine:         [{incompatible or duplicate refinement:} :arg1]
-    bad-refine-revoke:  {refinement's args must be either all unset or all set}
+    argument-revoked:   [:arg1 {refinement revoked, cannot supply} :arg2]
+    bad-refine-revoke:  [:arg1 {refinement in use, can't be revoked by} :arg2]
+    non-logic-refine:   [:arg1 {refinement must be LOGIC!, not} :arg2]
 
     invalid-path:       [{cannot access} :arg2 {in path} :arg1]
     bad-path-type:      [{path} :arg1 {is not valid for} :arg2 {type}]

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -143,7 +143,7 @@ options: context [  ; Options supplied to REBOL during startup
     lit-word-decay: false
     exit-functions-only: false
     broken-case-semantics: false
-    refinements-true: false
+    refinements-blank: false
     forever-64-bit-ints: false
     print-forms-everything: false
     break-with-overrides: false
@@ -155,7 +155,7 @@ options: context [  ; Options supplied to REBOL during startup
     arg1-arg2-arg3-error: false
 
     ; These option will only apply if the function which is currently executing
-    ; was created after legacy mode was enabled, and if refinements-true is
+    ; was created after legacy mode was enabled, and if refinements-blank is
     ; set (because that's what marks functions as "legacy" or not")
     ;
     no-switch-evals: false

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -867,6 +867,10 @@ static void Init_Root_Context(void)
     SET_TRASH_IF_DEBUG(&PG_Blank_Value[1]);
     MARK_CELL_UNWRITABLE_IF_DEBUG(&PG_Blank_Value[1]);
 
+    SET_BAR(&PG_Bar_Value[0]);
+    SET_TRASH_IF_DEBUG(&PG_Bar_Value[1]);
+    MARK_CELL_UNWRITABLE_IF_DEBUG(&PG_Bar_Value[1]);
+
     SET_FALSE(&PG_False_Value[0]);
     SET_TRASH_IF_DEBUG(&PG_False_Value[1]);
     MARK_CELL_UNWRITABLE_IF_DEBUG(&PG_False_Value[1]);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1284,6 +1284,36 @@ REBCTX *Error_Invalid_Arg(const REBVAL *value)
 
 
 //
+//  Error_Bad_Refine_Revoke: C
+//
+// We may have to search for the refinement, so we always do (speed of error
+// creation not considered that relevant to the evaluator, being overshadowed
+// by the error handling).  See the remarks about the state of f->refine in
+// the Reb_Frame definition.
+//
+REBCTX *Error_Bad_Refine_Revoke(struct Reb_Frame *f)
+{
+    assert(IS_TYPESET(f->param));
+
+    REBVAL param_name;
+    Val_Init_Word(&param_name, REB_WORD, VAL_TYPESET_SYM(f->param));
+
+    while (VAL_PARAM_CLASS(f->param) != PARAM_CLASS_REFINEMENT)
+        --f->param;
+
+    REBVAL refine_name;
+    Val_Init_Word(&refine_name, REB_REFINEMENT, VAL_TYPESET_SYM(f->param));
+
+    if (IS_VOID(f->arg)) // was void and shouldn't have been
+        return Error(RE_BAD_REFINE_REVOKE, &refine_name, &param_name, END_CELL);
+
+    // wasn't void and should have been
+    //
+    return Error(RE_ARGUMENT_REVOKED, &refine_name, &param_name, END_CELL);
+}
+
+
+//
 //  Error_No_Catch_For_Throw: C
 //
 REBCTX *Error_No_Catch_For_Throw(REBVAL *thrown)

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -842,11 +842,11 @@ void Make_Function(
     // If FUNC or MAKE FUNCTION! are being invoked from an array of code that
     // has been flagged "legacy" (e.g. the body of a function created after
     // `do <r3-legacy>` has been run) then mark the function with the setting
-    // to make refinements TRUE instead of WORD! when used, as well as their
-    // args NONE! instead of void when not used...if that option is on.
+    // to make refinements and args blank instead of FALSE/void...if that
+    // option is on.
     //
     if (
-        LEGACY_RUNNING(OPTIONS_REFINEMENTS_TRUE)
+        LEGACY_RUNNING(OPTIONS_REFINEMENTS_BLANK)
         || GET_ARR_FLAG(VAL_ARRAY(spec), SERIES_FLAG_LEGACY)
         || GET_ARR_FLAG(VAL_ARRAY(body), SERIES_FLAG_LEGACY)
     ) {

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -346,7 +346,7 @@ REBOOL Do_Path_Throws(
         // should balance!)
 
         for (; NOT_END(pvs.item); ++pvs.item) { // "the refinements"
-            if (IS_BLANK(pvs.item)) continue;
+            if (IS_VOID(pvs.item)) continue;
 
             if (IS_GROUP(pvs.item)) {
                 // Note it is not legal to use the data stack directly as the
@@ -357,13 +357,13 @@ REBOOL Do_Path_Throws(
                     DS_DROP_TO(dsp_orig);
                     return TRUE;
                 }
-                if (IS_BLANK(&refinement)) continue;
+                if (IS_VOID(&refinement)) continue;
                 DS_PUSH(&refinement);
             }
             else if (IS_GET_WORD(pvs.item)) {
                 DS_PUSH_TRASH;
                 *DS_TOP = *GET_OPT_VAR_MAY_FAIL(pvs.item);
-                if (IS_BLANK(DS_TOP)) {
+                if (IS_VOID(DS_TOP)) {
                     DS_DROP;
                     continue;
                 }
@@ -373,8 +373,9 @@ REBOOL Do_Path_Throws(
             // Whatever we were trying to use as a refinement should now be
             // on the top of the data stack, and only words are legal ATM
             //
-            if (!IS_WORD(DS_TOP))
+            if (!IS_WORD(DS_TOP)) {
                 fail (Error(RE_BAD_REFINE, DS_TOP));
+            }
 
             // Go ahead and canonize the word symbol so we don't have to
             // do it each time in order to get a case-insenstive compare

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1798,11 +1798,11 @@ exit_block:
     // SWITCH can run differently based on noticing it was dispatched from
     // a reference living in that legacy code.
     //
-    // !!! Currently cued by the REFINEMENTS_TRUE option which also applies
+    // !!! Currently cued by the REFINEMENTS_BLANK option which also applies
     // to functions, but should be its own independent switch.
     //
 #if !defined(NDEBUG)
-    if (LEGACY(OPTIONS_REFINEMENTS_TRUE))
+    if (LEGACY(OPTIONS_REFINEMENTS_BLANK))
         SET_ARR_FLAG(block, SERIES_FLAG_LEGACY);
 #endif
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -478,7 +478,7 @@ struct Reb_Frame {
     // * If IS_VOID(), then refinements are being skipped and the arguments
     //   that follow should not be written to.
     //
-    // * If NONE!, this is an arg to a refinement that was not used in the
+    // * If BLANK!, this is an arg to a refinement that was not used in the
     //   invocation.  No consumption should be performed, arguments should
     //   be written as unset, and any non-unset specializations of arguments
     //   should trigger an error.
@@ -488,10 +488,10 @@ struct Reb_Frame {
     //   from the callsite for each remaining argument, but those expressions
     //   must not evaluate to any value.
     //
-    // * If WORD! the refinement is active but revokable.  So if evaluation
-    //   produces no value, `refine` must become FALSE.
+    // * If TRUE the refinement is active but revokable.  So if evaluation
+    //   produces no value, `refine` must be mutated to be FALSE.
     //
-    // * If TRUE, it's an ordinary arg...and not a refinement.  It will be
+    // * If BAR!, it's an ordinary arg...and not a refinement.  It will be
     //   evaluated normally but is not involved with revocation.
     //
     // Because of how this lays out, IS_CONDITIONAL_TRUE() can be used to
@@ -1091,7 +1091,7 @@ struct Native_Refine {
     //
     #define REFINE(n,name) \
         const struct Native_Refine p_##name = { \
-            NOT(IS_BLANK(frame_->arg + (n) - 1)), \
+            IS_CONDITIONAL_TRUE(frame_->arg + (n) - 1), \
             frame_->arg + (n) - 1, \
             (n) \
         }
@@ -1108,15 +1108,15 @@ struct Native_Refine {
 
 #ifdef NDEBUG
     #define REF(name) \
-        NOT(IS_BLANK(ARG(name)))
+        IS_CONDITIONAL_TRUE(ARG(name))
 #else
     // An added useless ?: helps check in debug build to make sure we do not
     // try to use REF() on something defined as PARAM(), but only REFINE()
     //
     #define REF(name) \
         ((p_##name).used_cache \
-            ? NOT(IS_BLANK(ARG(name))) \
-            : NOT(IS_BLANK(ARG(name))))
+            ? IS_CONDITIONAL_TRUE(ARG(name)) \
+            : IS_CONDITIONAL_TRUE(ARG(name)))
 #endif
 
 
@@ -1208,7 +1208,7 @@ struct Native_Refine {
 #define D_OUT       FRM_OUT(frame_)         // GC-safe slot for output value
 #define D_ARGC      FRM_NUM_ARGS(frame_)        // count of args+refinements/args
 #define D_ARG(n)    FRM_ARG(frame_, (n))    // pass 1 for first arg
-#define D_REF(n)    NOT(IS_BLANK(D_ARG(n)))  // D_REFinement (not D_REFerence)
+#define D_REF(n)    IS_CONDITIONAL_TRUE(D_ARG(n))  // REFinement (!REFerence)
 #define D_FUNC      FRM_FUNC(frame_)        // REBVAL* of running function
 #define D_LABEL_SYM FRM_LABEL(frame_)       // symbol or placeholder for call
 #define D_DSP_ORIG  FRM_DSP_ORIG(frame_)    // Original data stack pointer

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -85,6 +85,7 @@ PVAR REBVAL PG_End_Cell;
 PVAR REBVAL PG_Void_Cell[2];
 
 PVAR REBVAL PG_Blank_Value[2];
+PVAR REBVAL PG_Bar_Value[2];
 PVAR REBVAL PG_False_Value[2];
 PVAR REBVAL PG_True_Value[2];
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -765,6 +765,8 @@ enum {
         (VAL_RESET_HEADER((v), REB_LIT_BAR), SET_TRACK_PAYLOAD(v))
 #endif
 
+#define BAR_VALUE (&PG_Bar_Value[0])
+
 
 //=////////////////////////////////////////////////////////////////////////=//
 //

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -144,7 +144,7 @@ repend: func [
     count [any-number! pair!]
 ][
     either any-value? :value [
-        append/part/:only/dup series reduce :value :limit :count
+        append/part/(if only 'only)/dup series reduce :value :limit :count
     ][
         head series ;-- simulating result of appending () returns the head
     ]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -416,7 +416,7 @@ get: function [
         any-path? :source
         any-context? :source
     ][
-        lib-get/(either any [opt_GET any_GET] 'opt blank) :source
+        lib-get/(if any [opt_GET any_GET] 'opt) :source
     ][
         if system/options/get-will-get-anything [:source]
         fail ["GET takes ANY-WORD!, ANY-PATH!, ANY-CONTEXT!, not" (:source)]
@@ -799,7 +799,7 @@ set 'r3-legacy* func [] [
                 ]
 
                 true [
-                    ; This requires system/options/refinements-true to work.
+                    ; This requires system/options/refinements-blank to work.
                     ;
                     ; Note that the heuristic here is not 100% right,
                     ; but probably works most of the time.  The goal is
@@ -809,7 +809,7 @@ set 'r3-legacy* func [] [
                     ; RETURN...if that happens and the RETURN just so
                     ; happens to be the input, this will return TRUE.
                     ;
-                    result: lib/parse/:case_PARSE input rules
+                    result: lib/parse/(if case_PARSE 'case) input rules
                     case [
                         blank? result [false]
                         same? result input [true]
@@ -1080,7 +1080,7 @@ set 'r3-legacy* func [] [
     system/options/lit-word-decay: true
     system/options/broken-case-semantics: true
     system/options/exit-functions-only: true
-    system/options/refinements-true: true
+    system/options/refinements-blank: true
     system/options/no-switch-evals: true
     system/options/no-switch-fallthrough: true
     system/options/forever-64-bit-ints: true

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -68,7 +68,7 @@ remold: func [
     /all  {Mold in serialized format}
     /flat {No indentation}
 ][
-    mold/:only/:all/:flat reduce :value
+    mold/(if only 'only)/(if all 'all)/(if flat 'flat) reduce :value
 ]
 
 charset: func [
@@ -121,7 +121,7 @@ array: func [
     head block
 ]
 
-replace: func [
+replace: function [
     "Replaces a search value with the replace value within the target series."
     target  [any-series!] "Series to replace within (modified)"
     pattern "Value to be replaced (converted if necessary)"
@@ -132,10 +132,11 @@ replace: func [
     /case "Case-sensitive replacement"
     /tail "Return target after the last replacement position"
 
-    /local save-target len value pos do-break
-
     ; Consider adding an /any refinement to use find/any, once that works.
 ][
+    case_REPLACE: case
+    case: :lib/case
+
     save-target: target
 
     ; !!! These conversions being missing seems a problem with FIND the native
@@ -151,7 +152,7 @@ replace: func [
     ; Note that if a FORM actually happens inside of FIND, it could wind up
     ; happening repeatedly in the /ALL case if that happens.
 
-    len: lib/case [
+    len: case [
         ; leave bitset patterns as-is regardless of target type, len = 1
         bitset? :pattern 1
 
@@ -171,7 +172,7 @@ replace: func [
         true 1
     ]
 
-    while [pos: find/:case target :pattern] [
+    while [pos: find/(if case_REPLACE 'case) target :pattern] [
         ; apply replacement if function, or drops pos if not
         ; the parens quarantine function invocation to maximum arity of 1
         (value: replacement pos)
@@ -336,7 +337,7 @@ reword: function [
         [a: any [to char b: char [escape | blank]] to end fout]
     ]
 
-    parse/:case_REWORD source rule
+    parse/(if case_REWORD 'case) source rule
 
     ; Return end of output with /into, head otherwise
     either into [output] [head output]
@@ -441,7 +442,7 @@ collect-with: func [
     keeper: func [
         value [<opt> any-value!] /only
     ][
-        output: insert/:only output :value
+        output: insert/(if only 'only) output :value
         :value
     ]
 

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -226,7 +226,7 @@ update-proto-state: func [
     either any [
         blank? ctx/protocol-state
         all [
-            next-state: get-next-proto-state/:write-state ctx
+            next-state: get-next-proto-state/(if write-state 'write-state) ctx
             find next-state new-state
         ]
     ] [


### PR DESCRIPTION
This canonizes refinement values in both system-called functions and
frame-invoked functions to only allowing LOGIC! true and false.

This is a change from one of the earliest Ren-C adaptations, which was
to try and take advantage of making refinements their own WORD! in
order to ease chaining.  e.g. a function with a refinement /ONLY could
then chain that to APPEND by writing `append/:only`, where if it were
none in the calling function it would not be applied, and if it were 'ONLY
in the calling function it would be used.

While that was a useful feature for its time, a lot has changed since.
With GROUP! executable in paths, one can write `append/(if only 'only)`
which is not much longer.  There are also other possibilities with
APPLY for doing proxying of words from the current frame conveniently.

What ultimately pushed the decision to TRUE and FALSE, was a technical
issue.  Consider the following:

    frame: make frame! :append
    frame/series: [1 2 3]
    frame/value: [4 5]
    frame/only: true
    do frame

This is likely what a user would want to write, instead of having to
say `frame/only: 'only`.  If one is not making a copy of this frame
but just running the function with the values "as is", then some
point in the process would have to canonize the true to 'only.  That
canonization adds complexity as opposed to just checking for LOGIC!
and is also "sketchy" as it is mutating the frame from its given form.

A similar line of argument can be applied to FALSE.  Ergonomically, it
would seem that one should be able to write FALSE, yet it would either
have to be canonized to a BLANK! or you make FALSE the only thing
accepted.

Trello notes here:

https://trello.com/c/H9I0261r