### PR TITLE
Specific. Binding. (Major.)

### DIFF
--- a/src/boot/core.r
+++ b/src/boot/core.r
@@ -84,7 +84,7 @@ rc4: command [
 rsa-make-key: func [
     "Creates a key object for RSA algorithm."
 ][
-    make object! [
+    has [
         n:          ;modulus
         e:          ;public exponent
         d:          ;private exponent
@@ -115,7 +115,7 @@ dh-make-key: func [
 ;       size [integer!] "Key length"
 ;       generator [integer!] "Generator number"
 ][
-    make object! [
+    has [
         priv-key:   ;private key
         pub-key:    ;public key
         g:          ;generator

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -28,7 +28,13 @@ Licensed under the Apache License, Version 2.0.
 See: http://www.apache.org/licenses/LICENSE-2.0
 }
 
-catalog: context [
+; !!! HAS is defined later, so this uses CONSTRUCT [] [body] instead.
+; MAKE OBJECT! is not used because that is too low-level (no evaluation or
+; collection of fields).  Reconsider if base-funcs should be loaded before
+; the system object here, or if it should be able to work with just the
+; low level MAKE OBJECT! and not use things like `x: y: z: none` etc.
+
+catalog: construct [] [
     ; Static (non-changing) values, blocks, objects
     datatypes: []
     actions: _
@@ -43,7 +49,7 @@ catalog: context [
     ]
 ]
 
-contexts: context [
+contexts: construct [] [
     root:
     sys:
     lib:
@@ -51,10 +57,10 @@ contexts: context [
         _
 ]
 
-state: context [
+state: construct [] [
     ; Mutable system state variables
     note: "contains protected hidden fields"
-    policies: context [ ; Security policies
+    policies: construct [] [ ; Security policies
         file:    ; file access
         net:     ; network access
         eval:    ; evaluation limit
@@ -73,9 +79,9 @@ state: context [
 
 modules: []
 
-codecs: context []
+codecs: make object! [[][]]
 
-dialects: context [
+dialects: construct [] [
     secure:
     draw:
     effect:
@@ -84,9 +90,9 @@ dialects: context [
         _
 ]
 
-schemes: context []
+schemes: make object! [[][]]
 
-ports: context [
+ports: construct [] [
     wait-list: []   ; List of ports to add to 'wait
     input:          ; Port for user input.
     output:         ; Port for user output
@@ -96,7 +102,7 @@ ports: context [
 ;   serial: _       ; serial device name block
 ]
 
-locale: context [
+locale: construct [] [
     language:   ; Human language locale
     language*:
     locale:
@@ -110,7 +116,7 @@ locale: context [
     ]
 ]
 
-options: context [  ; Options supplied to REBOL during startup
+options: construct [] [  ; Options supplied to REBOL during startup
     boot: _         ; The path to the executable
     home: _         ; Path of home directory
     path: _         ; Where script was started or the startup dir
@@ -126,7 +132,6 @@ options: context [  ; Options supplied to REBOL during startup
     secure: _       ; security policy
     version: _      ; script version needed
     boot-level: _   ; how far to boot up
-
 
     quiet: false    ; do not show startup info (compatibility)
 
@@ -171,7 +176,7 @@ options: context [  ; Options supplied to REBOL during startup
     set-word-void-is-error: false
 ]
 
-script: context [
+script: construct [] [
     title:          ; Title string of script
     header:         ; Script header as evaluated
     parent:         ; Script that loaded the current one
@@ -180,7 +185,7 @@ script: context [
         blank
 ]
 
-standard: context [
+standard: construct [] [
     ; FUNC+PROC implement a native-optimized variant of a function generator.
     ; This is the body template that it provides as the code *equivalent* of
     ; what it is doing (via a more specialized/internal method).  Though
@@ -236,7 +241,7 @@ standard: context [
     ; the archetypal context has to be created "by hand" for natives to use,
     ; with this archetype used by the REDESCRIBE Mezzanine.
     ;
-    function-meta: context [
+    function-meta: construct [] [
         description:
         parameter-types:
         parameter-notes:
@@ -248,35 +253,35 @@ standard: context [
     ; meta archetype to `function-meta` and subset the parameters.  Otherwise
     ; HELP just follows the `specializee` and gets descriptions there.
     ;
-    specialized-meta: context [
+    specialized-meta: construct [] [
         description:
         specializee:
         specializee-name:
             _
     ]
 
-    adapted-meta: context [
+    adapted-meta: construct [] [
         description:
         adaptee:
         adaptee-name:
             _
     ]
 
-    chained-meta: context [
+    chained-meta: construct [] [
         description:
         chainees:
         chainee-names:
             _
     ]
 
-    hijacked-meta: context [
+    hijacked-meta: construct [] [
         description:
         hijackee:
         hijackee-name:
             _
     ]
 
-    error: context [ ; Template used for all errors:
+    error: construct [] [ ; Template used for all errors:
         code: _
         type: 'user
         id: 'message
@@ -288,7 +293,7 @@ standard: context [
         ; necessary (errors with no arguments will just have a message)
     ]
 
-    script: context [
+    script: construct [] [
         title:
         header:
         parent:
@@ -297,7 +302,7 @@ standard: context [
             blank
     ]
 
-    header: context [
+    header: construct [] [
         title: {Untitled}
         name:
         type:
@@ -314,7 +319,7 @@ standard: context [
             blank
     ]
 
-    scheme: context [
+    scheme: construct [] [
         name:       ; word of http, ftp, sound, etc.
         title:      ; user-friendly title for the scheme
         spec:       ; custom spec for scheme (if needed)
@@ -326,7 +331,7 @@ standard: context [
             blank
     ]
 
-    port: context [ ; Port specification object
+    port: construct [] [ ; Port specification object
         spec:       ; published specification of the port
         scheme:     ; scheme object used for this port
         actor:      ; port action handler (script driven)
@@ -338,7 +343,7 @@ standard: context [
             blank
     ]
 
-    port-spec-head: context [
+    port-spec-head: construct [] [
         title:      ; user-friendly title for port
         scheme:     ; reference to scheme that defines this port
         ref:        ; reference path or url (for errors)
@@ -346,12 +351,12 @@ standard: context [
            blank    ; (extended here)
     ]
 
-    port-spec-net: make port-spec-head [
+    port-spec-net: construct port-spec-head [
         host: _
         port-id: 80
     ]
 
-    port-spec-serial: make port-spec-head [
+    port-spec-serial: construct port-spec-head [
         speed: 115200
         data-size: 8
         parity: _
@@ -359,11 +364,11 @@ standard: context [
         flow-control: _ ;not supported on all systems
     ]
 
-    port-spec-signal: make port-spec-head [
+    port-spec-signal: construct port-spec-head [
         mask: [all]
     ]
 
-    file-info: context [
+    file-info: construct [] [
         name:
         size:
         date:
@@ -371,7 +376,7 @@ standard: context [
             blank
     ]
 
-    net-info: context [
+    net-info: construct [] [
         local-ip:
         local-port:
         remote-ip:
@@ -379,7 +384,7 @@ standard: context [
             blank
     ]
 
-    extension: context [
+    extension: construct [] [
         lib-base:   ; handle to DLL
         lib-file:   ; file name loaded
         lib-boot:   ; module header and body
@@ -389,7 +394,7 @@ standard: context [
             blank
     ]
 
-    stats: context [ ; port stats
+    stats: construct [] [ ; port stats
         timer:      ; timer (nanos)
         evals:      ; evaluations
         eval-natives:
@@ -405,7 +410,7 @@ standard: context [
             blank
     ]
 
-    type-spec: context [
+    type-spec: construct [] [
         title:
         type:
             blank
@@ -416,7 +421,7 @@ standard: context [
     para: _  ; mezz-graphics.h
 ]
 
-view: context [
+view: construct [] [
     screen-gob: _
     handler: _
     event-port: _
@@ -561,7 +566,7 @@ view: context [
 ;       user-data:
 ;       awake:
 
-;   port-flags: context [
+;   port-flags: construct [] [
 ;       direct:
 ;       pass-thru:
 ;       open-append:
@@ -569,7 +574,7 @@ view: context [
 ;           blank
 ;   ]
 
-;   email: context [ ; Email header object
+;   email: construct [] [ ; Email header object
 ;       To:
 ;       CC:
 ;       BCC:
@@ -588,20 +593,20 @@ view: context [
 ;           blank
 ;   ]
 
-;user: context [
+;user: construct [] [
 ;   name:           ; User's name
 ;   email:          ; User's default email address
 ;   home:           ; The HOME environment variable
 ;   words: blank
 ;]
 
-;network: context [
+;network: construct [] [
 ;   host: ""        ; Host name of the user's computer
 ;   host-address: 0.0.0.0 ; Host computer's TCP-IP address
 ;   trace: blank
 ;]
 
-;console: context [
+;console: construct [] [
 ;   hide-types: _    ; types not to print
 ;   history: _       ; Log of user inputs
 ;   keys: _          ; Keymap for special key
@@ -618,7 +623,7 @@ view: context [
 ;           date-sep: #"-"  ; The character used as the date separator
 ;           date-month-num: false   ; True if months are displayed as numbers; False for names
 ;           time-sep: #":"  ; The character used as the time separator
-;   cgi: context [ ; CGI environment variables
+;   cgi: construct [] [ ; CGI environment variables
 ;       server-software:
 ;       server-name:
 ;       gateway-interface:

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -944,7 +944,7 @@ RL_API u32 *RL_Map_Words(REBARR *array)
 {
     REBCNT i = 1;
     u32 *words;
-    REBVAL *val = ARR_HEAD(array);
+    RELVAL *val = ARR_HEAD(array);
 
     words = OS_ALLOC_N(u32, ARR_LEN(array) + 2);
 
@@ -1100,7 +1100,7 @@ RL_API u32 RL_Set_Char(REBSER *series, u32 index, u32 chr)
 //
 RL_API int RL_Get_Value(REBARR *array, u32 index, RXIARG *result)
 {
-    REBVAL *value;
+    RELVAL *value;
     if (index >= ARR_LEN(array)) return 0;
     value = ARR_AT(array, index);
     Value_To_RXI(result, value);
@@ -1131,7 +1131,7 @@ RL_API REBOOL RL_Set_Value(REBARR *array, u32 index, RXIARG val, int type)
         return TRUE;
     }
 
-    *ARR_AT(array, index) = value;
+    *SINK(ARR_AT(array, index)) = value;
 
     return FALSE;
 }

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1103,7 +1103,7 @@ RL_API int RL_Get_Value(REBARR *array, u32 index, RXIARG *result)
     RELVAL *value;
     if (index >= ARR_LEN(array)) return 0;
     value = ARR_AT(array, index);
-    Value_To_RXI(result, value);
+    Value_To_RXI(result, KNOWN(value)); // !!! Only have array, no specifier!
     return Reb_To_RXT[VAL_TYPE_0(value)];
 }
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -475,7 +475,7 @@ RL_API int RL_Do_String(
         Resolve_Context(user, Lib_Context, &vali, FALSE, FALSE);
     }
 
-    if (Do_At_Throws(&result, code, 0)) {
+    if (Do_At_Throws(&result, code, 0, GUESSED)) {
         DROP_GUARD_ARRAY(code);
 
         if (
@@ -600,11 +600,21 @@ RL_API void RL_Do_Commands(REBARR *array, REBCNT flags, REBCEC *cec)
     cec_before = TG_Command_Execution_Context;
     TG_Command_Execution_Context = cec; // push
 
+    // !!! In a general sense, passing in any old array (that might be in
+    // the body of a function) will not work here to pass in SPECIFIED
+    // because it will not find locals.  If a block is completely constructed
+    // at runtime through RL_Api calls, it should however have all specific
+    // words and blocks.  If this is not the case (and it is important)
+    // then dynamic scoping could be used to try matching the words to
+    // the most recent call to the function they're in on the stack...but
+    // hopefully it won't be needed.
+
     indexor = Do_Array_At_Core(
         &result,
         NULL, // `first`: NULL means start at array head (no injected head)
         array,
         0, // start evaluating at index 0
+        SPECIFIED, // !!! see notes above
         DO_FLAG_TO_END | DO_FLAG_ARGS_EVALUATE | DO_FLAG_LOOKAHEAD
     );
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -368,7 +368,7 @@ static void Init_Datatypes(void)
 
     for (n = 1; NOT_END(word); word++, n++) {
         assert(n < REB_MAX_0);
-        value = Append_Context(Lib_Context, word, SYM_0);
+        value = Append_Context(Lib_Context, KNOWN(word), SYM_0);
         VAL_RESET_HEADER(value, REB_DATATYPE);
         VAL_TYPE_KIND(value) = KIND_FROM_0(n);
         VAL_TYPE_SPEC(value) = VAL_ARRAY(ARR_AT(specs, n - 1));
@@ -585,14 +585,14 @@ static void Init_Natives(void)
         // Do_Core() helps with stability and invariants.
 
         REBVAL *name;
-        REBVAL *spec;
+        RELVAL *spec;
         REBOOL has_body;
 
         // Get the name the native will be started at with in Lib_Context
         //
         if (!IS_SET_WORD(item))
             panic (Error(RE_NATIVE_BOOT));
-        name = item;
+        name = KNOWN(item);
         ++item;
 
         // See if it's being invoked with NATIVE or NATIVE/BODY

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -280,7 +280,7 @@ static void Do_Global_Block(
 
     SNAP_STATE(&state);
 
-    if (Do_At_Throws(&result, block, index))
+    if (Do_At_Throws(&result, block, index, SPECIFIED))
         panic (Error_No_Catch_For_Throw(&result));
 
     ASSERT_STATE_BALANCED(&state);

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -489,56 +489,6 @@ REBNATIVE(action)
 
 
 //
-//  context: native [
-//  
-//  "Defines a unique object."
-//  
-//      spec [block!] "Object words and values (modified)"
-//  ]
-//
-REBNATIVE(context)
-//
-// The spec block has already been bound to Lib_Context, to
-// allow any embedded values and functions to evaluate.
-// 
-// Note: Overlaps code in REBTYPE(Context)'s A_MAKE handling
-{
-    PARAM(1, spec);
-
-    REBVAL dummy; // doesn't need GC-safety for this use (at time of writing)
-
-    Val_Init_Object(
-        D_OUT,
-        Make_Selfish_Context_Detect(
-            REB_OBJECT, // kind
-            NULL, // spec
-            NULL, // body
-            VAL_ARRAY_HEAD(ARG(spec)), // values to scan for toplevel SET_WORDs
-            NULL // parent
-        )
-    );
-
-    // !!! This mutates the bindings of the spec block passed in, should it
-    // be making a copy instead (at least by default, perhaps with performance
-    // junkies saying `object/bind` or something like that?
-    //
-    Bind_Values_Deep(VAL_ARRAY_HEAD(ARG(spec)), VAL_CONTEXT(D_OUT));
-
-    // The evaluative result of running the spec is ignored and done into a
-    // scratch cell, but needs to be returned if a throw happens.
-    //
-    if (DO_VAL_ARRAY_AT_THROWS(&dummy, ARG(spec))) {
-        *D_OUT = dummy;
-        return R_OUT_IS_THROWN;
-    }
-
-    // On success, return the object (common case)
-    //
-    return R_OUT;
-}
-
-
-//
 //  Init_Ops: C
 //
 // This contains the weird words that the lexer doesn't easily let us make

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -45,8 +45,12 @@
 // Coded assuming most common case is to give an error on unbounds, and
 // that only read access is requested (so no checking on protection)
 //
-REBVAL *Get_Var_Core(REBOOL *lookback, const REBVAL *any_word, REBFLGS flags)
-{
+REBVAL *Get_Var_Core(
+    REBOOL *lookback,
+    const RELVAL *any_word,
+    REBCTX *specifier,
+    REBFLGS flags
+) {
     assert(ANY_WORD(any_word));
 
     if (GET_VAL_FLAG(any_word, VALUE_FLAG_RELATIVE)) {
@@ -120,7 +124,7 @@ REBVAL *Get_Var_Core(REBOOL *lookback, const REBVAL *any_word, REBFLGS flags)
         //
         // (Including e.g. looking up 'append' in the user context.)
 
-        REBCTX *context = VAL_WORD_CONTEXT(any_word);
+        REBCTX *context = VAL_WORD_CONTEXT(const_KNOWN(any_word));
         REBCNT index = VAL_WORD_INDEX(any_word);
         REBVAL *value;
 

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -142,7 +142,14 @@ REBVAL *Get_Var_Core(
 
             if (flags & GETVAR_UNBOUND_OK) return NULL;
 
-            fail (Error(RE_NO_RELATIVE, any_word));
+            REBVAL unbound;
+            Val_Init_Word(
+                &unbound,
+                VAL_TYPE(any_word),
+                VAL_WORD_SYM(any_word)
+            );
+
+            fail (Error(RE_NO_RELATIVE, &unbound));
         }
 
         assert(CTX_STACKVARS(context) != NULL);

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -209,13 +209,13 @@ REBVAL *Get_Var_Core(
 //
 static void Bind_Values_Inner_Loop(
     REBINT *binds,
-    REBVAL *head,
+    RELVAL *head,
     REBCTX *context,
     REBU64 bind_types, // !!! REVIEW: force word types low enough for 32-bit?
     REBU64 add_midstream_types,
     REBFLGS flags
 ) {
-    REBVAL *value = head;
+    RELVAL *value = head;
     for (; NOT_END(value); value++) {
         REBU64 type_bit = FLAGIT_KIND(VAL_TYPE(value));
 
@@ -290,7 +290,7 @@ static void Bind_Values_Inner_Loop(
 // bindings that come after the added value is seen will be bound.
 //
 void Bind_Values_Core(
-    REBVAL *head,
+    RELVAL *head,
     REBCTX *context,
     REBU64 bind_types,
     REBU64 add_midstream_types,
@@ -334,9 +334,9 @@ void Bind_Values_Core(
 // bound to a particular target (if target is NULL, then all
 // words will be unbound regardless of their VAL_WORD_CONTEXT).
 //
-void Unbind_Values_Core(REBVAL *head, REBCTX *context, REBOOL deep)
+void Unbind_Values_Core(RELVAL *head, REBCTX *context, REBOOL deep)
 {
-    REBVAL *value = head;
+    RELVAL *value = head;
     for (; NOT_END(value); value++) {
         if (
             ANY_WORD(value)
@@ -344,7 +344,8 @@ void Unbind_Values_Core(REBVAL *head, REBCTX *context, REBOOL deep)
                 !context
                 || (
                     IS_WORD_BOUND(value)
-                    && VAL_WORD_CONTEXT(value) == context
+                    && !IS_RELATIVE(value)
+                    && VAL_WORD_CONTEXT(KNOWN(value)) == context
                 )
             )
         ) {
@@ -492,10 +493,10 @@ void Bind_Stack_Word(REBFUN *func, REBVAL *word)
 void Rebind_Values_Deep(
     REBCTX *src,
     REBCTX *dst,
-    REBVAL *head,
+    RELVAL *head,
     REBINT *opt_binds
 ) {
-    REBVAL *value = head;
+    RELVAL *value = head;
     for (; NOT_END(value); value++) {
         if (ANY_ARRAY(value)) {
             Rebind_Values_Deep(src, dst, VAL_ARRAY_AT(value), opt_binds);
@@ -504,7 +505,7 @@ void Rebind_Values_Deep(
             ANY_WORD(value)
             && GET_VAL_FLAG(value, WORD_FLAG_BOUND)
             && !GET_VAL_FLAG(value, VALUE_FLAG_RELATIVE)
-            && VAL_WORD_CONTEXT(value) == src
+            && VAL_WORD_CONTEXT(KNOWN(value)) == src
         ) {
             INIT_WORD_CONTEXT(value, dst);
 
@@ -542,9 +543,9 @@ void Rebind_Values_Deep(
 void Rebind_Values_Relative_Deep(
     REBFUN *src,
     REBFUN *dst,
-    REBVAL *head
+    RELVAL *head
 ) {
-    REBVAL *value = head;
+    RELVAL *value = head;
     for (; NOT_END(value); value++) {
         if (ANY_ARRAY(value)) {
             Rebind_Values_Relative_Deep(src, dst, VAL_ARRAY_AT(value));
@@ -569,8 +570,8 @@ void Rebind_Values_Relative_Deep(
 // !!! This function is temporary and should not be necessary after the FRAME!
 // is implemented.
 //
-void Rebind_Values_Specifically_Deep(REBFUN *src, REBCTX *dst, REBVAL *head) {
-    REBVAL *value = head;
+void Rebind_Values_Specifically_Deep(REBFUN *src, REBCTX *dst, RELVAL *head) {
+    RELVAL *value = head;
     for (; NOT_END(value); value++) {
         if (ANY_ARRAY(value)) {
             Rebind_Values_Specifically_Deep(src, dst, VAL_ARRAY_AT(value));

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -47,7 +47,7 @@
 //
 REBIXO Do_Array_At_Core(
     REBVAL *out,
-    const RELVAL *opt_first,
+    const RELVAL *opt_first, // must also be relative to specifier if relative
     REBARR *array,
     REBCNT index,
     REBCTX *specifier,
@@ -56,7 +56,7 @@ REBIXO Do_Array_At_Core(
     struct Reb_Frame f;
 
     if (opt_first) {
-        f.value = opt_first; // must also be relative to specifier if relative
+        f.value = opt_first;
         f.indexor = index;
     }
     else {
@@ -267,7 +267,7 @@ REBIXO Do_Va_Core(
     else {
         // Do_Core() requires caller pre-seed first value, always
         //
-        f.value = va_arg(*vaptr, const REBVAL*);
+        f.value = va_arg(*vaptr, const REBVAL*); // not relative
     }
 
     if (IS_END(f.value)) {

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -47,15 +47,16 @@
 //
 REBIXO Do_Array_At_Core(
     REBVAL *out,
-    const REBVAL *opt_first,
+    const RELVAL *opt_first,
     REBARR *array,
     REBCNT index,
+    REBCTX *specifier,
     REBFLGS flags
 ) {
     struct Reb_Frame f;
 
     if (opt_first) {
-        f.value = opt_first;
+        f.value = opt_first; // must also be relative to specifier if relative
         f.indexor = index;
     }
     else {
@@ -72,6 +73,7 @@ REBIXO Do_Array_At_Core(
 
     f.out = out;
     f.source.array = array;
+    f.specifier = specifier;
     f.flags = flags;
     f.gotten = NULL; // so ET_WORD and ET_GET_WORD do their own Get_Var
     f.lookback = FALSE;
@@ -261,7 +263,7 @@ REBIXO Do_Va_Core(
     struct Reb_Frame f;
 
     if (opt_first)
-        f.value = opt_first;
+        f.value = opt_first; // doesn't need specifier, not relative
     else {
         // Do_Core() requires caller pre-seed first value, always
         //
@@ -278,6 +280,7 @@ REBIXO Do_Va_Core(
     f.source.vaptr = vaptr;
     f.gotten = NULL; // so ET_WORD and ET_GET_WORD do their own Get_Var
     f.lookback = FALSE;
+    f.specifier = SPECIFIED; // va_list values MUST be full REBVAL* already
 
     f.flags = flags | DO_FLAG_VALIST; // see notes in %sys-do.h on why needed
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1398,13 +1398,22 @@ REBCTX *Error_No_Catch_For_Throw(REBVAL *thrown)
 
 
 //
-//  Error_Has_Bad_Type: C
+//  Error_Has_Bad_Type_Core: C
 // 
 // <type> type is not allowed here
 //
-REBCTX *Error_Has_Bad_Type(const REBVAL *value)
+REBCTX *Error_Has_Bad_Type_Core(const RELVAL *value, REBCTX *specifier)
 {
     return Error(RE_INVALID_TYPE, Type_Of(value), END_CELL);
+}
+
+
+//
+//  Error_Has_Bad_Type: C
+//
+REBCTX *Error_Has_Bad_Type(const REBVAL *value)
+{
+    return Error_Has_Bad_Type_Core(value, SPECIFIED);
 }
 
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -946,6 +946,7 @@ REBCTX *Make_Error_Core(REBCNT code, va_list *vaptr)
     #else
         // Will get here even for a parameterless string due to throwing in
         // the extra "arguments" of the __FILE__ and __LINE__
+        //
         temp = IS_STRING(message) ? END_CELL : VAL_ARRAY_HEAD(message);
     #endif
 
@@ -1280,14 +1281,14 @@ REBCTX *Error_Bad_Func_Def(const REBVAL *spec, const REBVAL *body)
 //
 //  Error_No_Arg: C
 //
-REBCTX *Error_No_Arg(REBCNT label_sym, const REBVAL *key)
+REBCTX *Error_No_Arg(REBCNT label_sym, const RELVAL *key)
 {
-    REBVAL key_word;
-    REBVAL label;
-
     assert(IS_TYPESET(key));
 
+    REBVAL key_word;
     Val_Init_Word(&key_word, REB_WORD, VAL_TYPESET_SYM(key));
+
+    REBVAL label;
     Val_Init_Word(&label, REB_WORD, label_sym);
 
     return Error(
@@ -1491,7 +1492,7 @@ REBCTX *Error_Unexpected_Type(enum Reb_Kind expected, enum Reb_Kind actual)
 //
 REBCTX *Error_Arg_Type(
     REBCNT label_sym,
-    const REBVAL *param,
+    const RELVAL *param,
     enum Reb_Kind kind
 ) {
     assert(IS_TYPESET(param));
@@ -1731,8 +1732,9 @@ REBYTE *Security_Policy(REBSYM sym, REBVAL *name)
         errcode = RE_SECURITY;
         policy = name ? name : 0;
 
+    error:
+        ; // need statement
         REBVAL temp;
-error:
         if (!policy) {
             Val_Init_Word(&temp, REB_WORD, sym);
             policy = &temp;

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -991,6 +991,18 @@ REBCTX *Make_Error_Core(REBCNT code, va_list *vaptr)
                 #endif
                 }
 
+            #if !defined(NDEBUG)
+                if (IS_RELATIVE(arg)) {
+                    //
+                    // Make_Error doesn't have any way to pass in a specifier,
+                    // so only specific values should be used.
+                    //
+                    Debug_Fmt("Relative value passed to Make_Error()");
+                    PROBE_MSG(arg, "the value");
+                    PANIC_VALUE(arg);
+                }
+            #endif
+
                 ASSERT_VALUE_MANAGED(arg);
 
             #if !defined(NDEBUG)

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1411,22 +1411,13 @@ REBCTX *Error_No_Catch_For_Throw(REBVAL *thrown)
 
 
 //
-//  Error_Has_Bad_Type_Core: C
-// 
-// <type> type is not allowed here
+//  Error_Invalid_Type: C
 //
-REBCTX *Error_Has_Bad_Type_Core(const RELVAL *value, REBCTX *specifier)
+// <type> type is not allowed here.
+//
+REBCTX *Error_Invalid_Type(enum Reb_Kind kind)
 {
-    return Error(RE_INVALID_TYPE, Type_Of(value), END_CELL);
-}
-
-
-//
-//  Error_Has_Bad_Type: C
-//
-REBCTX *Error_Has_Bad_Type(const REBVAL *value)
-{
-    return Error_Has_Bad_Type_Core(value, SPECIFIED);
+    return Error(RE_INVALID_TYPE, Get_Type(kind), END_CELL);
 }
 
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -938,8 +938,8 @@ REBCTX *Make_Error_Core(REBCNT code, va_list *vaptr)
         SET_ARRAY_LEN(CTX_VARLIST(error), root_len + expected_args + 1);
         SET_ARRAY_LEN(CTX_KEYLIST(error), root_len + expected_args + 1);
 
-        key = CTX_KEY(error, root_len + 1);
-        value = CTX_VAR(error, root_len + 1);
+        key = CTX_KEY(error, root_len) + 1;
+        value = CTX_VAR(error, root_len) + 1;
 
     #ifdef NDEBUG
         temp = VAL_ARRAY_HEAD(message);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1598,7 +1598,13 @@ void Init_Errors(REBVAL *errors)
 
     // Create error objects and error type objects:
     *ROOT_ERROBJ = *Get_System(SYS_STANDARD, STD_ERROR);
-    errs = Construct_Context(REB_OBJECT, VAL_ARRAY_HEAD(errors), FALSE, NULL);
+    errs = Construct_Context(
+        REB_OBJECT,
+        VAL_ARRAY_HEAD(errors),
+        SPECIFIED, // we're confident source array isn't in a function body
+        FALSE,
+        NULL
+    );
 
     Val_Init_Object(Get_System(SYS_CATALOG, CAT_ERRORS), errs);
 
@@ -1606,7 +1612,13 @@ void Init_Errors(REBVAL *errors)
     // so self is in slot 1 and the actual errors start at context slot 2)
     //
     for (val = CTX_VAR(errs, SELFISH(1)); NOT_END(val); val++) {
-        errs = Construct_Context(REB_OBJECT, VAL_ARRAY_HEAD(val), FALSE, NULL);
+        errs = Construct_Context(
+            REB_OBJECT,
+            VAL_ARRAY_HEAD(val),
+            SPECIFIED, // source array not in a function body
+            FALSE,
+            NULL
+        );
         Val_Init_Object(val, errs);
     }
 }

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1614,7 +1614,6 @@ void Init_Errors(REBVAL *errors)
         REB_OBJECT,
         VAL_ARRAY_HEAD(errors),
         SPECIFIED, // we're confident source array isn't in a function body
-        FALSE,
         NULL
     );
 
@@ -1628,7 +1627,6 @@ void Init_Errors(REBVAL *errors)
             REB_OBJECT,
             VAL_ARRAY_HEAD(val),
             SPECIFIED, // source array not in a function body
-            FALSE,
             NULL
         );
         Val_Init_Object(val, errs);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1394,6 +1394,25 @@ REBCTX *Error_Bad_Refine_Revoke(struct Reb_Frame *f)
 
 
 //
+//  Error_No_Value_Core: C
+//
+REBCTX *Error_No_Value_Core(const RELVAL *target, REBCTX *specifier) {
+    REBVAL specified;
+    COPY_VALUE(&specified, target, specifier);
+
+    return Error(RE_NO_VALUE, &specified, END_CELL);
+}
+
+
+//
+//  Error_No_Value: C
+//
+REBCTX *Error_No_Value(const REBVAL *target) {
+    return Error_No_Value_Core(target, SPECIFIED);
+}
+
+
+//
 //  Error_No_Catch_For_Throw: C
 //
 REBCTX *Error_No_Catch_For_Throw(REBVAL *thrown)

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -200,7 +200,7 @@ do_next:
         f->eval_type = ET_INERT;
 
         INIT_CELL_WRITABLE_IF_DEBUG(&f->cell.eval);
-        if (Do_Signals_Throws(KNOWN(&f->cell.eval))) {
+        if (Do_Signals_Throws(SINK(&f->cell.eval))) {
             *f->out = *KNOWN(&f->cell.eval);
             goto finished;
         }

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1274,20 +1274,7 @@ reevaluate:
                 SET_END(f->out);
             }
             else if (args_evaluate && IS_QUOTABLY_SOFT(f->value)) {
-                // Can't use DO_VALUE_THROWS() macro on relative value
-                if (
-                    THROWN_FLAG
-                    == Do_Array_At_Core(
-                        f->arg,
-                        f->value, // first (and only) item to DO
-                        EMPTY_ARRAY, // empty array so isolated value runs
-                        0, // will get END immediately after f->value
-                        f->specifier,
-                        DO_FLAG_TO_END
-                            | DO_FLAG_ARGS_EVALUATE
-                            | DO_FLAG_LOOKAHEAD
-                    )
-                ) {
+                if (EVAL_VALUE_CORE_THROWS(f->arg, f->value, f->specifier)) {
                     *f->out = *f->arg;
                     Abort_Function_Args_For_Frame(f);
                     goto finished;

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1925,7 +1925,8 @@ static REBUPT Do_Core_Expression_Checks_Debug(struct Reb_Frame *f) {
     if (TG_Do_Count < MAX_U32) {
         f->do_count = ++TG_Do_Count;
         if (f->do_count == DO_COUNT_BREAKPOINT) {
-            REBVAL dump = *f->value;
+            REBVAL dump;
+            COPY_VALUE(&dump, f->value, f->specifier);
 
             PROBE_MSG(&dump, "DO_COUNT_BREAKPOINT hit at...");
 
@@ -1941,9 +1942,11 @@ static REBUPT Do_Core_Expression_Checks_Debug(struct Reb_Frame *f) {
             }
 
             if (f->eval_fetched && NOT_END(f->eval_fetched)) {
-                dump = *f->eval_fetched;
-
-                PROBE_MSG(&dump, "EVAL in progress, so next will be...");
+                assert(IS_SPECIFIC(f->eval_fetched));
+                PROBE_MSG(
+                    const_KNOWN(f->eval_fetched),
+                    "EVAL in progress, so next will be..."
+                );
             }
 
             if (IS_END(f->value)) {

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -591,7 +591,7 @@ reevaluate:
         // !!! The evaluation ordering of SET-PATH! evaluation seems to break
         // the "left-to-right" nature of the language:
         //
-        //     >> foo: make object! [bar: 10]
+        //     >> foo: make object! [[bar][bar: 10]]
         //
         //     >> foo/(print "left" 'bar): (print "right" 20)
         //     right

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1464,12 +1464,12 @@ REBOOL Is_Function_Frame_Fulfilling(struct Reb_Frame *f)
 
 
 //
-//  Frame_For_Relative_Word: C
+//  Frame_For_Word_Dynamic: C
 //
 // Looks up word from a relative binding to get a specific context.  Currently
 // this uses the stack (dynamic binding) but a better idea is in the works.
 //
-struct Reb_Frame *Frame_For_Relative_Word(
+struct Reb_Frame *Frame_For_Word_Dynamic(
     const RELVAL *any_word,
     REBOOL trap
 ) {

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -900,7 +900,7 @@ REBCTX *Make_Selfish_Context_Detect(
 //
 REBCTX *Construct_Context(
     enum Reb_Kind kind,
-    RELVAL *head,
+    RELVAL *head, // !!! Warning: modified binding
     REBCTX *specifier,
     REBCTX *opt_parent
 ) {
@@ -912,9 +912,9 @@ REBCTX *Construct_Context(
         opt_parent // parent
     );
 
-    const RELVAL *value = head;
+    const RELVAL *value = head ? head : END_CELL;
 
-    if (NOT_END(head)) Bind_Values_Shallow(head, context);
+    if (head) Bind_Values_Shallow(head, context);
 
     for (; NOT_END(value); value += 2) {
         //

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -921,7 +921,7 @@ REBCTX *Construct_Context(
         // !!! Objects are a rewrite in progress; error messages need to
         // be improved.
 
-        RELVAL *var;
+        REBVAL *var;
 
         if (!IS_SET_WORD(value))
             fail (Error(RE_INVALID_TYPE, Type_Of(value)));

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -996,11 +996,8 @@ void Do_Construct(const RELVAL* head, REBCTX *specifier)
 
         // Set prior set-words:
         while (DSP > dsp_orig) {
-            COPY_VALUE(
-                GET_MUTABLE_VAR_MAY_FAIL(DS_TOP, SPECIFIED),
-                &temp,
-                specifier
-            );
+            REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(DS_TOP, SPECIFIED);
+            *var = temp;
             DS_DROP;
         }
     }
@@ -1039,11 +1036,8 @@ void Do_Min_Construct(const RELVAL* head, REBCTX *specifier)
             // value and then drop them from the stack.
             //
             while (DSP > dsp_orig) {
-                COPY_VALUE(
-                    GET_MUTABLE_VAR_MAY_FAIL(DS_TOP, SPECIFIED),
-                    value,
-                    specifier
-                );
+                RELVAL *var = GET_MUTABLE_VAR_MAY_FAIL(DS_TOP, SPECIFIED);
+                COPY_VALUE(var, value, specifier);
                 DS_DROP;
             }
         }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -2132,6 +2132,7 @@ REB_R Apply_Frame_Core(struct Reb_Frame *f, REBSYM sym, REBVAL *opt_def)
     f->value = END_CELL;
     f->indexor = 0;
     f->source.array = EMPTY_ARRAY;
+    f->specifier = SPECIFIED;
     f->eval_fetched = NULL;
     f->lookback = FALSE;
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -117,12 +117,14 @@ REBARR *List_Func_Typesets(REBVAL *func)
 
     for (; !IS_END(typeset); typeset++) {
         REBVAL *value = Alloc_Tail_Array(array);
+
+        assert(IS_TYPESET(typeset));
         *value = *typeset;
 
         // !!! It's already a typeset, but this will clear out the header
         // bits.  This may not be desirable over the long run (what if
         // a typeset wishes to encode hiddenness, protectedness, etc?)
-
+        //
         VAL_RESET_HEADER(value, REB_TYPESET);
     }
 
@@ -308,7 +310,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                 // [catch] and [throw] during Rebol2 => Rebol3 migration,
                 // but ignore them.
                 //
-                REBVAL *attribute = VAL_ARRAY_AT(item);
+                RELVAL *attribute = VAL_ARRAY_AT(item);
                 for (; NOT_END(attribute); attribute++) {
                     if (IS_WORD(attribute)) {
                         if (VAL_WORD_SYM(attribute) == SYM_CATCH)
@@ -721,16 +723,16 @@ REBARR *Make_Paramlist_Managed_May_Fail(
 //
 REBCNT Find_Param_Index(REBARR *paramlist, REBSYM sym)
 {
-    REBVAL *params = ARR_AT(paramlist, 1);
+    RELVAL *param = ARR_AT(paramlist, 1);
     REBCNT len = ARR_LEN(paramlist);
 
     REBCNT canon = SYMBOL_TO_CANON(sym); // don't recalculate each time
 
     REBCNT n;
-    for (n = 1; n < len; n++, params++) {
+    for (n = 1; n < len; ++n, ++param) {
         if (
-            sym == VAL_TYPESET_SYM(params)
-            || canon == VAL_TYPESET_CANON(params)
+            sym == VAL_TYPESET_SYM(param)
+            || canon == VAL_TYPESET_CANON(param)
         ) {
             return n;
         }
@@ -2310,7 +2312,7 @@ REBNATIVE(apply)
 //
 REBVAL *FUNC_PARAM_Debug(REBFUN *f, REBCNT n) {
     assert(n != 0 && n < ARR_LEN(FUNC_PARAMLIST(f)));
-    return ARR_AT(FUNC_PARAMLIST(f), (n));
+    return SER_AT(REBVAL, ARR_SERIES(FUNC_PARAMLIST(f)), (n));
 }
 
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1306,6 +1306,20 @@ REB_R Action_Dispatcher(struct Reb_Frame *f)
         return R_FALSE;
     }
 
+    if (FUNC_ACT(f->func) == A_MAKE || FUNC_ACT(f->func) == A_TO) {
+        //
+        // !!! These should not be "actions"...but go through the MT_xxx
+        // routine for "Make Type".  The first value is allowed to be either
+        // a datatype or an instance of the datatype to use as an "exemplar",
+        // but avoid each routine having to check for that by canonizing as
+        // a datatype here.
+        //
+        if (type == REB_DATATYPE)
+            type = VAL_TYPE_KIND(FRM_ARG(f, 1)); // datatype...but which one?
+        else
+            Val_Init_Datatype(FRM_ARG(f, 1), type); // change to a datatype
+    }
+
     REBACT action = Value_Dispatch[TO_0_FROM_KIND(type)];
     if (!action) fail (Error_Illegal_Action(type, FUNC_ACT(f->func)));
 

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -109,7 +109,7 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
             = GET_MUTABLE_VAR_MAY_FAIL(pvs->item, pvs->item_specifier);
 
         if (IS_VOID(pvs->selector))
-            fail (Error(RE_NO_VALUE, pvs->item));
+            fail (Error_No_Value_Core(pvs->item, pvs->item_specifier));
 
         SET_TRASH_IF_DEBUG(&pvs->selector_temp);
     }
@@ -259,7 +259,7 @@ REBOOL Do_Path_Throws_Core(
         pvs.value = GET_MUTABLE_VAR_MAY_FAIL(pvs.item, pvs.item_specifier);
         pvs.value_specifier = SPECIFIED;
         if (IS_VOID(pvs.value))
-            fail (Error(RE_NO_VALUE, pvs.item));
+            fail (Error_No_Value_Core(pvs.item, pvs.item_specifier));
     }
     else {
         // !!! Ideally there would be some way to deal with writes to

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -382,7 +382,7 @@ REBOOL Do_Path_Throws_Core(
                     VAL_INDEX(pvs.item),
                     IS_RELATIVE(pvs.item)
                         ? pvs.specifier
-                        : VAL_SPECIFIER(pvs.item)
+                        : VAL_SPECIFIER(const_KNOWN(pvs.item))
                 )) {
                     *out = refinement;
                     DS_DROP_TO(dsp_orig);

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -117,7 +117,9 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
             &pvs->selector_temp,
             VAL_ARRAY(pvs->item),
             VAL_INDEX(pvs->item),
-            pvs->specifier
+            IS_RELATIVE(pvs->item)
+                ? pvs->specifier // if relative, use parent specifier...
+                : VAL_SPECIFIER(const_KNOWN(pvs->item)) // ...else use child's
         )) {
             *pvs->value = pvs->selector_temp;
             return TRUE;
@@ -396,8 +398,8 @@ REBOOL Do_Path_Throws_Core(
                     VAL_ARRAY(pvs.item),
                     VAL_INDEX(pvs.item),
                     IS_RELATIVE(pvs.item)
-                        ? pvs.specifier
-                        : VAL_SPECIFIER(const_KNOWN(pvs.item))
+                        ? pvs.specifier // if relative, use parent specifier
+                        : VAL_SPECIFIER(const_KNOWN(pvs.item)) // else embedded
                 )) {
                     *out = refinement;
                     DS_DROP_TO(dsp_orig);

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -229,9 +229,20 @@ REBOOL Do_Path_Throws_Core(
     // its array contents.
     //
     if (IS_RELATIVE(path)) {
-        assert(
-            VAL_RELATIVE(path) == VAL_FUNC(CTX_FRAME_FUNC_VALUE(specifier))
-        );
+        if (specifier == SPECIFIED)
+            specifier = GUESSED; // !!! Transitional tolerance...
+
+    #if !defined(NDEBUG)
+        if (
+            specifier != GUESSED
+            && VAL_RELATIVE(path) != VAL_FUNC(CTX_FRAME_FUNC_VALUE(specifier))
+        ) {
+            Debug_Fmt("Specificity mismatch found in path dispatch");
+            PROBE_MSG(path, "expected func");
+            PROBE_MSG(CTX_FRAME_FUNC_VALUE(specifier), "actual func");
+            assert(FALSE);
+        }
+    #endif
         pvs.specifier = specifier;
     }
     else pvs.specifier = VAL_SPECIFIER(const_KNOWN(path));

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -238,14 +238,10 @@ REBOOL Do_Path_Throws_Core(
     // its array contents.
     //
     if (IS_RELATIVE(path)) {
-        if (specifier == SPECIFIED)
-            specifier = GUESSED; // !!! Transitional tolerance...
-
     #if !defined(NDEBUG)
-        if (
-            specifier != GUESSED
-            && VAL_RELATIVE(path) != VAL_FUNC(CTX_FRAME_FUNC_VALUE(specifier))
-        ) {
+        assert(specifier != SPECIFIED);
+
+        if (VAL_RELATIVE(path) != VAL_FUNC(CTX_FRAME_FUNC_VALUE(specifier))) {
             Debug_Fmt("Specificity mismatch found in path dispatch");
             PROBE_MSG(path, "expected func");
             PROBE_MSG(CTX_FRAME_FUNC_VALUE(specifier), "actual func");

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -415,8 +415,13 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
     for (; NOT_END(param); ++param, ++arg) {
         enum Reb_Param_Class pclass = VAL_PARAM_CLASS(param);
 
-        if (pclass == PARAM_CLASS_LOCAL)
+        if (
+            pclass == PARAM_CLASS_LOCAL
+            || pclass == PARAM_CLASS_LEAVE
+            || pclass == PARAM_CLASS_RETURN
+        ) {
              continue; // don't add a callsite expression for it (can't)!
+        }
 
         if (pclass == PARAM_CLASS_REFINEMENT) {
             if (IS_CONDITIONAL_FALSE(arg)) {

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -302,7 +302,6 @@ void Sieve_Ports(REBARR *ports)
 {
     REBVAL *port;
     REBVAL *waked;
-    REBVAL *val;
     REBCNT n;
 
     port = Get_System(SYS_PORTS, PORTS_SYSTEM);
@@ -311,10 +310,13 @@ void Sieve_Ports(REBARR *ports)
     if (!IS_BLOCK(waked)) return;
 
     for (n = 0; ports && n < ARR_LEN(ports);) {
-        val = ARR_AT(ports, n);
+        RELVAL *val = ARR_AT(ports, n);
         if (IS_PORT(val)) {
             assert(VAL_LEN_HEAD(waked) != 0);
-            if (VAL_LEN_HEAD(waked) == Find_In_Array_Simple(VAL_ARRAY(waked), 0, val)) {//not found
+            if (
+                Find_In_Array_Simple(VAL_ARRAY(waked), 0, KNOWN(val))
+                == VAL_LEN_HEAD(waked) // `=len` means not found
+            ) {
                 Remove_Series(ARR_SERIES(ports), n, 1);
                 continue;
             }

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -314,7 +314,7 @@ void Sieve_Ports(REBARR *ports)
         if (IS_PORT(val)) {
             assert(VAL_LEN_HEAD(waked) != 0);
             if (
-                Find_In_Array_Simple(VAL_ARRAY(waked), 0, KNOWN(val))
+                Find_In_Array_Simple(VAL_ARRAY(waked), 0, val)
                 == VAL_LEN_HEAD(waked) // `=len` means not found
             ) {
                 Remove_Series(ARR_SERIES(ports), n, 1);

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -458,6 +458,7 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
         &first, // path not in array but will be "virtual" first array element
         code_array,
         0, // index
+        SPECIFIED, // reusing existing REBVAL arguments, no relative values
         DO_FLAG_TO_END | DO_FLAG_NO_ARGS_EVALUATE | DO_FLAG_LOOKAHEAD
     );
 

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -670,7 +670,7 @@ REBARR *Make_Spec_From_Function(REBVAL *func)
 
     REBCNT index = 1;
     for (; index <= ARR_LEN(words); ++index) {
-        Append_Value(spec, ARR_AT(words, index - 1));
+        Append_Value(spec, KNOWN(ARR_AT(words, index - 1)));
         if (types && IS_BLOCK(CTX_VAR(types, index)))
             Append_Value(spec, CTX_VAR(types, index));
         if (notes && IS_STRING(CTX_VAR(notes, index)))

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -385,7 +385,7 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
     // invocation (if it had no refinements or locals).
     //
     REBARR *code_array = Make_Array(FUNC_NUM_PARAMS(f->func));
-    REBVAL *code = ARR_HEAD(code_array);
+    RELVAL *code = ARR_HEAD(code_array);
 
     // We'll walk through the original functions param and arglist only, and
     // accept the error-checking the evaluator provides at this time (types,
@@ -403,11 +403,11 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
     // at the head...
     //
     REBARR *path_array = Make_Array(FUNC_NUM_PARAMS(f->func) + 1);
-    REBVAL *path = ARR_HEAD(path_array);
+    RELVAL *path = ARR_HEAD(path_array);
 
     REBVAL first;
 
-    *path = *FUNC_VALUE(func_new);
+    *SINK(path) = *FUNC_VALUE(func_new);
     ++path;
 
     for (; NOT_END(param); ++param, ++arg) {
@@ -439,7 +439,8 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
         //
         if (ignoring) continue;
 
-        *code++ = *arg;
+        *SINK(code) = *arg;
+        ++code;
     }
 
     SET_END(code);
@@ -455,7 +456,7 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
     //
     indexor = Do_Array_At_Core(
         f->out,
-        &first, // path not in array but will be "virtual" first array element
+        &first, // path not in array, will be "virtual" first element
         code_array,
         0, // index
         SPECIFIED, // reusing existing REBVAL arguments, no relative values

--- a/src/core/c-signal.c
+++ b/src/core/c-signal.c
@@ -32,6 +32,23 @@
 // (Note: Not to be confused with SIGINT and unix "signals", although on
 // unix an evaluator signal can be triggered by a unix signal.)
 //
+// Note in signal dispatch that R3-Alpha did not have a policy articulated on
+// dealing with the interrupt nature of the SIGINT signals sent by Ctrl-C:
+//
+// https://en.wikipedia.org/wiki/Unix_signal
+//
+// Guarding against errors being longjmp'd when an evaluation is in effect
+// isn't the only time these signals are processed.  Rebol's Process_Signals
+// currently happens during I/O, such as printing output.  As a consequence,
+// a Ctrl-C can be picked up and then triggered during an Out_Value, jumping
+// the stack from there.
+//
+// This means a top-level trap must always be in effect, even though no eval
+// is running.  This trap's job is to handle errors that happen *while
+// reporting another error*, with Ctrl-C triggering a HALT being the most
+// likely example if not running an evaluation (though any fail() could
+// cause it)
+//
 
 #include "sys-core.h"
 

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -281,10 +281,10 @@ REBOOL IS_END_Debug(const RELVAL *v, const char *file, int line) {
 // Variant of IS_CONDITIONAL_FALSE() macro for the debug build which checks to
 // ensure you never call it on a void
 //
-REBOOL IS_CONDITIONAL_FALSE_Debug(const REBVAL *v)
+REBOOL IS_CONDITIONAL_FALSE_Debug(const RELVAL *v)
 {
-    if (IS_END(v) || IS_VOID(v) || IS_TRASH_DEBUG(v)) {
-        Debug_Fmt("Conditional true/false test on END or void or trash");
+    if (IS_VOID(v)) {
+        Debug_Fmt("Conditional true/false test on void");
         PANIC_VALUE(v);
     }
 

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -467,6 +467,18 @@ const RELVAL *ENSURE_C_RELVAL_Debug(const RELVAL *value)
 
 
 //
+//  SINK_Debug: C
+//
+REBVAL *SINK_Debug(union Reb_Value_Payload *payload)
+{
+    return cast(
+        REBVAL*,
+        cast(char*, payload) - offsetof(struct Reb_Value, payload)
+    );
+}
+
+
+//
 //  const_KNOWN_Debug: C
 //
 const REBVAL *const_KNOWN_Debug(const RELVAL *value)

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -424,9 +424,9 @@ void COPY_VALUE_Debug(
 ) {
     if (IS_RELATIVE(src)) {
         if (specifier == SPECIFIED) {
-            Debug_Fmt("Internal Error: Relative word used with SPECIFIED");
+            Debug_Fmt("Internal Error: Relative item used with SPECIFIED");
             PROBE_MSG(src, "word or array");
-            PROBE_MSG(FUNC_VALUE(VAL_WORD_FUNC(src)), "func");
+            PROBE_MSG(FUNC_VALUE(VAL_RELATIVE(src)), "func");
             assert(FALSE);
         }
         else if (

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -99,11 +99,8 @@ ATTRIBUTE_NO_RETURN void Panic_Value_Debug(
 //
 // (A fringe benefit is catching writes to other unanticipated locations.)
 //
-void Assert_Cell_Writable(
-    const RELVAL *v,
-    const char *file,
-    int line
-) {
+void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
+{
     // REBVALs should not be written at addresses that do not match the
     // alignment of the processor.  This checks modulo the size of an unsigned
     // integer the same size as a platform pointer (REBUPT => uintptr_t)
@@ -350,13 +347,22 @@ const RELVAL *ENSURE_C_RELVAL_Debug(const RELVAL *value)
 
 
 //
-//  Assert_Is_Payload: C
+//  const_KNOWN_Debug: C
 //
-// Simple NOOP used as a helper in checking that a pointer is either a
-// REBVAL -or- a RELVAL in C.
-//
-void Assert_Is_Payload(const union Reb_Value_Payload *payload)
+const REBVAL *const_KNOWN_Debug(const RELVAL *value)
 {
+    assert(IS_SPECIFIC(value));
+    return cast(const REBVAL*, value);
+}
+
+
+//
+//  KNOWN_Debug: C
+//
+REBVAL *KNOWN_Debug(RELVAL *value)
+{
+    assert(IS_SPECIFIC(value));
+    return cast(REBVAL*, value);
 }
 
 
@@ -381,7 +387,7 @@ void Probe_Core_Debug(
     const char *msg,
     const char *file,
     int line,
-    const REBVAL *val
+    const RELVAL *val
 ) {
     if (msg)
         printf("\n** PROBE_MSG(\"%s\") ", msg);

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -74,6 +74,14 @@ void COPY_VALUE_Guessable(
     const RELVAL *src,
     REBCTX *specifier
 ) {
+    // !!! TEMPORARY TOLERANCE.  The default initialization for arrays that
+    // aren't coming from a deep function body copy will be specified long
+    // term.  But right now, it's used more widely.  If a relative value
+    // is used with specified, just treat it as guessed.
+    //
+    if (IS_RELATIVE(src) && specifier == SPECIFIED)
+        specifier = GUESSED;
+
     if (specifier != GUESSED || !IS_RELATIVE(src)) {
         COPY_VALUE_MACRO(dest, src, specifier);
         return;
@@ -497,7 +505,6 @@ void COPY_VALUE_Guessable_Debug(
             // !!! Temporary... allow "lying" specifieds by bumping them to
             // just being GUESSED.  This is being addressed incrementally.
             //
-            specifier = GUESSED;
         }
         else if (specifier == SPECIFIED) {
             Debug_Fmt("Internal Error: Relative word used with SPECIFIC");

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -138,7 +138,7 @@ void Expand_Hash(REBSER *ser)
 static void Expand_Word_Table(void)
 {
     REBCNT *hashes;
-    REBVAL *word;
+    RELVAL *word;
     REBINT hash;
     REBCNT size;
     REBINT skip;
@@ -152,15 +152,19 @@ static void Expand_Word_Table(void)
     word = ARR_AT(PG_Word_Table.array, 1);
     hashes = SER_HEAD(REBCNT, PG_Word_Table.hashes);
     size = SER_LEN(PG_Word_Table.hashes);
+
     for (n = 1; n < ARR_LEN(PG_Word_Table.array); n++, word++) {
         const REBYTE *name = VAL_SYM_NAME(word);
         hash = Hash_Word(name, LEN_BYTES(name));
-        skip  = (hash & 0x0000FFFF) % size;
+
+        skip = (hash & 0x0000FFFF) % size;
         if (skip == 0) skip = 1;
+
         hash = (hash & 0x00FFFF00) % size;
         while (hashes[hash]) {
             hash += skip;
-            if (hash >= (REBINT)size) hash -= size;
+            if (hash >= cast(REBINT, size))
+                hash -= size;
         }
         hashes[hash] = n;
     }
@@ -194,14 +198,14 @@ static REBCNT Make_Word_Name(const REBYTE *str, REBCNT len)
 //
 REBCNT Make_Word(const REBYTE *str, REBCNT len)
 {
-    REBINT  hash;
-    REBINT  size;
-    REBINT  skip;
-    REBINT  n;
-    REBCNT  h;
-    REBCNT  *hashes;
-    REBVAL  *words;
-    REBVAL  *w;
+    REBINT hash;
+    REBINT size;
+    REBINT skip;
+    REBINT n;
+    REBCNT h;
+    REBCNT *hashes;
+    RELVAL *words;
+    RELVAL *w;
 
     //REBYTE *sss = Get_Sym_Name(1);    // (Debugging method)
 

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -377,7 +377,7 @@ const REBYTE *Get_Type_Name(const REBVAL *value)
 // Note that words are kept UTF8 encoded.
 // Positive result if s > t and negative if s < t.
 //
-REBINT Compare_Word(const REBVAL *s, const REBVAL *t, REBOOL is_case)
+REBINT Compare_Word(const RELVAL *s, const RELVAL *t, REBOOL is_case)
 {
     REBYTE *sp = VAL_WORD_NAME(s);
     REBYTE *tp = VAL_WORD_NAME(t);

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -322,12 +322,12 @@ void Val_Init_Word_Bound(
 
 
 //
-//  Val_Init_Word: C
+//  Val_Init_Word_Core: C
 // 
 // Initialize a value as a word. Set frame as unbound--no context.  (See
 // also Val_Init_Word_Bound)
 //
-void Val_Init_Word(REBVAL *out, enum Reb_Kind type, REBSYM sym)
+void Val_Init_Word_Core(RELVAL *out, enum Reb_Kind type, REBSYM sym)
 {
     assert(sym != SYM_0);
 

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -163,9 +163,9 @@ REBOOL Do_Breakpoint_Throws(
 
             // The instruction was built from raw material, non-relative
             //
-            mode = VAL_ARRAY_AT_HEAD(&temp, RESUME_INST_MODE);
-            payload = VAL_ARRAY_AT_HEAD(&temp, RESUME_INST_PAYLOAD);
-            target = VAL_ARRAY_AT_HEAD(&temp, RESUME_INST_TARGET);
+            mode = KNOWN(VAL_ARRAY_AT_HEAD(&temp, RESUME_INST_MODE));
+            payload = KNOWN(VAL_ARRAY_AT_HEAD(&temp, RESUME_INST_PAYLOAD));
+            target = KNOWN(VAL_ARRAY_AT_HEAD(&temp, RESUME_INST_TARGET));
 
             assert(IS_FRAME(target));
 
@@ -422,11 +422,11 @@ REBNATIVE(resume)
 
     if (REF(with)) {
         SET_FALSE(ARR_AT(instruction, RESUME_INST_MODE)); // don't DO value
-        *ARR_AT(instruction, RESUME_INST_PAYLOAD) = *ARG(value);
+        *SINK(ARR_AT(instruction, RESUME_INST_PAYLOAD)) = *ARG(value);
     }
     else if (REF(do)) {
         SET_TRUE(ARR_AT(instruction, RESUME_INST_MODE)); // DO the value
-        *ARR_AT(instruction, RESUME_INST_PAYLOAD) = *ARG(code);
+        *SINK(ARR_AT(instruction, RESUME_INST_PAYLOAD)) = *ARG(code);
     }
     else {
         SET_BLANK(ARR_AT(instruction, RESUME_INST_MODE)); // use default

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -182,6 +182,18 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
         Free_Series(bytes);
     }
 
+#if !defined(NDEBUG)
+    //
+    // In a debug build, we'd like to try and cause a break so as not to lose
+    // the state of the panic, which would happen if we called out to the
+    // host kit's exit routine...
+    //
+    printf("%s\n", Str_Panic_Title);
+    printf("%s\n", message);
+    fflush(stdout);
+    debug_break(); // see %debug_break.h
+#endif
+
     OS_CRASH(cb_cast(Str_Panic_Title), cb_cast(message));
 
     // Note that since we crash, we never return so that the caller can run

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -121,7 +121,7 @@ void Dump_Bytes(REBYTE *bp, REBCNT limit)
 // Print out values in raw hex; If memory is corrupted
 // this function still needs to work.
 //
-void Dump_Values(REBVAL *vp, REBCNT count)
+void Dump_Values(RELVAL *vp, REBCNT count)
 {
     REBYTE buf[2048];
     REBYTE *cp;

--- a/src/core/d-legacy.c
+++ b/src/core/d-legacy.c
@@ -173,8 +173,8 @@ REBCTX *Make_Guarded_Arg123_Error(void)
     SET_ARRAY_LEN(CTX_VARLIST(error), root_len + 3);
     SET_ARRAY_LEN(CTX_KEYLIST(error), root_len + 3);
 
-    key = CTX_KEY(error, CTX_LEN(root_error) + 1);
-    var = CTX_VAR(error, CTX_LEN(root_error) + 1);
+    key = CTX_KEY(error, CTX_LEN(root_error)) + 1;
+    var = CTX_VAR(error, CTX_LEN(root_error)) + 1;
 
     for (n = 0; n < 3; n++, key++, var++) {
         Val_Init_Typeset(key, ALL_64, SYM_ARG1 + n);

--- a/src/core/d-legacy.c
+++ b/src/core/d-legacy.c
@@ -76,7 +76,7 @@ REBOOL In_Legacy_Function_Debug(void)
 
 
 //
-//  Legacy_Convert_Function_Args_Debug: C
+//  Legacy_Convert_Function_Args: C
 //
 // R3-Alpha and Rebol2 used BLANK for unused refinements and arguments to
 // a refinement which is not present.  Ren-C uses FALSE for unused refinements
@@ -86,7 +86,10 @@ REBOOL In_Legacy_Function_Debug(void)
 // better to isolate it into a post-phase.  This improves the readability of
 // the mainline code.
 //
-void Legacy_Convert_Function_Args_Debug(struct Reb_Frame *f)
+// Trigger is when OPTIONS_REFINEMENTS_TRUE is set during function creation,
+// which will give it FUNC_FLAG_LEGACY--leading to this being used.
+//
+void Legacy_Convert_Function_Args(struct Reb_Frame *f)
 {
     REBVAL *param = FUNC_PARAMS_HEAD(f->func);
     REBVAL *arg = FRM_ARGS_HEAD(f);

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -1235,12 +1235,18 @@ REBOOL Prin_GC_Safe_Value_Throws(
     if (mold)
         Mold_Value(&mo, value, TRUE);
     else {
+        REBCTX *specifier;
+        if ((ANY_WORD(value) || ANY_ARRAY(value)) && IS_SPECIFIC(value))
+            specifier = VAL_SPECIFIC(value);
+        else
+            specifier = SPECIFIED;
+
         if (Format_GC_Safe_Value_Throws(
             out_if_reduce,
             &mo,
             &pending_delimiter,
             value,
-            SPECIFIED,
+            specifier,
             LOGICAL(reduce && IS_BLOCK(value)), // `print 'word` won't GET it
             delimiter,
             0 // depth

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -990,6 +990,7 @@ REBOOL Format_GC_Safe_Value_Throws(
 
         f.indexor = VAL_INDEX(val_gc_safe) + 1;
         f.source.array = VAL_ARRAY(val_gc_safe);
+        f.specifier = VAL_SPECIFIER(val_gc_safe);
     }
     else {
         // Prefetch with value + an empty array to use same code path
@@ -997,6 +998,7 @@ REBOOL Format_GC_Safe_Value_Throws(
         f.value = val_gc_safe;
         f.indexor = 0;
         f.source.array = EMPTY_ARRAY;
+        f.specifier = NULL; // f.value is guaranteed non-relative
     }
 
     f.flags = DO_FLAG_NEXT | DO_FLAG_ARGS_EVALUATE | DO_FLAG_LOOKAHEAD;

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -380,7 +380,7 @@ void Debug_Series(REBSER *ser)
         //
         REBVAL value;
         VAL_RESET_HEADER(&value, REB_BLOCK);
-        INIT_VAL_SERIES(&value, ser);
+        INIT_VAL_ARRAY(&value, AS_ARRAY(ser));
         VAL_INDEX(&value) = 0;
 
         Debug_Fmt("%r", &value);
@@ -870,17 +870,25 @@ pick:
             /* for (; l > 0; l--, bp++) if (*bp < ' ') *bp = ' '; */
             break;
 
-        case 'm':  // Mold a series
+        case 'm': { // Mold a series
             // Val_Init_Block would Ensure_Series_Managed, we use a raw
             // VAL_SET instead.
             //
             // !!! Better approach?  Can the series be passed directly?
             //
-            VAL_RESET_HEADER(&value, REB_BLOCK);
-            INIT_VAL_SERIES(&value, va_arg(*vaptr, REBSER*));
+            REBSER* temp = va_arg(*vaptr, REBSER*);
+            if (Is_Array_Series(temp)) {
+                VAL_RESET_HEADER(&value, REB_BLOCK);
+                INIT_VAL_ARRAY(&value, AS_ARRAY(temp)); // careful, macro!
+            }
+            else {
+                VAL_RESET_HEADER(&value, REB_STRING);
+                INIT_VAL_SERIES(&value, temp); // careful, macro!
+            }
             VAL_INDEX(&value) = 0;
             Mold_Value(mo, &value, TRUE);
             break;
+        }
 
         case 'c':
             Append_Codepoint_Raw(

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -995,7 +995,8 @@ REBOOL Format_GC_Safe_Value_Throws(
     REBVAL *out,
     REB_MOLD *mold,
     REBVAL *pending_delimiter,
-    const REBVAL *val_gc_safe,
+    const RELVAL *val_gc_safe,
+    REBCTX *specifier,
     REBOOL reduce,
     const REBVAL *delimiter,
     REBCNT depth
@@ -1009,7 +1010,6 @@ REBOOL Format_GC_Safe_Value_Throws(
 
         f.indexor = VAL_INDEX(val_gc_safe) + 1;
         f.source.array = VAL_ARRAY(val_gc_safe);
-        f.specifier = VAL_SPECIFIER(val_gc_safe);
     }
     else {
         // Prefetch with value + an empty array to use same code path
@@ -1017,9 +1017,9 @@ REBOOL Format_GC_Safe_Value_Throws(
         f.value = val_gc_safe;
         f.indexor = 0;
         f.source.array = EMPTY_ARRAY;
-        f.specifier = NULL; // f.value is guaranteed non-relative
     }
 
+    f.specifier = specifier;
     f.flags = DO_FLAG_NEXT | DO_FLAG_ARGS_EVALUATE | DO_FLAG_LOOKAHEAD;
     f.eval_fetched = NULL;
 
@@ -1113,6 +1113,7 @@ REBOOL Format_GC_Safe_Value_Throws(
                 mold,
                 pending_delimiter,
                 f.value,
+                f.specifier,
                 nested_reduce,
                 delimiter,
                 depth + 1
@@ -1148,6 +1149,7 @@ REBOOL Format_GC_Safe_Value_Throws(
                 mold,
                 pending_delimiter,
                 out, // this level's output is recursion's input
+                SPECIFIED, // was a REBVAL
                 FALSE, // don't reduce the value again
                 delimiter,
                 depth // not nested block so no depth increment
@@ -1238,6 +1240,7 @@ REBOOL Prin_GC_Safe_Value_Throws(
             &mo,
             &pending_delimiter,
             value,
+            SPECIFIED,
             LOGICAL(reduce && IS_BLOCK(value)), // `print 'word` won't GET it
             delimiter,
             0 // depth

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -487,7 +487,7 @@ void Debug_Value(const REBVAL *value, REBCNT limit, REBOOL mold)
 //
 //  Debug_Values: C
 //
-void Debug_Values(const REBVAL *value, REBCNT count, REBCNT limit)
+void Debug_Values(const RELVAL *value, REBCNT count, REBCNT limit)
 {
     REBCNT i1;
     REBCNT i2;

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -404,7 +404,7 @@ REBNATIVE(backtrace)
     number = 0;
     for (frame = FS_TOP->prior; frame != NULL; frame = frame->prior) {
         REBCNT len;
-        REBVAL *temp;
+        RELVAL *temp;
 
         // Only consider invoked or pending functions in the backtrace.
         //

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -47,7 +47,7 @@
 //
 void Collapsify_Array(REBARR *array, REBCTX *specifier, REBCNT limit)
 {
-    REBVAL *item = ARR_HEAD(array);
+    RELVAL *item = ARR_HEAD(array);
     for (; NOT_END(item); ++item) {
         if (ANY_ARRAY(item) && VAL_LEN_AT(item) > limit) {
             REBARR *copy = Copy_Array_At_Max_Shallow(

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -45,7 +45,7 @@
 // ellipses to show they have been cut off.  It does not change the arrays
 // in question, but replaces them with copies.
 //
-void Collapsify_Array(REBARR *array, REBCNT limit)
+void Collapsify_Array(REBARR *array, REBCTX *specifier, REBCNT limit)
 {
     REBVAL *item = ARR_HEAD(array);
     for (; NOT_END(item); ++item) {
@@ -53,6 +53,7 @@ void Collapsify_Array(REBARR *array, REBCNT limit)
             REBARR *copy = Copy_Array_At_Max_Shallow(
                 VAL_ARRAY(item),
                 VAL_INDEX(item),
+                IS_RELATIVE(item) ? specifier : VAL_SPECIFIER(KNOWN(item)),
                 limit + 1
             );
 
@@ -60,6 +61,7 @@ void Collapsify_Array(REBARR *array, REBCNT limit)
 
             Collapsify_Array(
                 copy,
+                SPECIFIED,
                 limit
             );
 
@@ -144,7 +146,7 @@ REBARR *Make_Where_For_Frame(struct Reb_Frame *frame)
         SET_ARRAY_LEN(where, len);
         TERM_ARRAY(where);
 
-        Collapsify_Array(where, 3);
+        Collapsify_Array(where, SPECIFIED, 3);
     }
 
     // Making a shallow copy offers another advantage, that it's

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -113,7 +113,7 @@ void Trace_Line(struct Reb_Frame *f)
     }
 
     if (IS_WORD(f->value) || IS_GET_WORD(f->value)) {
-        const REBVAL *var = GET_OPT_VAR_MAY_FAIL(f->value);
+        const REBVAL *var = GET_OPT_VAR_MAY_FAIL(f->value, f->specifier);
         if (VAL_TYPE(var) < REB_FUNCTION)
             Debug_Fmt_(" : %50r", var);
         else if (VAL_TYPE(var) == REB_FUNCTION) {

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -168,11 +168,11 @@ void Trace_Return(REBCNT label_sym, const REBVAL *value)
 
 
 //
-//  Trace_Value: C
+//  Trace_Value_Core: C
 //
-void Trace_Value(
+void Trace_Value_Core(
     const char* label, // currently "match" or "input"
-    const REBVAL *value
+    const RELVAL *value
 ) {
     int depth;
     CHECK_DEPTH(depth);

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -168,9 +168,9 @@ void Trace_Return(REBCNT label_sym, const REBVAL *value)
 
 
 //
-//  Trace_Value_Core: C
+//  Trace_Value: C
 //
-void Trace_Value_Core(
+void Trace_Value(
     const char* label, // currently "match" or "input"
     const RELVAL *value
 ) {

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -264,11 +264,18 @@ void Clonify_Values_Len_Managed(
                             )
                         );
                     }
-                }
-                else
-                    series = Copy_Sequence(VAL_SERIES(value));
 
-                INIT_VAL_SERIES(value, series);
+                    INIT_VAL_ARRAY(value, AS_ARRAY(series)); // copies args
+
+                    // If it was relative, then copying with a specifier
+                    // means it isn't relative any more.
+                    //
+                    INIT_ARRAY_SPECIFIC(value, SPECIFIED);
+                }
+                else {
+                    series = Copy_Sequence(VAL_SERIES(value));
+                    INIT_VAL_SERIES(value, series);
+                }
             }
 
         #if !defined(NDEBUG)

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -488,7 +488,7 @@ REBVAL *Alloc_Tail_Array(REBARR *array)
 // series for the spec, body, and paramlist...the spec and body are blocks,
 // and so recursion would be found when the blocks were output.)
 //
-REBCNT Find_Same_Array(REBARR *search_values, const REBVAL *value)
+REBCNT Find_Same_Array(REBARR *search_values, const RELVAL *value)
 {
     REBCNT index = 0;
     REBARR *array;

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -543,7 +543,7 @@ REBCNT Find_Same_Array(REBARR *search_values, const RELVAL *value)
 
 
 //
-//  Unmark_Series: C
+//  Unmark_Array: C
 //
 void Unmark_Array(REBARR *array)
 {

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -280,7 +280,9 @@ void Clonify_Values_Len_Managed(
             if (types & FLAGIT_KIND(VAL_TYPE(value)) & TS_ARRAYS_OBJ) {
                 Clonify_Values_Len_Managed(
                      ARR_HEAD(AS_ARRAY(series)),
-                     ANY_ARRAY(value) ? VAL_SPECIFIER(value) : SPECIFIED,
+                     IS_SPECIFIC(value)
+                        ? VAL_SPECIFIER(KNOWN(value))
+                        : specifier,
                      VAL_LEN_HEAD(value),
                      deep,
                      types
@@ -290,7 +292,7 @@ void Clonify_Values_Len_Managed(
         else if (
             types & FLAGIT_KIND(VAL_TYPE(value)) & FLAGIT_KIND(REB_FUNCTION)
         ) {
-            Clonify_Function(value);
+            Clonify_Function(KNOWN(value)); // functions never "relative"
         }
         else {
             // The value is not on our radar as needing to be processed,
@@ -465,7 +467,7 @@ REBVAL *Alloc_Tail_Array(REBARR *array)
     REBVAL *tail;
 
     EXPAND_SERIES_TAIL(ARR_SERIES(array), 1);
-    tail = ARR_TAIL(array);
+    tail = SER_TAIL(REBVAL, ARR_SERIES(array));
     SET_END(tail);
 
     SET_TRASH_IF_DEBUG(tail - 1); // No-op in release builds
@@ -490,7 +492,7 @@ REBCNT Find_Same_Array(REBARR *search_values, const REBVAL *value)
 {
     REBCNT index = 0;
     REBARR *array;
-    REBVAL *other;
+    RELVAL *other;
 
     if (ANY_ARRAY(value))
         array = VAL_ARRAY(value);

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -548,18 +548,21 @@ REBNATIVE(make_command)
 
     REBVAL *def = ARG(def);
 
+    REBVAL spec;
+    REBVAL extension;
+    REBVAL command_num;
+
     if (VAL_LEN_AT(def) != 3)
         fail (Error_Invalid_Arg(def));
+
+    COPY_VALUE(&spec, VAL_ARRAY_AT(def), VAL_SPECIFIER(def));
+    COPY_VALUE(&extension, VAL_ARRAY_AT(def) + 1, VAL_SPECIFIER(def));
+    COPY_VALUE(&command_num, VAL_ARRAY_AT(def) + 2, VAL_SPECIFIER(def));
 
     // Validity checking on the 3 elements done inside Make_Command, will
     // fail() if the input is not good.
     //
-    Make_Command(
-        D_OUT,
-        VAL_ARRAY_AT(def), // spec
-        VAL_ARRAY_AT(def) + 1, // extension
-        VAL_ARRAY_AT(def) + 2 // command_num
-    );
+    Make_Command(D_OUT, &spec, &extension, &command_num);
 
     return R_OUT;
 }

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -590,7 +590,7 @@ REB_R Command_Dispatcher(struct Reb_Frame *f)
     // For a "body", a command has a data array with [ext-obj func-index]
     // See Make_Command() for an explanation of these two values.
     //
-    REBVAL *data = VAL_ARRAY_HEAD(FUNC_BODY(f->func));
+    REBVAL *data = KNOWN(VAL_ARRAY_HEAD(FUNC_BODY(f->func)));
     REBEXT *handler = &Ext_List[VAL_I32(VAL_CONTEXT_VAR(data, SELFISH(1)))];
     REBCNT cmd_num = cast(REBCNT, Int32(data + 1));
 

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -76,7 +76,7 @@ REBCNT Modify_Array(
         // Are we modifying ourselves? If so, copy src_val block first:
         if (dst_arr == VAL_ARRAY(src_val)) {
             REBARR *copy = Copy_Array_At_Shallow(
-                VAL_ARRAY(src_val), VAL_INDEX(src_val)
+                VAL_ARRAY(src_val), VAL_INDEX(src_val), VAL_SPECIFIER(src_val)
             );
             src_val = ARR_HEAD(copy);
         }

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -150,16 +150,16 @@ REBOOL Series_Common_Action_Returns(
 
 
 //
-//  Cmp_Block: C
+//  Cmp_Array: C
 // 
-// Compare two blocks and return the difference of the first
+// Compare two arrays and return the difference of the first
 // non-matching value.
 //
-REBINT Cmp_Block(const REBVAL *sval, const REBVAL *tval, REBOOL is_case)
+REBINT Cmp_Array(const RELVAL *sval, const RELVAL *tval, REBOOL is_case)
 {
-    REBVAL  *s = VAL_ARRAY_AT(sval);
-    REBVAL  *t = VAL_ARRAY_AT(tval);
-    REBINT  diff;
+    RELVAL *s = VAL_ARRAY_AT(sval);
+    RELVAL *t = VAL_ARRAY_AT(tval);
+    REBINT diff;
 
     if (C_STACK_OVERFLOWING(&s)) Trap_Stack_Overflow();
 
@@ -203,7 +203,7 @@ diff_of_ends:
 // 
 // is_case TRUE for case sensitive compare
 //
-REBINT Cmp_Value(const REBVAL *s, const REBVAL *t, REBOOL is_case)
+REBINT Cmp_Value(const RELVAL *s, const RELVAL *t, REBOOL is_case)
 {
     REBDEC  d1, d2;
 
@@ -274,7 +274,7 @@ chkDecimal:
     case REB_SET_PATH:
     case REB_GET_PATH:
     case REB_LIT_PATH:
-        return Cmp_Block(s, t, is_case);
+        return Cmp_Array(s, t, is_case);
 
     case REB_STRING:
     case REB_FILE:
@@ -335,12 +335,13 @@ chkDecimal:
 // Simple search for a value in an array. Return the index of
 // the value or the TAIL index if not found.
 //
-REBCNT Find_In_Array_Simple(REBARR *array, REBCNT index, const REBVAL *target)
+REBCNT Find_In_Array_Simple(REBARR *array, REBCNT index, const RELVAL *target)
 {
-    REBVAL *value = ARR_HEAD(array);
+    RELVAL *value = ARR_HEAD(array);
 
     for (; index < ARR_LEN(array); index++) {
-        if (0 == Cmp_Value(value+index, target, FALSE)) return index;
+        if (0 == Cmp_Value(value + index, target, FALSE))
+            return index;
     }
 
     return ARR_LEN(array);

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -389,7 +389,7 @@ REB_R Destroy_External_Storage(REBVAL *out,
         elem = Alloc_Tail_Array(array);
         SET_INTEGER(elem, cast(REBUPT, SER_DATA_RAW(ser)));
 
-        threw = Do_At_Throws(&safe, array, 0);
+        threw = Do_At_Throws(&safe, array, 0, SPECIFIED); // 2 non-relative val
 
         DROP_GUARD_ARRAY(array);
 

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -427,6 +427,7 @@ void Val_Init_Series_Index_Core(
     VAL_RESET_HEADER(value, type);
     INIT_VAL_SERIES(value, series);
     VAL_INDEX(value) = index;
+    INIT_ARRAY_SPECIFIC(value, SPECIFIED);
 }
 
 

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -411,7 +411,7 @@ REBINT Get_System_Int(REBCNT i1, REBCNT i2, REBINT default_int)
 // Common function.
 //
 void Val_Init_Series_Index_Core(
-    RELVAL *value,
+    REBVAL *value,
     enum Reb_Kind type,
     REBSER *series,
     REBCNT index,
@@ -441,6 +441,17 @@ void Val_Init_Series_Index_Core(
     value->payload.any_series.series = series;
     VAL_INDEX(value) = index;
     INIT_ARRAY_SPECIFIC(value, specifier);
+
+#if !defined(NDEBUG)
+    if (ANY_ARRAY(value) && specifier == SPECIFIED) {
+        //
+        // If a SPECIFIED is used for an array, then that top level of the
+        // array cannot have any relative values in it.  Catch it here vs.
+        // waiting until a later assertion.
+        //
+        ASSERT_NO_RELATIVE(AS_ARRAY(series), FALSE);
+    }
+#endif
 }
 
 
@@ -467,7 +478,7 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 // is its canon form from a single pointer...the REBVAL sitting in the 0 slot
 // of the context's varlist.
 //
-void Val_Init_Context_Core(RELVAL *out, enum Reb_Kind kind, REBCTX *context) {
+void Val_Init_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *context) {
     //
     // In a debug build we check to make sure the type of the embedded value
     // matches the type of what is intended (so someone who thinks they are

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -438,7 +438,7 @@ void Val_Init_Series_Index_Core(
     }
 
     VAL_RESET_HEADER(value, type);
-    INIT_VAL_SERIES(value, series);
+    value->payload.any_series.series = series;
     VAL_INDEX(value) = index;
     INIT_ARRAY_SPECIFIC(value, specifier);
 }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -724,10 +724,10 @@ void Make_OS_Error(REBVAL *out, int errnum)
 // 
 // Scan a block, collecting all of its SET words as a block.
 //
-REBARR *Collect_Set_Words(REBVAL *val)
+REBARR *Collect_Set_Words(RELVAL *val)
 {
     REBCNT count = 0;
-    REBVAL *val2 = val;
+    RELVAL *val2 = val;
     REBARR *array;
 
     for (; NOT_END(val); val++) if (IS_SET_WORD(val)) count++;

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -295,6 +295,18 @@ REBVAL *Get_Type(enum Reb_Kind kind)
 
 
 //
+//  Type_Of_Core: C
+// 
+// Returns the datatype value for the given value.
+// The datatypes are all at the head of the context.
+//
+REBVAL *Type_Of_Core(const RELVAL *value)
+{
+    return CTX_VAR(Lib_Context, SYM_FROM_KIND(VAL_TYPE(value)));
+}
+
+
+//
 //  Get_Field_Name: C
 // 
 // Get the name of a field of an object.
@@ -399,10 +411,11 @@ REBINT Get_System_Int(REBCNT i1, REBCNT i2, REBINT default_int)
 // Common function.
 //
 void Val_Init_Series_Index_Core(
-    REBVAL *value,
+    RELVAL *value,
     enum Reb_Kind type,
     REBSER *series,
-    REBCNT index
+    REBCNT index,
+    REBCTX *specifier
 ) {
     assert(series);
     ENSURE_SERIES_MANAGED(series);
@@ -427,7 +440,7 @@ void Val_Init_Series_Index_Core(
     VAL_RESET_HEADER(value, type);
     INIT_VAL_SERIES(value, series);
     VAL_INDEX(value) = index;
-    INIT_ARRAY_SPECIFIC(value, SPECIFIED);
+    INIT_ARRAY_SPECIFIC(value, specifier);
 }
 
 
@@ -446,7 +459,7 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 
 
 //
-//  Val_Init_Context: C
+//  Val_Init_Context_Core: C
 //
 // Common routine for initializing OBJECT, MODULE!, PORT!, and ERROR!
 //
@@ -454,7 +467,7 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 // is its canon form from a single pointer...the REBVAL sitting in the 0 slot
 // of the context's varlist.
 //
-void Val_Init_Context(REBVAL *out, enum Reb_Kind kind, REBCTX *context) {
+void Val_Init_Context_Core(RELVAL *out, enum Reb_Kind kind, REBCTX *context) {
     //
     // In a debug build we check to make sure the type of the embedded value
     // matches the type of what is intended (so someone who thinks they are

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1686,7 +1686,7 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
             value = SINK(ARR_TAIL(emitbuf));
             SET_ARRAY_LEN(emitbuf, ARR_LEN(emitbuf) + 1); // Protect from GC
             Bind_Values_All_Deep(ARR_HEAD(block), Lib_Context);
-            if (!Construct_Value(value, block)) {
+            if (!Construct_Value(value, block, SPECIFIED)) {
                 if (IS_END(value)) Val_Init_Block(value, block);
                 fail (Error(RE_MALCONSTRUCT, value));
             }

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1788,7 +1788,9 @@ exit_block:
 #endif
 
     len = ARR_LEN(emitbuf);
-    block = Copy_Values_Len_Shallow(ARR_AT(emitbuf, begin), len - begin);
+    block = Copy_Values_Len_Shallow(
+        ARR_AT(emitbuf, begin), SPECIFIED, len - begin // no RELVALs in scan
+    );
     ASSERT_SERIES_TERM(ARR_SERIES(block));
 
     SET_ARRAY_LEN(emitbuf, begin);

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1471,7 +1471,7 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
                 } else token = REB_PATH;
             }
             VAL_RESET_HEADER(value, cast(enum Reb_Kind, token));
-            INIT_VAL_ARRAY(value, block);
+            INIT_VAL_ARRAY(value, block); // copies args
             VAL_INDEX(value) = 0;
             token = TOKEN_PATH;
         } else {

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1382,7 +1382,7 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
     REBCNT len;
     const REBYTE *bp;
     const REBYTE *ep;
-    REBVAL *value = 0;
+    REBVAL *value = NULL;
     REBARR *emitbuf = BUF_EMIT;
     REBARR *block;
     REBCNT begin = ARR_LEN(emitbuf);   // starting point in block buffer
@@ -1425,7 +1425,7 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
         if (token >= TOKEN_WORD && SER_FULL(ARR_SERIES(emitbuf)))
             Extend_Series(ARR_SERIES(emitbuf), 1024);
 
-        value = ARR_TAIL(emitbuf);
+        value = SINK(ARR_TAIL(emitbuf));
         SET_END(value);
 
         // If in a path, handle start of path /word or word//word cases:
@@ -1452,7 +1452,7 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
             && mode_char != '/'
         ) {
             block = Scan_Block(scan_state, '/');  // (could realloc emitbuf)
-            value = ARR_TAIL(emitbuf);
+            value = SINK(ARR_TAIL(emitbuf));
             if (token == TOKEN_LIT) {
                 token = REB_LIT_PATH;
                 VAL_RESET_HEADER(ARR_HEAD(block), REB_WORD);
@@ -1553,9 +1553,9 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
             );
             // (above line could have realloced emitbuf)
             ep = scan_state->end;
-            value = ARR_TAIL(emitbuf);
+            value = SINK(ARR_TAIL(emitbuf));
             if (scan_state->errors) {
-                *value = *ARR_LAST(block); // Copy the error
+                *value = *KNOWN(ARR_LAST(block)); // Copy the error
                 SET_ARRAY_LEN(emitbuf, ARR_LEN(emitbuf) + 1);
                 goto exit_block;
             }
@@ -1683,7 +1683,7 @@ static REBARR *Scan_Block(SCAN_STATE *scan_state, REBYTE mode_char)
 
         case TOKEN_CONSTRUCT:
             block = Scan_Full_Block(scan_state, ']');
-            value = ARR_TAIL(emitbuf);
+            value = SINK(ARR_TAIL(emitbuf));
             SET_ARRAY_LEN(emitbuf, ARR_LEN(emitbuf) + 1); // Protect from GC
             Bind_Values_All_Deep(ARR_HEAD(block), Lib_Context);
             if (!Construct_Value(value, block)) {

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -33,7 +33,7 @@
 #include "sys-dec-to-char.h"
 #include <errno.h>
 
-typedef REBOOL (*MAKE_FUNC)(REBVAL *, REBVAL *, enum Reb_Kind);
+typedef REBOOL (*MAKE_FUNC)(REBVAL *, RELVAL *, REBCTX *, enum Reb_Kind);
 #include "tmp-maketypes.h"
 
 
@@ -807,7 +807,7 @@ const REBYTE *Scan_Any(
 // Keep in mind that this function is being called as part of the
 // scanner, so optimal performance is critical.
 //
-REBOOL Construct_Value(REBVAL *out, REBARR *spec)
+REBOOL Construct_Value(REBVAL *out, REBARR *spec, REBCTX *specifier)
 {
     RELVAL *val;
     REBSYM sym;
@@ -868,7 +868,7 @@ REBOOL Construct_Value(REBVAL *out, REBARR *spec)
         // out of the spec referred to again...)
 
         PUSH_GUARD_ARRAY(spec);
-        if (func(out, KNOWN(val), type)) { // !!! might this be relative?
+        if (func(out, val, specifier, type)) {
             DROP_GUARD_ARRAY(spec);
             return TRUE;
         }

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -809,7 +809,7 @@ const REBYTE *Scan_Any(
 //
 REBOOL Construct_Value(REBVAL *out, REBARR *spec)
 {
-    REBVAL *val;
+    RELVAL *val;
     REBSYM sym;
     enum Reb_Kind type;
     MAKE_FUNC func;
@@ -868,7 +868,7 @@ REBOOL Construct_Value(REBVAL *out, REBARR *spec)
         // out of the spec referred to again...)
 
         PUSH_GUARD_ARRAY(spec);
-        if (func(out, val, type)) {
+        if (func(out, KNOWN(val), type)) { // !!! might this be relative?
             DROP_GUARD_ARRAY(spec);
             return TRUE;
         }
@@ -952,12 +952,13 @@ REBNATIVE(scan_net_header)
 
         if (*cp == ':') {
             REBSYM sym = Make_Word(start, cp-start);
+            RELVAL *item;
             cp++;
             // Search if word already present:
-            for (val = ARR_HEAD(result); NOT_END(val); val += 2) {
-                if (VAL_WORD_SYM(val) == sym) {
+            for (item = ARR_HEAD(result); NOT_END(item); item += 2) {
+                if (VAL_WORD_SYM(item) == sym) {
                     // Does it already use a block?
-                    if (IS_BLOCK(val+1)) {
+                    if (IS_BLOCK(item + 1)) {
                         // Block of values already exists:
                         val = Alloc_Tail_Array(VAL_ARRAY(val + 1));
                         SET_BLANK(val);
@@ -975,7 +976,7 @@ REBNATIVE(scan_net_header)
                     break;
                 }
             }
-            if (IS_END(val)) {
+            if (IS_END(item)) {
                 val = Alloc_Tail_Array(result); // add new word
                 Val_Init_Word(val, REB_SET_WORD, sym);
                 val = Alloc_Tail_Array(result); // for new value

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1512,7 +1512,7 @@ void Guard_Series_Core(REBSER *series)
 //
 //  Guard_Value_Core: C
 //
-void Guard_Value_Core(const REBVAL *value)
+void Guard_Value_Core(const RELVAL *value)
 {
     // Cheap check; require that the value already contain valid data when
     // the guard call is made (even if GC isn't necessarily going to happen
@@ -1534,7 +1534,7 @@ void Guard_Value_Core(const REBVAL *value)
     if (SER_FULL(GC_Value_Guard)) Extend_Series(GC_Value_Guard, 8);
 
     *SER_AT(
-        const REBVAL*,
+        const RELVAL*,
         GC_Value_Guard,
         SER_LEN(GC_Value_Guard)
     ) = value;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1433,7 +1433,7 @@ REBCNT Recycle_Core(REBOOL shutdown)
     // are being freed.
     //
     if (!shutdown) {
-
+        //
         // !!! This code was added by Atronix to deal with frequent garbage
         // collection, but the logic is not correct.  The issue has been
         // raised and is commented out pending a correct solution.

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1399,9 +1399,11 @@ REBCNT Recycle_Core(REBOOL shutdown)
                         NOT_END(chunk_value)
                         && !IS_VOID_OR_SAFE_TRASH(chunk_value)
                     ) {
-                        // The chunk stack stores REBVAL, not RELVAL
-                        //
-                        assert(!IS_RELATIVE(chunk_value));
+                        // !!! The chunk stack should store REBVAL, not RELVAL
+                        // (can't turn this assert on until the system has
+                        // all the RELVAL/REBVAL type correctness in)
+
+                        /* assert(!IS_RELATIVE(chunk_value)); */
                         Queue_Mark_Value_Deep(chunk_value);
                     }
                     chunk_value++;

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1686,7 +1686,7 @@ void Manage_Series(REBSER *series)
 // with either managed or unmanaged value states for variables w/o needing
 // this test to know which it has.)
 //
-REBOOL Is_Value_Managed(const REBVAL *value)
+REBOOL Is_Value_Managed(const RELVAL *value)
 {
     assert(!THROWN(value));
 

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -553,7 +553,7 @@ void Assert_Series_Core(REBSER *series)
 // as an actual function gives you a place to set breakpoints.
 //
 ATTRIBUTE_NO_RETURN void Panic_Series_Debug(
-    const REBSER *series,
+    REBSER *series,
     const char *file,
     int line
 ) {

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -481,7 +481,7 @@ REBFUN *Find_Underlying_Func(
     // the frame needs to be "for that", so it is the underlying function.
 
     if (IS_FUNCTION_PLAIN(value)) {
-        REBVAL *body = VAL_FUNC_BODY(value);
+        RELVAL *body = VAL_FUNC_BODY(value);
         assert(IS_RELATIVE(body));
         return VAL_RELATIVE(body);
     }
@@ -817,8 +817,14 @@ finished:
 //
 REBVAL *FRM_ARG_Debug(struct Reb_Frame *frame, REBCNT n)
 {
+    REBVAL *var;
     assert(n != 0 && n <= FRM_NUM_ARGS(frame));
-    return &frame->arg[n - 1];
+
+    var = &frame->arg[n - 1];
+    assert(!THROWN(var));
+    assert(!IS_RELATIVE(var));
+
+    return var;
 }
 
 #endif

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -205,7 +205,9 @@ REBARR *Pop_Stack_Values(REBDSP dsp_start)
     REBCNT len = DSP - dsp_start;
     REBVAL *values = ARR_AT(DS_Array, dsp_start + 1);
 
-    REBARR *array = Copy_Values_Len_Shallow(values, len);
+    // Data stack should be fully specified--no relative values
+    //
+    REBARR *array = Copy_Values_Len_Shallow(values, SPECIFIED, len);
 
     DS_DROP_TO(dsp_start);
     return array;

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -677,7 +677,9 @@ REBCTX *Context_For_Frame_May_Reify_Core(struct Reb_Frame *f) {
     // that has already been managed.  The arglist array was managed when
     // created and kept alive by Mark_Call_Frames
     //
-    INIT_CTX_KEYLIST_SHARED(context, FUNC_PARAMLIST(f->func));
+    REBCTX *exemplar;
+    REBFUN *under = Find_Underlying_Func(&exemplar, FUNC_VALUE(f->func));
+    INIT_CTX_KEYLIST_SHARED(context, FUNC_PARAMLIST(under));
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(context));
 
     // We do not manage the varlist, because we'd like to be able to free

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1657,9 +1657,9 @@ REBNATIVE(switch)
             D_OUT,
             VAL_ARRAY(e.value),
             VAL_INDEX(e.value),
-            IS_SPECIFIC(e.value)
-                ? VAL_SPECIFIER(const_KNOWN(e.value))
-                : VAL_SPECIFIER(ARG(cases))
+            IS_RELATIVE(e.value)
+                ? VAL_SPECIFIER(ARG(cases)) // if relative, use parent's...
+                : VAL_SPECIFIER(const_KNOWN(e.value)) // ...else use child's
         )) {
             goto return_thrown;
         }

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1660,7 +1660,7 @@ REBNATIVE(switch)
                 ? VAL_SPECIFIER(const_KNOWN(e.value))
                 : VAL_SPECIFIER(ARG(cases))
         )) {
-            return R_OUT_IS_THROWN;
+            goto return_thrown;
         }
 
         // Only keep processing if the /ALL refinement was specified

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1327,6 +1327,7 @@ REBNATIVE(fail)
                 &mo,
                 &pending_delimiter, // variable shared by recursions
                 reason,
+                SPECIFIED,
                 TRUE, // reduce
                 ROOT_DEFAULT_PRINT_DELIMITER, // same as PRINT (customizable?)
                 0 // depth

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1657,7 +1657,7 @@ REBNATIVE(switch)
             VAL_ARRAY(e.value),
             VAL_INDEX(e.value),
             IS_SPECIFIC(e.value)
-                ? VAL_SPECIFIER(KNOWN(e.value))
+                ? VAL_SPECIFIER(const_KNOWN(e.value))
                 : VAL_SPECIFIER(ARG(cases))
         )) {
             return R_OUT_IS_THROWN;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -205,7 +205,7 @@ static int Protect(struct Reb_Frame *frame_, REBFLGS flags)
             RELVAL *val;
             for (val = VAL_ARRAY_AT(value); NOT_END(val); val++) {
                 REBVAL word; // need binding intact, can't just pass RELVAL
-                COPY_RELVAL(&word, val, VAL_SPECIFIER(value));
+                COPY_VALUE(&word, val, VAL_SPECIFIER(value));
                 Protect_Word_Value(&word, flags);  // will unmark if deep
             }
             goto return_value_arg;
@@ -669,7 +669,7 @@ REBNATIVE(catch)
                     if (IS_BLOCK(candidate))
                         fail (Error(RE_INVALID_ARG, ARG(names)));
 
-                    COPY_RELVAL(temp1, candidate, VAL_SPECIFIER(ARG(names)));
+                    COPY_VALUE(temp1, candidate, VAL_SPECIFIER(ARG(names)));
                     *temp2 = *D_OUT;
 
                     // Return the THROW/NAME's arg if the names match

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -317,7 +317,7 @@ REBNATIVE(bind)
         // specific frame, this needs to ensure that the Reb_Frame's data
         // is a real context, not just a chunk of data.
         //
-        context = VAL_WORD_CONTEXT_MAY_REIFY(target);
+        context = VAL_WORD_CONTEXT(target);
     }
 
     if (ANY_WORD(value)) {
@@ -391,7 +391,7 @@ REBNATIVE(context_of)
     // !!! Mechanically it is likely that in the future, all FRAME!s for
     // user functions will be reified from the moment of invocation.
     //
-    *D_OUT = *CTX_VALUE(VAL_WORD_CONTEXT_MAY_REIFY(ARG(word)));
+    *D_OUT = *CTX_VALUE(VAL_WORD_CONTEXT(ARG(word)));
 
     return R_OUT;
 }
@@ -570,7 +570,7 @@ REBNATIVE(get)
         }
 
         SET_END(dest);
-        SET_ARRAY_LEN(array, dest - ARR_HEAD(array));
+        SET_ARRAY_LEN(array, cast(RELVAL*, dest) - ARR_HEAD(array));
         Val_Init_Block(D_OUT, array);
     }
     else {
@@ -1411,6 +1411,7 @@ REBNATIVE(aliases_q)
 REBNATIVE(set_q)
 {
     PARAM(1, location);
+
     REBVAL *location = ARG(location);
 
     if (ANY_WORD(location)) {

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -533,7 +533,7 @@ REBNATIVE(get)
         // !!! This is a questionable feature, a shallow copy of the vars of
         // the context being put into a BLOCK!:
         //
-        //     >> get make object! [a: 10 b: 20]
+        //     >> get make object! [[a b][a: 10 b: 20]]
         //     == [10 20]
         //
         // Certainly an oddity for GET.  Should either be turned into a

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1197,19 +1197,25 @@ REBNATIVE(unset)
     REBVAL *target = ARG(target);
 
     if (ANY_WORD(target)) {
-        REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(target, GUESSED);
+        REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(target, SPECIFIED);
         SET_VOID(var);
         return R_VOID;
     }
 
     assert(IS_BLOCK(target));
 
-    REBVAL *word;
+    RELVAL *word;
     for (word = VAL_ARRAY_AT(target); NOT_END(word); ++word) {
         if (!ANY_WORD(word))
-            fail (Error_Invalid_Arg(word));
+            fail (Error_Invalid_Arg_Core(word, VAL_SPECIFIER(target)));
 
-        REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(word, GUESSED);
+        if (IS_WORD_UNBOUND(word)) {
+            REBVAL specific;
+            COPY_RELVAL(&specific, word, VAL_SPECIFIER(target));
+            fail (Error(RE_NOT_BOUND, &specific));
+        }
+
+        REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(word, VAL_SPECIFIER(target));
         SET_VOID(var);
     }
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -360,7 +360,7 @@ REBNATIVE(bind)
         array = Copy_Array_At_Deep_Managed(
             VAL_ARRAY(value), VAL_INDEX(value), VAL_SPECIFIER(value)
         );
-        INIT_VAL_ARRAY(D_OUT, array);
+        INIT_VAL_ARRAY(D_OUT, array); // warning: macro copies args
     }
     else
         array = VAL_ARRAY(value);

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -193,7 +193,7 @@ REBNATIVE(assert)
 
             if (IS_END(value + 1)) fail (Error(RE_MISSING_ARG));
 
-            COPY_RELVAL(&type, value + 1, specifier);
+            COPY_VALUE(&type, value + 1, specifier);
 
             if (
                 IS_BLOCK(&type)
@@ -203,7 +203,7 @@ REBNATIVE(assert)
             ) {
                 if (!Is_Type_Of(val, &type)) {
                     REBVAL specific;
-                    COPY_RELVAL(&specific, value, specifier);
+                    COPY_VALUE(&specific, value, specifier);
 
                     fail (Error(RE_WRONG_TYPE, value));
                 }
@@ -1053,7 +1053,7 @@ REBNATIVE(set)
                 SET_BLANK(var);
                 continue;
             }
-            COPY_RELVAL(var, value, value_specifier);
+            COPY_VALUE(var, value, value_specifier);
             if (set_with_block) value++;
         }
 
@@ -1115,7 +1115,7 @@ REBNATIVE(set)
     //
     for (; NOT_END(target); target++) {
         if (IS_WORD(target) || IS_SET_WORD(target) || IS_LIT_WORD(target)) {
-            COPY_RELVAL(
+            COPY_VALUE(
                 GET_MUTABLE_VAR_MAY_FAIL(target, target_specifier),
                 value,
                 value_specifier
@@ -1133,7 +1133,7 @@ REBNATIVE(set)
                     = *GET_OPT_VAR_MAY_FAIL(value, value_specifier);
             }
             else {
-                COPY_RELVAL(
+                COPY_VALUE(
                     GET_MUTABLE_VAR_MAY_FAIL(target, target_specifier),
                     value,
                     value_specifier
@@ -1211,7 +1211,7 @@ REBNATIVE(unset)
 
         if (IS_WORD_UNBOUND(word)) {
             REBVAL specific;
-            COPY_RELVAL(&specific, word, VAL_SPECIFIER(target));
+            COPY_VALUE(&specific, word, VAL_SPECIFIER(target));
             fail (Error(RE_NOT_BOUND, &specific));
         }
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -579,7 +579,7 @@ REBNATIVE(get)
     }
 
     if (!REF(opt) && IS_VOID(D_OUT))
-        fail (Error(RE_NO_VALUE, source));
+        fail (Error_No_Value(source));
 
     return R_OUT;
 }

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -111,6 +111,7 @@ REBNATIVE(form)
             &mo,
             &pending_delimiter,
             value,
+            SPECIFIED,
             LOGICAL(!REF(quote) && IS_BLOCK(value)),
             delimiter,
             0 // depth

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -368,7 +368,7 @@ REBNATIVE(wait)
         REBVAL unsafe; // temporary not safe from GC
 
         if (Reduce_Array_Throws(
-            &unsafe, VAL_ARRAY(val), VAL_INDEX(val), FALSE
+            &unsafe, VAL_ARRAY(val), VAL_INDEX(val), VAL_SPECIFIER(val), FALSE
         )) {
             *D_OUT = unsafe;
             return R_OUT_IS_THROWN;

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -234,7 +234,9 @@ static REBOOL Loop_Integer_Throws(
         }
 
     next_iteration:
-        if (!IS_INTEGER(var)) fail (Error_Has_Bad_Type(var));
+        if (!IS_INTEGER(var))
+            fail (Error_Invalid_Type(VAL_TYPE(var)));
+
         start = VAL_INT64(var);
 
         if (REB_I64_ADD_OF(start, incr, &start))
@@ -296,7 +298,9 @@ static REBOOL Loop_Number_Throws(
         }
 
     next_iteration:
-        if (!IS_DECIMAL(var)) fail (Error_Has_Bad_Type(var));
+        if (!IS_DECIMAL(var))
+            fail (Error_Invalid_Type(VAL_TYPE(var)));
+
         s = VAL_DECIMAL(var);
     }
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -98,6 +98,7 @@ static REBARR *Init_Loop(
     REBARR *body_out;
 
     const RELVAL *item;
+    REBCTX *specifier;
 
     assert(IS_BLOCK(body));
 
@@ -122,16 +123,18 @@ static REBARR *Init_Loop(
 
     if (IS_BLOCK(spec)) {
         item = VAL_ARRAY_AT(spec);
+        specifier = VAL_SPECIFIER(spec);
     }
     else {
         item = spec;
+        specifier = SPECIFIED;
     }
 
     // Optimally create the FOREACH context:
     while (len-- > 0) {
         if (!IS_WORD(item) && !IS_SET_WORD(item)) {
             FREE_CONTEXT(context);
-            fail (Error_Invalid_Arg(item));
+            fail (Error_Invalid_Arg_Core(item, specifier));
         }
 
         Val_Init_Typeset(key, ALL_64, VAL_WORD_SYM(item));
@@ -539,7 +542,10 @@ static REB_R Loop_Each(struct Reb_Frame *frame_, LOOP_MODE mode)
                 Set_Vector_Value(var, series, index);
             }
             else if (IS_MAP(data_value)) {
-                REBVAL *val = ARR_AT(AS_ARRAY(series), index | 1);
+                //
+                // MAP! does not store RELVALs
+                //
+                REBVAL *val = KNOWN(ARR_AT(AS_ARRAY(series), index | 1));
                 if (!IS_VOID(val)) {
                     if (j == 0) {
                         COPY_VALUE(

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -636,10 +636,12 @@ REBNATIVE(same_q)
                 return R_FALSE;
             }
 
-            if (IS_RELATIVE(value1) != IS_RELATIVE(value2))
+            if (!(IS_SPECIFIC(value1) && IS_SPECIFIC(value2)))
                 return R_FALSE; // Relatively bound words can't match specific
 
-            if (VAL_WORD_CONTEXT(value1) != VAL_WORD_CONTEXT(value2))
+            REBCTX *ctx1 = VAL_WORD_CONTEXT(value1);
+            REBCTX *ctx2 = VAL_WORD_CONTEXT(value2);
+            if (ctx1 != ctx2)
                 return R_FALSE;
         }
         return R_TRUE;

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -390,7 +390,7 @@ REBNATIVE(shift)
 // in native code that can overwrite its argument values without
 // that being a problem, so it doesn't matter.
 //
-REBINT Compare_Modify_Values(REBVAL *a, REBVAL *b, REBINT strictness)
+REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
 {
     REBCNT ta = VAL_TYPE(a);
     REBCNT tb = VAL_TYPE(b);
@@ -509,7 +509,12 @@ REBNATIVE(equal_q)
 //
 REBNATIVE(not_equal_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), 0)) return R_FALSE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), 0))
+        return R_FALSE;
+
     return R_TRUE;
 }
 
@@ -525,7 +530,12 @@ REBNATIVE(not_equal_q)
 //
 REBNATIVE(strict_equal_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), 1)) return R_TRUE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), 1))
+        return R_TRUE;
+
     return R_FALSE;
 }
 
@@ -541,7 +551,12 @@ REBNATIVE(strict_equal_q)
 //
 REBNATIVE(strict_not_equal_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), 1)) return R_FALSE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), 1))
+        return R_FALSE;
+
     return R_TRUE;
 }
 
@@ -692,7 +707,12 @@ REBNATIVE(same_q)
 //
 REBNATIVE(lesser_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), -1)) return R_FALSE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), -1))
+        return R_FALSE;
+
     return R_TRUE;
 }
 
@@ -707,7 +727,12 @@ REBNATIVE(lesser_q)
 //
 REBNATIVE(lesser_or_equal_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), -2)) return R_FALSE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), -2))
+        return R_FALSE;
+
     return R_TRUE;
 }
 
@@ -722,7 +747,12 @@ REBNATIVE(lesser_or_equal_q)
 //
 REBNATIVE(greater_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), -2)) return R_TRUE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), -2))
+        return R_TRUE;
+
     return R_FALSE;
 }
 
@@ -737,7 +767,12 @@ REBNATIVE(greater_q)
 //
 REBNATIVE(greater_or_equal_q)
 {
-    if (Compare_Modify_Values(D_ARG(1), D_ARG(2), -1)) return R_TRUE;
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    if (Compare_Modify_Values(ARG(value1), ARG(value2), -1))
+        return R_TRUE;
+
     return R_FALSE;
 }
 
@@ -753,16 +788,22 @@ REBNATIVE(greater_or_equal_q)
 //
 REBNATIVE(maximum)
 {
-    if (IS_PAIR(D_ARG(1)) || IS_PAIR(D_ARG(2))) {
-        Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), TRUE);
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    const REBVAL *value1 = ARG(value1);
+    const REBVAL *value2 = ARG(value2);
+
+    if (IS_PAIR(value1) || IS_PAIR(value2)) {
+        Min_Max_Pair(D_OUT, value1, value2, TRUE);
     }
     else {
-        REBVAL a = *D_ARG(1);
-        REBVAL b = *D_ARG(2);
-        if (Compare_Modify_Values(&a, &b, -1))
-            *D_OUT = *D_ARG(1);
+        REBVAL coerced1 = *value1;
+        REBVAL coerced2 = *value2;
+        if (Compare_Modify_Values(&coerced1, &coerced2, -1))
+            *D_OUT = *value1;
         else
-            *D_OUT = *D_ARG(2);
+            *D_OUT = *value2;
     }
     return R_OUT;
 }
@@ -779,17 +820,23 @@ REBNATIVE(maximum)
 //
 REBNATIVE(minimum)
 {
-    if (IS_PAIR(D_ARG(1)) || IS_PAIR(D_ARG(2))) {
-        Min_Max_Pair(D_OUT, D_ARG(1), D_ARG(2), FALSE);
+    PARAM(1, value1);
+    PARAM(2, value2);
+
+    const REBVAL *value1 = ARG(value1);
+    const REBVAL *value2 = ARG(value2);
+
+    if (IS_PAIR(ARG(value1)) || IS_PAIR(ARG(value2))) {
+        Min_Max_Pair(D_OUT, ARG(value1), ARG(value2), FALSE);
     }
     else {
-        REBVAL a = *D_ARG(1);
-        REBVAL b = *D_ARG(2);
+        REBVAL coerced1 = *value1;
+        REBVAL coerced2 = *value2;
 
-        if (Compare_Modify_Values(&a, &b, -1))
-            *D_OUT = *D_ARG(2);
+        if (Compare_Modify_Values(&coerced1, &coerced2, -1))
+            *D_OUT = *value2;
         else
-            *D_OUT = *D_ARG(1);
+            *D_OUT = *value1;
     }
     return R_OUT;
 }
@@ -805,10 +852,14 @@ REBNATIVE(minimum)
 //
 REBNATIVE(negative_q)
 {
-    REBVAL zero;
-    SET_ZEROED(&zero, VAL_TYPE(D_ARG(1)));
+    PARAM(1, number);
 
-    if (Compare_Modify_Values(D_ARG(1), &zero, -1)) return R_FALSE;
+    REBVAL zero;
+    SET_ZEROED(&zero, VAL_TYPE(ARG(number)));
+
+    if (Compare_Modify_Values(ARG(number), &zero, -1))
+        return R_FALSE;
+
     return R_TRUE;
 }
 
@@ -823,10 +874,13 @@ REBNATIVE(negative_q)
 //
 REBNATIVE(positive_q)
 {
-    REBVAL zero;
-    SET_ZEROED(&zero, VAL_TYPE(D_ARG(1)));
+    PARAM(1, number);
 
-    if (Compare_Modify_Values(D_ARG(1), &zero, -2)) return R_TRUE;
+    REBVAL zero;
+    SET_ZEROED(&zero, VAL_TYPE(ARG(number)));
+
+    if (Compare_Modify_Values(ARG(number), &zero, -2))
+        return R_TRUE;
 
     return R_FALSE;
 }
@@ -842,13 +896,16 @@ REBNATIVE(positive_q)
 //
 REBNATIVE(zero_q)
 {
-    enum Reb_Kind type = VAL_TYPE(D_ARG(1));
+    PARAM(1, value);
+
+    enum Reb_Kind type = VAL_TYPE(ARG(value));
 
     if (type >= REB_INTEGER && type <= REB_TIME) {
         REBVAL zero;
         SET_ZEROED(&zero, type);
 
-        if (Compare_Modify_Values(D_ARG(1), &zero, 1)) return R_TRUE;
+        if (Compare_Modify_Values(ARG(value), &zero, 1))
+            return R_TRUE;
     }
     return R_FALSE;
 }

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -393,14 +393,12 @@ REBOOL Compose_Values_Throws(
                     // compose [copy/(orig) (copy)] => [copy/(orig) (copy)]
                     // !!! path and second group are copies, first group isn't
                     //
-                    INIT_VAL_ARRAY(
-                        DS_TOP,
-                        Copy_Array_At_Shallow(
-                            VAL_ARRAY(value),
-                            VAL_INDEX(value),
-                            specifier
-                        )
+                    REBARR *copy = Copy_Array_At_Shallow(
+                        VAL_ARRAY(value),
+                        VAL_INDEX(value),
+                        specifier
                     );
+                    INIT_VAL_ARRAY(DS_TOP, copy); // warning: macro copies args
                     MANAGE_ARRAY(VAL_ARRAY(DS_TOP));
                 }
             }

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -128,7 +128,7 @@ static REBSER *Make_Set_Operation_Series(
             //
             i = VAL_INDEX(val1);
             for (; i < SER_LEN(ser); i += skip) {
-                REBVAL *item = ARR_AT(AS_ARRAY(ser), i);
+                RELVAL *item = ARR_AT(AS_ARRAY(ser), i);
                 if (flags & SOP_FLAG_CHECK) {
                     h = Find_Key_Hashed(
                         VAL_ARRAY(val2), hser, item, skip, cased, 1
@@ -171,7 +171,7 @@ static REBSER *Make_Set_Operation_Series(
         if (hret)
             Free_Series(hret);
 
-        out_ser = ARR_SERIES(Copy_Array_Shallow(AS_ARRAY(buffer)));
+        out_ser = ARR_SERIES(Copy_Array_Shallow(AS_ARRAY(buffer), SPECIFIED));
         RESET_TAIL(buffer); // required - allow reuse
     }
     else {

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -117,7 +117,7 @@ static REBSER *Make_Set_Operation_Series(
         // and extending Find_Key to FIND on the value itself w/o the hash.
 
         do {
-            REBSER *ser = VAL_SERIES(val1); // val1 and val2 swapped 2nd pass!
+            REBARR *array1 = VAL_ARRAY(val1); // val1 and val2 swapped 2nd pass!
 
             // Check what is in series1 but not in series2
             //
@@ -127,23 +127,35 @@ static REBSER *Make_Set_Operation_Series(
             // Iterate over first series
             //
             i = VAL_INDEX(val1);
-            for (; i < SER_LEN(ser); i += skip) {
-                RELVAL *item = ARR_AT(AS_ARRAY(ser), i);
+            for (; i < ARR_LEN(array1); i += skip) {
+                RELVAL *item = ARR_AT(array1, i);
                 if (flags & SOP_FLAG_CHECK) {
                     h = Find_Key_Hashed(
-                        VAL_ARRAY(val2), hser, item, skip, cased, 1
+                        VAL_ARRAY(val2),
+                        hser,
+                        item,
+                        VAL_SPECIFIER(val1),
+                        skip,
+                        cased,
+                        1
                     );
                     h = (h >= 0);
                     if (flags & SOP_FLAG_INVERT) h = !h;
                 }
                 if (h) {
                     Find_Key_Hashed(
-                        AS_ARRAY(buffer), hret, item, skip, cased, 2
+                        AS_ARRAY(buffer),
+                        hret,
+                        item,
+                        VAL_SPECIFIER(val1),
+                        skip,
+                        cased,
+                        2
                     );
                 }
             }
 
-            if (i != SER_LEN(ser)) {
+            if (i != ARR_LEN(array1)) {
                 //
                 // In the current philosophy, the semantics of what to do
                 // with things like `intersect/skip [1 2 3] [7] 2` is too

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -131,8 +131,10 @@ REBNATIVE(ajoin)
 {
     PARAM(1, block);
 
+    REBVAL *block = ARG(block);
+
     if (Form_Reduce_Throws(
-        D_OUT, VAL_ARRAY(ARG(block)), VAL_INDEX(ARG(block))
+        D_OUT, VAL_ARRAY(block), VAL_INDEX(block), VAL_SPECIFIER(block)
     )) {
         return R_OUT_IS_THROWN;
     }
@@ -439,7 +441,11 @@ REBNATIVE(construct)
     Val_Init_Object(
         D_OUT,
         Construct_Context(
-            REB_OBJECT, VAL_ARRAY_AT(spec_value), REF(only), parent
+            REB_OBJECT,
+            VAL_ARRAY_AT(spec_value),
+            VAL_SPECIFIER(spec_value),
+            REF(only),
+            parent
         )
     );
 

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -390,69 +390,6 @@ REBNATIVE(decompress)
 
 
 //
-//  construct: native [
-//  
-//  "Creates an object with scant (safe) evaluation."
-//  
-//      spec [block! string! binary!]
-//          "Specification (modified)"
-//      /with
-//          "Create from a default object"
-//      object [object!]
-//          "Default object"
-//      /only
-//          "Values are kept as-is"
-//  ]
-//
-REBNATIVE(construct)
-{
-    PARAM(1, spec);
-    REFINE(2, with);
-    PARAM(3, object);
-    REFINE(4, only);
-
-    REBVAL *spec_value = ARG(spec);
-    REBCTX *parent = NULL;
-
-    // !!! What is this?
-    //
-    if (IS_STRING(spec_value) || IS_BINARY(spec_value)) {
-        REBCNT index;
-        REBARR *array;
-        REBSER *temp;
-
-        // Just a guess at size:
-        array = Make_Array(10);     // Use a std BUF_?
-        Val_Init_Block(D_OUT, array); // Keep safe
-
-        // Convert string if necessary. Store back for safety.
-        temp = Temp_Bin_Str_Managed(spec_value, &index, 0);
-        INIT_VAL_SERIES(spec_value, temp); // caution: macro copies args!
-
-        // !!! "Is this what we really want here?" <= but *what is it*?
-        //
-        Scan_Net_Header(array, VAL_BIN(spec_value) + index);
-        spec_value = D_OUT;
-    }
-
-    if (REF(with)) parent = VAL_CONTEXT(ARG(object));
-
-    Val_Init_Object(
-        D_OUT,
-        Construct_Context(
-            REB_OBJECT,
-            VAL_ARRAY_AT(spec_value),
-            VAL_SPECIFIER(spec_value),
-            REF(only),
-            parent
-        )
-    );
-
-    return R_OUT;
-}
-
-
-//
 //  debase: native [
 //  
 //  {Decodes binary-coded string (BASE-64 default) to binary value.}

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -419,16 +419,15 @@ REBNATIVE(construct)
     if (IS_STRING(spec_value) || IS_BINARY(spec_value)) {
         REBCNT index;
         REBARR *array;
+        REBSER *temp;
 
         // Just a guess at size:
         array = Make_Array(10);     // Use a std BUF_?
         Val_Init_Block(D_OUT, array); // Keep safe
 
         // Convert string if necessary. Store back for safety.
-        INIT_VAL_SERIES(
-            spec_value,
-            Temp_Bin_Str_Managed(spec_value, &index, 0)
-        );
+        temp = Temp_Bin_Str_Managed(spec_value, &index, 0);
+        INIT_VAL_SERIES(spec_value, temp); // caution: macro copies args!
 
         // !!! "Is this what we really want here?" <= but *what is it*?
         //

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -257,7 +257,10 @@ REBNATIVE(evoke)
 #ifdef NDEBUG
     fail (Error(RE_DEBUG_ONLY));
 #else
-    REBVAL *arg = D_ARG(1);
+
+    PARAM(1, chant);
+
+    RELVAL *arg = ARG(chant);
     REBCNT len;
 
     Check_Security(SYM_DEBUG, POL_READ, 0);
@@ -287,7 +290,7 @@ REBNATIVE(evoke)
             }
         }
         if (IS_INTEGER(arg)) {
-            switch (Int32(arg)) {
+            switch (Int32(KNOWN(arg))) {
             case 0:
                 Check_Memory();
                 Assert_Bind_Table_Empty();

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -222,6 +222,7 @@ static REB_R Dir_Actor(struct Reb_Frame *frame_, REBCTX *port, REBCNT action)
                 Copy_Array_Core_Managed(
                     VAL_ARRAY(state),
                     0, // at
+                    VAL_SPECIFIER(state),
                     VAL_ARRAY_LEN_AT(state), // tail
                     0, // extra
                     FALSE, // !deep

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -95,7 +95,7 @@ REBVAL *Append_Event(void)
         }
     }
     SET_SERIES_LEN(VAL_SERIES(state), VAL_LEN_HEAD(state) + 1);
-    value = VAL_ARRAY_TAIL(state);
+    value = SINK(VAL_ARRAY_TAIL(state));
     SET_END(value);
     value--;
     SET_BLANK(value);
@@ -115,7 +115,7 @@ REBVAL *Append_Event(void)
 REBVAL *Find_Last_Event(REBINT model, REBINT type)
 {
     REBVAL *port;
-    REBVAL *value;
+    RELVAL *value;
     REBVAL *state;
 
     port = Get_System(SYS_PORTS, PORTS_SYSTEM);
@@ -129,7 +129,7 @@ REBVAL *Find_Last_Event(REBINT model, REBINT type)
     for (; value >= VAL_ARRAY_HEAD(state); --value) {
         if (VAL_EVENT_MODEL(value) == model) {
             if (VAL_EVENT_TYPE(value) == type) {
-                return value;
+                return KNOWN(value);
             } else {
                 return NULL;
             }

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -266,7 +266,7 @@ REBCNT Hash_Value(const RELVAL *val, REBCTX *specifier)
         // a PROTECT/DEEP array to be locked and stay locked as the key...
         // and then have a lightweight hash of it.  Review if needed.
         //
-        fail (Error_Has_Bad_Type_Core(val, specifier));
+        fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     case REB_DATATYPE:
         name = Get_Sym_Name(VAL_TYPE_SYM(val));
@@ -282,7 +282,7 @@ REBCNT Hash_Value(const RELVAL *val, REBCTX *specifier)
         //
         // !!! Why not?
         //
-        fail (Error_Has_Bad_Type_Core(val, specifier));
+        fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     case REB_WORD:
     case REB_SET_WORD:
@@ -341,7 +341,7 @@ REBCNT Hash_Value(const RELVAL *val, REBCTX *specifier)
         //
         // !!! Review hashing behavior or needs of these types if necessary.
         //
-        fail (Error_Has_Bad_Type_Core(val, specifier));
+        fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     default:
         assert(FALSE); // the list above should be comprehensive

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -406,7 +406,7 @@ REBSER *Hash_Block(const REBVAL *block, REBCNT skip, REBOOL cased)
     REBSER *hashlist;
     REBCNT *hashes;
     REBARR *array = VAL_ARRAY(block);
-    REBVAL *value;
+    RELVAL *value;
 
     // Create the hash array (integer indexes):
     hashlist = Make_Hash_Sequence(VAL_LEN_AT(block));

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -181,7 +181,7 @@ static void Make_CRC32_Table(void);
 // 
 // Fails if datatype cannot be hashed.
 //
-REBCNT Hash_Value(const REBVAL *val)
+REBCNT Hash_Value(const RELVAL *val, REBCTX *specifier)
 {
     REBCNT ret;
     const REBYTE *name;
@@ -266,7 +266,7 @@ REBCNT Hash_Value(const REBVAL *val)
         // a PROTECT/DEEP array to be locked and stay locked as the key...
         // and then have a lightweight hash of it.  Review if needed.
         //
-        fail (Error_Has_Bad_Type(val));
+        fail (Error_Has_Bad_Type_Core(val, specifier));
 
     case REB_DATATYPE:
         name = Get_Sym_Name(VAL_TYPE_SYM(val));
@@ -282,7 +282,7 @@ REBCNT Hash_Value(const REBVAL *val)
         //
         // !!! Why not?
         //
-        fail (Error_Has_Bad_Type(val));
+        fail (Error_Has_Bad_Type_Core(val, specifier));
 
     case REB_WORD:
     case REB_SET_WORD:
@@ -341,7 +341,7 @@ REBCNT Hash_Value(const REBVAL *val)
         //
         // !!! Review hashing behavior or needs of these types if necessary.
         //
-        fail (Error_Has_Bad_Type(val));
+        fail (Error_Has_Bad_Type_Core(val, specifier));
 
     default:
         assert(FALSE); // the list above should be comprehensive
@@ -420,7 +420,9 @@ REBSER *Hash_Block(const REBVAL *block, REBCNT skip, REBOOL cased)
     while (TRUE) {
         REBCNT skip_index = skip;
 
-        REBCNT hash = Find_Key_Hashed(array, hashlist, value, 1, cased, 0);
+        REBCNT hash = Find_Key_Hashed(
+            array, hashlist, value, VAL_SPECIFIER(block), 1, cased, 0
+        );
         hashes[hash] = (n / skip) + 1;
 
         while (skip_index != 0) {

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -40,7 +40,7 @@
 // 
 // Used for: Binary comparision function
 //
-REBINT Compare_Binary_Vals(const REBVAL *v1, const REBVAL *v2)
+REBINT Compare_Binary_Vals(const RELVAL *v1, const RELVAL *v2)
 {
     REBCNT l1 = VAL_LEN_AT(v1);
     REBCNT l2 = VAL_LEN_AT(v2);

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -589,7 +589,7 @@ REBSER *Append_UTF8_May_Fail(REBSER *dst, const REBYTE *src, REBINT len)
 REBSER *Join_Binary(const REBVAL *blk, REBINT limit)
 {
     REBSER *series = BYTE_BUF;
-    REBVAL *val;
+    RELVAL *val;
     REBCNT tail = 0;
     REBCNT len;
     REBCNT bl;
@@ -604,7 +604,7 @@ REBSER *Join_Binary(const REBVAL *blk, REBINT limit)
 
         case REB_INTEGER:
             if (VAL_INT64(val) > cast(i64, 255) || VAL_INT64(val) < 0)
-                fail (Error_Out_Of_Range(val));
+                fail (Error_Out_Of_Range(KNOWN(val)));
             EXPAND_SERIES_TAIL(series, 1);
             *BIN_AT(series, tail) = (REBYTE)VAL_INT32(val);
             break;
@@ -645,7 +645,7 @@ REBSER *Join_Binary(const REBVAL *blk, REBINT limit)
             break;
 
         default:
-            fail (Error_Invalid_Arg(val));
+            fail (Error_Invalid_Arg_Core(val, VAL_SPECIFIER(blk)));
         }
 
         tail = SER_LEN(series);

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1086,7 +1086,7 @@ static void Mold_Error(const REBVAL *value, REB_MOLD *mold, REBOOL molded)
 // 
 // Mold or form any value to string series tail.
 //
-void Mold_Value(REB_MOLD *mold, const REBVAL *value, REBOOL molded)
+void Mold_Value_Core(REB_MOLD *mold, const RELVAL *value, REBOOL molded)
 {
     REBYTE buf[60];
     REBINT len;

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1456,8 +1456,12 @@ REBSER *Copy_Mold_Value(const REBVAL *value, REBFLGS opts)
 // 
 // Reduce a block and then form each value into a string REBVAL.
 //
-REBOOL Form_Reduce_Throws(REBVAL *out, REBARR *block, REBCNT index)
-{
+REBOOL Form_Reduce_Throws(
+    REBVAL *out,
+    REBARR *block,
+    REBCNT index,
+    REBCTX *specifier
+) {
     REBIXO indexor = index;
 
     REB_MOLD mo;
@@ -1466,7 +1470,7 @@ REBOOL Form_Reduce_Throws(REBVAL *out, REBARR *block, REBCNT index)
     Push_Mold(&mo);
 
     while (indexor != END_FLAG) {
-        DO_NEXT_MAY_THROW(indexor, out, block, indexor);
+        DO_NEXT_MAY_THROW(indexor, out, block, indexor, specifier);
         if (indexor == THROWN_FLAG)
             return TRUE;
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -619,7 +619,7 @@ void Mold_Array_At(
     // managed value, and the incoming series may be from an unmanaged source
     // !!! Review how to avoid needing to put the series into a value
     VAL_RESET_HEADER(value, REB_BLOCK);
-    INIT_VAL_ARRAY(value, array);
+    INIT_VAL_ARRAY(value, array); // copies args
     VAL_INDEX(value) = 0;
 
     if (sep[1]) {

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1470,7 +1470,7 @@ check_and_return:
 // 
 // Form a value based on the mold opts provided.
 //
-REBSER *Copy_Form_Value(const REBVAL *value, REBFLGS opts)
+REBSER *Copy_Form_Value_Core(const RELVAL *value, REBFLGS opts)
 {
     REB_MOLD mo;
     CLEARS(&mo);

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -849,5 +849,5 @@ REBARR *Split_Lines(REBVAL *val)
         SET_VAL_FLAG(val, VALUE_FLAG_LINE);
     }
 
-    return Copy_Array_Shallow(array);
+    return Copy_Array_Shallow(array, SPECIFIED); // no relative values
 }

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -109,7 +109,7 @@ REBOOL MT_Bitset(
 
         {
             REBVAL specific;
-            COPY_RELVAL(&specific, data, specifier);
+            COPY_VALUE(&specific, data, specifier);
             Set_Bits(ser, &specific, TRUE);
         }
 
@@ -119,7 +119,7 @@ REBOOL MT_Bitset(
 
     if (!IS_BINARY(data)) return FALSE;
 
-    Val_Init_Bitset(out, Copy_Sequence_At_Position(data));
+    Val_Init_Bitset(out, Copy_Sequence_At_Position(KNOWN(data)));
     INIT_BITS_NOT(VAL_SERIES(out), FALSE);
     return TRUE;
 }

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -468,7 +468,7 @@ scan_bits:
 
         default: {
             REBVAL specific;
-            COPY_RELVAL(&specific, item, VAL_SPECIFIER(val));
+            COPY_VALUE(&specific, item, VAL_SPECIFIER(val));
             fail (Error_Has_Bad_Type(&specific));
         }
         }

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -45,7 +45,7 @@ static inline void INIT_BITS_NOT(REBSER *s, REBOOL negated) {
 //
 //  CT_Bitset: C
 //
-REBINT CT_Bitset(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Bitset(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0) return (
         BITS_NOT(VAL_SERIES(a)) == BITS_NOT(VAL_SERIES(b))

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -322,7 +322,8 @@ REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
         return TRUE;
     }
 
-    if (!ANY_ARRAY(val)) fail (Error_Has_Bad_Type(val));
+    if (!ANY_ARRAY(val))
+        fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     item = VAL_ARRAY_AT(val);
     if (NOT_END(item) && IS_SAME_WORD(item, SYM_NOT)) {
@@ -425,7 +426,8 @@ REBOOL Check_Bits(REBSER *bset, const REBVAL *val, REBOOL uncased)
     if (ANY_BINSTR(val))
         return Check_Bit_Str(bset, val, uncased);
 
-    if (!ANY_ARRAY(val)) fail (Error_Has_Bad_Type(val));
+    if (!ANY_ARRAY(val))
+        fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     // Loop through block of bit specs:
     for (item = VAL_ARRAY_AT(val); NOT_END(item); item++) {
@@ -477,11 +479,8 @@ scan_bits:
             if (Check_Bit_Str(bset, KNOWN(item), uncased)) goto found;
             break;
 
-        default: {
-            REBVAL specific;
-            COPY_VALUE(&specific, item, VAL_SPECIFIER(val));
-            fail (Error_Has_Bad_Type(&specific));
-        }
+        default:
+            fail (Error_Invalid_Type(VAL_TYPE(item)));
         }
     }
     return FALSE;

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -93,21 +93,32 @@ void Mold_Bitset(const REBVAL *value, REB_MOLD *mold)
 //
 //  MT_Bitset: C
 //
-REBOOL MT_Bitset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Bitset(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     REBOOL is_not = FALSE;
 
     if (IS_BLOCK(data)) {
         REBINT len = Find_Max_Bit(data);
         REBSER *ser;
-        if (len < 0 || len > 0xFFFFFF) fail (Error_Invalid_Arg(data));
+
+        if (len < 0 || len > 0xFFFFFF)
+            fail (Error_Invalid_Arg_Core(data, specifier));
+
         ser = Make_Bitset(len);
-        Set_Bits(ser, data, TRUE);
+
+        {
+            REBVAL specific;
+            COPY_RELVAL(&specific, data, specifier);
+            Set_Bits(ser, &specific, TRUE);
+        }
+
         Val_Init_Bitset(out, ser);
         return TRUE;
     }
 
     if (!IS_BINARY(data)) return FALSE;
+
     Val_Init_Bitset(out, Copy_Sequence_At_Position(data));
     INIT_BITS_NOT(VAL_SERIES(out), FALSE);
     return TRUE;

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -34,20 +34,21 @@
 //
 //  CT_Array: C
 // 
-// "Compare Type" dispatcher for the following types:
+// "Compare Type" dispatcher for the following types: (list here to help
+// text searches)
 // 
-//     CT_Block(REBVAL *a, REBVAL *b, REBINT mode)
-//     CT_Group(REBVAL *a, REBVAL *b, REBINT mode)
-//     CT_Path(REBVAL *a, REBVAL *b, REBINT mode)
-//     CT_Set_Path(REBVAL *a, REBVAL *b, REBINT mode)
-//     CT_Get_Path(REBVAL *a, REBVAL *b, REBINT mode)
-//     CT_Lit_Path(REBVAL *a, REBVAL *b, REBINT mode)
+//     CT_Block()
+//     CT_Group()
+//     CT_Path()
+//     CT_Set_Path()
+//     CT_Get_Path()
+//     CT_Lit_Path()
 //
-REBINT CT_Array(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Array(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT num;
 
-    num = Cmp_Block(a, b, LOGICAL(mode == 1));
+    num = Cmp_Array(a, b, LOGICAL(mode == 1));
     if (mode >= 0) return (num == 0);
     if (mode == -1) return (num >= 0);
     return (num > 0);

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -695,12 +695,12 @@ REBTYPE(Array)
         // make block! ...
         // to block! ...
         //
+        assert(IS_DATATYPE(value));
+
         if (
             Make_Block_Type_Throws(
                 value, // out
-                IS_DATATYPE(value)
-                    ? VAL_TYPE_KIND(value)
-                    : VAL_TYPE(value), // type
+                VAL_TYPE_KIND(value), // type
                 LOGICAL(action == A_MAKE), // make? (as opposed to to?)
                 arg // size, block to copy, or value to convert
             )

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -136,7 +136,7 @@ REBCNT Find_In_Array(
     REBARR *array,
     REBCNT index,
     REBCNT end,
-    const REBVAL *target,
+    const RELVAL *target,
     REBCNT len,
     REBCNT flags,
     REBINT skip

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -228,7 +228,9 @@ REBOOL Make_Block_Type_Throws(
         len = VAL_ARRAY_LEN_AT(arg);
         if (len > 0 && type >= REB_PATH && type <= REB_LIT_PATH)
             No_Nones(arg);
-        array = Copy_Values_Len_Shallow(VAL_ARRAY_AT(arg), len);
+        array = Copy_Values_Len_Shallow(
+            VAL_ARRAY_AT(arg), VAL_SPECIFIER(arg), len
+        );
         goto done;
     }
 
@@ -356,7 +358,7 @@ REBOOL Make_Block_Type_Throws(
         fail (Error_Invalid_Arg(arg));
     }
 
-    array = Copy_Values_Len_Shallow(arg, 1);
+    array = Copy_Values_Len_Shallow(arg, SPECIFIED, 1); // REBVAL, known
 
 done:
     Val_Init_Array(out, type, array);
@@ -778,7 +780,7 @@ pick_using_arg:
             *D_OUT = ARR_HEAD(array)[index];
         else
             Val_Init_Block(
-                D_OUT, Copy_Array_At_Max_Shallow(array, index, len)
+                D_OUT, Copy_Array_At_Max_Shallow(array, index, GUESSED, len)
             );
         Remove_Series(ARR_SERIES(array), index, len);
         return R_OUT;
@@ -895,6 +897,7 @@ pick_using_arg:
         copy = Copy_Array_Core_Managed(
             array,
             VAL_INDEX(value), // at
+            GUESSED,
             VAL_INDEX(value) + Partial1(value, ARG(limit)), // tail
             0, // extra
             REF(deep), // deep

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -236,7 +236,8 @@ REBOOL Make_Block_Type_Throws(
 
     if (IS_STRING(arg)) {
         REBCNT index, len = 0;
-        INIT_VAL_SERIES(arg, Temp_Bin_Str_Managed(arg, &index, &len));
+        REBSER *temp = Temp_Bin_Str_Managed(arg, &index, &len);
+        INIT_VAL_SERIES(arg, temp); // caution: macro copies args!
         array = Scan_Source(VAL_BIN(arg), VAL_LEN_AT(arg));
         goto done;
     }

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -34,7 +34,7 @@
 //
 //  CT_Char: C
 //
-REBINT CT_Char(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Char(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT num;
 

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -81,7 +81,7 @@ REBTYPE(Datatype)
             REBVAL *var;
             REBVAL *key;
 
-            REBVAL *value;
+            RELVAL *value;
 
             REBCTX *context = Copy_Context_Shallow(
                 VAL_CONTEXT(Get_System(SYS_STANDARD, STD_TYPE_SPEC))
@@ -105,7 +105,12 @@ REBTYPE(Datatype)
 
             for (; NOT_END(var); ++var, ++key) {
                 if (IS_END(value)) SET_BLANK(var);
-                else *var = *value++;
+                else {
+                    // typespec array does not contain relative values
+                    //
+                    COPY_VALUE(var, value, SPECIFIED);
+                    ++value;
+                }
             }
 
             Val_Init_Object(D_OUT, context);

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -34,7 +34,7 @@
 //
 //  CT_Datatype: C
 //
-REBINT CT_Datatype(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Datatype(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0) return (VAL_TYPE_KIND(a) == VAL_TYPE_KIND(b));
     return -1;

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -44,8 +44,9 @@ REBINT CT_Datatype(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MT_Datatype: C
 //
-REBOOL MT_Datatype(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Datatype(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     REBSYM sym;
     if (!IS_WORD(data)) return FALSE;
     sym = VAL_WORD_CANON(data);
@@ -122,7 +123,7 @@ REBTYPE(Datatype)
     case A_MAKE:
     case A_TO:
         assert(kind == REB_DATATYPE);
-        if (MT_Datatype(D_OUT, arg, REB_DATATYPE))
+        if (MT_Datatype(D_OUT, arg, SPECIFIED, REB_DATATYPE))
             break;
 
         fail (Error_Bad_Make(REB_DATATYPE, arg));

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -116,13 +116,7 @@ REBTYPE(Datatype)
 
     case A_MAKE:
     case A_TO:
-        if (kind != REB_DATATYPE) {
-            act = Value_Dispatch[TO_0_FROM_KIND(kind)];
-            if (act) return act(frame_, action);
-            //return R_BLANK;
-            fail (Error_Bad_Make(kind, arg));
-        }
-        // if (IS_BLANK(arg)) return R_BLANK;
+        assert(kind == REB_DATATYPE);
         if (MT_Datatype(D_OUT, arg, REB_DATATYPE))
             break;
 

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -72,7 +72,7 @@ void Set_Date(REBVAL *val, REBOL_DAT *dat)
 //
 //  CT_Date: C
 //
-REBINT CT_Date(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Date(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT num = Cmp_Date(a, b);
     if (mode == 1)
@@ -390,7 +390,7 @@ void Subtract_Date(REBVAL *d1, REBVAL *d2, REBVAL *result)
 //
 //  Cmp_Date: C
 //
-REBINT Cmp_Date(const REBVAL *d1, const REBVAL *d2)
+REBINT Cmp_Date(const RELVAL *d1, const RELVAL *d2)
 {
     REBINT diff;
 

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -415,7 +415,7 @@ REBOOL MT_Date(
     REBCNT year, month, day;
 
     if (IS_DATE(arg)) {
-        COPY_RELVAL(val, arg, specifier);
+        COPY_VALUE(val, arg, specifier);
         return TRUE;
     }
 

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -475,7 +475,7 @@ REBOOL MT_Date(REBVAL *val, REBVAL *arg, enum Reb_Kind type)
 REBINT PD_Date(REBPVS *pvs)
 {
     const REBVAL *sel = pvs->selector;
-    REBVAL *value = pvs->value;
+    REBVAL *value = KNOWN(pvs->value);
     const REBVAL *setval;
 
     REBINT i;
@@ -536,8 +536,8 @@ REBINT PD_Date(REBPVS *pvs)
         // not aleady adusted.
         //
         REBVAL *store = pvs->store;
-        if (pvs->value != store)
-            *store = *pvs->value;
+        if (value != store)
+            *store = *value;
 
         if (i != 8) Adjust_Date_Zone(store, FALSE);
 
@@ -688,7 +688,7 @@ REBINT PD_Date(REBPVS *pvs)
         VAL_RESET_HEADER(pvs->value, REB_DATE);
         VAL_DATE(pvs->value) = date;
         VAL_TIME(pvs->value) = secs;
-        Adjust_Date_Zone(pvs->value, TRUE);
+        Adjust_Date_Zone(KNOWN(pvs->value), TRUE);
 
         return PE_OK;
     }

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -168,7 +168,7 @@ REBOOL Eq_Decimal2(REBDEC a, REBDEC b)
 //
 //  CT_Decimal: C
 //
-REBINT CT_Decimal(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Decimal(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0) {
         if (mode == 0)
@@ -510,10 +510,10 @@ setDec:
 //
 //  VAL_DECIMAL_Ptr_Debug: C
 //
-REBDEC *VAL_DECIMAL_Ptr_Debug(const REBVAL *value)
+REBDEC *VAL_DECIMAL_Ptr_Debug(const RELVAL *value)
 {
     assert(IS_DECIMAL(value) || IS_PERCENT(value));
-    return &m_cast(REBVAL*, value)->payload.decimal.dec;
+    return &m_cast(REBVAL*, const_KNOWN(value))->payload.decimal.dec;
 }
 
 #endif

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -414,7 +414,7 @@ REBTYPE(Decimal)
                         d1 = VAL_DECIMAL(item);
                     else {
                         REBVAL specific;
-                        COPY_RELVAL(&specific, item, VAL_SPECIFIER(val));
+                        COPY_VALUE(&specific, item, VAL_SPECIFIER(val));
                         fail (Error_Bad_Make(REB_DECIMAL, &specific));
                     }
 
@@ -426,7 +426,7 @@ REBTYPE(Decimal)
                         exp = VAL_DECIMAL(item);
                     else {
                         REBVAL specific;
-                        COPY_RELVAL(&specific, item, VAL_SPECIFIER(val));
+                        COPY_VALUE(&specific, item, VAL_SPECIFIER(val));
                         fail (Error_Bad_Make(REB_DECIMAL, &specific));
                     }
 

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -189,7 +189,7 @@ static void Set_Event_Vars(REBVAL *evt, RELVAL *blk, REBCTX *specifier)
 {
     while (NOT_END(blk)) {
         REBVAL var;
-        COPY_RELVAL(&var, blk, specifier);
+        COPY_VALUE(&var, blk, specifier);
         ++blk;
 
         REBVAL val;
@@ -221,7 +221,7 @@ static REBOOL Get_Event_Var(const REBVAL *value, REBSYM sym, REBVAL *val)
         if (VAL_EVENT_TYPE(value) == 0) goto is_blank;
         arg = Get_System(SYS_VIEW, VIEW_EVENT_TYPES);
         if (IS_BLOCK(arg) && VAL_LEN_HEAD(arg) >= EVT_MAX) {
-            COPY_RELVAL(
+            COPY_VALUE(
                 val,
                 VAL_ARRAY_AT_HEAD(arg, VAL_EVENT_TYPE(value)),
                 VAL_SPECIFIER(arg)
@@ -281,7 +281,7 @@ static REBOOL Get_Event_Var(const REBVAL *value, REBSYM sym, REBVAL *val)
             arg = Get_System(SYS_VIEW, VIEW_EVENT_KEYS);
             n = (n >> 16) - 1;
             if (IS_BLOCK(arg) && n < cast(REBINT, VAL_LEN_HEAD(arg))) {
-                COPY_RELVAL(
+                COPY_VALUE(
                     val,
                     VAL_ARRAY_AT_HEAD(arg, n),
                     VAL_SPECIFIER(arg)

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -40,7 +40,7 @@
 //
 //  CT_Event: C
 //
-REBINT CT_Event(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Event(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT diff = Cmp_Event(a, b);
     if (mode >=0) return diff == 0;
@@ -53,7 +53,7 @@ REBINT CT_Event(const REBVAL *a, const REBVAL *b, REBINT mode)
 // 
 // Given two events, compare them.
 //
-REBINT Cmp_Event(const REBVAL *t1, const REBVAL *t2)
+REBINT Cmp_Event(const RELVAL *t1, const RELVAL *t2)
 {
     REBINT  diff;
 

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -198,7 +198,7 @@ static void Set_Event_Vars(REBVAL *evt, REBVAL *blk)
         if (IS_END(val))
             val = BLANK_VALUE;
         else {
-            Get_Simple_Value_Into(&safe, val);
+            Get_Simple_Value_Into(&safe, val, GUESSED);
             val = &safe;
         }
         if (!Set_Event_Var(evt, var, val))

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -55,7 +55,7 @@ static REBOOL Same_Func(const REBVAL *val, const REBVAL *arg)
 //
 //  CT_Function: C
 //
-REBINT CT_Function(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Function(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0) return Same_Func(a, b) ? 1 : 0;
     return -1;

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -176,7 +176,7 @@ REBTYPE(Function)
 
                 REBOOL is_fake;
                 REBARR *body = Get_Maybe_Fake_Func_Body(&is_fake, value);
-                Val_Init_Block(D_OUT, Copy_Array_Deep_Managed(body));
+                Val_Init_Block(D_OUT, Copy_Array_Deep_Managed(body, SPECIFIED));
 
                 if (IS_FUNC_DURABLE(value)) {
                     // See #2221 for why durable body copies unbind locals
@@ -197,7 +197,7 @@ REBTYPE(Function)
                 D_OUT,
                 REB_BLOCK,
                 Copy_Array_Deep_Managed(
-                    VAL_ARRAY(VAL_FUNC_BODY(value))
+                    VAL_ARRAY(VAL_FUNC_BODY(value)), SPECIFIED
                 )
             );
             return R_OUT;

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -98,14 +98,14 @@ REBOOL MT_Function(
     if (!IS_BLOCK(def)) return FALSE;
     if (VAL_LEN_AT(def) != 2) return FALSE;
 
-    COPY_RELVAL(
+    COPY_VALUE(
         &spec,
         VAL_ARRAY_AT_HEAD(def, 0),
         IS_SPECIFIC(def) ? VAL_SPECIFIER(KNOWN(def)) : specifier
     );
     if (!IS_BLOCK(&spec)) return FALSE;
 
-    COPY_RELVAL(
+    COPY_VALUE(
         &body,
         VAL_ARRAY_AT_HEAD(def, 1),
         IS_SPECIFIC(def) ? VAL_SPECIFIER(KNOWN(def)) : specifier

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -176,7 +176,7 @@ static void Insert_Gobs(REBGOB *gob, const REBVAL *arg, REBCNT index, REBCNT len
     sarg = arg;
     for (n = count = 0; n < len; n++, val++) {
         val = arg++;
-        if (IS_WORD(val)) val = GET_OPT_VAR_MAY_FAIL(val);
+        if (IS_WORD(val)) val = GET_OPT_VAR_MAY_FAIL(val, GUESSED);
         if (IS_GOB(val)) {
             count++;
             if (GOB_PARENT(VAL_GOB(val))) {
@@ -223,7 +223,7 @@ static void Insert_Gobs(REBGOB *gob, const REBVAL *arg, REBCNT index, REBCNT len
     ptr = GOB_AT(gob, index);
     for (n = 0; n < len; n++) {
         val = arg++;
-        if (IS_WORD(val)) val = GET_OPT_VAR_MAY_FAIL(val);
+        if (IS_WORD(val)) val = GET_OPT_VAR_MAY_FAIL(val, GUESSED);
         if (IS_GOB(val)) {
             // !!! Temporary error of some kind (supposed to trap, not panic?)
             if (GOB_PARENT(VAL_GOB(val))) fail (Error(RE_MISC));
@@ -603,7 +603,7 @@ static void Set_GOB_Vars(REBGOB *gob, const REBVAL *blk)
             fail (Error(RE_NEED_VALUE, var));
 
         REBVAL safe;
-        Get_Simple_Value_Into(&safe, val);
+        Get_Simple_Value_Into(&safe, val, GUESSED);
         if (!Set_GOB_Var(gob, var, &safe))
             fail (Error(RE_BAD_FIELD_SET, var, Type_Of(val)));
     }

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -54,7 +54,7 @@ const REBCNT Gob_Flag_Words[] = {
 //
 //  CT_Gob: C
 //
-REBINT CT_Gob(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Gob(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0)
         return VAL_GOB(a) == VAL_GOB(b) && VAL_GOB_INDEX(a) == VAL_GOB_INDEX(b);
@@ -82,7 +82,7 @@ REBGOB *Make_Gob(void)
 //
 //  Cmp_Gob: C
 //
-REBINT Cmp_Gob(const REBVAL *g1, const REBVAL *g2)
+REBINT Cmp_Gob(const RELVAL *g1, const RELVAL *g2)
 {
     REBINT n;
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -719,6 +719,7 @@ REBINT PD_Gob(REBPVS *pvs)
                 PUSH_GUARD_VALUE(&sel_orig);
 
                 pvs->value = pvs->store;
+                pvs->value_specifier = SPECIFIED;
 
                 if (Next_Path_Throws(pvs)) { // sets value in pvs->store
                     DROP_GUARD_VALUE(&sel_orig);

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -613,7 +613,7 @@ static void Set_GOB_Vars(REBGOB *gob, const RELVAL *blk, REBCTX *specifier)
         assert(!IS_VOID(blk));
 
         REBVAL var;
-        COPY_RELVAL(&var, blk, specifier);
+        COPY_VALUE(&var, blk, specifier);
         ++blk;
 
         if (!IS_SET_WORD(&var))
@@ -625,7 +625,7 @@ static void Set_GOB_Vars(REBGOB *gob, const RELVAL *blk, REBCTX *specifier)
         assert(!IS_VOID(blk));
 
         REBVAL val;
-        COPY_RELVAL(&val, blk, specifier);
+        COPY_VALUE(&val, blk, specifier);
         ++blk;
 
         if (IS_SET_WORD(&val))
@@ -888,7 +888,7 @@ REBTYPE(Gob)
             len = VAL_ARRAY_LEN_AT(arg);
             arg = KNOWN(VAL_ARRAY_AT(arg)); // !!! REVIEW
         }
-        else goto is_arg_error;;
+        else goto is_arg_error;
         Insert_Gobs(gob, arg, index, len, FALSE);
         break;
 

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -42,7 +42,7 @@
 //
 //  CT_Image: C
 //
-REBINT CT_Image(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Image(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode < 0)
         return -1;

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -274,7 +274,7 @@ void Bin_To_Alpha(REBYTE *rgba, REBCNT size, REBYTE *bin, REBINT len)
 // TRUE and `index_out` will contain the index position from the head of
 // the array of the non-tuple.  Otherwise returns FALSE.
 //
-REBOOL Array_Has_Non_Tuple(REBCNT *index_out, REBVAL *blk)
+REBOOL Array_Has_Non_Tuple(REBCNT *index_out, RELVAL *blk)
 {
     REBCNT len;
 
@@ -479,7 +479,7 @@ REBVAL *Create_Image(RELVAL *block, REBCTX *specifier, REBVAL *val, REBCNT modes
         }
 
         if (NOT_END(block) && IS_INTEGER(block)) {
-            VAL_INDEX(val) = (Int32s(block, 1) - 1);
+            VAL_INDEX(val) = (Int32s(KNOWN(block), 1) - 1);
             block++;
         }
     }
@@ -496,7 +496,10 @@ REBVAL *Create_Image(RELVAL *block, REBCTX *specifier, REBVAL *val, REBCNT modes
         REBCNT bad_index;
         if (Array_Has_Non_Tuple(&bad_index, block))
             fail (Error_Invalid_Arg_Core(
-                VAL_ARRAY_AT_HEAD(block, bad_index), VAL_SPECIFIER(block)
+                VAL_ARRAY_AT_HEAD(block, bad_index),
+                IS_SPECIFIC(block)
+                    ? VAL_SPECIFIER(KNOWN(block))
+                    : specifier
             ));
 
         Tuples_To_RGBA(ip, size, KNOWN(VAL_ARRAY_AT(block)), VAL_LEN_AT(block));

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -575,7 +575,7 @@ REBVAL *Modify_Image(struct Reb_Frame *frame_, REBCNT action)
             if (dupx == 0 || dupy == 0) return value;
         }
         else
-            fail (Error_Has_Bad_Type(count));
+            fail (Error_Invalid_Type(VAL_TYPE(count)));
     }
 
     // Get the /part refinement. Only allowed when arg is a series.
@@ -613,7 +613,7 @@ REBVAL *Modify_Image(struct Reb_Frame *frame_, REBCNT action)
                 if (partx == 0 || party == 0) return value;
             }
             else
-                fail (Error_Has_Bad_Type(len));
+                fail (Error_Invalid_Type(VAL_TYPE(len)));
         }
         else
             fail (Error_Invalid_Arg(arg)); // /part not allowed
@@ -633,7 +633,7 @@ REBVAL *Modify_Image(struct Reb_Frame *frame_, REBCNT action)
             part = VAL_LEN_AT(arg);
         }
         else if (!IS_INTEGER(arg) && !IS_TUPLE(arg))
-            fail (Error_Has_Bad_Type(arg));
+            fail (Error_Invalid_Type(VAL_TYPE(arg)));
     }
 
     // Expand image data if necessary:
@@ -682,7 +682,7 @@ REBVAL *Modify_Image(struct Reb_Frame *frame_, REBCNT action)
             Tuples_To_RGBA(ip, part, KNOWN(VAL_ARRAY_AT(arg)), part);
     }
     else
-        fail (Error_Has_Bad_Type(arg));
+        fail (Error_Invalid_Type(VAL_TYPE(arg)));
 
     Reset_Height(value);
 
@@ -746,7 +746,7 @@ REBVAL *Find_Image(struct Reb_Frame *frame_)
         p = 0;
     }
     else
-        fail (Error_Has_Bad_Type(arg));
+        fail (Error_Invalid_Type(VAL_TYPE(arg)));
 
     // Post process the search (failure or apply /match and /tail):
     if (p) {
@@ -994,7 +994,7 @@ REBTYPE(Image)
                 len = VAL_INDEX(val) - VAL_INDEX(value); // may not be same, is ok
             }
             else
-                fail (Error_Has_Bad_Type(val));
+                fail (Error_Invalid_Type(VAL_TYPE(val)));
         }
         else len = 1;
 
@@ -1044,7 +1044,7 @@ REBTYPE(Image)
             );
             break;
         }
-        fail (Error_Has_Bad_Type(arg));
+        fail (Error_Invalid_Type(VAL_TYPE(arg)));
 
     case A_MAKE:
         // make image! img
@@ -1075,7 +1075,7 @@ REBTYPE(Image)
         else if (IS_BLOCK(arg)) {
             if (Create_Image(VAL_ARRAY_AT(arg), VAL_SPECIFIER(arg), value, 0)) break;
         }
-        fail (Error_Has_Bad_Type(arg));
+        fail (Error_Invalid_Type(VAL_TYPE(arg)));
 
     case A_COPY:  // copy series /part len
         if (!D_REF(2)) {
@@ -1115,7 +1115,7 @@ REBTYPE(Image)
 //          VAL_IMAGE_TRANSP(D_OUT) = VAL_IMAGE_TRANSP(value);
             return R_OUT;
         }
-        fail (Error_Has_Bad_Type(arg));
+        fail (Error_Invalid_Type(VAL_TYPE(arg)));
 
 makeCopy:
         // Src image is arg.

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -36,7 +36,7 @@
 //
 //  CT_Integer: C
 //
-REBINT CT_Integer(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Integer(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0)  return (VAL_INT64(a) == VAL_INT64(b));
     if (mode == -1) return (VAL_INT64(a) >= VAL_INT64(b));
@@ -498,10 +498,10 @@ REBTYPE(Integer)
 //
 //  VAL_INT64_Ptr_Debug: C
 //
-REBI64 *VAL_INT64_Ptr_Debug(const REBVAL *value)
+REBI64 *VAL_INT64_Ptr_Debug(const RELVAL *value)
 {
     assert(IS_INTEGER(value));
-    return &m_cast(REBVAL*, value)->payload.integer.i64;
+    return &m_cast(REBVAL*, const_KNOWN(value))->payload.integer.i64;
 }
 
 #endif

--- a/src/core/t-library.c
+++ b/src/core/t-library.c
@@ -37,7 +37,7 @@
 //
 //  CT_Library: C
 //
-REBINT CT_Library(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Library(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     //RL_Print("%s, %d\n", __func__, __LINE__);
     if (mode >= 0) {

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -51,8 +51,9 @@ REBINT CT_Logic(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MT_Logic: C
 //
-REBOOL MT_Logic(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Logic(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     if (!IS_INTEGER(data)) return FALSE;
     SET_LOGIC(out, VAL_INT64(data) != 0);
     return TRUE;

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -41,7 +41,7 @@
 //
 //  CT_Logic: C
 //
-REBINT CT_Logic(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Logic(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0)  return (VAL_LOGIC(a) == VAL_LOGIC(b));
     return -1;

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -57,10 +57,10 @@
 //
 //  CT_Map: C
 //
-REBINT CT_Map(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Map(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode < 0) return -1;
-    return 0 == Cmp_Block(a, b, FALSE);
+    return 0 == Cmp_Array(a, b, FALSE);
 }
 
 
@@ -98,7 +98,7 @@ static REBMAP *Make_Map(REBCNT capacity)
 REBINT Find_Key_Hashed(
     REBARR *array,
     REBSER *hashlist,
-    const REBVAL *key,
+    const RELVAL *key,
     REBINT wide,
     REBOOL cased,
     REBYTE mode
@@ -111,7 +111,7 @@ REBINT Find_Key_Hashed(
     REBCNT uncased;
     REBCNT len;
     REBCNT n;
-    REBVAL *val;
+    RELVAL *val;
 
     // Compute hash for value:
     len = SER_LEN(hashlist);

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -317,7 +317,7 @@ static REBCNT Find_Map_Entry(
 
     // Must set the value:
     if (n) {  // re-set it:
-        COPY_RELVAL(ARR_AT(pairlist, ((n - 1) * 2) + 1), val, val_specifier);
+        COPY_VALUE(ARR_AT(pairlist, ((n - 1) * 2) + 1), val, val_specifier);
         return n;
     }
 
@@ -405,7 +405,7 @@ static void Append_Map(
     REBCTX *specifier,
     REBCNT len
 ) {
-    REBVAL *item = ARR_AT(array, index);
+    RELVAL *item = ARR_AT(array, index);
     REBCNT n = 0;
 
     while (n < len && NOT_END(item)) {
@@ -490,7 +490,7 @@ REBARR *Map_To_Array(REBMAP *map, REBINT what)
     REBVAL *val;
     REBCNT cnt = 0;
     REBARR *array;
-    REBVAL *out;
+    REBVAL *dest;
 
     // Count number of set entries:
     //
@@ -502,17 +502,17 @@ REBARR *Map_To_Array(REBMAP *map, REBINT what)
     // Copy entries to new block:
     //
     array = Make_Array(cnt * ((what == 0) ? 2 : 1));
-    out = SINK(ARR_HEAD(array));
+    dest = SINK(ARR_HEAD(array));
     val = KNOWN(ARR_HEAD(MAP_PAIRLIST(map)));
     for (; NOT_END(val) && NOT_END(val+1); val += 2) {
-        if (!IS_BLANK(val+1)) {
-            if (what <= 0) *out++ = val[0];
-            if (what >= 0) *out++ = val[1];
+        if (!IS_BLANK(val + 1)) {
+            if (what <= 0) *dest++ = val[0];
+            if (what >= 0) *dest++ = val[1];
         }
     }
 
-    SET_END(out);
-    SET_ARRAY_LEN(array, out - ARR_HEAD(array));
+    SET_END(dest);
+    SET_ARRAY_LEN(array, cast(RELVAL*, dest) - ARR_HEAD(array));
     return array;
 }
 

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -363,12 +363,16 @@ REBINT PD_Map(REBPVS *pvs)
     if (n == 0)
         val = VOID_CELL;
     else
-        val = ARR_AT(MAP_PAIRLIST(VAL_MAP(pvs->value)), ((n - 1) * 2) + 1);
+        val = KNOWN(
+            ARR_AT(MAP_PAIRLIST(VAL_MAP(pvs->value)), ((n - 1) * 2) + 1)
+        );
 
     if (IS_VOID(val))
         return PE_NONE;
 
     pvs->value = val;
+    pvs->value_specifier = SPECIFIED;
+
     return PE_OK;
 }
 
@@ -585,9 +589,8 @@ REBTYPE(Map)
     switch (action) {
 
     case A_PICK:
-        val = Pick_Block(val, arg);
-        if (!val) return R_BLANK;
-        *D_OUT = *val;
+        Pick_Block(D_OUT, val, arg);
+        if (IS_VOID(D_OUT)) return R_BLANK;
         return R_OUT;
 
     case A_FIND:

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -35,7 +35,7 @@
 //
 //  CT_Money: C
 //
-REBINT CT_Money(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Money(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBOOL e, g;
 

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -33,7 +33,7 @@
 //
 //  CT_Unit: C
 //
-REBINT CT_Unit(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Unit(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0) return (VAL_TYPE(a) == VAL_TYPE(b));
     return -1;

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -43,8 +43,9 @@ REBINT CT_Unit(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MT_Unit: C
 //
-REBOOL MT_Unit(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Unit(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     VAL_RESET_HEADER(out, type);
     return TRUE;
 }
@@ -59,7 +60,7 @@ REBTYPE(Unit)
 
     if (action == A_MAKE || action == A_TO) {
         assert(IS_DATATYPE(val) && VAL_TYPE_KIND(val) != REB_0);
-        if (!MT_Unit(D_OUT, NULL, VAL_TYPE_KIND(val)))
+        if (!MT_Unit(D_OUT, NULL, SPECIFIED, VAL_TYPE_KIND(val)))
             assert(FALSE);
         return R_OUT;
     }

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -282,7 +282,9 @@ REBOOL MT_Context(REBVAL *out, REBVAL *data, enum Reb_Kind type)
     REBCTX *context;
     if (!IS_BLOCK(data)) return FALSE;
 
-    context = Construct_Context(type, VAL_ARRAY_AT(data), FALSE, NULL);
+    context = Construct_Context(
+        type, VAL_ARRAY_AT(data), VAL_SPECIFIER(data), FALSE, NULL
+    );
 
     Val_Init_Context(out, type, context);
 
@@ -644,7 +646,7 @@ REBTYPE(Context)
             else types |= VAL_TYPESET_BITS(arg);
         }
         context = AS_CONTEXT(
-            Copy_Array_Shallow(CTX_VARLIST(VAL_CONTEXT(value)))
+            Copy_Array_Shallow(CTX_VARLIST(VAL_CONTEXT(value)), SPECIFIED)
         );
         INIT_CTX_KEYLIST_SHARED(context, CTX_KEYLIST(VAL_CONTEXT(value)));
         SET_ARR_FLAG(CTX_VARLIST(context), ARRAY_FLAG_CONTEXT_VARLIST);
@@ -652,6 +654,7 @@ REBTYPE(Context)
         if (types != 0) {
             Clonify_Values_Len_Managed(
                 CTX_VARS_HEAD(context),
+                SPECIFIED,
                 CTX_LEN(context),
                 D_REF(ARG_COPY_DEEP),
                 types

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -210,7 +210,7 @@ static void Append_To_Context(REBCTX *context, REBVAL *arg)
         if (IS_END(word + 1))
             SET_BLANK(var);
         else
-            COPY_RELVAL(var, &word[1], VAL_SPECIFIER(arg));
+            COPY_VALUE(var, &word[1], VAL_SPECIFIER(arg));
 
         if (IS_END(word + 1)) break; // fix bug#708
     }

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -336,6 +336,8 @@ REBINT PD_Context(REBPVS *pvs)
     }
 
     pvs->value = CTX_VAR(context, n);
+    pvs->value_specifier = SPECIFIED;
+
     return PE_SET_IF_END;
 }
 

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -267,7 +267,7 @@ static REBCTX *Trim_Context(REBCTX *context)
 //
 //  CT_Context: C
 //
-REBINT CT_Context(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Context(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode < 0) return -1;
     return Equal_Context(a, b) ? 1 : 0;

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -49,13 +49,14 @@ REBINT CT_Pair(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MT_Pair: C
 //
-REBOOL MT_Pair(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Pair(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     REBD32 x;
     REBD32 y;
 
     if (IS_PAIR(data)) {
-        *out = *data;
+        *out = *KNOWN(data);
         return TRUE;
     }
 
@@ -344,7 +345,7 @@ REBTYPE(Pair)
                 goto setPair;
             }
             if (ANY_ARRAY(val) && VAL_LEN_AT(val) <= 2) {
-                if (MT_Pair(D_OUT, val, REB_PAIR))
+                if (MT_Pair(D_OUT, val, SPECIFIED, REB_PAIR))
                     return R_OUT;
             }
 

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -34,7 +34,7 @@
 //
 //  CT_Pair: C
 //
-REBINT CT_Pair(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Pair(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode >= 0) return Cmp_Pair(a, b) == 0; // works for INTEGER=0 too (spans x y)
     if (IS_PAIR(b) && 0 == VAL_INT64(b)) { // for negative? and positive?
@@ -87,7 +87,7 @@ REBOOL MT_Pair(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 // 
 // Given two pairs, compare them.
 //
-REBINT Cmp_Pair(const REBVAL *t1, const REBVAL *t2)
+REBINT Cmp_Pair(const RELVAL *t1, const RELVAL *t2)
 {
     REBD32  diff;
 

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -34,7 +34,7 @@
 //
 //  CT_Port: C
 //
-REBINT CT_Port(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Port(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode < 0) return -1;
     return VAL_CONTEXT(a) == VAL_CONTEXT(b);

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -44,8 +44,9 @@ REBINT CT_Port(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MT_Port: C
 //
-REBOOL MT_Port(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Port(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     return FALSE;
 }
 

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -856,7 +856,10 @@ void Call_Routine(REBROT *rot, REBARR *args, REBVAL *ret)
         // reset length
         SET_SERIES_LEN(ROUTINE_FFI_ARG_TYPES(rot), n_fixed + 1);
 
-        ROUTINE_ALL_ARGS(rot) = Copy_Array_Shallow(ROUTINE_FIXED_ARGS(rot));
+        ROUTINE_ALL_ARGS(rot) = Copy_Array_Shallow(
+            ROUTINE_FIXED_ARGS(rot), SPECIFIED
+        );
+
         MANAGE_ARRAY(ROUTINE_ALL_ARGS(rot));
 
         for (i = 1, j = 1; i < VAL_LEN_HEAD(va_values) + 1; i ++, j ++) {
@@ -1103,7 +1106,7 @@ static void callback_dispatcher(
     }
 
     REBVAL safe;
-    if (Do_At_Throws(&safe, array, 0)) {
+    if (Do_At_Throws(&safe, array, 0, SPECIFIED)) {
         // !!! Does not check for thrown cases...what should this
         // do in case of THROW, BREAK, QUIT?
         fail (Error_No_Catch_For_Throw(&safe));
@@ -1284,7 +1287,10 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
             fail (Error_Unexpected_Type(REB_BLOCK, VAL_TYPE(&blk[0])));
 
         REBVAL lib;
-        DO_NEXT_MAY_THROW(indexor, &lib, VAL_ARRAY(data), 1);
+        DO_NEXT_MAY_THROW(
+            indexor, &lib, VAL_ARRAY(data), 1, VAL_SPECIFIER(data)
+        );
+
         if (indexor == THROWN_FLAG)
             fail (Error_No_Catch_For_Throw(&lib));
 
@@ -1352,7 +1358,10 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
             fail (Error_Invalid_Arg(&blk[0]));
 
         REBVAL fun;
-        DO_NEXT_MAY_THROW(indexor, &fun, VAL_ARRAY(data), 1);
+        DO_NEXT_MAY_THROW(
+            indexor, &fun, VAL_ARRAY(data), 1, VAL_SPECIFIER(data)
+        );
+
         if (indexor == THROWN_FLAG)
             fail (Error_No_Catch_For_Throw(&fun));
 
@@ -1382,8 +1391,11 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
                             fail (Error_Invalid_Arg(blk)); /* duplicate ellipsis */
                         }
                         ROUTINE_SET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARIADIC);
-                        //Change the argument list to be a block
-                        VAL_ROUTINE_FIXED_ARGS(out) = Copy_Array_Shallow(VAL_ROUTINE_PARAMLIST(out));
+
+                        // Change the argument list to be a block
+                        VAL_ROUTINE_FIXED_ARGS(out) = Copy_Array_Shallow(
+                            VAL_ROUTINE_PARAMLIST(out), SPECIFIED
+                        );
                         MANAGE_ARRAY(VAL_ROUTINE_FIXED_ARGS(out));
                         Remove_Series(
                             ARR_SERIES(VAL_ROUTINE_PARAMLIST(out)),

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -396,10 +396,10 @@ static REBOOL rebol_type_to_ffi(const REBVAL *out, const REBVAL *elem, REBCNT id
         // when it's first call for return type, all_args has not been initialized yet
         if (ROUTINE_GET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARIADIC)
             && idx > ARR_LEN(VAL_ROUTINE_FIXED_ARGS(out))) {
-            rebol_args = ARR_HEAD(VAL_ROUTINE_ALL_ARGS(out));
+            rebol_args = KNOWN(ARR_HEAD(VAL_ROUTINE_ALL_ARGS(out)));
         }
         else {
-            rebol_args = ARR_HEAD(VAL_ROUTINE_PARAMLIST(out));
+            rebol_args = KNOWN(ARR_HEAD(VAL_ROUTINE_PARAMLIST(out)));
         }
     }
 
@@ -477,7 +477,7 @@ static REBOOL rebol_type_to_ffi(const REBVAL *out, const REBVAL *elem, REBCNT id
             return FALSE;
         }
         if (idx == 0) {
-            to = ARR_HEAD(VAL_ROUTINE_FFI_ARG_STRUCTS(out));
+            to = KNOWN(ARR_HEAD(VAL_ROUTINE_FFI_ARG_STRUCTS(out)));
         } else {
             to = Alloc_Tail_Array(VAL_ROUTINE_FFI_ARG_STRUCTS(out));
         }
@@ -513,7 +513,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_UINT8:
             if (!IS_INTEGER(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
 #ifdef BIG_ENDIAN
@@ -526,7 +526,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_SINT8:
             if (!IS_INTEGER(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
 #ifdef BIG_ENDIAN
@@ -539,7 +539,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_UINT16:
             if (!IS_INTEGER(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
 #ifdef BIG_ENDIAN
@@ -552,7 +552,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_SINT16:
             if (!IS_INTEGER(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
 #ifdef BIG_ENDIAN
@@ -565,7 +565,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_UINT32:
             if (!IS_INTEGER(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
 #ifdef BIG_ENDIAN
@@ -578,7 +578,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_SINT32:
             if (!IS_INTEGER(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
 #ifdef BIG_ENDIAN
@@ -592,7 +592,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_SINT64:
             if (!IS_INTEGER(arg))
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             return &VAL_INT64(arg);
 
@@ -617,7 +617,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
                     return &ptrs[idx];
                 default:
                     fail (Error_Arg_Type(
-                        D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                        D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                     ));
             }
 
@@ -625,7 +625,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
             /* hackish, store the signle precision floating point number in a double precision variable */
             if (!IS_DECIMAL(arg)) {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             } else {
                 float a = (float)VAL_DECIMAL(arg);
@@ -636,7 +636,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
         case FFI_TYPE_DOUBLE:
             if (!IS_DECIMAL(arg))
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             return &VAL_DECIMAL(arg);
 
@@ -646,7 +646,9 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
             } else {
                 if (!IS_STRUCT(arg))
                     fail (Error_Arg_Type(
-                        D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                        D_LABEL_SYM,
+                        KNOWN(ARR_AT(rebol_args, idx)),
+                        VAL_TYPE(arg)
                     ));
             }
             return SER_AT(
@@ -660,7 +662,7 @@ static void *arg_to_ffi(const REBVAL *rot, REBVAL *arg, REBCNT idx, void **ptrs)
                 return NULL;
             } else {
                 fail (Error_Arg_Type(
-                    D_LABEL_SYM, ARR_AT(rebol_args, idx), VAL_TYPE(arg)
+                    D_LABEL_SYM, KNOWN(ARR_AT(rebol_args, idx)), VAL_TYPE(arg)
                 ));
             }
 
@@ -814,7 +816,7 @@ void Call_Routine(REBROT *rot, REBARR *args, REBVAL *ret)
     }
 
     if (is_va_list_routine) {
-        va_values = ARR_HEAD(args);
+        va_values = KNOWN(ARR_HEAD(args));
         if (!IS_BLOCK(va_values))
             fail (Error_Invalid_Arg(va_values));
 
@@ -863,7 +865,7 @@ void Call_Routine(REBROT *rot, REBARR *args, REBVAL *ret)
         MANAGE_ARRAY(ROUTINE_ALL_ARGS(rot));
 
         for (i = 1, j = 1; i < VAL_LEN_HEAD(va_values) + 1; i ++, j ++) {
-            REBVAL *reb_arg = VAL_ARRAY_AT_HEAD(va_values, i - 1);
+            REBVAL *reb_arg = KNOWN(VAL_ARRAY_AT_HEAD(va_values, i - 1));
             if (i <= n_fixed) { /* fix arguments */
                 if (!TYPE_CHECK(
                     ARR_AT(ROUTINE_FIXED_ARGS(rot), i),
@@ -871,7 +873,7 @@ void Call_Routine(REBROT *rot, REBARR *args, REBVAL *ret)
                 )) {
                     fail (Error_Arg_Type(
                         D_LABEL_SYM,
-                        ARR_AT(ROUTINE_FIXED_ARGS(rot), i),
+                        KNOWN(ARR_AT(ROUTINE_FIXED_ARGS(rot), i)),
                         VAL_TYPE(reb_arg)
                     ));
                 }
@@ -882,7 +884,7 @@ void Call_Routine(REBROT *rot, REBARR *args, REBVAL *ret)
                 if (i == VAL_LEN_HEAD(va_values)) /* type is missing */
                     fail (Error_Invalid_Arg(reb_arg));
 
-                reb_type = VAL_ARRAY_AT_HEAD(va_values, i);
+                reb_type = KNOWN(VAL_ARRAY_AT_HEAD(va_values, i));
                 if (!IS_BLOCK(reb_type))
                     fail (Error_Invalid_Arg(reb_type));
 
@@ -923,7 +925,7 @@ void Call_Routine(REBROT *rot, REBARR *args, REBVAL *ret)
         for (i = 1; i < SER_LEN(ROUTINE_FFI_ARG_TYPES(rot)); i ++) {
             ffi_args[i - 1] = arg_to_ffi(
                 &out,
-                ARR_AT(args, i - 1),
+                KNOWN(ARR_AT(args, i - 1)),
                 i,
                 SER_HEAD(void*, ffi_args_ptrs)
             );
@@ -985,7 +987,7 @@ void Free_Routine(REBRIN *rin)
 static void process_type_block(const REBVAL *out, REBVAL *blk, REBCNT n, REBOOL make)
 {
     if (IS_BLOCK(blk)) {
-        REBVAL *t = VAL_ARRAY_AT(blk);
+        REBVAL *t = KNOWN(VAL_ARRAY_AT(blk));
         if (IS_WORD(t) && VAL_WORD_CANON(t) == SYM_STRUCT_TYPE) {
             /* followed by struct definition */
             REBVAL tmp;
@@ -996,7 +998,7 @@ static void process_type_block(const REBVAL *out, REBVAL *blk, REBCNT n, REBOOL 
             if (!IS_BLOCK(t) || VAL_LEN_AT(blk) != 2)
                 fail (Error_Invalid_Arg(blk));
 
-            if (!MT_Struct(&tmp, t, REB_STRUCT))
+            if (!MT_Struct(&tmp, t, SPECIFIED, REB_STRUCT))
                 fail (Error_Invalid_Arg(blk));
 
             if (!rebol_type_to_ffi(out, &tmp, n, make))
@@ -1086,9 +1088,13 @@ static void callback_dispatcher(
                 break;
             case FFI_TYPE_STRUCT:
                 if (!IS_STRUCT(ARR_AT(RIN_ARGS_STRUCTS(rin), i + 1)))
-                    fail (Error_Invalid_Arg(ARR_AT(RIN_ARGS_STRUCTS(rin), i + 1)));
+                    fail (Error_Invalid_Arg(
+                        KNOWN(ARR_AT(RIN_ARGS_STRUCTS(rin), i + 1))
+                    ));
 
-                Copy_Struct_Val(ARR_AT(RIN_ARGS_STRUCTS(rin), i + 1), elem);
+                Copy_Struct_Val(
+                    KNOWN(ARR_AT(RIN_ARGS_STRUCTS(rin), i + 1)), elem
+                );
                 memcpy(
                     SER_AT(
                         REBYTE,
@@ -1177,11 +1183,15 @@ static void callback_dispatcher(
 //     abi: word "note"
 // ] lib "name"]
 //
-REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
-{
+REBOOL MT_Routine(
+    REBVAL *out,
+    REBVAL *data,
+    REBCTX *specifier,
+    REBOOL is_callback
+) {
     //RL_Print("%s, %d\n", __func__, __LINE__);
     ffi_type ** args = NULL;
-    REBVAL *blk = NULL;
+    RELVAL *blk = NULL;
     REBCNT eval_idx = 0; /* for spec block evaluation */
     REBSER *extra_mem = NULL;
     REBOOL ret = TRUE;
@@ -1288,7 +1298,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
 
         REBVAL lib;
         DO_NEXT_MAY_THROW(
-            indexor, &lib, VAL_ARRAY(data), 1, VAL_SPECIFIER(data)
+            indexor, &lib, VAL_ARRAY(data), 1, specifier
         );
 
         if (indexor == THROWN_FLAG)
@@ -1296,7 +1306,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
 
         if (IS_INTEGER(&lib)) {
             if (indexor != END_FLAG)
-                fail (Error_Invalid_Arg(&blk[cast(REBCNT, indexor)]));
+                fail (Error_Invalid_Arg(KNOWN(&blk[cast(REBCNT, indexor)])));
 
             //treated as a pointer to the function
             if (VAL_INT64(&lib) == 0)
@@ -1317,10 +1327,10 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
                 fail (Error_Invalid_Arg(&lib));
 
             if (!IS_STRING(&blk[fn_idx]))
-                fail (Error_Invalid_Arg(&blk[fn_idx]));
+                fail (Error_Invalid_Arg(KNOWN(&blk[fn_idx])));
 
             if (NOT_END(&blk[fn_idx + 1]))
-                fail (Error_Invalid_Arg(&blk[fn_idx + 1]));
+                fail (Error_Invalid_Arg(KNOWN(&blk[fn_idx + 1])));
 
             VAL_ROUTINE_LIB(out) = VAL_LIB_HANDLE(&lib);
             if (!VAL_ROUTINE_LIB(out)) {
@@ -1337,7 +1347,9 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
             //
             b_index = VAL_INDEX(&blk[fn_idx]);
             b_len = VAL_LEN_AT(&blk[fn_idx]);
-            byte_sized = Temp_Bin_Str_Managed(&blk[fn_idx], &b_index, &b_len);
+            byte_sized = Temp_Bin_Str_Managed(
+                KNOWN(&blk[fn_idx]), &b_index, &b_len
+            );
 
             func = OS_FIND_FUNCTION(
                 LIB_FD(VAL_ROUTINE_LIB(out)),
@@ -1345,7 +1357,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
             );
 
             if (!func) {
-                fail (Error_Invalid_Arg(&blk[fn_idx]));
+                fail (Error_Invalid_Arg(KNOWN(&blk[fn_idx])));
                 //printf("Couldn't find function: %s\n", VAL_DATA_AT(&blk[2]));
             } else {
                 VAL_ROUTINE_FUNCPTR(out) = func;
@@ -1355,11 +1367,11 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
         REBIXO indexor = 0;
 
         if (!IS_BLOCK(&blk[0]))
-            fail (Error_Invalid_Arg(&blk[0]));
+            fail (Error_Invalid_Arg(KNOWN(&blk[0])));
 
         REBVAL fun;
         DO_NEXT_MAY_THROW(
-            indexor, &fun, VAL_ARRAY(data), 1, VAL_SPECIFIER(data)
+            indexor, &fun, VAL_ARRAY(data), 1, specifier
         );
 
         if (indexor == THROWN_FLAG)
@@ -1370,7 +1382,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
         VAL_CALLBACK_FUNC(out) = VAL_FUNC(&fun);
 
         if (indexor != END_FLAG)
-            fail (Error_Invalid_Arg(&blk[cast(REBCNT, indexor)]));
+            fail (Error_Invalid_Arg(KNOWN(&blk[cast(REBCNT, indexor)])));
 
         //printf("RIN: %p, func: %p\n", VAL_ROUTINE_INFO(out), &blk[1]);
     }
@@ -1388,7 +1400,8 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
                     REBVAL *v = NULL;
                     if (VAL_WORD_CANON(blk) == SYM_ELLIPSIS) {
                         if (ROUTINE_GET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARIADIC)) {
-                            fail (Error_Invalid_Arg(blk)); /* duplicate ellipsis */
+                            fail (Error_Invalid_Arg(KNOWN(blk)));
+                            /* duplicate ellipsis */
                         }
                         ROUTINE_SET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARIADIC);
 
@@ -1410,14 +1423,14 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
                     else {
                         if (ROUTINE_GET_FLAG(VAL_ROUTINE_INFO(out), ROUTINE_VARIADIC)) {
                             //... has to be the last argument
-                            fail (Error_Invalid_Arg(blk));
+                            fail (Error_Invalid_Arg(KNOWN(blk)));
                         }
                         v = Alloc_Tail_Array(VAL_ROUTINE_PARAMLIST(out));
                         Val_Init_Typeset(v, 0, VAL_WORD_SYM(blk));
                         EXPAND_SERIES_TAIL(VAL_ROUTINE_FFI_ARG_TYPES(out), 1);
 
                         ++ blk;
-                        process_type_block(out, blk, n, TRUE);
+                        process_type_block(out, KNOWN(blk), n, TRUE);
                     }
 
                     // Function dispatch needs to know whether parameters are
@@ -1433,7 +1446,7 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
                     case SYM_ABI:
                         ++ blk;
                         if (!IS_WORD(blk) || has_abi > 1)
-                            fail (Error_Invalid_Arg(blk));
+                            fail (Error_Invalid_Arg(KNOWN(blk)));
 
                         switch (VAL_WORD_CANON(blk)) {
                             case SYM_DEFAULT:
@@ -1492,24 +1505,24 @@ REBOOL MT_Routine(REBVAL *out, REBVAL *data, REBOOL is_callback)
                                 break;
 #endif //X86_WIN64
                             default:
-                                fail (Error_Invalid_Arg(blk));
+                                fail (Error_Invalid_Arg(KNOWN(blk)));
                         }
                         has_abi ++;
                         break;
                     case SYM_RETURN:
                         if (has_return > 1) {
-                            fail (Error_Invalid_Arg(blk));
+                            fail (Error_Invalid_Arg(KNOWN(blk)));
                         }
                         has_return ++;
                         ++ blk;
-                        process_type_block(out, blk, 0, TRUE);
+                        process_type_block(out, KNOWN(blk), 0, TRUE);
                         break;
                     default:
-                        fail (Error_Invalid_Arg(blk));
+                        fail (Error_Invalid_Arg(KNOWN(blk)));
                 }
                 break;
             default:
-                fail (Error_Invalid_Arg(blk));
+                fail (Error_Invalid_Arg(KNOWN(blk)));
         }
     }
 
@@ -1576,7 +1589,7 @@ REBNATIVE(make_routine)
 
     const REBOOL is_callback = FALSE;
 
-    MT_Routine(D_OUT, ARG(def), is_callback);
+    MT_Routine(D_OUT, ARG(def), SPECIFIED, is_callback);
 
     return R_OUT;
 }
@@ -1596,7 +1609,7 @@ REBNATIVE(make_callback)
 
     const REBOOL is_callback = TRUE;
 
-    MT_Routine(D_OUT, ARG(def), is_callback);
+    MT_Routine(D_OUT, ARG(def), SPECIFIED, is_callback);
 
     return R_OUT;
 }

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -287,7 +287,7 @@ static void init_type_map()
 //
 //  CT_Routine: C
 //
-REBINT CT_Routine(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Routine(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     //RL_Print("%s, %d\n", __func__, __LINE__);
     if (mode >= 0) {
@@ -299,7 +299,7 @@ REBINT CT_Routine(const REBVAL *a, const REBVAL *b, REBINT mode)
 //
 //  CT_Callback: C
 //
-REBINT CT_Callback(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Callback(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     //RL_Print("%s, %d\n", __func__, __LINE__);
     return -1;

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -36,7 +36,7 @@
 //
 //  CT_String: C
 //
-REBINT CT_String(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_String(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT num;
 

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -351,18 +351,21 @@ static REBSER *make_binary(REBVAL *arg, REBOOL make)
 //
 //  MT_String: C
 //
-REBOOL MT_String(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_String(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     REBCNT i;
 
     if (!ANY_BINSTR(data)) return FALSE;
-    *out = *data++;
+    *out = *KNOWN(data);
+    ++data;
+
     VAL_RESET_HEADER(out, type);
 
     // !!! This did not have special END handling previously, but it would have
     // taken the 0 branch.  Review if this is sensible.
     //
-    i = NOT_END(data) && IS_INTEGER(data) ? Int32(data) - 1 : 0;
+    i = NOT_END(data) && IS_INTEGER(data) ? Int32(KNOWN(data)) - 1 : 0;
 
     if (i > VAL_LEN_HEAD(out)) i = VAL_LEN_HEAD(out); // clip it
     VAL_INDEX(out) = i;
@@ -568,7 +571,7 @@ REBINT PD_File(REBPVS *pvs)
     if (pvs->opt_setval)
         fail (Error_Bad_Path_Set(pvs));
 
-    ser = Copy_Sequence_At_Position(pvs->value);
+    ser = Copy_Sequence_At_Position(KNOWN(pvs->value));
 
     // This makes sure there's always a "/" at the end of the file before
     // appending new material via a selector:

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -726,7 +726,9 @@ REBOOL MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
         REBUPT raw_addr = 0;
         REBCNT alignment = 0;
 
-        VAL_STRUCT_SPEC(out) = Copy_Array_Shallow(VAL_ARRAY(data));
+        VAL_STRUCT_SPEC(out) = Copy_Array_Shallow(
+            VAL_ARRAY(data), VAL_SPECIFIER(data)
+        );
         VAL_STRUCT_DATA(out) = Make_Series(
             1, sizeof(struct Struct_Data), MKS_NONE
         );
@@ -804,16 +806,19 @@ REBOOL MT_Struct(REBVAL *out, REBVAL *data, enum Reb_Kind type)
                 if (IS_END(blk)) {
                    fail (Error_Invalid_Arg(blk));
                 } else if (IS_BLOCK(blk)) {
-                    if (Reduce_Array_Throws(init, VAL_ARRAY(blk), 0, FALSE))
+                    if (Reduce_Array_Throws(
+                        init, VAL_ARRAY(blk), 0, VAL_SPECIFIER(blk), FALSE
+                    )) {
                         fail (Error_No_Catch_For_Throw(init));
-
+                    }
                     ++ blk;
                 } else {
                     DO_NEXT_MAY_THROW(
                         eval_idx,
                         init,
                         VAL_ARRAY(data),
-                        blk - VAL_ARRAY_AT(data)
+                        blk - VAL_ARRAY_AT(data),
+                        VAL_SPECIFIER(data)
                     );
                     if (eval_idx == THROWN_FLAG)
                         fail (Error_No_Catch_For_Throw(init));
@@ -1260,7 +1265,10 @@ REBTYPE(Struct)
                         break;
                     case SYM_SPEC:
                         Val_Init_Block(
-                            ret, Copy_Array_Deep_Managed(VAL_STRUCT_SPEC(val))
+                            ret,
+                            Copy_Array_Deep_Managed(
+                                VAL_STRUCT_SPEC(val), SPECIFIED
+                            )
                         );
                         Unbind_Values_Deep(VAL_ARRAY_HEAD(val));
                         break;

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -818,7 +818,7 @@ REBOOL MT_Struct(
                         eval_idx,
                         init,
                         VAL_ARRAY(data),
-                        blk - VAL_ARRAY_AT(data),
+                        cast(RELVAL*, blk) - VAL_ARRAY_AT(data),
                         specifier
                     );
                     if (eval_idx == THROWN_FLAG)

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1003,14 +1003,20 @@ REBINT PD_Struct(REBPVS *pvs)
             PUSH_GUARD_VALUE(&sel_orig);
 
             pvs->value = pvs->store;
+            pvs->value_specifier = SPECIFIED;
 
             if (Next_Path_Throws(pvs)) { // updates pvs->store, pvs->selector
                 DROP_GUARD_VALUE(&sel_orig);
                 fail (Error_No_Catch_For_Throw(pvs->store)); // !!! Review
             }
 
-            if (!Set_Struct_Var(stu, &sel_orig, pvs->selector, pvs->value))
-                fail (Error_Bad_Path_Set(pvs));
+            {
+                REBVAL specific;
+                COPY_VALUE(&specific, pvs->value, pvs->value_specifier);
+
+                if (!Set_Struct_Var(stu, &sel_orig, pvs->selector, &specific))
+                    fail (Error_Bad_Path_Set(pvs));
+            }
 
             DROP_GUARD_VALUE(&sel_orig);
 

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1035,7 +1035,7 @@ REBINT PD_Struct(REBPVS *pvs)
 //
 //  Cmp_Struct: C
 //
-REBINT Cmp_Struct(const REBVAL *s, const REBVAL *t)
+REBINT Cmp_Struct(const RELVAL *s, const RELVAL *t)
 {
     REBINT n = VAL_STRUCT_FIELDS(s) - VAL_STRUCT_FIELDS(t);
     fail_if_non_accessible(s);
@@ -1051,7 +1051,7 @@ REBINT Cmp_Struct(const REBVAL *s, const REBVAL *t)
 //
 //  CT_Struct: C
 //
-REBINT CT_Struct(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Struct(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     //printf("comparing struct a (%p) with b (%p), mode: %d\n", a, b, mode);
     switch (mode) {

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -166,7 +166,7 @@ void Emit_Time(REB_MOLD *mold, const REBVAL *value)
 //
 //  CT_Time: C
 //
-REBINT CT_Time(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Time(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT num = Cmp_Time(a, b);
     if (mode >= 0)  return (num == 0);
@@ -267,7 +267,7 @@ REBOOL MT_Time(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 // 
 // Given two times, compare them.
 //
-REBINT Cmp_Time(const REBVAL *v1, const REBVAL *v2)
+REBINT Cmp_Time(const RELVAL *v1, const RELVAL *v2)
 {
     REBI64 t1 = VAL_TIME(v1);
     REBI64 t2 = VAL_TIME(v2);

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -255,7 +255,7 @@ REBOOL MT_Time(
     REBI64 secs;
 
     REBVAL specified;
-    COPY_RELVAL(&specified, data, specifier);
+    COPY_VALUE(&specified, data, specifier);
 
     secs = Make_Time(&specified);
 

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -34,7 +34,7 @@
 //
 //  CT_Tuple: C
 //
-REBINT CT_Tuple(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Tuple(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT num = Cmp_Tuple(a, b);
     if (mode > 1) return (num == 0 && VAL_TUPLE_LEN(a) == VAL_TUPLE_LEN(b));
@@ -81,7 +81,7 @@ REBOOL MT_Tuple(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 // 
 // Given two tuples, compare them.
 //
-REBINT Cmp_Tuple(const REBVAL *t1, const REBVAL *t2)
+REBINT Cmp_Tuple(const RELVAL *t1, const RELVAL *t2)
 {
     REBCNT  len;
     const REBYTE *vp1, *vp2;

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -47,8 +47,9 @@ REBINT CT_Tuple(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MT_Tuple: C
 //
-REBOOL MT_Tuple(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Tuple(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     REBYTE  *vp;
     REBINT len = 0;
     REBINT n;
@@ -57,7 +58,7 @@ REBOOL MT_Tuple(REBVAL *out, REBVAL *data, enum Reb_Kind type)
     for (; NOT_END(data); data++, vp++, len++) {
         if (len >= 10) return FALSE;
         if (IS_INTEGER(data)) {
-            n = Int32(data);
+            n = Int32(KNOWN(data));
         }
         else if (IS_CHAR(data)) {
             n = VAL_CHAR(data);
@@ -377,8 +378,11 @@ REBTYPE(Tuple)
         }
 
         if (ANY_ARRAY(arg)) {
-            if (!MT_Tuple(D_OUT, VAL_ARRAY_AT(arg), REB_TUPLE))
+            if (!MT_Tuple(
+                D_OUT, VAL_ARRAY_AT(arg), VAL_SPECIFIER(arg), REB_TUPLE
+            )) {
                 fail (Error_Bad_Make(REB_TUPLE, arg));
+            }
             return R_OUT;
         }
 

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -139,7 +139,7 @@ REBOOL Update_Typeset_Bits_Core(
     assert(IS_TYPESET(typeset));
     VAL_TYPESET_BITS(typeset) = 0;
 
-    const REBVAL *item = head;
+    const RELVAL *item = head;
     if (!IS_END(item) && IS_BLOCK(item)) {
         // Double blocks are a variadic signal.
         if (!IS_END(item + 1))
@@ -229,7 +229,7 @@ REBOOL Update_Typeset_Bits_Core(
         else {
             if (trap) return FALSE;
 
-            fail (Error_Invalid_Arg(item));
+            fail (Error_Invalid_Arg_Core(item, specifier));
         }
     }
 

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -105,7 +105,7 @@ void Init_Typesets(void)
 
 
 //
-//  Val_Init_Typeset: C
+//  Val_Init_Typeset_Core: C
 // 
 // Note: sym is optional, and can be SYM_0
 //

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -105,11 +105,11 @@ void Init_Typesets(void)
 
 
 //
-//  Val_Init_Typeset_Core: C
+//  Val_Init_Typeset: C
 // 
 // Note: sym is optional, and can be SYM_0
 //
-void Val_Init_Typeset_Core(RELVAL *value, REBU64 bits, REBSYM sym)
+void Val_Init_Typeset(RELVAL *value, REBU64 bits, REBSYM sym)
 {
     VAL_RESET_HEADER(value, REB_TYPESET);
     VAL_TYPESET_SYM(value) = sym;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -109,7 +109,7 @@ void Init_Typesets(void)
 // 
 // Note: sym is optional, and can be SYM_0
 //
-void Val_Init_Typeset(REBVAL *value, REBU64 bits, REBSYM sym)
+void Val_Init_Typeset_Core(RELVAL *value, REBU64 bits, REBSYM sym)
 {
     VAL_RESET_HEADER(value, REB_TYPESET);
     VAL_TYPESET_SYM(value) = sym;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -152,9 +152,12 @@ REBOOL Update_Typeset_Bits_Core(
     REBARR *types = VAL_ARRAY(ROOT_TYPESETS);
 
     for (; NOT_END(item); item++) {
-        const REBVAL *var = NULL;
+        const RELVAL *var = NULL;
 
-        if (IS_WORD(item) && !(var = TRY_GET_OPT_VAR(item, GUESSED))) {
+        if (
+            IS_WORD(item)
+            && !(var = TRY_GET_OPT_VAR(item, specifier))
+        ) {
             REBSYM sym = VAL_WORD_SYM(item);
 
             // See notes: if a word doesn't look up to a variable, then its
@@ -240,8 +243,9 @@ REBOOL Update_Typeset_Bits_Core(
 //
 //  MT_Typeset: C
 //
-REBOOL MT_Typeset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
-{
+REBOOL MT_Typeset(
+    REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
+) {
     if (!IS_BLOCK(data)) return FALSE;
 
     Val_Init_Typeset(out, 0, SYM_0);
@@ -249,7 +253,7 @@ REBOOL MT_Typeset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
     if (!Update_Typeset_Bits_Core(
         out,
         VAL_ARRAY_HEAD(data),
-        VAL_SPECIFIER(data),
+        specifier,
         TRUE // `trap`: true means to return FALSE instead of fail() on error
     )) {
         return FALSE;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -131,8 +131,9 @@ void Val_Init_Typeset(REBVAL *value, REBU64 bits, REBSYM sym)
 // reviewed to see if anything actually used it.
 //
 REBOOL Update_Typeset_Bits_Core(
-    REBVAL *typeset,
-    const REBVAL *head,
+    RELVAL *typeset,
+    const RELVAL *head,
+    REBCTX *specifier,
     REBOOL trap // if TRUE, then return FALSE instead of failing
 ) {
     assert(IS_TYPESET(typeset));
@@ -153,7 +154,7 @@ REBOOL Update_Typeset_Bits_Core(
     for (; NOT_END(item); item++) {
         const REBVAL *var = NULL;
 
-        if (IS_WORD(item) && !(var = TRY_GET_OPT_VAR(item))) {
+        if (IS_WORD(item) && !(var = TRY_GET_OPT_VAR(item, GUESSED))) {
             REBSYM sym = VAL_WORD_SYM(item);
 
             // See notes: if a word doesn't look up to a variable, then its
@@ -248,6 +249,7 @@ REBOOL MT_Typeset(REBVAL *out, REBVAL *data, enum Reb_Kind type)
     if (!Update_Typeset_Bits_Core(
         out,
         VAL_ARRAY_HEAD(data),
+        VAL_SPECIFIER(data),
         TRUE // `trap`: true means to return FALSE instead of fail() on error
     )) {
         return FALSE;
@@ -319,6 +321,7 @@ REBTYPE(Typeset)
             Update_Typeset_Bits_Core(
                 D_OUT,
                 VAL_ARRAY_AT(arg),
+                VAL_SPECIFIER(arg),
                 FALSE // `trap`: false means fail() instead of FALSE on error
             );
             return R_OUT;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -69,7 +69,7 @@ const struct {
 //
 //  CT_Typeset: C
 //
-REBINT CT_Typeset(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Typeset(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (mode < 0) return -1;
     return EQUAL_TYPESET(a, b);

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -68,7 +68,7 @@
 REBIXO Do_Vararg_Op_Core(
     REBVAL *out,
     REBARR *feed, // may be varlist or 1-element-long array w/shared value
-    const REBVAL *param,
+    const RELVAL *param,
     REBVAL *arg, // for updating VALUE_FLAG_EVALUATED
     REBSYM sym_func, // symbol of the function invocation param belongs to
     enum Reb_Vararg_Op op
@@ -168,7 +168,7 @@ handle_subfeed:
             goto return_end_flag;
 
         if (op == VARARG_OP_FIRST) {
-            COPY_RELVAL(out, f->value, f->specifier);
+            COPY_VALUE(out, f->value, f->specifier);
             return VALIST_FLAG;
         }
     }
@@ -575,7 +575,7 @@ void Mold_Varargs(const REBVAL *value, REB_MOLD *mold) {
             Mold_Value(mold, ARR_HEAD(VAL_VARARGS_ARRAY1(value)), TRUE);
     }
     else {
-        const REBVAL *varargs_param = VAL_VARARGS_PARAM(value);
+        const RELVAL *varargs_param = VAL_VARARGS_PARAM(value);
 
         REBVAL param_word;
 

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -261,7 +261,7 @@ handle_subfeed:
         ) {
             if (op == VARARG_OP_TAIL_Q) return VALIST_FLAG;
 
-            if (EVAL_VALUE_THROWS(out, f->value))
+            if (EVAL_VALUE_CORE_THROWS(out, f->value, f->specifier))
                 return THROWN_FLAG;
 
             if (GET_VAL_FLAG(out, VALUE_FLAG_EVALUATED))

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -521,7 +521,7 @@ REBTYPE(Varargs)
 // Simple comparison function stub (required for every type--rules TBD for
 // levels of "exactness" in equality checking, or sort-stable comparison.)
 //
-REBINT CT_Varargs(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Varargs(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     if (GET_VAL_FLAG(a, VARARGS_FLAG_NO_FRAME)) {
         if (!GET_VAL_FLAG(b, VARARGS_FLAG_NO_FRAME)) return 1;

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -387,7 +387,7 @@ REBVAL *Make_Vector_Spec(RELVAL *bp, REBCTX *specifier, REBVAL *value)
 
     // BITS
     if (IS_INTEGER(bp)) {
-        bits = Int32(bp);
+        bits = Int32(KNOWN(bp));
         if (
             (bits == 32 || bits == 64)
             ||
@@ -398,8 +398,8 @@ REBVAL *Make_Vector_Spec(RELVAL *bp, REBCTX *specifier, REBVAL *value)
 
     // SIZE
     if (NOT_END(bp) && IS_INTEGER(bp)) {
-        if (Int32(bp) < 0) return 0;
-        size = Int32(bp);
+        if (Int32(KNOWN(bp)) < 0) return 0;
+        size = Int32(KNOWN(bp));
         bp++;
     }
 
@@ -408,7 +408,7 @@ REBVAL *Make_Vector_Spec(RELVAL *bp, REBCTX *specifier, REBVAL *value)
         REBCNT len = VAL_LEN_AT(bp);
         if (IS_BINARY(bp) && type == 1) return 0;
         if (len > size) size = len;
-        iblk = bp;
+        iblk = KNOWN(bp);
         bp++;
     }
 
@@ -416,7 +416,7 @@ REBVAL *Make_Vector_Spec(RELVAL *bp, REBCTX *specifier, REBVAL *value)
 
     // Index offset:
     if (NOT_END(bp) && IS_INTEGER(bp)) {
-        VAL_INDEX(value) = (Int32s(bp, 1) - 1);
+        VAL_INDEX(value) = (Int32s(KNOWN(bp), 1) - 1);
         bp++;
     }
     else VAL_INDEX(value) = 0;

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -572,8 +572,7 @@ REBTYPE(Vector)
         return R_OUT;
 
     case A_MAKE:
-        // We only allow MAKE VECTOR! ...
-        if (!IS_DATATYPE(value)) goto bad_make;
+        assert(IS_DATATYPE(value) && VAL_TYPE_KIND(value) == REB_VECTOR);
 
         // CASE: make vector! 100
         if (IS_INTEGER(arg) || IS_DECIMAL(arg)) {
@@ -591,7 +590,7 @@ REBTYPE(Vector)
         // fall thru
 
     case A_TO:
-        // CASE: make vector! [...]
+        assert(IS_DATATYPE(value) && VAL_TYPE_KIND(value) == REB_VECTOR);
         if (IS_BLOCK(arg) && Make_Vector_Spec(VAL_ARRAY_AT(arg), value)) break;
         goto bad_make;
 

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -228,7 +228,7 @@ REBARR *Vector_To_Array(REBVAL *vect)
 //
 //  Compare_Vector: C
 //
-REBINT Compare_Vector(const REBVAL *v1, const REBVAL *v2)
+REBINT Compare_Vector(const RELVAL *v1, const RELVAL *v2)
 {
     REBCNT l1 = VAL_LEN_AT(v1);
     REBCNT l2 = VAL_LEN_AT(v2);
@@ -450,7 +450,7 @@ REBOOL MT_Vector(REBVAL *out, REBVAL *data, enum Reb_Kind type)
 //
 //  CT_Vector: C
 //
-REBINT CT_Vector(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Vector(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT n = Compare_Vector(a, b);  // needs to be expanded for equality
     if (mode >= 0) {

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -38,7 +38,7 @@
 // the words are equal or not (1 or 0).  This creates bad invariants for
 // sorting etc.  Review.
 //
-REBINT CT_Word(const REBVAL *a, const REBVAL *b, REBINT mode)
+REBINT CT_Word(const RELVAL *a, const RELVAL *b, REBINT mode)
 {
     REBINT e;
     REBINT diff;

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -75,7 +75,6 @@ REBTYPE(Word)
 {
     REBVAL *val = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
-    enum Reb_Kind type = VAL_TYPE(val);
     REBINT diff;
     REBSYM sym;
 
@@ -83,13 +82,13 @@ REBTYPE(Word)
     case A_MAKE:
     case A_TO:
         // TO word! ...
-        if (type == REB_DATATYPE) type = VAL_TYPE_KIND(val);
+        assert(IS_DATATYPE(val));
         if (ANY_WORD(arg)) {
             //
             // Only reset the type, not all the header bits (the bits must
             // stay in sync with the binding state)
             //
-            VAL_SET_TYPE_BITS(arg, type);
+            VAL_SET_TYPE_BITS(arg, VAL_TYPE_KIND(val));
             *D_OUT = *D_ARG(2);
             return R_OUT;
         }
@@ -107,7 +106,7 @@ REBTYPE(Word)
                     arg, MAX_SCAN_WORD, &len, allow_utf8
                 );
 
-                if (type == REB_ISSUE) sym = Scan_Issue(bp, len);
+                if (VAL_TYPE_KIND(val) == REB_ISSUE) sym = Scan_Issue(bp, len);
                 else sym = Scan_Word(bp, len);
                 if (!sym) fail (Error(RE_BAD_CHAR, arg));
             }
@@ -137,12 +136,13 @@ REBTYPE(Word)
             else
                 fail (Error_Unexpected_Type(REB_WORD, VAL_TYPE(arg)));
 
-            Val_Init_Word(D_OUT, type, sym);
+            Val_Init_Word(D_OUT, VAL_TYPE_KIND(val), sym);
         }
         break;
 
     default:
-        fail (Error_Illegal_Action(type, action));
+        assert(ANY_WORD(val));
+        fail (Error_Illegal_Action(VAL_TYPE(val), action));
     }
 
     return R_OUT;

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -73,10 +73,10 @@ REBVAL *Find_Mutable_In_Contexts(REBSYM sym, REBVAL *where)
 
     for (; NOT_END(where); where++) {
         if (IS_WORD(where)) {
-            val = GET_MUTABLE_VAR_MAY_FAIL(where);
+            val = GET_MUTABLE_VAR_MAY_FAIL(where, GUESSED);
         }
         else if (IS_PATH(where)) {
-            if (Do_Path_Throws(&safe, NULL, where, 0))
+            if (Do_Path_Throws_Core(&safe, NULL, where, GUESSED, NULL))
                 fail (Error_No_Catch_For_Throw(&safe));
             val = &safe;
         }
@@ -171,12 +171,15 @@ static REBVAL *Eval_Arg(REBDIA *dia)
                 );
                 if (value) break;
             }
-            value = TRY_GET_MUTABLE_VAR(val); // NULL if protected or not found
+
+            // value comes back NULL if protected or not found
+            //
+            value = TRY_GET_MUTABLE_VAR(val, GUESSED);
         }
         break;
 
     case REB_PATH:
-        if (Do_Path_Throws(&safe, NULL, value, NULL))
+        if (Do_Path_Throws_Core(&safe, NULL, value, GUESSED, NULL))
             fail (Error_No_Catch_For_Throw(&safe));
         if (IS_FUNCTION(&safe)) return NULL;
         DS_PUSH(&safe);
@@ -262,7 +265,8 @@ again:
                 }
                 // Is it a typeset?
                 else if (
-                    (temp = TRY_GET_MUTABLE_VAR(fargs)) && IS_TYPESET(temp)
+                    (temp = TRY_GET_MUTABLE_VAR(fargs, GUESSED))
+                    && IS_TYPESET(temp)
                 ) {
                     if (TYPE_CHECK(temp, VAL_TYPE(value))) accept = 1;
                 }

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -73,10 +73,10 @@ REBVAL *Find_Mutable_In_Contexts(REBSYM sym, REBVAL *where)
 
     for (; NOT_END(where); where++) {
         if (IS_WORD(where)) {
-            val = GET_MUTABLE_VAR_MAY_FAIL(where, GUESSED);
+            val = GET_MUTABLE_VAR_MAY_FAIL(where, SPECIFIED);
         }
         else if (IS_PATH(where)) {
-            if (Do_Path_Throws_Core(&safe, NULL, where, GUESSED, NULL))
+            if (Do_Path_Throws_Core(&safe, NULL, where, SPECIFIED, NULL))
                 fail (Error_No_Catch_For_Throw(&safe));
             val = &safe;
         }
@@ -155,7 +155,7 @@ static int Count_Dia_Args(REBVAL *args)
 //
 static REBVAL *Eval_Arg(REBDIA *dia)
 {
-    REBVAL *value = ARR_AT(dia->args, dia->argi);
+    REBVAL *value = KNOWN(ARR_AT(dia->args, dia->argi));
 
     REBVAL safe;
 
@@ -229,14 +229,14 @@ static REBINT Add_Arg(REBDIA *dia, REBVAL *value)
     REBVAL *outp;
     REBINT rept = 0;
 
-    outp = ARR_AT(dia->out, dia->outi);
+    outp = KNOWN(ARR_AT(dia->out, dia->outi));
 
     // Scan all formal args, looking for one that matches given value:
     for (fargi = dia->fargi;; fargi++) {
 
         //Debug_Fmt("Add_Arg fargi: %d outi: %d", fargi, outi);
 
-        if (IS_END(fargs = ARR_AT(dia->fargs, fargi))) return 0;
+        if (IS_END(fargs = KNOWN(ARR_AT(dia->fargs, fargi)))) return 0;
 
 again:
         // Formal arg can be a word (type or refinement), datatype, or * (repeater):
@@ -347,8 +347,8 @@ again:
         break;
 
     case 4: // refinement:
-        dia->fargi = fargs - ARR_HEAD(dia->fargs) + 1;
-        dia->outi = outp - ARR_HEAD(dia->out) + 1;
+        dia->fargi = fargs - KNOWN(ARR_HEAD(dia->fargs)) + 1;
+        dia->outi = outp - KNOWN(ARR_HEAD(dia->out)) + 1;
         *outp = *value;
         return 1;
 
@@ -384,7 +384,7 @@ static REBINT Do_Cmd(REBDIA *dia)
     fargs = CTX_VAR(dia->dialect, dia->cmd);
     if (!IS_BLOCK(fargs)) return -REB_DIALECT_BAD_SPEC;
     dia->fargs = VAL_ARRAY(fargs);
-    fargs = VAL_ARRAY_AT(fargs);
+    fargs = KNOWN(VAL_ARRAY_AT(fargs));
     size = Count_Dia_Args(fargs); // approximate
 
     ser = ARR_SERIES(dia->out);
@@ -451,7 +451,7 @@ static REBINT Do_Cmd(REBDIA *dia)
 //
 static REBINT Do_Dia(REBDIA *dia)
 {
-    REBVAL *next = ARR_AT(dia->args, dia->argi);
+    REBVAL *next = KNOWN(ARR_AT(dia->args, dia->argi));
     REBVAL *head;
     REBINT err;
 
@@ -606,7 +606,7 @@ REBNATIVE(delect)
         dia.contexts = ARG(where);
         if (!IS_BLOCK(dia.contexts))
             fail (Error_Invalid_Arg(dia.contexts));
-        dia.contexts = VAL_ARRAY_AT(dia.contexts);
+        dia.contexts = KNOWN(VAL_ARRAY_AT(dia.contexts));
     }
 
     dsp_orig = DSP;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -417,7 +417,7 @@ static REBCNT Parse_Next_Array(
 
     case REB_LIT_PATH:
         index++;
-        if (IS_PATH(blk) && !Cmp_Block(blk, item, FALSE)) break;
+        if (IS_PATH(blk) && !Cmp_Array(blk, item, FALSE)) break;
         goto no_result;
 
     case REB_BLANK:

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -191,7 +191,7 @@ static const RELVAL *Get_Parse_Value(
         // by REB_WORD in %c-do.c)
         //
         if (IS_VOID(var))
-            fail (Error(RE_NO_VALUE, item));
+            fail (Error_No_Value_Core(item, specifier));
 
         return var;
     }
@@ -206,7 +206,7 @@ static const RELVAL *Get_Parse_Value(
         // See notes above about voids
         //
         if (IS_VOID(safe))
-            fail (Error(RE_NO_VALUE, item));
+            fail (Error_No_Value_Core(item, specifier));
 
         return safe;
     }
@@ -1759,7 +1759,8 @@ static REBCNT Parse_Rules_Loop(struct Reb_Frame *f, REBCNT depth) {
                     // new value...comment said "CHECK FOR QUOTE!!"
                     item = Get_Parse_Value(&save, item, P_SPECIFIER);
 
-                    if (IS_VOID(item)) fail (Error(RE_NO_VALUE, P_RULE - 1));
+                    if (IS_VOID(item))
+                        fail (Error_No_Value_Core(P_RULE - 1, P_SPECIFIER));
 
                     if (IS_END(item)) goto bad_end;
 

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -44,13 +44,9 @@
 // construct is relevant to the Assert_Cell_Writable checks.
 //
 #ifdef REB_DEF
-    struct Reb_Value; // A Rebol value cell
-     #define RELVAL struct Reb_Value // maybe IS_RELATIVE()
+    struct Reb_Value;
+    #define RELVAL struct Reb_Value // maybe IS_RELATIVE()
 
-    // !!! Specific Values are from the specific binding branch, but included
-    // here in order to get the automatic C++ writability check (without
-    // having to format every cell that gets created)
-    //
     #ifdef __cplusplus
         #define REBVAL struct Reb_Specific_Value // guaranteed IS_SPECIFIC()
     #else

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -367,6 +367,11 @@ enum REB_Mold_Opts {
 #define Mold_Value(mold,value,molded) \
     Mold_Value_Core((mold), (value), (molded))
 
+#define Pre_Mold(value,mold) \
+    Pre_Mold_Core((value), (mold))
+
+#define Post_Mold(value,mold) \
+    Post_Mold_Core((value), (mold))
 
 // Special flags for decimal formatting:
 enum {

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -598,34 +598,46 @@ extern "C" {
 extern REBVAL *Get_Var_Core(
     REBOOL *lookback,
     const REBVAL *any_word,
+    REBCTX *specifier,
     REBFLGS flags
 );
 #ifdef __cplusplus
 }
 #endif
 
-static inline const REBVAL *GET_OPT_VAR_MAY_FAIL(const REBVAL *any_word) {
+static inline const REBVAL *GET_OPT_VAR_MAY_FAIL(
+    const REBVAL *any_word,
+    REBCTX *specifier
+) {
     REBOOL dummy;
-    return Get_Var_Core(&dummy, any_word, 0);
+    return Get_Var_Core(&dummy, any_word, specifier, 0);
 }
 
-static inline const REBVAL *TRY_GET_OPT_VAR(const REBVAL *any_word) {
+static inline const REBVAL *TRY_GET_OPT_VAR(
+    const REBVAL *any_word,
+    REBCTX *specifier
+) {
     REBOOL dummy;
-    return Get_Var_Core(&dummy, any_word, GETVAR_UNBOUND_OK);
+    return Get_Var_Core(&dummy, any_word, specifier, GETVAR_UNBOUND_OK);
 }
 
-static inline REBVAL *GET_MUTABLE_VAR_MAY_FAIL(const REBVAL *any_word) {
+static inline REBVAL *GET_MUTABLE_VAR_MAY_FAIL(
+    const REBVAL *any_word,
+    REBCTX *specifier
+) {
     REBOOL lookback = FALSE; // resets infix/postfix/etc. flag
-    return Get_Var_Core(&lookback, any_word, GETVAR_IS_SETVAR);
+    return Get_Var_Core(&lookback, any_word, specifier, GETVAR_IS_SETVAR);
 }
 
-static inline REBVAL *TRY_GET_MUTABLE_VAR(const REBVAL *any_word) {
+static inline REBVAL *TRY_GET_MUTABLE_VAR(
+    const REBVAL *any_word,
+    REBCTX *specifier
+) {
     REBOOL lookback = FALSE; // resets infix/postfix/etc. flag
     return Get_Var_Core(
-        &lookback, any_word, GETVAR_IS_SETVAR | GETVAR_UNBOUND_OK
+        &lookback, any_word, specifier, GETVAR_IS_SETVAR | GETVAR_UNBOUND_OK
     );
 }
-
 
 
 /***********************************************************************

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -605,7 +605,7 @@ extern "C" {
 #endif
 extern REBVAL *Get_Var_Core(
     REBOOL *lookback,
-    const REBVAL *any_word,
+    const RELVAL *any_word,
     REBCTX *specifier,
     REBFLGS flags
 );
@@ -614,7 +614,7 @@ extern REBVAL *Get_Var_Core(
 #endif
 
 static inline const REBVAL *GET_OPT_VAR_MAY_FAIL(
-    const REBVAL *any_word,
+    const RELVAL *any_word,
     REBCTX *specifier
 ) {
     REBOOL dummy;
@@ -622,7 +622,7 @@ static inline const REBVAL *GET_OPT_VAR_MAY_FAIL(
 }
 
 static inline const REBVAL *TRY_GET_OPT_VAR(
-    const REBVAL *any_word,
+    const RELVAL *any_word,
     REBCTX *specifier
 ) {
     REBOOL dummy;
@@ -630,7 +630,7 @@ static inline const REBVAL *TRY_GET_OPT_VAR(
 }
 
 static inline REBVAL *GET_MUTABLE_VAR_MAY_FAIL(
-    const REBVAL *any_word,
+    const RELVAL *any_word,
     REBCTX *specifier
 ) {
     REBOOL lookback = FALSE; // resets infix/postfix/etc. flag
@@ -638,7 +638,7 @@ static inline REBVAL *GET_MUTABLE_VAR_MAY_FAIL(
 }
 
 static inline REBVAL *TRY_GET_MUTABLE_VAR(
-    const REBVAL *any_word,
+    const RELVAL *any_word,
     REBCTX *specifier
 ) {
     REBOOL lookback = FALSE; // resets infix/postfix/etc. flag

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -367,6 +367,9 @@ enum REB_Mold_Opts {
 #define Mold_Value(mold,value,molded) \
     Mold_Value_Core((mold), (value), (molded))
 
+#define Copy_Form_Value(value,opts) \
+    Copy_Form_Value_Core((value), (opts))
+
 #define Pre_Mold(value,mold) \
     Pre_Mold_Core((value), (mold))
 
@@ -901,6 +904,13 @@ typedef struct rebol_time_fields {
     REBCNT n;
 } REB_TIMEF;
 
+
+//
+// Tracing !!! move to separate file?
+//
+
+#define Trace_Value(label,value) \
+    Trace_Value_Core((label), (value))
 
 
 /***********************************************************************

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -295,7 +295,7 @@ enum {
 #define TS_GC (~TS_NO_GC)
 
 #define Type_Of(value) \
-    Get_Type(VAL_TYPE(value))
+    Type_Of_Core(value)
 
 
 // Garbage collection marker function (GC Hook)

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -365,6 +365,10 @@ enum REB_Mold_Opts {
 
 #define GET_MOPT(v, f) GET_FLAG(v->opts, f)
 
+#define Mold_Value(mold,value,molded) \
+    Mold_Value_Core((mold), (value), (molded))
+
+
 // Special flags for decimal formatting:
 enum {
     DEC_MOLD_PERCENT = 1 << 0,      // follow num with %

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -364,18 +364,6 @@ enum REB_Mold_Opts {
 
 #define GET_MOPT(v, f) GET_FLAG(v->opts, f)
 
-#define Mold_Value(mold,value,molded) \
-    Mold_Value_Core((mold), (value), (molded))
-
-#define Copy_Form_Value(value,opts) \
-    Copy_Form_Value_Core((value), (opts))
-
-#define Pre_Mold(value,mold) \
-    Pre_Mold_Core((value), (mold))
-
-#define Post_Mold(value,mold) \
-    Post_Mold_Core((value), (mold))
-
 // Special flags for decimal formatting:
 enum {
     DEC_MOLD_PERCENT = 1 << 0,      // follow num with %
@@ -903,14 +891,6 @@ typedef struct rebol_time_fields {
     REBCNT s;
     REBCNT n;
 } REB_TIMEF;
-
-
-//
-// Tracing !!! move to separate file?
-//
-
-#define Trace_Value(label,value) \
-    Trace_Value_Core((label), (value))
 
 
 /***********************************************************************

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -354,7 +354,6 @@ enum REB_Mold_Opts {
     MOPT_FILE,          // Molding %file
     MOPT_INDENT,        // Indentation
     MOPT_TIGHT,         // No space between block values
-    MOPT_NO_NONE,       // Do not output UNSET or NONE object vars
     MOPT_EMAIL,         // ?
     MOPT_ONLY,          // Mold/only - no outer block []
     MOPT_LINES,         // add a linefeed between each value

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1113,7 +1113,7 @@ enum Path_Eval_Result {
 
 typedef REBINT (*REBPEF)(REBPVS *pvs); // Path evaluator function
 
-typedef REBINT (*REBCTF)(const REBVAL *a, const REBVAL *b, REBINT s);
+typedef REBINT (*REBCTF)(const RELVAL *a, const RELVAL *b, REBINT s);
 
 
 //=////////////////////////////////////////////////////////////////////////=//

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -414,7 +414,7 @@ struct Reb_Frame {
     // then if any problem needing a where came up, a series would be made
     // to put it in.  (The where series is paying for a copy anyway.)
     //
-    const REBVAL *value;
+    const RELVAL *value;
 
     // `gotten`
     //
@@ -444,7 +444,7 @@ struct Reb_Frame {
     // by virtue of not being NULL signals to just use the value on the
     // next fetch instead of fetching again.
     //
-    const REBVAL *eval_fetched;
+    const RELVAL *eval_fetched;
 
     // source.array, source.vaptr [INPUT, READ-ONLY, GC-PROTECTED]
     //
@@ -535,6 +535,8 @@ struct Reb_Frame {
     // but also because it is used as a temporary to store value if it is
     // advanced but we'd like to hold the old one...this makes it important
     // to protect it from GC if we have advanced beyond as well!)
+    //
+    // Made relative just to have another RELVAL on hand.
     //
     const RELVAL *param;
 
@@ -1046,7 +1048,7 @@ typedef struct Reb_Path_Value_State {
     // `item` is the current element within the path that is being processed.
     // It is advanced as the path is consumed.
     //
-    const REBVAL *item;
+    const RELVAL *item;
 
     // `selector` is the result of evaluating the current path item if
     // necessary.  So if the path is `a/(1 + 2)` and processing the second
@@ -1081,7 +1083,7 @@ typedef struct Reb_Path_Value_State {
 
     // `orig` original path input, saved for error messages
     //
-    const REBVAL *orig;
+    const RELVAL *orig;
 
     // A specifier is needed because the PATH! is processed by incrementing
     // through values, which may be resident in an array that was part of

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1058,6 +1058,16 @@ typedef struct Reb_Path_Value_State {
     //
     const REBVAL *selector;
 
+    // !!! `selector_temp` was added as a patch to push the temporary
+    // variable used to hold evaluated selectors into the PVS, when it was
+    // observed that callers of Next_Path() were expecting the selector to
+    // survive the call.  That meant it couldn't be in a C stack temporary.
+    // The method needs serious review, but keeping the temporary used for
+    // the selector in the PVS doesn't incur any more storage and bridges
+    // past the problem for now.
+    //
+    REBVAL selector_temp;
+
     // `value` holds the path value that should be chained from.  (It is the
     // type of `value` that dictates which dispatcher is given the `selector`
     // to get the next step.)

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1027,10 +1027,13 @@ typedef struct Reb_Frame Reb_Enumerator;
 // an EVAL and not a DO...hence if you pass it a block, then the block will
 // just evaluate to itself!
 //
-#define EVAL_VALUE_THROWS(out,value) \
+#define EVAL_VALUE_CORE_THROWS(out,value,specifier) \
     LOGICAL(THROWN_FLAG == Do_Array_At_Core((out), \
-        (value), EMPTY_ARRAY, 0, SPECIFIED, \
+        (value), EMPTY_ARRAY, 0, specifier, \
         DO_FLAG_TO_END | DO_FLAG_ARGS_EVALUATE | DO_FLAG_LOOKAHEAD))
+
+#define EVAL_VALUE_THROWS(out,value) \
+    EVAL_VALUE_CORE_THROWS((out), (value), SPECIFIED)
 
 
 //=////////////////////////////////////////////////////////////////////////=//

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1053,6 +1053,14 @@ typedef struct Reb_Path_Value_State {
     //
     const RELVAL *item;
 
+    // A specifier is needed because the PATH! is processed by incrementing
+    // through values, which may be resident in an array that was part of
+    // the cloning of a function body.  The specifier allows the path
+    // evaluation to disambiguate which variable a word's relative binding
+    // would match.
+    //
+    REBCTX *item_specifier;
+
     // `selector` is the result of evaluating the current path item if
     // necessary.  So if the path is `a/(1 + 2)` and processing the second
     // `item`, then the selector would be the computed value `3`.
@@ -1073,9 +1081,14 @@ typedef struct Reb_Path_Value_State {
 
     // `value` holds the path value that should be chained from.  (It is the
     // type of `value` that dictates which dispatcher is given the `selector`
-    // to get the next step.)
+    // to get the next step.)  This has to be a relative value in order to
+    // use the SET_IF_END option which writes into arrays.
     //
-    REBVAL *value;
+    RELVAL *value;
+
+    // `value_specifier` has to be updated whenever value is updated
+    //
+    REBCTX *value_specifier;
 
     // `store` is the storage for constructed values, and also where any
     // thrown value will be written.
@@ -1097,14 +1110,6 @@ typedef struct Reb_Path_Value_State {
     // `orig` original path input, saved for error messages
     //
     const RELVAL *orig;
-
-    // A specifier is needed because the PATH! is processed by incrementing
-    // through values, which may be resident in an array that was part of
-    // the cloning of a function body.  The specifier allows the path
-    // evaluation to disambiguate which variable a word's relative binding
-    // would match.
-    //
-    REBCTX *specifier;
 } REBPVS;
 
 enum Path_Eval_Result {

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -835,6 +835,7 @@ typedef struct Reb_Frame Reb_Enumerator;
             (f)->value = va_arg(*(f)->source.vaptr, const REBVAL*); \
             assert(IS_END((f)->value) || !IS_VOID((f)->value) || \
                 NOT((f)->flags & DO_FLAG_ARGS_EVALUATE)); \
+            assert(IS_END((f)->value) || !IS_RELATIVE((f)->value)); \
         } \
     } while (0)
 
@@ -876,7 +877,7 @@ typedef struct Reb_Frame Reb_Enumerator;
                     (f_.eval_type == ET_INERT) \
                     && (IS_END((f)->value + 1) || !ANY_EVAL((f)->value + 1)) \
                 ) { \
-                    *(dest) = *(f)->value; \
+                    COPY_VALUE((dest), (f)->value, (f)->specifier); \
                     (f)->value = ARR_AT((f)->source.array, (f)->indexor); \
                     ++(f)->indexor; \
                     break; \
@@ -921,7 +922,7 @@ typedef struct Reb_Frame Reb_Enumerator;
 #ifdef NDEBUG
     #define QUOTE_NEXT_REFETCH(dest,f) \
         do { \
-            COPY_RELVAL((dest), (f)->value, (f)->specifier); \
+            COPY_VALUE((dest), (f)->value, (f)->specifier); \
             FETCH_NEXT_ONLY_MAYBE_END(f); \
             CLEAR_VAL_FLAG(dest, VALUE_FLAG_EVALUATED); \
         } while (0)
@@ -1287,7 +1288,7 @@ struct Native_Refine {
 // Uses ARR_AT instead of CTX_VAR because the varlist may not be finished.
 //
 #define FRM_ARGS_HEAD(f) \
-    ((f)->stackvars ? &(f)->stackvars[0] : ARR_AT((f)->varlist, 1))
+    ((f)->stackvars ? &(f)->stackvars[0] : KNOWN(ARR_AT((f)->varlist, 1)))
 
 // ARGS is the parameters and refinements
 // 1-based indexing into the arglist (0 slot is for object/function value)

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -921,7 +921,7 @@ typedef struct Reb_Frame Reb_Enumerator;
 #ifdef NDEBUG
     #define QUOTE_NEXT_REFETCH(dest,f) \
         do { \
-            *dest = *(f)->value; \
+            COPY_RELVAL((dest), (f)->value, (f)->specifier); \
             FETCH_NEXT_ONLY_MAYBE_END(f); \
             CLEAR_VAL_FLAG(dest, VALUE_FLAG_EVALUATED); \
         } while (0)

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -919,23 +919,27 @@ struct Reb_Array {
 #define Append_Value(a,v) \
     (*Alloc_Tail_Array((a)) = *(v), NOOP)
 
-#define Copy_Values_Len_Shallow(v,l) \
-    Copy_Values_Len_Extra_Shallow((v), (l), 0)
+#define Copy_Values_Len_Shallow(v,s,l) \
+    Copy_Values_Len_Extra_Shallow((v), (s), (l), 0)
 
-#define Copy_Array_Shallow(a) \
-    Copy_Array_At_Shallow((a), 0)
+#define Copy_Array_Shallow(a,s) \
+    Copy_Array_At_Shallow((a), 0, (s))
 
-#define Copy_Array_Deep_Managed(a) \
-    Copy_Array_At_Extra_Deep_Managed((a), 0, 0)
+#define Copy_Array_Deep_Managed(a,s) \
+    Copy_Array_At_Extra_Deep_Managed((a), 0, (s), 0)
 
-#define Copy_Array_At_Deep_Managed(a,i) \
-    Copy_Array_At_Extra_Deep_Managed((a), (i), 0)
+#define Copy_Array_At_Deep_Managed(a,i,s) \
+    Copy_Array_At_Extra_Deep_Managed((a), (i), (s), 0)
 
-#define Copy_Array_At_Shallow(a,i) \
-    Copy_Array_At_Extra_Shallow((a), (i), 0)
+#define COPY_ANY_ARRAY_AT_DEEP_MANAGED(v) \
+    Copy_Array_At_Extra_Deep_Managed( \
+        VAL_ARRAY(v), VAL_INDEX(v), VAL_SPECIFIER(v), 0)
 
-#define Copy_Array_Extra_Shallow(a,e) \
-    Copy_Array_At_Extra_Shallow((a), 0, (e))
+#define Copy_Array_At_Shallow(a,i,s) \
+    Copy_Array_At_Extra_Shallow((a), (i), (s), 0)
+
+#define Copy_Array_Extra_Shallow(a,s,e) \
+    Copy_Array_At_Extra_Shallow((a), 0, (s), (e))
 
 #define Free_Array(a) \
     Free_Series(ARR_SERIES(a))

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -923,7 +923,10 @@ struct Reb_Array {
     ENSURE_SERIES_MANAGED(ARR_SERIES(array))
 
 #define Append_Value(a,v) \
-    (*Alloc_Tail_Array((a)) = *(v), NOOP)
+    (*Alloc_Tail_Array(a) = *(v), NOOP)
+
+#define Append_Value_Core(a,v,s) \
+    COPY_RELVAL(Alloc_Tail_Array(a), (v), (s))
 
 #define Copy_Values_Len_Shallow(v,s,l) \
     Copy_Values_Len_Extra_Shallow((v), (s), (l), 0)

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -378,7 +378,7 @@ struct Reb_Series {
         // rest of the bits in the debug build as it is checked whenver a
         // REBVAL tries to write a new header.)
         //
-        struct Reb_Value values[1];
+        REBVAL values[1];
     } content;
 
     // `info` is the information about the series which needs to be known
@@ -926,7 +926,7 @@ struct Reb_Array {
     (*Alloc_Tail_Array(a) = *(v), NOOP)
 
 #define Append_Value_Core(a,v,s) \
-    COPY_RELVAL(Alloc_Tail_Array(a), (v), (s))
+    COPY_VALUE(Alloc_Tail_Array(a), (v), (s))
 
 #define Copy_Values_Len_Shallow(v,s,l) \
     Copy_Values_Len_Extra_Shallow((v), (s), (l), 0)
@@ -1076,7 +1076,7 @@ struct Reb_Context {
 //
 #define CTX_VALUE(c) \
     (GET_CTX_FLAG((c), CONTEXT_FLAG_STACK) \
-        ? &ARR_SERIES(CTX_VARLIST(c))->content.values[0] \
+        ? KNOWN(&ARR_SERIES(CTX_VARLIST(c))->content.values[0]) \
         : SER_HEAD(REBVAL, ARR_SERIES(CTX_VARLIST(c)))) // not a RELVAL
 
 // Navigate from context to context components.  Note that the context's

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -378,7 +378,7 @@ struct Reb_Series {
         // rest of the bits in the debug build as it is checked whenver a
         // REBVAL tries to write a new header.)
         //
-        REBVAL values[1];
+        RELVAL values[1];
     } content;
 
     // `info` is the information about the series which needs to be known

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -147,12 +147,16 @@ typedef unsigned int REBDSP;
 #define DS_PUSH(v) \
     (assert(!IS_VOID(v)), DS_PUSH_MAYBE_VOID(v))
 
-#define DS_PUSH_RELVAL(v,s) \
+#define DS_PUSH_RELVAL_MAYBE_VOID(v,s) \
     do { \
         ASSERT_VALUE_MANAGED(v); \
         DS_PUSH_TRASH; \
         COPY_VALUE(DS_TOP, (v), (s)); \
     } while(0)
+
+// !!! add assert when inlined
+#define DS_PUSH_RELVAL(v,s) \
+    DS_PUSH_RELVAL_MAYBE_VOID((v), (s))
 
 // POPPING AND "DROPPING"
 

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -147,6 +147,13 @@ typedef unsigned int REBDSP;
 #define DS_PUSH(v) \
     (assert(!IS_VOID(v)), DS_PUSH_MAYBE_VOID(v))
 
+#define DS_PUSH_RELVAL(v,s) \
+    do { \
+        ASSERT_VALUE_MANAGED(v); \
+        DS_PUSH_TRASH; \
+        COPY_VALUE(DS_TOP, (v), (s)); \
+    } while(0)
+
 // POPPING AND "DROPPING"
 
 #ifdef NDEBUG

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -974,7 +974,8 @@ struct Reb_Decimal {
 #ifdef NDEBUG
     #define VAL_DECIMAL_BITS(v) (*cast(REBI64*, &(v)->payload.decimal.dec))
 #else
-    #define VAL_DECIMAL_BITS(v) (*cast(REBI64*, VAL_DECIMAL_Ptr_Debug(v)))
+    #define VAL_DECIMAL_BITS(v) \
+        (*cast(REBI64*, VAL_DECIMAL_Ptr_Debug(v)))
 #endif
 
 #define SET_DECIMAL(v,n) \
@@ -2852,10 +2853,10 @@ struct Reb_Value
 //
 #ifdef NDEBUG
     #define COPY_VALUE(dest,src,specifier) \
-        COPY_VALUE_Guessable((dest),(src),(specifier))
+        COPY_VALUE_Guessable(SINK(dest),(src),(specifier))
 #else
     #define COPY_VALUE(dest,src,specifier) \
-        COPY_VALUE_Guessable_Debug((dest),(src),(specifier))
+        COPY_VALUE_Guessable_Debug(SINK(dest),(src),(specifier))
 #endif
 
 #ifdef NDEBUG

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1947,7 +1947,7 @@ struct Reb_Any_Context {
     ((v)->payload.any_context.exit_from)
 
 #define VAL_CONTEXT_STACKVARS(v) \
-    ((v)->payload.any_context.more.frame->stackvars)
+    cast(REBVAL*, (v)->payload.any_context.more.frame->stackvars)
 
 #define VAL_CONTEXT_STACKVARS_LEN(v) \
     (assert(ANY_CONTEXT(v)), \

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -486,7 +486,7 @@ enum {
 //
 #define VAL_SET_TYPE_BITS(v,t) \
     ((v)->header.bits &= ~cast(REBUPT, HEADER_TYPE_MASK), \
-        (v)->header.bits |= (t))
+        (v)->header.bits |= cast(REBUPT, (t)))
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -1855,9 +1855,6 @@ struct Reb_Typeset {
 #define INIT_VAL_PARAM_CLASS(v,c) \
     ((v)->header.bits &= ~PCLASS_MASK, \
     (v)->header.bits |= ((c) << TYPE_SPECIFIC_BIT))
-
-#define Val_Init_Typeset(value,bits,sym) \
-    Val_Init_Typeset_Core((value), (bits), (sym))
 
 
 //=////////////////////////////////////////////////////////////////////////=//

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1568,7 +1568,7 @@ struct Reb_Any_Word {
     (assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND)), VAL_SPECIFIC(v))
 
 #define VAL_WORD_CONTEXT_MAY_REIFY(v) \
-    (GET_VAL_FLAG((v), VALUE_FLAG_RELATIVE) \
+    (IS_RELATIVE(v) \
         ? Context_For_Frame_May_Reify_Managed( \
             Frame_For_Word_Dynamic((v), FALSE)) \
         : VAL_WORD_CONTEXT(v))

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1241,7 +1241,7 @@ struct Reb_Any_Series {
 // (Or perhaps just use proper inlining and support it in those builds.)
 
 #define Val_Init_Series_Index(v,t,s,i) \
-    Val_Init_Series_Index_Core((v), (t), (s), (i))
+    Val_Init_Series_Index_Core((v), (t), (s), (i), SPECIFIED)
 
 #define Val_Init_Series(v,t,s) \
     Val_Init_Series_Index((v), (t), (s), 0)
@@ -1522,7 +1522,7 @@ union Reb_Any_Word_Place {
     // refinement has had its chance to take the earlier fulfillments.
     //
     struct {
-        const REBVAL *param;
+        const RELVAL *param;
         REBVAL *arg;
     } pickup;
 };
@@ -1602,6 +1602,9 @@ struct Reb_Any_Word {
     VAL_SYM_NAME(ARR_AT(PG_Word_Table.array, VAL_WORD_SYM(v)))
 
 #define VAL_WORD_NAME_STR(v)    BIN_HEAD(VAL_WORD_NAME(v))
+
+#define Val_Init_Word(out,kind,sym) \
+    Val_Init_Word_Core((out), (kind), (sym))
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -1844,6 +1847,9 @@ struct Reb_Typeset {
     ((v)->header.bits &= ~PCLASS_MASK, \
     (v)->header.bits |= ((c) << TYPE_SPECIFIC_BIT))
 
+#define Val_Init_Typeset(value,bits,sym) \
+    Val_Init_Typeset_Core((value), (bits), (sym))
+
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
@@ -1961,6 +1967,9 @@ struct Reb_Any_Context {
 // more easily than if it were left as just + 1.
 //
 #define SELFISH(n) (n + 1)
+
+#define Val_Init_Context(out,kind,context) \
+    Val_Init_Context_Core((out), (kind), (context))
 
 #define Val_Init_Object(v,c) \
     Val_Init_Context((v), REB_OBJECT, (c))
@@ -2764,13 +2773,13 @@ struct Reb_Value
 //
 // Use for: "invalid conversion from 'Reb_Value*' to 'Reb_Specific_Value*'"
 //
-//#ifdef NDEBUG
+#ifdef NDEBUG
     #define const_KNOWN(v)      cast(const REBVAL*, (v))
     #define KNOWN(v)            cast(REBVAL*, (v))
-//#else
-//    #define const_KNOWN(v)      const_KNOWN_Debug(v)
-//    #define KNOWN(v)            KNOWN_Debug(v)
-//#endif
+#else
+    #define const_KNOWN(v)      const_KNOWN_Debug(v)
+    #define KNOWN(v)            KNOWN_Debug(v)
+#endif
 
 // To make it easier to look for places that think they aren't dealing
 // with any relative values, pass this as the specifier instead of NULL.

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -208,7 +208,7 @@ load: function [
             header [
                 unless hdr? [cause-error 'syntax 'no-header source]
                 remove data
-                data/1: attempt [construct/with first data system/standard/header]
+                data/1: attempt [construct/only system/standard/header (first data)]
             ]
             load_ALL blank ; /header overrides /all
             hdr? [remove/part data 2]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -85,6 +85,9 @@ make-action: func [
     ; COLLECT-WORDS interface to efficiently give this result.
     ;
     spec: copy spec
+    unless find spec <durable> [
+        insert spec <durable>
+    ]
     for-next words [
         append spec to set-word! words/1
     ]

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -32,7 +32,7 @@ dp: delta-profile: func [
         change end end/1 - num
         end: next end
     ]
-    start: make system/standard/stats []
+    start: construct system/standard/stats []
     set start head end
     start
 ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -202,7 +202,7 @@ help: procedure [
                 "It is of the general type" value/type newline
             ]
         ]
-        if all [any-word? :word | not set? :word] [leave]
+        if all [word? :word | not set? :word] [leave]
         types: dump-obj/match lib :word
         sort types
         if not empty? types [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -437,44 +437,14 @@ r3-alpha-apply: function [
     do frame ;-- voids are optionals
 ]
 
-
-; CLOSURE has been unified with FUNCTION by attacking the two facets that it
-; offers separately.  One is the ability for its arguments and locals to
-; survive the call, which has been recast using the tag `<durable>`.  The
-; other is the specific binding of words in the body to the frame of origin
-; vs to whichever call to the function is on the stack.  That is desired to
-; be pushed as a feature of FUNCTION! that runs at acceptable cost and one
-; never has to ask for.
+; In Ren-C, FUNCTION's variables have indefinite extent (aka <durable>), and
+; the body is specifically bound to those variables.  (There is no dynamic
+; binding in Ren-C)
 ;
-; For the moment, the acceptable-cost version is in mid-design, so `<durable>`
-; in the function spec indicates a request for both properties.
-;
-closure: func [
-    {Defines a closure function with all set-words as locals.}
-    spec [block!]
-        {Help string (opt) followed by arg words (and opt type and string)}
-    body [block!]
-        {The body block of the function}
-    /with
-        {Define or use a persistent object (self)}
-    object [object! block! map!]
-        {The object or spec}
-    /extern
-        {These words are not local}
-    words [block!]
-][
-    apply 'function [
-        spec: compose [<durable> (spec)]
-        body: body
-        if with: with [
-            object: object
-        ]
-        if extern: extern [
-            words: :words
-        ]
-    ]
-]
+closure: :function
 
+; FUNC variables are not durable by default, it must be specified explicitly.
+;
 clos: func [
     "Defines a closure function."
     spec [block!]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -293,7 +293,7 @@ set: function [
     set_OPT: opt
     opt: :lib/opt
 
-    apply :lib-set [
+    apply 'lib-set [
         target: target
         value: :value
         opt: any? [set_ANY set_OPT]

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -89,7 +89,7 @@ save: function [
             trim :header-data
         ][
             ; standard/header intentionally not used
-            construct :header-data
+            has/only :header-data
         ]
 
         if compress [ ; Make the header option match

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -1,10 +1,10 @@
 REBOL [
-    title: "REBOL 3 TLSv1.0 protocol scheme"
-    name: 'tls
-    type: 'module
-    author: rights: "Richard 'Cyphre' Smolak"
-    version: 0.6.1
-    todo: {
+    Title: "REBOL 3 TLSv1.0 protocol scheme"
+    Name: tls
+    Type: module
+    Author: "Richard 'Cyphre' Smolak"
+    Version: 0.6.1
+    Todo: {
         -cached sessions
         -automagic cert data lookup
         -add more cipher suites (based on DSA, 3DES, ECDH, ECDHE, ECDSA, SHA256, SHA384 ...)
@@ -44,7 +44,7 @@ make-tls-error: func [
     ]
 ]
 
-cipher-suites: make object! [
+cipher-suites: has [
     TLS_RSA_WITH_RC4_128_MD5:               #{00 04}
     TLS_RSA_WITH_RC4_128_SHA:               #{00 05}
     TLS_RSA_WITH_AES_128_CBC_SHA:           #{00 2F}
@@ -1105,7 +1105,7 @@ tls-awake: function [event [event!]] [
 sys/make-scheme [
     name: 'tls
     title: "TLS protocol v1.0"
-    spec: make system/standard/port-spec-net []
+    spec: construct system/standard/port-spec-net []
     actor: [
         read: func [
             port [port!]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -135,7 +135,7 @@ do*: function [
 
         ; Make the new script object
         scr: system/script  ; and save old one
-        system/script: make system/standard/script [
+        system/script: construct system/standard/script [
             title: select hdr 'title
             header: hdr
             parent: :scr

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -22,7 +22,7 @@ REBOL [
 for-each [codec handler] system/codecs [
     if handle? handler [
         ; Change boot handle into object:
-        codec: set codec make object! [
+        codec: set codec construct [] [
             entry: handler
             title: form reduce ["Internal codec for" codec "media type"]
             name: codec

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -160,7 +160,7 @@ load-header: function/with [
             return 'no-header
         ]
 
-        not attempt [hdr: construct/with :hdr system/standard/header] [
+        not attempt [hdr: construct/only system/standard/header :hdr] [
             return 'bad-header
         ]
 

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -58,8 +58,8 @@ make-port*: func [
     ][cause-error 'access 'no-scheme name]
 
     ; Create the port with the correct scheme spec:
-    port: make system/standard/port []
-    port/spec: make any [scheme/spec system/standard/port-spec-head] spec
+    port: construct system/standard/port []
+    port/spec: construct any [scheme/spec system/standard/port-spec-head] spec
     port/spec/scheme: name
     port/scheme: scheme
 
@@ -77,7 +77,7 @@ make-port*: func [
     port
 ]
 
-*parse-url: make object! [
+*parse-url: has [
     digit:       make bitset! "0123456789"
     digits:      [1 5 digit]
     alpha-num:   make bitset! [#"a" - #"z" #"A" - #"Z" #"0" - #"9"]
@@ -170,7 +170,7 @@ make-scheme: func [
     with: either with [get in system/schemes scheme][system/standard/scheme]
     unless with [cause-error 'access 'no-scheme scheme]
 
-    def: make with def
+    def: construct with def
     ;print ["Scheme:" def/name]
     unless def/name [cause-error 'access 'no-scheme-name def]
     set-scheme def

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -174,7 +174,7 @@ finish-rl-start: proc [
     unless blank? boot-embedded [
         code: load/header/type boot-embedded 'unbound
         ;boot-print ["executing embedded script:" mold code]
-        system/script: make system/standard/script [
+        system/script: construct system/standard/script [
             title: select first code 'title
             header: first code
             parent: _
@@ -205,7 +205,7 @@ finish-rl-start: proc [
             boot-print ["Evaluating:" script]
             code: load/header/type second script-path 'unbound
             ; update system/script (Make into a function?)
-            system/script: make system/standard/script [
+            system/script: construct system/standard/script [
                 title: select first code 'title
                 header: first code
                 parent: _

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -380,7 +380,7 @@ int Do_String(
         Bind_Values_Deep(ARR_HEAD(code), Lib_Context); */
     }
 
-    if (Do_At_Throws(out, code, 0)) { // `code` is implicitly GC protected
+    if (Do_At_Throws(out, code, 0, SPECIFIED)) { // `code` will be GC protected
         if (at_breakpoint) {
             if (
                 IS_FUNCTION(out)

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -234,7 +234,7 @@ for-each-record-NO-RETURN: func [
             ]
         ]
 
-        set record make object! spec
+        set record has spec
 
         do body
     ]

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -909,7 +909,7 @@ change/only at-value platform reduce [
     any [select third any [find/skip plats version/4 3 []] version/5 ""]
 ]
 
-ob: context boot-sysobj
+ob: has boot-sysobj
 
 make-obj-defs: func [obj prefix depth /selfless /local f] [
     uppercase prefix
@@ -1153,7 +1153,22 @@ for-each file first mezz-files [
 ]
 
 emit-head "Sys Context" %sysctx.h
-sctx: construct boot-sys
+
+; We don't actually want to create the object in the R3-MAKE Rebol, because
+; the constructs are intended to run in the Rebol being built.  But the list
+; of top-level SET-WORD!s is needed.  R3-Alpha used a non-evaluating CONSTRUCT
+; to do this, but Ren-C's non-evaluating construct expects direct alternation
+; of SET-WORD! and unevaluated value (even another SET-WORD!).  So we just
+; gather the top-level set-words manually.
+
+sctx: has collect [
+    for-each item boot-sys [
+        if set-word? :item [
+            keep item
+            keep "stub proxy for %sys-base.r item"
+        ]
+    ]
+]
 
 ; !!! The SYS_CTX has no SELF...it is not produced by the ordinary gathering
 ; constructor, but uses Alloc_Context() directly.  Rather than try and force

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -257,10 +257,10 @@ libr3.lib:	r3.o
 ;** Options and Config
 ;******************************************************************************
 
-file-base: make object! load %file-base.r
-
 do %common.r
 do %systems.r
+
+file-base: has load %file-base.r
 config: config-system/guess system/options/args
 
 print ["Option set for building:" config/id config/os-name]
@@ -416,7 +416,7 @@ unless flag? -SP [ ; Use standard paths:
 if flag? EXE [macro+ BIN_SUFFIX %.exe]
 macro++ CLIB linker-flags
 macro++ RAPI_FLAGS compiler-flags
-macro++ HOST_FLAGS make compiler-flags [PIC: NCM: _]
+macro++ HOST_FLAGS construct compiler-flags [PIC: NCM: _]
 macro+  HOST_FLAGS compiler-flags/f64 ; default for all
 
 if flag? +SC [remove find os-specific-objs 'host-readline.c]

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -28,7 +28,7 @@ config: config-system/guess system/options/args
 
 do %form-header.r
 
-file-base: make object! load %file-base.r
+file-base: has load %file-base.r
 
 change-dir %../os/
 

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -3,6 +3,18 @@
 ; clearly, and to make the day to day testing run with 0 errors so that a
 ; log diffing is not required.
 
+
+; Having guarantees about mold--down to the tab--is something that's a bit
+; outside the realm of reasonable formalism in Ren-C just yet.  If it's to
+; be done, it should be done in a systemic way.
+; Mold recursive object
+[
+    o: object [a: 1 r: _]
+    o/r: o
+    (ajoin ["<" mold o  ">"])
+        = "<make object! [^/    a: 1^/    r: make object! [...]^/]>"
+]
+
 ; This is a lot of different ways of saying "REDUCE errors when an expression
 ; evaluates to void".  While this is inconvenient for using blocks to erase
 ; the state of variables, that is what NONE! (blank) is for...to serve as

--- a/tests/run-recover.r
+++ b/tests/run-recover.r
@@ -18,7 +18,8 @@ do %test-framework.r
 ; Example runner for the REBOL/Core tests which chooses
 ; appropriate flags depending on the interpreter version.
 
-do-core-tests: has [
+do-core-tests: func [
+    <local>
     flags result log-file summary interpreter-checksum log-file-prefix
 ] [
     ; Check if we run R3 or R2.


### PR DESCRIPTION
This is the base state of the long-pending specific binding branch.  Each function invocation gets its own unique identity for the words of its arguments and locals--instead of having them looked up in the most recent invocation of that function on the stack.

Though in R3-Alpha it was possible to get this behavior, it required using a different function constructor: the CLOSURE.  This had a number of undesirable characteristics--including that it meant the function body would have to be deep-copied and rebound on every invocation.  But also, it meant the user had to be conscious of two different function constructors, and deal with the puzzle of understanding their difference.

The nature of the underlying problem--and the trick used to solve it--are roughly outlined here:

https://github.com/metaeducation/ren-c/wiki/Relative-Binding-and-FRAME!-Internals

This is a major change affecting basically every part of the code.  However, it has been running successfully since about mid-March.  In the interests of re-cohering the system and un-forking the branches, it is being integrated to master now.