### PR TITLE
Mutation bugfix for common.r's to-c-name

### DIFF
--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -54,21 +54,21 @@ to-c-name: function [
         ; Take care of special cases of singular symbols
 
         ; Used specifically by t-routine.c to make SYM_ELLIPSIS
-        ... ["ellipsis"]
+        ... [copy "ellipsis"]
 
         ; Used to make SYM_HYPHEN which is needed by `charset [#"A" - #"Z"]`
-        - ["hyphen"]
+        - [copy "hyphen"]
 
         ; Used by u-dialect apparently
-        * ["asterisk"]
+        * [copy "asterisk"]
 
         ; None of these are used at present, but included in case
-        . ["period"]
-        ? ["question"]
-        ! ["exclamation"]
-        + ["plus"]
-        ~ ["tilde"]
-        | ["bar"]
+        . [copy "period"]
+        ? [copy "question"]
+        ! [copy "exclamation"]
+        + [copy "plus"]
+        ~ [copy "tilde"]
+        | [copy "bar"]
     ][
         ; If these symbols occur composite in a longer word, they use a
         ; shorthand; e.g. `true?` => `true_q`


### PR DESCRIPTION
The routine `to-c-name` was turning things like "+" into "plus" with
a switch statement.  However, it was not copying the strings.

As a consequence, callers who used `to-c-name` with the expectation that
they could modify the result (e.g. that it was acting like a FORM)
would wind up modifying the strings in the switch statement.

This is one good example of why there are likely strong good reasons for
considering source immutable by default.