### PR TITLE
Macros => inline static functions

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -255,8 +255,8 @@ RL_API int RL_Start(REBYTE *bin, REBINT len, REBYTE *script, REBINT script_len, 
 
         if (
             IS_FUNCTION(&result) && (
-                VAL_FUNC_DISPATCH(&result) == &N_quit
-                || VAL_FUNC_DISPATCH(&result) == &N_exit
+                VAL_FUNC_DISPATCHER(&result) == &N_quit
+                || VAL_FUNC_DISPATCHER(&result) == &N_exit
             )
         ) {
             int status;
@@ -480,8 +480,8 @@ RL_API int RL_Do_String(
 
         if (
             IS_FUNCTION(&result) && (
-                VAL_FUNC_DISPATCH(&result) == &N_quit
-                || VAL_FUNC_DISPATCH(&result) == &N_exit
+                VAL_FUNC_DISPATCHER(&result) == &N_quit
+                || VAL_FUNC_DISPATCHER(&result) == &N_exit
             )
         ) {
             CATCH_THROWN(&result, &result);
@@ -1131,7 +1131,7 @@ RL_API REBOOL RL_Set_Value(REBARR *array, u32 index, RXIARG val, int type)
         return TRUE;
     }
 
-    *SINK(ARR_AT(array, index)) = value;
+    *ARR_AT(array, index) = value;
 
     return FALSE;
 }

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -271,7 +271,7 @@ static void Do_Global_Block(
                     // Steal binding, but keep the same word type
                     //
                     enum Reb_Kind kind = VAL_TYPE(path_item);
-                    *SINK(path_item) = *opt_toplevel_word;
+                    *path_item = *opt_toplevel_word;
                     VAL_SET_TYPE_BITS(path_item, kind);
                 }
             }
@@ -598,7 +598,7 @@ static void Init_Natives(void)
         // See if it's being invoked with NATIVE or NATIVE/BODY
         //
         if (IS_WORD(item)) {
-            if (!VAL_WORD_SYM(item) == SYM_NATIVE)
+            if (VAL_WORD_SYM(item) != SYM_NATIVE)
                 panic (Error(RE_NATIVE_BOOT));
             has_body = FALSE;
         }

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -246,11 +246,6 @@ static void Bind_Values_Inner_Loop(
         if (type_bit & bind_types) {
             REBCNT n = binds[VAL_WORD_CANON(value)];
             if (n != 0) {
-                //
-                // Word is in context, bind it.  Note that VAL_RESET_HEADER
-                // is a macro and VAL_TYPE is a macro, so we cannot directly
-                // initialize the header while also needing the type.
-                //
                 assert(ANY_WORD(value));
                 assert(n <= CTX_LEN(context));
 
@@ -438,12 +433,9 @@ static void Bind_Relative_Inner_Loop(
             if ((n = binds[VAL_WORD_CANON(value)]) != 0) {
                 //
                 // Word's canon symbol is in frame.  Relatively bind it.
-                // (clear out existing header flags first).  Note that
-                // VAL_RESET_HEADER is a macro and it's not safe to pass
-                // it VAL_TYPE(value) directly while initializing value...
+                // (clear out existing header flags first).
                 //
-                enum Reb_Kind kind = VAL_TYPE(value);
-                VAL_RESET_HEADER(value, kind);
+                VAL_RESET_HEADER(value, VAL_TYPE(value));
                 SET_VAL_FLAGS(value, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
                 INIT_WORD_FUNC(value, AS_FUNC(paramlist)); // incomplete func
                 INIT_WORD_INDEX(value, n);

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -491,7 +491,7 @@ void Collect_Context_Keys(REBCTX *context, REBOOL check_dups)
             // keys.  If they did, what sort of rule should the typesets
             // have when being inherited?
             //
-            *SINK(collect) = *key;
+            *collect = *key;
             ++collect;
 
             binds[canon] = bind_index++;
@@ -1386,32 +1386,6 @@ void Init_Collector(void)
 #ifndef NDEBUG
 
 //
-//  CTX_KEY_Debug: C
-//
-REBVAL *CTX_KEY_Debug(REBCTX *c, REBCNT n) {
-    assert(n != 0 && n <= CTX_LEN(c));
-    return CTX_KEYS_HEAD(c) + (n) - 1;
-}
-
-
-//
-//  CTX_VAR_Debug: C
-//
-REBVAL *CTX_VAR_Debug(REBCTX *c, REBCNT n) {
-    REBVAL *var;
-    assert(n != 0 && n <= CTX_LEN(c));
-    assert(GET_ARR_FLAG(CTX_VARLIST(c), ARRAY_FLAG_CONTEXT_VARLIST));
-
-    var = CTX_VARS_HEAD(c) + (n) - 1;
-
-    assert(IS_SPECIFIC(var));
-    assert(!THROWN(var));
-
-    return var;
-}
-
-
-//
 //  Assert_Context_Core: C
 //
 void Assert_Context_Core(REBCTX *context)
@@ -1499,6 +1473,7 @@ void Assert_Context_Core(REBCTX *context)
 
     key = CTX_KEYS_HEAD(context);
     var = CTX_VARS_HEAD(context);
+    REBVAL *xxx = var;
 
     for (n = 1; n < keys_len; n++, var++, key++) {
         if (IS_END(key) || IS_END(var)) {

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -409,7 +409,7 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
 
     REBVAL first;
 
-    *SINK(path) = *FUNC_VALUE(func_new);
+    *path = *FUNC_VALUE(func_new);
     ++path;
 
     for (; NOT_END(param); ++param, ++arg) {
@@ -446,7 +446,7 @@ REBOOL Redo_Func_Throws(struct Reb_Frame *f, REBFUN *func_new)
         //
         if (ignoring) continue;
 
-        *SINK(code) = *arg;
+        *code = *arg;
         ++code;
     }
 
@@ -519,7 +519,7 @@ int Do_Port_Action(struct Reb_Frame *frame_, REBCTX *port, REBCNT action)
 
     // If actor is a function (!!! Note: must be native !!!)
     if (IS_FUNCTION(actor))
-        return cast(REBPAF, VAL_FUNC_DISPATCH(actor))(frame_, port, action);
+        return cast(REBPAF, VAL_FUNC_DISPATCHER(actor))(frame_, port, action);
 
     // actor must be an object:
     if (!IS_OBJECT(actor)) fail (Error(RE_INVALID_ACTOR));

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -186,8 +186,8 @@ REBOOL Do_Breakpoint_Throws(
                 if (
                     frame != FS_TOP
                     && (
-                        FUNC_DISPATCH(frame->func) == &N_pause
-                        || FUNC_DISPATCH(frame->func) == &N_breakpoint
+                        FUNC_DISPATCHER(frame->func) == &N_pause
+                        || FUNC_DISPATCHER(frame->func) == &N_breakpoint
                     )
                 ) {
                     // We hit a breakpoint (that wasn't this call to
@@ -462,8 +462,8 @@ REBNATIVE(resume)
             if (Is_Function_Frame_Fulfilling(frame)) continue;
 
             if (
-                FUNC_DISPATCH(frame->func) == &N_pause
-                || FUNC_DISPATCH(frame->func) == &N_breakpoint
+                FUNC_DISPATCHER(frame->func) == &N_pause
+                || FUNC_DISPATCHER(frame->func) == &N_breakpoint
             ) {
                 break;
             }

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -430,8 +430,8 @@ REBNATIVE(backtrace)
             if (
                 first
                 && (
-                    FUNC_DISPATCH(frame->func) == &N_pause
-                    || FUNC_DISPATCH(frame->func) == &N_breakpoint
+                    FUNC_DISPATCHER(frame->func) == &N_pause
+                    || FUNC_DISPATCHER(frame->func) == &N_breakpoint
                 )
             ) {
                 // Omitting breakpoints from the list entirely presents a
@@ -457,10 +457,10 @@ REBNATIVE(backtrace)
         // function frames to do binding in the REPL with.
         //
         if (!pending) {
-            REBCNT temp_num;
             REBVAL temp_val;
             SET_INTEGER(&temp_val, number);
 
+            REBCNT temp_num;
             if (
                 Frame_For_Stack_Level(&temp_num, &temp_val, TRUE) != frame
                 || temp_num != number
@@ -660,8 +660,8 @@ struct Reb_Frame *Frame_For_Stack_Level(
 
         if (first) {
             if (
-                FUNC_DISPATCH(frame->func) == &N_pause
-                || FUNC_DISPATCH(frame->func) == N_breakpoint
+                FUNC_DISPATCHER(frame->func) == &N_pause
+                || FUNC_DISPATCHER(frame->func) == N_breakpoint
             ) {
                 // this is considered the "0".  Return it only if 0 was requested
                 // specifically (you don't "count down to it");

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -171,7 +171,7 @@ REBINT Cmp_Array(const RELVAL *sval, const RELVAL *tval, REBOOL is_case)
 
     while (
         (VAL_TYPE(s) == VAL_TYPE(t) ||
-        (IS_NUMBER(s) && IS_NUMBER(t)))
+        (ANY_NUMBER(s) && ANY_NUMBER(t)))
     ) {
         if ((diff = Cmp_Value(s, t, is_case)) != 0)
             return diff;
@@ -207,7 +207,7 @@ REBINT Cmp_Value(const RELVAL *s, const RELVAL *t, REBOOL is_case)
 {
     REBDEC  d1, d2;
 
-    if (VAL_TYPE(t) != VAL_TYPE(s) && !(IS_NUMBER(s) && IS_NUMBER(t)))
+    if (VAL_TYPE(t) != VAL_TYPE(s) && !(ANY_NUMBER(s) && ANY_NUMBER(t)))
         return VAL_TYPE(s) - VAL_TYPE(t);
 
     assert(NOT_END(s) && NOT_END(t));

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -442,16 +442,20 @@ void Val_Init_Series_Index_Core(
     VAL_INDEX(value) = index;
     INIT_ARRAY_SPECIFIC(value, specifier);
 
-#if !defined(NDEBUG)
-    if (ANY_ARRAY(value) && specifier == SPECIFIED) {
-        //
-        // If a SPECIFIED is used for an array, then that top level of the
-        // array cannot have any relative values in it.  Catch it here vs.
-        // waiting until a later assertion.
-        //
-        ASSERT_NO_RELATIVE(AS_ARRAY(series), FALSE);
+    if (Is_Array_Series(series)) {
+        SET_VAL_FLAG(value, VALUE_FLAG_ARRAY);
+
+    #if !defined(NDEBUG)
+        if (specifier == SPECIFIED) {
+            //
+            // If a SPECIFIED is used for an array, then that top level of the
+            // array cannot have any relative values in it.  Catch it here vs.
+            // waiting until a later assertion.
+            //
+            ASSERT_NO_RELATIVE(AS_ARRAY(series), FALSE);
+        }
+    #endif
     }
-#endif
 }
 
 
@@ -531,19 +535,6 @@ void Val_Init_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *context) {
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(context));
 
     *out = *CTX_VALUE(context);
-}
-
-
-//
-//  Val_Series_Len_At: C
-// 
-// Get length of an ANY-SERIES! value, taking the current index into account.
-// Avoid negative values.
-//
-REBCNT Val_Series_Len_At(const RELVAL *value)
-{
-    if (VAL_INDEX(value) >= VAL_LEN_HEAD(value)) return 0;
-    return VAL_LEN_HEAD(value) - VAL_INDEX(value);
 }
 
 

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -473,26 +473,6 @@ REBSER *Copy_Buffer(REBSER *buf, REBCNT index, void *end)
 #if !defined(NDEBUG)
 
 //
-//  SER_AT_RAW_Debug: C
-//
-// This functionality is extremely common, and having too much checking on
-// each invocation as part of the macro expansion was creating explosions
-// of unreadable macro code in asserts.  Putting it into a function in
-// the debug build reigns in the expansions...and since performance is
-// not a concern in the debug build, it's ok.
-//
-REBYTE *SER_AT_RAW_Debug(size_t w, REBSER *s, REBCNT i) {
-    //
-    // Callsites know the type of pointer they are asking for, so they often
-    // know the width without having to look in the series to get it.  Assert
-    // the width they think is consistent with what SER_WIDE thinks.
-    //
-    assert(w == SER_WIDE(s));
-    return SER_AT_RAW_MACRO(w, s, i);
-}
-
-
-//
 //  Assert_Series_Term_Core: C
 //
 void Assert_Series_Term_Core(REBSER *series)

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -472,11 +472,9 @@ REBNATIVE(break)
     REFINE(1, with);
     PARAM(2, value);
 
-    REBVAL *value = REF(with) ? ARG(value) : VOID_CELL;
-
     *D_OUT = *FUNC_VALUE(D_FUNC);
 
-    CONVERT_NAME_TO_THROWN(D_OUT, value);
+    CONVERT_NAME_TO_THROWN(D_OUT, REF(with) ? ARG(value) : VOID_CELL);
 
     return R_OUT_IS_THROWN;
 }
@@ -635,11 +633,11 @@ REBNATIVE(catch)
         if (
             (
                 REF(any)
-                && (!IS_FUNCTION(D_OUT) || VAL_FUNC_DISPATCH(D_OUT) != &N_quit)
+                && (!IS_FUNCTION(D_OUT) || VAL_FUNC_DISPATCHER(D_OUT) != &N_quit)
             )
             || (
                 REF(quit)
-                && (IS_FUNCTION(D_OUT) && VAL_FUNC_DISPATCH(D_OUT) == &N_quit)
+                && (IS_FUNCTION(D_OUT) && VAL_FUNC_DISPATCHER(D_OUT) == &N_quit)
             )
         ) {
             goto was_caught;
@@ -875,11 +873,9 @@ REBNATIVE(continue)
     REFINE(1, with);
     PARAM(2, value);
 
-    REBVAL *value = REF(with) ? ARG(value) : VOID_CELL;
-
     *D_OUT = *FUNC_VALUE(D_FUNC);
 
-    CONVERT_NAME_TO_THROWN(D_OUT, value);
+    CONVERT_NAME_TO_THROWN(D_OUT, REF(with) ? ARG(value) : VOID_CELL);
 
     return R_OUT_IS_THROWN;
 }
@@ -937,8 +933,7 @@ REBNATIVE(do)
         if (REF(next)) {
             REBIXO indexor = VAL_INDEX(value);
 
-            DO_NEXT_MAY_THROW(
-                indexor, // updated
+            indexor = DO_NEXT_MAY_THROW(
                 D_OUT,
                 VAL_ARRAY(value),
                 indexor,
@@ -1276,11 +1271,10 @@ REBNATIVE(fail)
             RELVAL *item = VAL_ARRAY_AT(reason);
 
             REBVAL pending_delimiter;
+            SET_END(&pending_delimiter);
 
             REB_MOLD mo;
             CLEARS(&mo);
-
-            SET_END(&pending_delimiter);
 
             // Check to make sure we're only drawing from the limited types
             // we accept (reserving room for future dialect expansion)

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -157,7 +157,7 @@ REBNATIVE(assert)
         while (indexor != END_FLAG) {
             i = cast(REBCNT, indexor);
 
-            DO_NEXT_MAY_THROW(indexor, D_OUT, block, indexor, specifier);
+            indexor = DO_NEXT_MAY_THROW(D_OUT, block, indexor, specifier);
             if (indexor == THROWN_FLAG)
                 return R_OUT_IS_THROWN;
 
@@ -1016,6 +1016,7 @@ REBNATIVE(set)
             if (!REF(opt) && IS_VOID(value)) {
                 REBVAL key_name;
                 Val_Init_Word(&key_name, REB_WORD, VAL_TYPESET_SYM(key));
+
                 fail (Error(RE_NEED_VALUE, &key_name));
             }
 
@@ -1208,12 +1209,6 @@ REBNATIVE(unset)
     for (word = VAL_ARRAY_AT(target); NOT_END(word); ++word) {
         if (!ANY_WORD(word))
             fail (Error_Invalid_Arg_Core(word, VAL_SPECIFIER(target)));
-
-        if (IS_WORD_UNBOUND(word)) {
-            REBVAL specific;
-            COPY_VALUE(&specific, word, VAL_SPECIFIER(target));
-            fail (Error(RE_NOT_BOUND, &specific));
-        }
 
         REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(word, VAL_SPECIFIER(target));
         SET_VOID(var);
@@ -1761,22 +1756,3 @@ REBNATIVE(map_gob_offset)
 
     return R_OUT;
 }
-
-
-#if !defined(NDEBUG)
-
-
-//
-//  VAL_SERIES_Debug: C
-//
-// Variant of VAL_SERIES() macro for the debug build which checks to ensure
-// that you have an ANY-SERIES! value you're calling it on (or one of the
-// exception types that use REBSERs)
-//
-REBSER *VAL_SERIES_Debug(const RELVAL *v)
-{
-    assert(ANY_SERIES(v) || IS_MAP(v) || IS_VECTOR(v) || IS_IMAGE(v));
-    return (v)->payload.any_series.series;
-}
-
-#endif

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -58,13 +58,13 @@ REBOOL Catching_Break_Or_Continue(REBVAL *val, REBOOL *stop)
     if (!IS_FUNCTION(val))
         return FALSE;
 
-    if (VAL_FUNC_DISPATCH(val) == &N_break) {
+    if (VAL_FUNC_DISPATCHER(val) == &N_break) {
         *stop = TRUE; // was BREAK or BREAK/WITH
         CATCH_THROWN(val, val); // will be unset if no /WITH was used
         return TRUE;
     }
 
-    if (VAL_FUNC_DISPATCH(val) == &N_continue) {
+    if (VAL_FUNC_DISPATCHER(val) == &N_continue) {
         *stop = FALSE; // was CONTINUE or CONTINUE/WITH
         CATCH_THROWN(val, val); // will be unset if no /WITH was used
         return TRUE;
@@ -538,6 +538,7 @@ static REB_R Loop_Each(struct Reb_Frame *frame_, LOOP_MODE mode)
                     // !!! Review this error (and this routine...)
                     REBVAL key_name;
                     Val_Init_Word(&key_name, REB_WORD, VAL_TYPESET_SYM(key));
+
                     fail (Error_Invalid_Arg(&key_name));
                 }
                 j++;
@@ -573,6 +574,7 @@ static REB_R Loop_Each(struct Reb_Frame *frame_, LOOP_MODE mode)
                         Val_Init_Word(
                             &key_name, REB_WORD, VAL_TYPESET_SYM(key)
                         );
+
                         fail (Error_Invalid_Arg(&key_name));
                     }
                     j++;

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -409,7 +409,7 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
             }
             else if (tb == REB_MONEY) {
                 deci amount = int_to_deci(VAL_INT64(a));
-                SET_MONEY_AMOUNT(a, amount);
+                SET_MONEY(a, amount);
                 goto compare;
             }
             break;
@@ -422,8 +422,7 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
                 goto compare;
             }
             else if (tb == REB_MONEY) {
-                deci amount = decimal_to_deci(VAL_DECIMAL(a));
-                SET_MONEY_AMOUNT(a, amount);
+                SET_MONEY(a, decimal_to_deci(VAL_DECIMAL(a)));
                 goto compare;
             }
             else if (tb == REB_DECIMAL || tb == REB_PERCENT) // equivalent types
@@ -432,13 +431,11 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
 
         case REB_MONEY:
             if (tb == REB_INTEGER) {
-                deci amount = int_to_deci(VAL_INT64(b));
-                SET_MONEY_AMOUNT(b, amount);
+                SET_MONEY(b, int_to_deci(VAL_INT64(b)));
                 goto compare;
             }
             if (tb == REB_DECIMAL || tb == REB_PERCENT) {
-                deci amount = decimal_to_deci(VAL_DECIMAL(b));
-                SET_MONEY_AMOUNT(b, amount);
+                SET_MONEY(b, decimal_to_deci(VAL_DECIMAL(b)));
                 goto compare;
             }
             break;
@@ -634,26 +631,6 @@ REBNATIVE(same_q)
         if (IS_WORD_BOUND(value1) != IS_WORD_BOUND(value2))
             return R_FALSE;
         if (IS_WORD_BOUND(value1)) {
-            if (IS_RELATIVE(value1) && IS_RELATIVE(value2)) {
-                //
-                // Prior to specific binding, relative words with the same
-                // symbol are indistinguishable if they are bound relative to
-                // the same function.  So ecursions of a function cannot
-                // distinguish the word instances originating from each level.
-                //
-                // !!! This problem is fixed in the specific binding branch,
-                // which distinguishes REBVALs (fully specific) from REBVALs
-                // (may be relative).  Function arguments are always REBVAL,
-                // so this relative processing code would never run.
-                //
-                if (VAL_WORD_FUNC(value1) == VAL_WORD_FUNC(value2))
-                    return R_TRUE;
-                return R_FALSE;
-            }
-
-            if (!(IS_SPECIFIC(value1) && IS_SPECIFIC(value2)))
-                return R_FALSE; // Relatively bound words can't match specific
-
             REBCTX *ctx1 = VAL_WORD_CONTEXT(value1);
             REBCTX *ctx2 = VAL_WORD_CONTEXT(value2);
             if (ctx1 != ctx2)

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -73,8 +73,7 @@ REBOOL Reduce_Array_Throws(
 
     while (indexor != END_FLAG) {
         REBVAL reduced;
-        DO_NEXT_MAY_THROW(indexor, &reduced, array, indexor, specifier);
-
+        indexor = DO_NEXT_MAY_THROW(&reduced, array, indexor, specifier);
         if (indexor == THROWN_FLAG) {
             *out = reduced;
             DS_DROP_TO(dsp_orig);
@@ -197,12 +196,14 @@ REBOOL Reduce_Array_No_Set_Throws(
         }
         else {
             REBVAL reduced;
-            DO_NEXT_MAY_THROW(indexor, &reduced, block, indexor, specifier);
+            indexor = DO_NEXT_MAY_THROW(&reduced, block, indexor, specifier);
+
             if (indexor == THROWN_FLAG) {
                 *out = reduced;
                 DS_DROP_TO(dsp_orig);
                 return TRUE;
             }
+
             DS_PUSH(&reduced);
         }
     }

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -143,6 +143,7 @@ static int sig_word_num(REBSYM canon)
         default: {
             REBVAL word;
             Val_Init_Word(&word, REB_WORD, canon);
+
             fail (Error(RE_INVALID_SPEC, &word));
         }
     }

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -365,6 +365,7 @@ REBSER *Make_Hash_Sequence(REBCNT len)
     if (!n) {
         REBVAL temp;
         SET_INTEGER(&temp, len);
+
         fail (Error(RE_SIZE_LIMIT, &temp));
     }
 

--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -323,7 +323,10 @@ REBCHR *Val_Str_To_OS_Managed(REBSER **out, REBVAL *val)
         return cast(REBCHR*, VAL_UNI_AT(val));
     }
 #else
-    if (VAL_STR_IS_ASCII(val)) {
+    if (
+        VAL_BYTE_SIZE(val)
+        && All_Bytes_ASCII(VAL_BIN_AT(val), VAL_LEN_AT(val))
+    ) {
         if (out) *out = VAL_SERIES(val);
 
         // On Linux/Unix we can use ASCII directly (it is valid UTF-8):

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -883,7 +883,8 @@ static void Mold_Function(const REBVAL *value, REB_MOLD *mold)
         //         index: 1
         //     ]]
         //
-        Mold_Value(mold, VAL_FUNC_EXEMPLAR(value), TRUE);
+        REBVAL *exemplar = KNOWN(VAL_FUNC_BODY(value));
+        Mold_Value(mold, exemplar, TRUE);
     }
 
     Append_Codepoint_Raw(mold->series, ']');
@@ -1534,7 +1535,7 @@ REBOOL Form_Reduce_Throws(
     Push_Mold(&mo);
 
     while (indexor != END_FLAG) {
-        DO_NEXT_MAY_THROW(indexor, out, block, indexor, specifier);
+        indexor = DO_NEXT_MAY_THROW(out, block, indexor, specifier);
         if (indexor == THROWN_FLAG)
             return TRUE;
 

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -182,7 +182,13 @@ REBSER *Temp_Bin_Str_Managed(REBVAL *val, REBCNT *index, REBCNT *length)
     // reallocate under a new width) so consider having an EMPTY_BYTE_STRING
     // like EMPTY_ARRAY which is protected to hand back.
     //
-    if (IS_BINARY(val) || VAL_STR_IS_ASCII(val)) {
+    if (
+        IS_BINARY(val)
+        || (
+            VAL_BYTE_SIZE(val)
+            && All_Bytes_ASCII(VAL_BIN_AT(val), VAL_LEN_AT(val))
+        )
+    ){
         //
         // It's BINARY!, or an ANY-STRING! whose codepoints are all values in
         // ASCII (0x00 => 0x7F), hence not needing any UTF-8 encoding.
@@ -212,6 +218,7 @@ REBSER *Temp_Bin_Str_Managed(REBVAL *val, REBCNT *index, REBCNT *length)
         {
             REBVAL protect;
             Val_Init_String(&protect, series);
+
             Protect_Value(&protect, FLAGIT(PROT_SET));
 
             // just a string...not /DEEP...shouldn't need to Unmark()

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -326,7 +326,7 @@ REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
         fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     item = VAL_ARRAY_AT(val);
-    if (NOT_END(item) && IS_SAME_WORD(item, SYM_NOT)) {
+    if (NOT_END(item) && IS_WORD(item) && VAL_WORD_CANON(item) == SYM_NOT) {
         INIT_BITS_NOT(bset, TRUE);
         item++;
     }
@@ -339,10 +339,13 @@ REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
         case REB_CHAR:
             c = VAL_CHAR(item);
 
-            // !!! Modified to check for END, used to be just the test for
-            // IS_SAME_WORD() ... is the `else` path actually correct?
+            // !!! Modified to check for END, is the `else` actually correct?
             //
-            if (NOT_END(item + 1) && IS_SAME_WORD(item + 1, SYM_HYPHEN)) {
+            if (
+                NOT_END(item + 1)
+                && IS_WORD(item + 1)
+                && VAL_WORD_CANON(item + 1) == SYM_HYPHEN
+            ) {
                 item += 2;
                 if (IS_CHAR(item)) {
                     n = VAL_CHAR(item);
@@ -359,7 +362,7 @@ span_bits:
         case REB_INTEGER:
             n = Int32s(KNOWN(item), 0);
             if (n > MAX_BITSET) return FALSE;
-            if (IS_SAME_WORD(item + 1, SYM_HYPHEN)) {
+            if (IS_WORD(item + 1) && VAL_WORD_CANON(item + 1) == SYM_HYPHEN) {
                 c = n;
                 item += 2;
                 if (IS_INTEGER(item)) {
@@ -384,7 +387,8 @@ span_bits:
 
         case REB_WORD:
             // Special: BITS #{000...}
-            if (!IS_SAME_WORD(item, SYM_BITS)) return FALSE;
+            if (!IS_WORD(item) || VAL_WORD_CANON(item) != SYM_BITS)
+                return FALSE;
             item++;
             if (!IS_BINARY(item)) return FALSE;
             n = VAL_LEN_AT(item);
@@ -436,7 +440,7 @@ REBOOL Check_Bits(REBSER *bset, const REBVAL *val, REBOOL uncased)
 
         case REB_CHAR:
             c = VAL_CHAR(item);
-            if (IS_SAME_WORD(item + 1, SYM_HYPHEN)) {
+            if (IS_WORD(item + 1) && VAL_WORD_CANON(item + 1) == SYM_HYPHEN) {
                 item += 2;
                 if (IS_CHAR(item)) {
                     n = VAL_CHAR(item);
@@ -455,7 +459,7 @@ scan_bits:
         case REB_INTEGER:
             n = Int32s(KNOWN(item), 0);
             if (n > 0xffff) return FALSE;
-            if (IS_SAME_WORD(item + 1, SYM_HYPHEN)) {
+            if (IS_WORD(item + 1) && VAL_WORD_CANON(item + 1) == SYM_HYPHEN) {
                 c = n;
                 item += 2;
                 if (IS_INTEGER(item)) {

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -100,6 +100,7 @@ REBOOL MT_Array(
     ++data;
 
     VAL_RESET_HEADER(out, type);
+    SET_VAL_FLAG(out, VALUE_FLAG_ARRAY);
 
     i = NOT_END(data) && IS_INTEGER(data) ? Int32(KNOWN(data)) - 1 : 0;
 
@@ -295,20 +296,17 @@ REBOOL Make_Block_Type_Throws(
         // a normal or soft-quoted varargs, but a hard-quoted varargs will
         // grab all the values to the end of the source.
 
-        REBDSP dsp_orig = DSP;
-
-        REBARR *feed;
-        REBARR **subfeed_addr;
-
-        const RELVAL *param;
-        REBVAL fake_param;
-
         // !!! This MAKE will be destructive to its input (the varargs will
         // be fetched and exhausted).  That's not necessarily obvious, but
         // with a TO conversion it would be even less obvious...
         //
         if (!make)
             fail (Error(RE_VARARGS_MAKE_ONLY));
+
+        const RELVAL *param;
+        REBVAL fake_param;
+
+        REBARR *feed;
 
         if (GET_VAL_FLAG(arg, VARARGS_FLAG_NO_FRAME)) {
             feed = VAL_VARARGS_ARRAY1(arg);
@@ -325,6 +323,8 @@ REBOOL Make_Block_Type_Throws(
             feed = CTX_VARLIST(VAL_VARARGS_FRAME_CTX(arg));
             param = VAL_VARARGS_PARAM(arg);
         }
+
+        REBDSP dsp_orig = DSP;
 
         do {
             REBIXO indexor = Do_Vararg_Op_Core(
@@ -352,7 +352,7 @@ REBOOL Make_Block_Type_Throws(
             // that has been evaluated, and subfeeds can't be fixed up
             // like this either...disabled for now.
             //
-            subfeed_addr = SUBFEED_ADDR_OF_FEED(feed);
+            REBARR **subfeed_addr = SUBFEED_ADDR_OF_FEED(feed);
             assert(*subfeed_addr == NULL); // all values should be exhausted
             *subfeed_addr = Make_Singular_Array(out);
             MANAGE_ARRAY(*subfeed_addr);

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -264,8 +264,7 @@ REBTYPE(Decimal)
                 if (action == A_DIVIDE) type = REB_DECIMAL;
                 else if (!IS_PERCENT(val)) type = VAL_TYPE(val);
             } else if (type == REB_MONEY) {
-                VAL_MONEY_AMOUNT(val) = decimal_to_deci(VAL_DECIMAL(val));
-                VAL_RESET_HEADER(val, REB_MONEY);
+                SET_MONEY(val, decimal_to_deci(VAL_DECIMAL(val)));
                 return T_Money(frame_, action);
             } else if (type == REB_CHAR) {
                 d2 = (REBDEC)VAL_CHAR(arg);
@@ -415,6 +414,7 @@ REBTYPE(Decimal)
                     else {
                         REBVAL specific;
                         COPY_VALUE(&specific, item, VAL_SPECIFIER(val));
+
                         fail (Error_Bad_Make(REB_DECIMAL, &specific));
                     }
 
@@ -427,6 +427,7 @@ REBTYPE(Decimal)
                     else {
                         REBVAL specific;
                         COPY_VALUE(&specific, item, VAL_SPECIFIER(val));
+
                         fail (Error_Bad_Make(REB_DECIMAL, &specific));
                     }
 
@@ -447,10 +448,9 @@ REBTYPE(Decimal)
             num = Get_Round_Flags(frame_);
             if (D_REF(2)) { // to
                 if (IS_MONEY(arg)) {
-                    VAL_RESET_HEADER(D_OUT, REB_MONEY);
-                    VAL_MONEY_AMOUNT(D_OUT) = Round_Deci(
+                    SET_MONEY(D_OUT, Round_Deci(
                         decimal_to_deci(d1), num, VAL_MONEY_AMOUNT(arg)
-                    );
+                    ));
                     return R_OUT;
                 }
                 if (IS_TIME(arg)) fail (Error_Invalid_Arg(arg));
@@ -491,17 +491,3 @@ setDec:
 
     return R_OUT;
 }
-
-
-#if !defined(NDEBUG)
-
-//
-//  VAL_DECIMAL_Ptr_Debug: C
-//
-REBDEC *VAL_DECIMAL_Ptr_Debug(const RELVAL *value)
-{
-    assert(IS_DECIMAL(value) || IS_PERCENT(value));
-    return &m_cast(REBVAL*, const_KNOWN(value))->payload.decimal.dec;
-}
-
-#endif

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -622,8 +622,6 @@ static void Set_GOB_Vars(REBGOB *gob, const RELVAL *blk, REBCTX *specifier)
         if (IS_END(blk))
             fail (Error(RE_NEED_VALUE, var));
 
-        assert(!IS_VOID(blk));
-
         REBVAL val;
         COPY_VALUE(&val, blk, specifier);
         ++blk;
@@ -847,7 +845,7 @@ REBTYPE(Gob)
         break;
 
     case A_PICK:
-        if (!IS_NUMBER(arg) && !IS_BLANK(arg)) fail (Error_Invalid_Arg(arg));
+        if (!ANY_NUMBER(arg) && !IS_BLANK(arg)) fail (Error_Invalid_Arg(arg));
         if (!GOB_PANE(gob)) goto is_blank;
         index += Get_Num_From_Arg(arg) - 1;
         if (index >= tail) goto is_blank;

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -330,8 +330,7 @@ REBTYPE(Integer)
                     return T_Decimal(frame_, action);
                 }
                 if (IS_MONEY(val2)) {
-                    VAL_MONEY_AMOUNT(val) = int_to_deci(VAL_INT64(val));
-                    VAL_RESET_HEADER(val, REB_MONEY);
+                    SET_MONEY(val, int_to_deci(VAL_INT64(val)));
                     return T_Money(frame_, action);
                 }
                 if (n > 0) {
@@ -423,10 +422,9 @@ REBTYPE(Integer)
         n = Get_Round_Flags(frame_);
         if (D_REF(2)) { // to
             if (IS_MONEY(val2)) {
-                VAL_MONEY_AMOUNT(D_OUT) = Round_Deci(
+                SET_MONEY(D_OUT, Round_Deci(
                     int_to_deci(num), n, VAL_MONEY_AMOUNT(val2)
-                );
-                VAL_SET_TYPE_BITS(D_OUT, REB_MONEY);
+                ));
                 return R_OUT;
             }
             if (IS_DECIMAL(val2) || IS_PERCENT(val2)) {
@@ -491,17 +489,3 @@ REBTYPE(Integer)
     SET_INTEGER(D_OUT, num);
     return R_OUT;
 }
-
-
-#if !defined(NDEBUG)
-
-//
-//  VAL_INT64_Ptr_Debug: C
-//
-REBI64 *VAL_INT64_Ptr_Debug(const RELVAL *value)
-{
-    assert(IS_INTEGER(value));
-    return &m_cast(REBVAL*, const_KNOWN(value))->payload.integer.i64;
-}
-
-#endif

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -55,7 +55,7 @@ REBOOL MT_Logic(
     REBVAL *out, RELVAL *data, REBCTX *specifier, enum Reb_Kind type
 ) {
     if (!IS_INTEGER(data)) return FALSE;
-    SET_LOGIC(out, VAL_INT64(data) != 0);
+    SET_LOGIC(out, LOGICAL(VAL_INT64(data) != 0));
     return TRUE;
 }
 
@@ -65,7 +65,7 @@ REBOOL MT_Logic(
 //
 REBTYPE(Logic)
 {
-    REBOOL val1 = VAL_LOGIC(D_ARG(1));
+    REBOOL val1;
     REBOOL val2;
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
 
@@ -77,6 +77,9 @@ REBTYPE(Logic)
         else
             fail (Error_Unexpected_Type(REB_LOGIC, VAL_TYPE(arg)));
     }
+
+    if (action != A_MAKE && action != A_TO)
+        val1 = VAL_LOGIC(D_ARG(1));
 
     switch (action) {
 

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -379,12 +379,9 @@ REBINT PD_Map(REBPVS *pvs)
     );
 
     if (n == 0)
-        val = VOID_CELL;
-    else
-        val = KNOWN(
-            ARR_AT(MAP_PAIRLIST(VAL_MAP(pvs->value)), ((n - 1) * 2) + 1)
-        );
+        return PE_NONE;
 
+    val = KNOWN(ARR_AT(MAP_PAIRLIST(VAL_MAP(pvs->value)), ((n - 1) * 2) + 1));
     if (IS_VOID(val))
         return PE_NONE;
 
@@ -683,7 +680,7 @@ REBTYPE(Map)
 //      } else if (IS_BLANK(arg)) {
 //          n = 3; // just a start
         // make map! 10000
-        } else if (IS_NUMBER(arg)) {
+        } else if (ANY_NUMBER(arg)) {
             if (action == A_TO) fail (Error_Invalid_Arg(arg));
             n = Int32s(arg, 0);
         }

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -544,7 +544,7 @@ REBTYPE(Context)
 
         // `make object! 10` - currently not prohibited for any context type
         //
-        if (IS_NUMBER(arg)) {
+        if (ANY_NUMBER(arg)) {
             REBINT n = Int32s(arg, 0);
 
             // !!! Temporary!  Ultimately SELF will be a user protocol.
@@ -696,7 +696,7 @@ REBTYPE(Context)
 
     case A_TAIL_Q:
         if (IS_OBJECT(value)) {
-            SET_LOGIC(D_OUT, CTX_LEN(VAL_CONTEXT(value)) == 0);
+            SET_LOGIC(D_OUT, LOGICAL(CTX_LEN(VAL_CONTEXT(value)) == 0));
             return R_OUT;
         }
         fail (Error_Illegal_Action(VAL_TYPE(value), action));

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -570,7 +570,7 @@ static void set_ext_storage (REBVAL *out, REBINT raw_size, REBUPT raw_addr)
         Is_Array_Series(data_ser) ? (MKS_ARRAY | MKS_EXTERNAL) : MKS_EXTERNAL
     );
 
-    SER_SET_EXTERNAL_DATA(ser, raw_addr);
+    SER_SET_EXTERNAL_DATA(ser, cast(REBYTE*, raw_addr));
     SET_SER_FLAG(ser, SERIES_FLAG_ACCESSIBLE); // accessible by default
     SET_SERIES_LEN(ser, SER_LEN(VAL_STRUCT_DATA_BIN(out)));
 
@@ -765,9 +765,6 @@ REBOOL MT_Struct(
             struct Struct_Field *field = NULL;
             u64 step = 0;
 
-            REBVAL inner;
-            REBVAL spec;
-
             EXPAND_SERIES_TAIL(VAL_STRUCT_FIELDS(out), 1);
 
             // !!! MT_Struct is recursively called, and it performs evaluation.
@@ -777,6 +774,7 @@ REBOOL MT_Struct(
             //
             // Given that this code was written to evaluate, protect `inner`
             //
+            REBVAL inner;
             SET_BLANK(&inner);
             PUSH_GUARD_VALUE(&inner);
 
@@ -805,6 +803,7 @@ REBOOL MT_Struct(
             if (IS_END(blk) || !IS_BLOCK(blk))
                 fail (Error_Invalid_Arg_Core(blk, specifier));
 
+            REBVAL spec;
             COPY_VALUE(&spec, blk, specifier);
 
             if (!parse_field_type(field, &spec, &inner, &init))
@@ -841,8 +840,7 @@ REBOOL MT_Struct(
                     }
                     ++ blk;
                 } else {
-                    DO_NEXT_MAY_THROW(
-                        eval_idx,
+                    eval_idx = DO_NEXT_MAY_THROW(
                         init,
                         VAL_ARRAY(data),
                         cast(RELVAL*, blk) - VAL_ARRAY_AT(data),

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -112,7 +112,7 @@ void Init_Typesets(void)
 void Val_Init_Typeset(RELVAL *value, REBU64 bits, REBSYM sym)
 {
     VAL_RESET_HEADER(value, REB_TYPESET);
-    VAL_TYPESET_SYM(value) = sym;
+    VAL_TYPESET_SYM_INIT(value, sym);
     VAL_TYPESET_BITS(value) = bits;
 }
 

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -363,14 +363,12 @@ REBIXO Do_Vararg_Op_May_Throw(
         // With these choices, no errors should be reported which would
         // require a named symbol.  However, we name it `...` anyway.
 
-        REBIXO indexor;
-
         REBVAL fake_param;
         Val_Init_Typeset(&fake_param, ALL_64, SYM_ELLIPSIS); // any type
         SET_VAL_FLAG(&fake_param, TYPESET_FLAG_VARIADIC); // pretend <...> tag
         INIT_VAL_PARAM_CLASS(&fake_param, PARAM_CLASS_HARD_QUOTE);
 
-        indexor = Do_Vararg_Op_Core(
+        REBIXO indexor = Do_Vararg_Op_Core(
             out,
             VAL_VARARGS_ARRAY1(varargs), // single-element array w/shared value
             &fake_param,
@@ -432,7 +430,7 @@ REBTYPE(Varargs)
 
             VAL_RESET_HEADER(D_OUT, REB_VARARGS);
             SET_VAL_FLAG(D_OUT, VARARGS_FLAG_NO_FRAME);
-            VAL_VARARGS_ARRAY1(D_OUT) = array1;
+            D_OUT->payload.varargs.feed.array1 = array1;
 
             return R_OUT;
         }
@@ -614,6 +612,7 @@ void Mold_Varargs(const REBVAL *value, REB_MOLD *mold) {
             };
 
             // Note varargs_param is distinct from f->param!
+            REBVAL param_word;
             Val_Init_Word(&param_word, kind, VAL_TYPESET_SYM(varargs_param));
 
             Mold_Value(mold, &param_word, TRUE);

--- a/src/include/mem-series.h
+++ b/src/include/mem-series.h
@@ -53,11 +53,11 @@
 // REBYTE and dodge the comparison if so.
 //
 
-#define MAX_SERIES_WIDE 0x100 \
+#define MAX_SERIES_WIDE 0x100
 
-#define SER_SET_WIDE(s,w) \
-    ((s)->info.bits = ((s)->info.bits & 0xffff) | (w << 16))
-
+inline static void SER_SET_WIDE(REBSER *s, REBCNT w) {
+    s->info.bits = (s->info.bits & 0xffff) | (w << 16);
+}
 
 //
 // Bias is empty space in front of head:
@@ -66,14 +66,19 @@
 #define SER_BIAS(s) \
     cast(REBCNT, ((s)->content.dynamic.bias >> 16) & 0xffff)
 
-#define MAX_SERIES_BIAS 0x1000 \
+#define MAX_SERIES_BIAS 0x1000
 
-#define SER_SET_BIAS(s,b) \
-    ((s)->content.dynamic.bias = \
-        ((s)->content.dynamic.bias & 0xffff) | (b << 16))
+inline static void SER_SET_BIAS(REBSER *s, REBCNT bias) {
+    s->content.dynamic.bias =
+        (s->content.dynamic.bias & 0xffff) | (bias << 16);
+}
 
 #define SER_ADD_BIAS(s,b) \
     ((s)->content.dynamic.bias += (b << 16))
 
 #define SER_SUB_BIAS(s,b) \
     ((s)->content.dynamic.bias -= (b << 16))
+
+inline static size_t SER_TOTAL(REBSER *s) {
+    return (SER_REST(s) + SER_BIAS(s)) * SER_WIDE(s);
+}

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -1,0 +1,615 @@
+//
+//  File: %sys-frame.h
+//  Summary: {Evaluator "Do State"}
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2015 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The primary routine that performs DO and DO/NEXT is called Do_Core().  It
+// takes a single parameter which holds the running state of the evaluator.
+// This state may be allocated on the C variable stack:  Do_Core() is
+// written such that a longjmp up to a failure handler above it can run
+// safely and clean up even though intermediate stacks have vanished.
+//
+// Ren-C can not only run the evaluator across a REBSER-style series of
+// input based on index, it can also fetch those values from a standard C
+// array of REBVAL[].  Alternately, it can enumerate through C's `va_list`,
+// providing the ability to pass pointers as REBVAL* to comma-separated input
+// at the source level.
+//
+// To provide even greater flexibility, it allows the very first element's
+// pointer in an evaluation to come from an arbitrary source.  It doesn't
+// have to be resident in the same sequence from which ensuing values are
+// pulled, allowing a free head value (such as a FUNCTION! REBVAL in a local
+// C variable) to be evaluated in combination from another source (like a
+// va_list or series representing the arguments.)  This avoids the cost and
+// complexity of allocating a series to combine the values together.
+//
+// These features alone would not cover the case when REBVAL pointers that
+// are originating with C source were intended to be supplied to a function
+// with no evaluation.  In R3-Alpha, the only way in an evaluative context
+// to suppress such evaluations would be by adding elements (such as QUOTE).
+// Besides the cost and labor of inserting these, the risk is that the
+// intended functions to be called without evaluation, if they quoted
+// arguments would then receive the QUOTE instead of the arguments.
+//
+// The problem was solved by adding a feature to the evaluator which was
+// also opened up as a new privileged native called EVAL.  EVAL's refinements
+// completely encompass evaluation possibilities in R3-Alpha, but it was also
+// necessary to consider cases where a value was intended to be provided
+// *without* evaluation.  This introduced EVAL/ONLY.
+//
+
+
+//
+// DO_FLAGS
+//
+// Used by low level routines, these flags specify behaviors which are
+// exposed at a higher level through EVAL, EVAL/ONLY, and EVAL/NOFIX
+//
+// The flags are specified either way for clarity.
+//
+enum {
+    DO_FLAG_0 = 0, // unused
+
+    // As exposed by the DO native and its /NEXT refinement, a call to the
+    // evaluator can either run to the finish from a position in an array
+    // or just do one eval.  Rather than achieve execution to the end by
+    // iterative function calls to the /NEXT variant (as in R3-Alpha), Ren-C
+    // offers a controlling flag to do it from within the core evaluator
+    // as a loop.
+    //
+    // However: since running to the end follows a different code path than
+    // performing DO/NEXT several times, it is important to ensure they
+    // achieve equivalent results.  There are nuances to preserve this
+    // invariant and especially in light of potential interaction with
+    // DO_FLAG_LOOKAHEAD.
+    //
+    // NOTE: DO_FLAG_NEXT is *non-continuable* with va_list.  This is due to
+    // contention with DO_FLAG_LOOKAHEAD which would not be able to "un-fetch"
+    // in the case of a lookahead for infix that failed (and NO_LOOKAHEAD is
+    // very rare with API clients).  But also, the va_list could need a
+    // conversion to an array during evaluation...and any continuation would
+    // need to be sensitive to this change, which is extra trouble for very
+    // little likely benefit.
+    //
+    DO_FLAG_NEXT = 1 << 1,
+    DO_FLAG_TO_END = 1 << 2,
+
+    // When we're in mid-dispatch of an infix function, the precedence is such
+    // that we don't want to do further infix lookahead while getting the
+    // arguments.  (e.g. with `1 + 2 * 3` we don't want infix `+` to
+    // "look ahead" past the 2 to see the infix `*`)
+    //
+    // Actions taken during lookahead may have no side effects.  If it's used
+    // to evaluate a form of source input that cannot be backtracked (e.g.
+    // a C variable argument list) then it will not be possible to resume.
+    //
+    DO_FLAG_LOOKAHEAD = 1 << 3,
+    DO_FLAG_NO_LOOKAHEAD = 1 << 4,
+
+    // Write more comments here when feeling in more of a commenting mood
+    //
+    DO_FLAG_ARGS_EVALUATE = 1 << 5,
+    DO_FLAG_NO_ARGS_EVALUATE = 1 << 6,
+
+    // A pre-built frame can be executed "in-place" without a new allocation.
+    // It will be type checked, and also any BAR! parameters will indicate
+    // a desire to acquire that argument (permitting partial specialization).
+    //
+    DO_FLAG_EXECUTE_FRAME = 1 << 7,
+
+    // Usually VALIST_FLAG is enough to tell when there is a source array to
+    // examine or not.  However, when the end is reached it is written over
+    // with END_FLAG and it's no longer possible to tell if there's an array
+    // available to inspect or not.  The few cases that "need to know" are
+    // things like error delivery, which want to process the array after
+    // expression evaluation is complete.  Review to see if they actually
+    // would rather know something else, but this is a cheap flag for now.
+    //
+    DO_FLAG_VALIST = 1 << 8,
+
+    // While R3-Alpha permitted modifications of an array while it was being
+    // executed, Ren-C does not.  It takes a lock if the source is not already
+    // read only, and sets it back when Do_Core is finished (or on errors)
+    //
+    DO_FLAG_TOOK_FRAME_LOCK = 1 << 9,
+
+    // DO_FLAG_APPLYING is used to indicate that the Do_Core code is entering
+    // a situation where the frame was already set up.
+    //
+    DO_FLAG_APPLYING = 1 << 10
+};
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  DO INDEX OR FLAG (a.k.a. "INDEXOR")
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// * END_FLAG if end of series prohibited a full evaluation
+//
+// * THROWN_FLAG if the output is THROWN()--you MUST check!
+//
+// * ...or the next index position where one might continue evaluation
+//
+// ===========================((( IMPORTANT )))==============================
+//
+//      The THROWN_FLAG means your value does not represent a directly
+//      usable value, so you MUST check for it.  It signifies getting
+//      back a THROWN()--see notes in sys-value.h about what that means.
+//      If you don't know how to handle it, then at least do:
+//
+//              fail (Error_No_Catch_For_Throw(out));
+//
+//      If you *do* handle it, be aware it's a throw label with
+//      VALUE_FLAG_THROWN set in its header, and shouldn't leak to the
+//      rest of the system.
+//
+// ===========================================================================
+//
+// Note that THROWN() is not an indicator of an error, rather something that
+// ordinary language constructs might meaningfully want to process as they
+// bubble up the stack.  Some examples would be BREAK, RETURN, and QUIT.
+//
+// Errors are handled with a different mechanism using longjmp().  So if an
+// actual error happened during the DO then there wouldn't even *BE* a return
+// value...because the function call would never return!  See PUSH_TRAP()
+// and fail() for more information.
+//
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  EVALUATION TYPES ("ET_XXX")
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The REB_XXX types are not sequential, but skip by 4 in order to have the
+// low 2 bits clear on all values in the enumeration.  This means faster
+// extraction and comparison without needing to bit-shift, but it also
+// means that a `switch` statement can't be optimized into a jump table--
+// which generally requires contiguous values:
+//
+// http://stackoverflow.com/questions/17061967/c-switch-and-jump-tables
+//
+// By having a table that can quickly convert an `enum Reb_Kind` into a
+// small integer suitable for a switch statement in the evaluator, the
+// optimization can be leveraged.  The special value of "0" is picked for
+// no evaluation behavior, so the table can have a second use as the quick
+// implementation behind the ANY_EVAL macro.  All non-zero values then can
+// mean "has some behavior in the evaluator".
+//
+enum Reb_Eval_Type {
+    ET_INERT = 0, // does double duty as logic FALSE in "ANY_EVAL()"
+    ET_BAR,
+    ET_LIT_BAR,
+    ET_WORD,
+    ET_SET_WORD,
+    ET_GET_WORD,
+    ET_LIT_WORD,
+    ET_GROUP,
+    ET_PATH,
+    ET_SET_PATH,
+    ET_GET_PATH,
+    ET_LIT_PATH,
+    ET_FUNCTION,
+
+#if !defined(NDEBUG)
+    ET_TRASH,
+#endif
+
+    ET_MAX
+};
+
+#ifdef NDEBUG
+    typedef REBUPT REBET; // native-sized integer is faster in release builds
+#else
+    typedef enum Reb_Eval_Type REBET; // typed enum is better info in debugger
+#endif
+
+// If the type has evaluator behavior (vs. just passing through).  So like
+// WORD!, GROUP!, FUNCTION! (as opposed to BLOCK!, INTEGER!, OBJECT!).
+// The types are not arranged in an order that makes a super fast test easy
+// (though perhaps someday it could be tweaked so that all the evaluated types
+// had a certain bit set?) hence use a small fixed table.
+//
+// Note that this table has 256 entries, of which only those corresponding
+// to having the two lowest bits zero are set.  This is to avoid needing
+// shifting to check if a value is evaluable.  The other storage could be
+// used for properties of the type +1, +2, +3 ... at the cost of a bit of
+// math but reusing the values.  Any integer property could be stored for
+// the evaluables so long as non-evaluables are 0 in this list.
+//
+extern const REBET Eval_Table[REB_MAX];
+
+#define ANY_EVAL(v) LOGICAL(Eval_Table[VAL_TYPE(v)])
+
+
+union Reb_Frame_Source {
+    REBARR *array;
+    va_list *vaptr;
+};
+
+// NOTE: The ordering of the fields in `Reb_Frame` are specifically done so
+// as to accomplish correct 64-bit alignment of pointers on 64-bit systems
+// (as long as REBCNT and REBINT are 32-bit on such platforms).  If modifying
+// the structure, be sensitive to this issue.
+//
+// Because performance in the core evaluator loop is system-critical, this
+// uses full platform `int`s instead of REBCNTs.
+//
+struct Reb_Frame {
+    //
+    // `eval` [INTERNAL, NON-READABLE, not GC-PROTECTED?]
+    //
+    // Placed at the head of the structure for alignment reasons, but the most
+    // difficult field of Reb_Frame to explain.  It serves the purpose of a
+    // holding cell that is needed while an EVAL is running, because the
+    // calculated value that had lived in `c->out` which is being evaluated
+    // can't stay in that spot while the next evaluation is writing into it.
+    // Frameless natives and other code with call frame access should not
+    // tamper w/it or read it--from their point of view it is "random".
+    //
+    // Once a function evaluation has started and the fields of the FUNC
+    // extracted, however, then specifically the eval slot is free up until
+    // the function evaluation is over.  As a result, it is used by VARARGS!
+    // to hold a piece of state that is visible to all bit-pattern-instances
+    // of that same VARARGS! in other locations.  See notes in %sys-value.h
+    //
+    union {
+        RELVAL eval;
+        REBARR *subfeed; // during VARARGS! (see also REBSER.misc.subfeed)
+    } cell;
+
+    // `func` [INTERNAL, READ-ONLY, GC-PROTECTED]
+    //
+    // If a function call is currently in effect, `func` holds a pointer to
+    // the function being run.  Because functions are identified and passed
+    // by a platform pointer as their paramlist REBSER*, you must use
+    // `FUNC_VALUE(c->func)` to get a pointer to a canon REBVAL representing
+    // that function (to examine its function flags, for instance).
+    //
+    REBFUN *func;
+
+    // `dsp_orig` [INTERNAL, READ-ONLY]
+    //
+    // The data stack pointer captured on entry to the evaluation.  It is used
+    // by debug checks to make sure the data stack stays balanced after each
+    // sub-operation.  Yet also, refinements are pushed to the data stack and
+    // something to compare against to find out how many is needed.  At this
+    // position to sync alignment with same-sized `flags`.
+    //
+    REBUPT dsp_orig; // type is REBDSP, but enforce alignment here
+
+    // `flags` [INPUT, READ-ONLY]
+    //
+    // These are DO_FLAG_xxx or'd together.  If the call is being set up
+    // for an Apply as opposed to Do, this must be 0.
+    //
+    REBUPT flags; // type is REBFLGS, but enforce alignment here
+
+    // `out` [INPUT pointer of where to write an OUTPUT, GC-SAFE cell]
+    //
+    // This is where to write the result of the evaluation.  It should not be
+    // in "movable" memory, hence not in a series data array.  Often it is
+    // used as an intermediate free location to do calculations en route to
+    // a final result, due to being GC-safe
+    //
+    REBVAL *out;
+
+    // `value` [INPUT, REUSABLE, GC-PROTECTS pointed-to REBVAL]
+    //
+    // This is the value currently being processed.  Callers pass in the
+    // first value pointer...which for any successive evaluations will be
+    // updated via picking from `array` based on `index`.  But having the
+    // caller pass in the initial value gives the *option* of that value
+    // not being resident in the series.
+    //
+    // (Hence if one has the series `[[a b c] [d e]]` it would be possible to
+    // have an independent path value `append/only` and NOT insert it in the
+    // series, yet get the effect of `append/only [a b c] [d e]`.  This only
+    // works for one value, but is a convenient no-cost trick for apply-like
+    // situations...as insertions usually have to "slide down" the values in
+    // the series and may also need to perform alloc/free/copy to expand.)
+    //
+    // !!! The ramifications of using a disconnected value on debugging
+    // which is *not* part of the series is that the "where" will come up
+    // with missing information.  This is not the only case where the
+    // optimization of not making a series or not making a frame creates
+    // a problem--and in general, optimization will interfere with almost any
+    // debug feedback.  The proposed solution is to have a "debug mode" which
+    // causes more conservatism--for instance, if it is noticed in an
+    // evaluation that the value pointer does *not* line up at the head of
+    // the series for the evaluation given, it would be cached somewhere...
+    // then if any problem needing a where came up, a series would be made
+    // to put it in.  (The where series is paying for a copy anyway.)
+    //
+    const RELVAL *value;
+
+    // `gotten`
+    //
+    // Work in Get_Var that might need to be reused makes use of this pointer.
+    //
+    const REBVAL *gotten;
+
+    // This flag is used to tell the function code whether it needs to
+    // "lookback" (into f->out) to find its next argument instead of going
+    // through normal evaluation.
+    //
+    // A lookback binding that takes two arguments is "infix".
+    // A lookback binding that takes one argument is "postfix".
+    // A lookback binding that takes > 2 arguments can be cool (`->` lambdas)
+    // A lookback binding that takes zero arguments blocks subsequent lookback
+    //
+    REBOOL lookback;
+
+    // `eval_fetched` [INTERNAL, READ-ONLY, GC-PROTECTS pointed-to REBVAL]
+    //
+    // Mechanically speaking, running an EVAL has to overwrite `value` from
+    // the natural pre-fetching course, so that the evaluated value can be
+    // simulated as living in the line of execution.  Because fetching moves
+    // forward only, we'd lose the next value if we didn't save it somewhere.
+    //
+    // This pointer saves the prefetched value that eval overwrites, and
+    // by virtue of not being NULL signals to just use the value on the
+    // next fetch instead of fetching again.
+    //
+    const RELVAL *eval_fetched;
+
+    // source.array, source.vaptr [INPUT, READ-ONLY, GC-PROTECTED]
+    //
+    // This is the source from which new values will be fetched.  The most
+    // common dispatch of the evaluator is on values that live inside of a
+    // Rebol BLOCK! or GROUP!...but something to know is that the `array`
+    // could have come from any ANY-ARRAY! (e.g. a PATH!).  The fact that it
+    // came from a value marked REB_PATH is not known here: value-bearing
+    // series will all "evaluate like a block" when passed to Do_Core.
+    //
+    // In addition to working with a source of values in a traditional series,
+    // in Ren-C it is also possible to feed the evaluator arbitrary REBVAL*s
+    // through a variable argument list.  Though this means no array needs to
+    // be dynamically allocated, some conditions require the va_list to be
+    // converted to an array.  See notes on Reify_Va_To_Array_In_Frame().
+    //
+    union Reb_Frame_Source source;
+
+    // `indexor` [INPUT, OUTPUT]
+    //
+    // This can hold an "index OR a flag" related to the current state of
+    // the enumeration of the values being evaluated.  For the flags, see
+    // notes on REBIXO and END_FLAG, THROWN_FLAG.  Note also the case of
+    // a C va_list where the actual index of the REBVAL* is intrinsic to
+    // the enumeration...so the indexor will be VA_LIST flag vs. a count.
+    //
+    // Successive fetching is always done by index and not with `++c-value`.
+    // This is for several reasons, but one of them is to avoid crashing if
+    // the input array is modified during the evaluation.
+    //
+    // !!! While it doesn't *crash*, a good user-facing explanation of
+    // handling what it does instead seems not to have been articulated!  :-/
+    //
+    REBIXO indexor;
+
+    // `specifier` [INPUT, READ-ONLY, GC-PROTECTED]
+    //
+    // The specifier context is where any relatively bound words are looked
+    // up to become "specific".  (If the function inside the specifier does
+    // not match the function of any relatively bound words that happen to
+    // be fetched into Reb_Frame.value, then that is a problem that will
+    // assert in the debug build.)
+    //
+    // Typically the specifier used is extracted from the payload of the
+    // Reb_Any_Series that provided the source.array for the call to DO.
+    // It may also be NULL if it is known that there are no relatively bound
+    // words that will be encountered from the source.
+    //
+    REBCTX *specifier;
+
+    // `label_sym` [INTERNAL, READ-ONLY]
+    //
+    // Functions don't have "names", though they can be assigned to words.
+    // Typically the label symbol is passed into the evaluator as SYM_0 and
+    // then only changed if a function dispatches by WORD!, however it
+    // is possible for Do_Core to be called with a preloaded symbol for
+    // better debugging descriptivity.
+    //
+    REBSYM label_sym;
+
+    // `stackvars` [INTERNAL, VALUES MUTABLE and GC-SAFE]
+    //
+    // For functions without "indefinite extent", the invocation arguments are
+    // stored in the "chunk stack", where allocations are fast, address stable,
+    // and implicitly terminated.  If a function has indefinite extent, this
+    // will be set to NULL.
+    //
+    // This can contain END markers at any position during arg fulfillment.
+    //
+    REBVAL *stackvars;
+
+    // `varlist`
+    //
+    // For functions with "indefinite extent", the varlist is the CTX_VARLIST
+    // of a FRAME! context in which the function's arguments live.  It is
+    // also possible for this varlist to come into existence even for functions
+    // like natives, if the frame's context is "reified" (e.g. by the debugger)
+    // If neither of these conditions are true, it will be NULL
+    //
+    // This can contain END markers at any position during arg fulfillment,
+    // and this means it cannot have a MANAGE_ARRAY call until that is over.
+    //
+    REBARR *varlist;
+
+    // `param` [INTERNAL, REUSABLE, GC-PROTECTS pointed-to REBVALs]
+    //
+    // We use the convention that "param" refers to the TYPESET! (plus symbol)
+    // from the spec of the function--a.k.a. the "formal argument".  This
+    // pointer is moved in step with `arg` during argument fulfillment.
+    //
+    // (Note: It is const because we don't want to be changing the params,
+    // but also because it is used as a temporary to store value if it is
+    // advanced but we'd like to hold the old one...this makes it important
+    // to protect it from GC if we have advanced beyond as well!)
+    //
+    // Made relative just to have another RELVAL on hand.
+    //
+    const RELVAL *param;
+
+    // `arg` [INTERNAL, also CACHE of `ARR_HEAD(arglist)`]
+    //
+    // "arg" is the "actual argument"...which holds the pointer to the
+    // REBVAL slot in the `arglist` for that corresponding `param`.  These
+    // are moved in sync during parameter fulfillment.
+    //
+    // While a function is running, `arg` is a cache to the data pointer for
+    // arglist.  It is used by the macros ARG() and PARAM()...which index
+    // by integer constants and may be used several times.  Avoiding the
+    // extra indirection can be beneficial.
+    //
+    REBVAL *arg;
+
+    // `refine` [INTERNAL, REUSABLE, GC-PROTECTS pointed-to REBVAL]
+    //
+    // During parameter fulfillment, this might point to the `arg` slot
+    // of a refinement which is having its arguments processed.  Or it may
+    // point to another *read-only* value whose content signals information
+    // about how arguments should be handled.  The states are chosen to line
+    // up naturally with tests in the evaluator, so there's a reasoning:.
+    //
+    // * If IS_VOID(), then refinements are being skipped and the arguments
+    //   that follow should not be written to.
+    //
+    // * If BLANK!, this is an arg to a refinement that was not used in the
+    //   invocation.  No consumption should be performed, arguments should
+    //   be written as unset, and any non-unset specializations of arguments
+    //   should trigger an error.
+    //
+    // * If FALSE, this is an arg to a refinement that was used in the
+    //   invocation but has been *revoked*.  It still consumes expressions
+    //   from the callsite for each remaining argument, but those expressions
+    //   must not evaluate to any value.
+    //
+    // * If TRUE the refinement is active but revokable.  So if evaluation
+    //   produces no value, `refine` must be mutated to be FALSE.
+    //
+    // * If BAR!, it's an ordinary arg...and not a refinement.  It will be
+    //   evaluated normally but is not involved with revocation.
+    //
+    // Because of how this lays out, IS_CONDITIONAL_TRUE() can be used to
+    // determine if an argument should be type checked normally...while
+    // IS_CONDITIONAL_FALSE() means that the arg's bits must be set to void.
+    //
+    REBVAL *refine;
+
+    // `prior` [INTERNAL, READ-ONLY]
+    //
+    // The prior call frame (may be NULL if this is the topmost stack call).
+    //
+    struct Reb_Frame *prior;
+
+    // `mode` [INTERNAL, READ-ONLY]
+    //
+    // State variable during parameter fulfillment.  So before refinements,
+    // in refinement, skipping...etc.
+    //
+    // One particularly important usage is CALL_MODE_FUNCTION, which needs to
+    // be checked by `Get_Var`.  This is a necessarily evil while FUNCTION!
+    // does not have the semantics of CLOSURE!, because pathological cases
+    // in "stack-relative" addressing can get their hands on "reused" bound
+    // words during the formation process, e.g.:
+    //
+    //      leaker: func [/exec e /gimme g] [
+    //          either gimme [return [g]] [reduce e]
+    //      ]
+    //
+    //      leaker/exec reduce leaker/gimme 10
+    //
+    // Since a leaked word from another instance of a function can give
+    // access to a call frame during its formation, we need a way to tell
+    // when a call frame is finished forming...CALL_MODE_FUNCTION is it.
+    //
+    REBET eval_type; // enum in debug build, faster REBUPT in release
+
+    // `expr_index` [INTERNAL, READ-ONLY]
+    //
+    // Although the evaluator has to know what the current `index` is, the
+    // error reporting machinery typically wants to know where the index
+    // was *before* the last evaluation started...in order to present an
+    // idea of the expression that caused the error.  This is the index
+    // of where the currently evaluating expression started.
+    //
+    REBIXO expr_index;
+
+    // Definitional Return gives back a "corrupted" REBVAL of a return native,
+    // whose body is actually an indicator of the return target.  The
+    // Reb_Frame only stores the FUNC so we must extract this body from the
+    // value if it represents a exit_from
+    //
+    REBARR *exit_from;
+
+#if !defined(NDEBUG)
+    //
+    // `label_str` [INTERNAL, DEBUG, READ-ONLY]
+    //
+    // Knowing the label symbol is not as handy as knowing the actual string
+    // of the function this call represents (if any).  It is in UTF8 format,
+    // and cast to `char*` to help debuggers that have trouble with REBYTE.
+    //
+    const char *label_str;
+
+    // `do_count` [INTERNAL, DEBUG, READ-ONLY]
+    //
+    // The `do_count` represents the expression evaluation "tick" where the
+    // Reb_Frame is starting its processing.  This is helpful for setting
+    // breakpoints on certain ticks in reproducible situations.
+    //
+    REBUPT do_count; // !!! Move to dynamic data, available in a debug mode?
+
+    // Debug reuses PUSH_TRAP's snapshotting to check for leaks on each step
+    //
+    struct Reb_State state;
+#endif
+};
+
+
+// It's helpful when looking in the debugger to be able to look at a frame
+// and see a cached string for the function it's running (if there is one).
+// The release build only considers the frame symbol valid if ET_FUNCTION
+//
+#ifdef NDEBUG
+    #define SET_FRAME_SYM(f,s) \
+        ((f)->label_sym = (s))
+
+    #define CLEAR_FRAME_SYM(f) \
+        NOOP
+#else
+    #define SET_FRAME_SYM(f,s) \
+        (assert((f)->eval_type == ET_FUNCTION), \
+            (f)->label_sym = (s), \
+            (f)->label_str = cast(const char*, Get_Sym_Name((f)->label_sym)))
+
+    #define CLEAR_FRAME_SYM(f) \
+        ((f)->label_sym = SYM_0, (f)->label_str = NULL)
+#endif

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -1,0 +1,387 @@
+//
+//  File: %sys-rebser.h
+//  Summary: {Structure Definition for Series (REBSER)}
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2016 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// This contains the struct definition for a REBSER (`struct Reb_Series`)
+// It is a small descriptor for a series, and contains information
+// about its content and flags.  Every string and block in REBOL has one,
+// and the code implementing them is reused in many places that Rebol needs
+// a general-purpose dynamically growing structure.
+//
+// The REBSER is fixed-size, and is allocated as a "node" from a memory pool.
+// That pool quickly grants and releases memory ranges that are sizeof(REBSER)
+// without needing to use malloc() and free() for each individual allocation.
+// These nodes can also be enumerated in the pool without needing the series
+// to be tracked via a linked list or other structure.  The garbage collector
+// is one example of code that performs such an enumeration.
+//
+// A REBSER node pointer will remain valid as long as outstanding references
+// to the series exist in values visible to the GC.  On the other hand, the
+// series's data pointer may be freed and reallocated to respond to the needs
+// of resizing.  (In the future, it may be reallocated just as an idle task
+// by the GC to reclaim or optimize space.)  Hence pointers into data in a
+// managed series *must not be held onto across evaluations*.
+//
+// If the data requirements of a series are small, then rather than using the
+// space in the REBSER to track a dynamic allocation, the data can be placed
+// directly in the node itself.  The capacity is chosen to be exactly enough
+// to store a single REBVAL so that length 0 or 1 series can be represented.
+// However, that same amount of capacity may be used by arbitrary series (such
+// as strings) if they are small enough to fit.
+//
+// Notes:
+//
+// * For the forward declarations of series subclasses, see %reb-defs.h
+//
+// * Because a series contains a union member that embeds a REBVAL directly,
+//   `struct Reb_Value` must be fully defined before this file can compile.
+//   Hence %sys-rebval.h must already be included.
+//
+// * For the API of operations available on REBSER types, see %sys-series.h
+//
+// * REBARR is a series that contains Rebol values (REBVALs).  It has many
+//   concerns specific to special treatment and handling, in interaction with
+//   the garbage collector as well as handling "relative vs specific" values.
+//
+// * Several related types (REBFUN for function, REBCTX for context) are
+//   actually stylized arrays.  They are laid out with special values in their
+//   content (e.g. at the [0] index), or by links to other series in their
+//   `->misc` field of the REBSER node.  Hence series are the basic building
+//   blocks of nearly all variable-size structures in the system.
+//
+
+// Series Flags
+//
+enum {
+    // `SERIES_FLAG_0_IS_FALSE` represents the lowest bit and should always
+    // be set to zero.  This is because it means that when Reb_Series_Content
+    // is interpreted as a REBVAL's worth of data, then the info bits are in
+    // a location where they do double-duty serving as an END marker.  For a
+    // description of the method see notes on NOT_END_MASK.
+    //
+    SERIES_FLAG_0_IS_FALSE = 1 << 0,
+
+    // `SERIES_FLAG_1_IS_FALSE` is the second lowest bit, and is set to zero
+    // as a safety precaution.  In the debug build this is checked by value
+    // writes to ensure that when the info flags are serving double duty
+    // as an END marker, they do not get overwritten by rogue code that
+    // thought a REBVAL* pointing at the memory had a full value's worth
+    // of memory to write into.  See WRITABLE_MASK_DEBUG.
+    //
+    SERIES_FLAG_1_IS_FALSE = 1 << 1,
+
+    // `SERIES_FLAG_HAS_DYNAMIC` indicates that this series has a dynamically
+    // allocated portion.  If it does not, then its data pointer is the
+    // address of the embedded value inside of it (marked terminated by
+    // the SERIES_FLAG_0_IS_ZERO if it has an element in it)
+    //
+    SERIES_FLAG_HAS_DYNAMIC = 1 << 2,
+
+    // `SERIES_FLAG_MARK` is used in the "mark and sweep" method of garbage
+    // collection.  It is also used for other purposes which need to go
+    // through and set a generic bit, e.g. to protect against loops in
+    // the transitive closure ("if you hit a SER_MARK, then you've already
+    // processed this series").
+    //
+    // Because of the dual purpose, it's important to be sure to not run
+    // garbage collection while one of these alternate uses is in effect.
+    // It's also important to reset the bit when done, as GC assumes when
+    // it starts that all bits are cleared.  (The GC itself clears all
+    // the bits by enumerating every series in the series pool during the
+    // sweeping phase.)
+    //
+    // !!! With more series bits now available, the dual purpose is something
+    // that should be reexamined--so long as bits are free, why reuse if it
+    // creates more risk?
+    //
+    SERIES_FLAG_MARK = 1 << 3,
+
+    // `SERIES_FLAG_MANAGED` indicates that a series is managed by garbage
+    // collection.  If this bit is not set, then during the GC's sweeping
+    // phase the simple fact that it hasn't been SER_MARK'd won't be enough
+    // to let it be considered for freeing.
+    //
+    // See MANAGE_SERIES for details on the lifecycle of a series (how it
+    // starts out manually managed, and then must either become managed or be
+    // freed before the evaluation that created it ends).
+    //
+    SERIES_FLAG_MANAGED = 1 << 4,
+
+    // `SERIES_FLAG_ARRAY` indicates that this is a series of REBVAL values,
+    // and suitable for using as the payload of an ANY-ARRAY! value.  When a
+    // series carries this bit, that means that if it is also SER_MANAGED
+    // then the garbage collector will process its transitive closure to
+    // make sure all the values it contains (and the values its references
+    // contain) do not have series GC'd out from under them.
+    //
+    // (In R3-Alpha, whether a series was an array or not was tested by if
+    // its width was sizeof(REBVAL).  The Ren-C approach allows for the
+    // creation of series that contain items that incidentally happen to be
+    // the same size as a REBVAL, while not actually being REBVALs.)
+    //
+    SERIES_FLAG_ARRAY = 1 << 5,
+
+    // `ARRAY_FLAG_CONTEXT_VARLIST` indicates this series represents the
+    // "varlist" of a context.  A second series can be reached from it via
+    // the `->misc` field in the series node, which is a second array known
+    // as a "keylist".
+    //
+    // See notes on REBCTX for further details about what a context is.
+    //
+    ARRAY_FLAG_CONTEXT_VARLIST = 1 << 6,
+
+    // `SERIES_FLAG_LOCKED` indicates that the series size or values cannot
+    // be modified.  This check is honored by some layers of abstraction, but
+    // if one manages to get a raw pointer into a value in the series data
+    // then by that point it cannot be enforced.
+    //
+    // !!! Could the 'writable' flag be used for this in the debug build,
+    // if the locking process went through and cleared writability...then
+    // put it back if the series were unlocked?
+    //
+    // This is related to the feature in PROTECT (OPT_TYPESET_LOCKED) which
+    // protects a certain variable in a context from being changed.  Yet
+    // it is distinct as it's a protection on a series itself--which ends
+    // up affecting all variable content with that series in the payload.
+    //
+    SERIES_FLAG_LOCKED = 1 << 7,
+
+    // `SERIES_FLAG_FIXED_SIZE` indicates the size is fixed, and the series
+    // cannot be expanded or contracted.  Values within the series are still
+    // writable, assuming SERIES_FLAG_LOCKED isn't set.
+    //
+    // !!! Is there checking in all paths?  Do series contractions check this?
+    //
+    // One important reason for ensuring a series is fixed size is to avoid
+    // the possibility of the data pointer being reallocated.  This allows
+    // code to ignore the usual rule that it is unsafe to hold a pointer to
+    // a value inside the series data.
+    //
+    // !!! Strictly speaking, SERIES_FLAG_NO_RELOCATE could be different
+    // from fixed size... if there would be a reason to reallocate besides
+    // changing size (such as memory compaction).
+    //
+    SERIES_FLAG_FIXED_SIZE  = 1 << 8,
+
+    // `SERIES_FLAG_POWER_OF_2` is set when an allocation size was rounded to
+    // a power of 2.  This flag was introduced in Ren-C when accounting was
+    // added to make sure the system's notion of how much memory allocation
+    // was outstanding would balance out to zero by the time of exiting the
+    // interpreter.
+    //
+    // The problem was that the allocation size was measured in terms of the
+    // number of elements.  If the elements themselves were not the size of
+    // a power of 2, then to get an even power-of-2 size of memory allocated
+    // the memory block would not be an even multiple of the element size.
+    // Rather than track the actual memory allocation size as a 32-bit number,
+    // a single bit flag remembering that the allocation was a power of 2
+    // was enough to recreate the number to balance accounting at free time.
+    //
+    // !!! The rationale for why series were ever allocated to a power of 2
+    // should be revisited.  Current conventional wisdom suggests that asking
+    // for the amount of memory you need and not using powers of 2 is
+    // generally a better idea:
+    //
+    // http://stackoverflow.com/questions/3190146/
+    //
+    SERIES_FLAG_POWER_OF_2  = 1 << 9,
+
+    // `SERIES_FLAG_EXTERNAL` indicates that when the series was created, the
+    // `->data` pointer was poked in by the creator.  It takes responsibility
+    // for freeing it, so don't free() on GC.
+    //
+    // !!! It's not clear what the lifetime management of data used in this
+    // way is.  If the external system receives no notice when Rebol is done
+    // with the data and GC's the series, how does it know when it's safe
+    // to free the data or not?  The feature is not used by the core or
+    // Ren-Cpp, but by relatively old extensions...so there may be no good
+    // answer in the case of those clients (likely either leaks or crashes).
+    //
+    SERIES_FLAG_EXTERNAL = 1 << 10,
+
+    // `SERIES_FLAG_ACCESSIBLE` indicates that the external memory pointed by
+    // `->data` is accessible. This is not checked at every access to the
+    // `->data` for the performance consideration, only on those that are
+    // known to have possible external memory storage.  Currently this is
+    // used for STRUCT! and to note when a CONTEXT_FLAG_STACK series has its
+    // stack level popped (there's no data to lookup for words bound to it)
+    //
+    SERIES_FLAG_ACCESSIBLE = 1 << 11,
+
+    // `CONTEXT_FLAG_STACK` indicates that varlist data lives on the stack.
+    // This is a work in progress to unify objects and function call frames
+    // as a prelude to unifying FUNCTION! and CLOSURE!.
+    //
+    // !!! Ultimately this flag may be unnecessary because stack-based and
+    // dynamic series will "hybridize" so that they may have some stack
+    // fields and some fields in dynamic memory.  The foundation already
+    // exists, and both can be stored in the same REBSER.  It's just a problem
+    // of mapping index numbers in the function paramlist into either the
+    // stack array or the dynamic array during binding in an efficient way.
+    //
+    CONTEXT_FLAG_STACK = 1 << 12,
+
+    // `KEYLIST_FLAG_SHARED` is indicated on the keylist array of a context
+    // when that same array is the keylist for another object.  If this flag
+    // is set, then modifying an object using that keylist (such as by adding
+    // a key/value pair) will require that object to make its own copy.
+    //
+    // (Note: This flag did not exist in R3-Alpha, so all expansions would
+    // copy--even if expanding the same object by 1 item 100 times with no
+    // sharing of the keylist.  That would make 100 copies of an arbitrary
+    // long keylist that the GC would have to clean up.)
+    //
+    KEYLIST_FLAG_SHARED = 1 << 13,
+
+    // `ARRAY_FLAG_VOIDS_LEGAL` identifies arrays in which it is legal to
+    // have void elements.  This is used for instance on reified C va_list()s
+    // which were being used for unevaluated applies.  When those va_lists
+    // need to be put into arrays for the purposes of GC protection, they may
+    // contain voids which they need to track.
+    //
+    // Note: ARRAY_FLAG_CONTEXT_VARLIST also implies legality of voids, which
+    // are used to represent unset variables.
+    //
+    ARRAY_FLAG_VOIDS_LEGAL = 1 << 14,
+
+    // `SERIES_FLAG_LEGACY` is a flag which is marked at the root set of the
+    // body of legacy functions.  It can be used in a dynamic examination of
+    // a call to see if it "originates from legacy code".  This is a vague
+    // concept given the ability to create blocks and run them--so functions
+    // like COPY would have to propagate the flag to make it "more accurate".
+    // But it's good enough for casual compatibility in many cases.
+    //
+#if !defined NDEBUG
+    SERIES_FLAG_LEGACY = 1 << 14,
+#endif
+
+    SERIES_FLAG_NO_COMMA_NEEDED = 0 // solves dangling comma from above
+};
+
+struct Reb_Series_Dynamic {
+    //
+    // `data` is the "head" of the series data.  It may not point directly at
+    // the memory location that was returned from the allocator if it has
+    // bias included in it.
+    //
+    REBYTE *data;
+
+    // `len` is one past end of useful data.
+    //
+    REBCNT len;
+
+    // `rest` is the total number of units from bias to end.  Having a
+    // slightly weird name draws attention to the idea that it's not really
+    // the "capacity", just the "rest of the capacity after the bias".
+    //
+    REBCNT rest;
+
+    // This is the 4th pointer on 32-bit platforms which could be used for
+    // something when a series is dynamic.  Previously the bias was not
+    // a full REBCNT but was limited in range to 16 bits or so.  This means
+    // 16 info bits are likely available if needed for dynamic series.
+    //
+    REBCNT bias;
+
+#if defined(__LP64__) || defined(__LLP64__)
+    //
+    // The Reb_Series_Dynamic is used in Reb_Series inside of a union with a
+    // REBVAL.  On 64-bit machines this will leave one unused 32-bit slot
+    // (which will couple with the previous REBCNT) and one naturally aligned
+    // 64-bit pointer.  These could be used for some enhancement that would
+    // be available per-dynamic-REBSER on 64-bit architectures.
+    //
+    REBCNT unused_32;
+    void *unused_64;
+#endif
+};
+
+struct Reb_Series {
+
+    union {
+        //
+        // If the series does not fit into the REBSER node, then it must be
+        // dynamically allocated.  This is the tracking structure for that
+        // dynamic data allocation.
+        //
+        struct Reb_Series_Dynamic dynamic;
+
+        // If not SERIES_FLAG_HAS_DYNAMIC, 0 or 1 length arrays can be held
+        // directly in the series node.  The SERIES_FLAG_0_IS_FALSE bit is set
+        // to zero and signals an IS_END().
+        //
+        // It is thus an "array" of effectively up to length two.  Either the
+        // [0] full element is IS_END(), or the [0] element is another value
+        // and the [1] element is read-only and passes IS_END() to terminate
+        // (but can't have any other value written, as the info bits are
+        // marked as unwritable by SERIES_FLAG_1_IS_FALSE...this protects the
+        // rest of the bits in the debug build as it is checked whenver a
+        // REBVAL tries to write a new header.)
+        //
+        RELVAL values[1];
+    } content;
+
+    // `info` is the information about the series which needs to be known
+    // even if it is not using a dynamic allocation.  So even if the alloc
+    // size, length, and bias aren't relevant...the series flags need to
+    // be known...including the flag of whether this is a dynamic series
+    // node or not!
+    //
+    // The lowest 2 bits of info are required to be 0 when used with the trick
+    // of implicitly terminating series data.  See SERIES_FLAG_0_IS_FALSE and
+    // SERIES_FLAG_1_IS_FALSE for more information.
+    //
+    // !!! Only the low 32-bits are used on 64-bit platforms.  There could
+    // be some interesting added caching feature or otherwise that would use
+    // it, while not making any feature specifically require a 64-bit CPU.
+    //
+    struct Reb_Value_Header info;
+
+    // The `misc` field is an extra pointer-sized piece of data which is
+    // resident in the series node, and hence visible to all REBVALs that
+    // might be referring to the series.
+    //
+    union {
+        REBNAT dispatcher; // native dispatcher code, see Reb_Function's body
+        REBCNT len; // length of non-arrays when !SERIES_FLAG_HAS_DYNAMIC
+        REBCNT size;    // used for vectors and bitsets
+        REBSER *hashlist; // MAP datatype uses this
+        REBARR *keylist; // used by CONTEXT
+        struct {
+            REBCNT wide:16;
+            REBCNT high:16;
+        } area;
+        REBOOL negated; // for bitsets (must be shared, can't be in REBVAL)
+        REBARR *subfeed; // for *non-frame* VARARGS! ("array1") shared feed
+        REBCTX *meta; // paramlists and keylists can store a "meta" object
+    } misc;
+
+#if !defined(NDEBUG)
+    int *guard; // intentionally alloc'd and freed for use by Panic_Series
+    REBUPT do_count; // also maintains sizeof(REBSER) % sizeof(REBI64) == 0
+#endif
+};

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -1,0 +1,1113 @@
+//
+//  File: %sys-rebval.h
+//  Summary: {Definitions for the Rebol Boxed Value Struct (REBVAL)}
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2016 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// REBVAL is the structure/union for all Rebol values. It's designed to be
+// four C pointers in size (so 16 bytes on 32-bit platforms and 32 bytes
+// on 64-bit platforms).  Operation will be most efficient with those sizes,
+// and there are checks on boot to ensure that `sizeof(REBVAL)` is the
+// correct value for the platform.  But from a mechanical standpoint, the
+// system should be *able* to work even if the size is different.
+//
+// Of the four 32-or-64-bit slots that each value has, the first is used for
+// the value's "Header".  This includes the data type, such as REB_INTEGER,
+// REB_BLOCK, REB_STRING, etc.  Then there are 8 flags which are for general
+// purposes that could apply equally well to any type of value (including
+// whether the value should have a new-line after it when molded out inside
+// of a block).  There are 8 bits which are custom to each type--for
+// instance whether a key in an object is hidden or not.  Then there are
+// 8 bits currently reserved for future use.
+//
+// The remaining content of the REBVAL struct is the "Payload".  It is the
+// size of three (void*) pointers, and is used to hold whatever bits that
+// are needed for the value type to represent itself.  Perhaps obviously,
+// an arbitrarily long string will not fit into 3*32 bits, or even 3*64 bits!
+// You can fit the data for an INTEGER or DECIMAL in that (at least until
+// they become arbitrary precision) but it's not enough for a generic BLOCK!
+// or a FUNCTION! (for instance).  So those pointers are used to point to
+// things, and often they will point to one or more Rebol Series (see
+// %sys-series.h for an explanation of REBSER, REBARR, REBCTX, and REBMAP.)
+//
+
+//
+// Note: Forward declarations are in %reb-defs.h
+//
+
+// The definition of the REBVAL struct has a header followed by a payload.
+// On 32-bit platforms the header is 32 bits, and on 64-bit platforms it is
+// 64-bits.  However, even on 32-bit platforms, some payloads contain 64-bit
+// quantities (doubles or 64-bit integers).  By default, the compiler would
+// pad a payload with one 64-bit quantity and one 32-bit quantity to 128-bits,
+// which would not leave room for the header (if REBVALs are to be 128-bits).
+//
+// So since R3-Alpha, a `#pragma pack` of 4 is requested for this file:
+//
+//     http://stackoverflow.com/questions/3318410/
+//
+// It is restored to the default via `#pragma pack()` at the end of the file.
+// (Note that pack(push) and pack(pop) are not supported by older compilers.)
+//
+// Compilers are free to ignore pragmas (or error on them).  Also, this
+// packing subverts the automatic alignment handling of the compiler.  So if
+// the manually packed structures do not position 64-bit values on 64-bit
+// alignments, there can be problems.  On x86 this is generally just slower
+// reads and writes, but on more esoteric platforms (like the C-to-Javascript
+// translator "emscripten") some instances do not work at all.
+//
+// Hence REBVAL payloads that contain quantities that need 64-bit alignment
+// put those *after* a platform-pointer sized field, even if that field is
+// just padding.  On 32-bit platforms this will pair with the header to make
+// enough space to get to a 64-bit alignment
+//
+// If #pragma pack is disabled, a REBVAL will wind up being 160 bits.  This
+// won't give ideal performance, and will trigger an assertion in
+// Assert_Basics.  But the code *should* be able to work otherwise if that
+// assertion is removed.
+//
+// Note also that a trick which attempted to put a header into each payload
+// won't work.  There would be no way to generically adjust the bits of the
+// header without picking a specific instance of the union to do it in, which
+// would invalidate the payload for any other type.
+//
+#pragma pack(4)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  VALUE HEADER (`struct Reb_Value_Header`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The layout of the header corresponds to the following bitfield
+// structure on big endian machines:
+//
+//    unsigned specific:16;     // flags that are specific to this REBVAL kind
+//    unsigned general:8;       // flags that can apply to any kind of REBVAL
+//    unsigned kind:6;          // underlying system datatype (64 kinds)
+//    unsigned settable:1;      // for debug build only--"formatted" to write
+//    unsigned not_end:1;       // not an end marker
+//
+// Due to a desire to be able to assign all the header bits in one go
+// with a native-platform-sized int, this is done with bit masking.
+// Using bitfields would bring in questions of how smart the
+// optimizer is, as well as the endianness of the underlyling machine.
+//
+// We use REBUPT (Rebol's pre-C99 compatibility type for uintptr_t,
+// which is just uintptr_t from C99 on).  Only the low 32 bits are used
+// on 64-bit machines in order to make sure all the features work on
+// 32-bit machines...but could be used for some optimization or caching
+// purpose to enhance the 64-bit build.  No such uses implemented yet.
+//
+
+struct Reb_Value_Header {
+    REBUPT bits;
+};
+
+// `NOT_END_MASK`
+//
+// If set, it means this is *not* an end marker.  The bit has been picked
+// strategically to be in the negative sense, and in the lowest bit position.
+// This means that any even-valued unsigned integer REBUPT value can be used
+// to implicitly signal an end.
+//
+// If this bit is 0, it means that *no other header bits are valid*, as it
+// may contain arbitrary data used for non-REBVAL purposes.
+//
+// Note that the value doing double duty as a number for one purpose and an
+// END marker as another *must* be another REBUPT.  It cannot be a pointer
+// (despite being guaranteed-REBUPT-sized, and despite having a value that
+// is 0 when you mod it by 2.  So-called "type-punning" is unsafe with a
+// likelihood of invoking "undefined behavior", while it's the compiler's
+// responsibility to guarantee that pointers to memory of the same type of
+// data be compatibly read-and-written.
+//
+#define NOT_END_MASK \
+    cast(REBUPT, 0x01)
+
+#define GENERAL_VALUE_BIT 8
+#define TYPE_SPECIFIC_BIT 16
+
+// `WRITABLE_MASK_DEBUG`
+//
+// This is for the debug build, to make it safer to use the implementation
+// trick of NOT_END_MASK.  It indicates the slot is "REBVAL sized", and can
+// be written into--including to be written with SET_END().
+//
+// It's again a strategic choice--the 2nd lowest bit and in the negative.
+// This means any REBUPT value whose % 4 within a container doing
+// double-duty as an implicit terminator for the contained values can
+// trigger an alert if the values try to overwrite it.
+//
+#ifdef NDEBUG
+    //
+    // Though in the abstract it is desirable to have a way to protect an
+    // individual value from writing even in the release build, this is
+    // a debug-only check...it makes every value header initialization have
+    // to do two writes instead of one (one to format, then later to write
+    // and check that it is properly formatted space)
+    //
+#else
+    // We want to be assured that we are not trying to take the type of a
+    // value that is actually an END marker, because end markers chew out only
+    // one bit--the rest of the REBUPT bits besides the bottom two may be
+    // anything necessary for the purpose.
+    //
+    #define WRITABLE_MASK_DEBUG \
+        cast(REBUPT, 0x02)
+#endif
+
+// The type mask comes up a bit and it's a fairly obvious constant, so this
+// hardcodes it for obviousness.  High 6 bits of the lowest byte.
+//
+#define HEADER_TYPE_MASK \
+    cast(REBUPT, 0xFC)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  GENERAL FLAGS common to every REBVAL
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The value option flags are 8 individual bitflags which apply to every
+// value of every type.  Due to their scarcity, they are chosen carefully.
+//
+
+enum {
+    // `VALUE_FLAG_FALSE`
+    //
+    // Both NONE! and LOGIC!'s false state are FALSE? ("conditionally false").
+    // All other types are TRUE?.  To make checking FALSE? and TRUE? faster,
+    // this bit is set when creating NONE! or FALSE.  As a result, LOGIC!
+    // does not need to store any data in its payload... its data of being
+    // true or false is already covered by this header bit.
+    //
+    VALUE_FLAG_FALSE = 1 << (GENERAL_VALUE_BIT + 0),
+
+    // `VALUE_FLAG_LINE`
+    //
+    // If the line marker bit is 1, then when the value is molded it will put
+    // a newline before the value.  The logic is a bit more subtle than that,
+    // because an ANY-PATH! could not be LOADed back if this were allowed.
+    // The bit is set initially by what the scanner detects, and then left
+    // to the user's control after that.
+    //
+    // !!! The native `new-line` is used set this, which has a somewhat
+    // poor name considering its similarity to `newline` the line feed char.
+    //
+    VALUE_FLAG_LINE = 1 << (GENERAL_VALUE_BIT + 1),
+
+    // `VALUE_FLAG_THROWN`
+    //
+    // When a REBVAL slot wishes to signal that it is a "throw" (e.g. a
+    // RETURN, BREAK, CONTINUE or generic THROW signal), this bit is set on
+    // that cell.
+    //
+    // The bit being set does not mean the cell contains the thrown quantity
+    // (e.g. it would not be the `1020` in `throw 1020`)  That evaluator
+    // thread enters a modal "thrown state", and it's the state which hold
+    // the value--which must be processed (or converted into an error) before
+    // another throw occurs.
+    //
+    // Instead the bit indicates that the cell contains a value indicating
+    // the label, or "name", of the throw.  Having the label quickly available
+    // in the slot being bubbled up makes it easy for recipients to decide if
+    // they are interested in throws of that type or not.
+    //
+    // R3-Alpha code would frequently forget to check for thrown values, and
+    // wind up acting as if they did not happen.  In addition to enforcing that
+    // all thrown values are handled by entering a "thrown state" for the
+    // interpreter, all routines that can potentially return thrown values
+    // have been adapted to return a boolean and adopt the XXX_Throws()
+    // naming convention:
+    //
+    //     if (XXX_Throws()) {
+    //        /* handling code */
+    //     }
+    //
+    VALUE_FLAG_THROWN = 1 << (GENERAL_VALUE_BIT + 2),
+
+    // `VALUE_FLAG_RELATIVE` is used to indicate a value that needs to have
+    // a specific context added into it before it can have its bits copied
+    // or used for some purposes.  An ANY-WORD! is relative if it refers to
+    // a local or argument of a function, and has its bits resident in the
+    // deep copy of that function's body.  An ANY-ARRAY! in the deep copy
+    // of a function body must be relative also to the same function if
+    // it contains any instances of such relative words.
+    //
+    VALUE_FLAG_RELATIVE = 1 << (GENERAL_VALUE_BIT + 4),
+
+    // `VALUE_FLAG_ARRAY` is an acceleration of the ANY_ARRAY() test, which
+    // also helps keep this file's COPY_VALUE from being dependent on
+    // VAL_TYPE() which is provided in %sys-value.h
+    //
+    VALUE_FLAG_ARRAY = 1 << (GENERAL_VALUE_BIT + 5),
+
+    // `VALUE_FLAG_EVALUATED` is a somewhat dodgy-yet-important concept.
+    // This is that some functions wish to be sensitive to whether or not
+    // their argument came as a literal in source or as a product of an
+    // evaluation.  While all values carry the bit, it is only guaranteed
+    // to be meaningful on arguments in function frames...though it is
+    // valid on any result at the moment of taking it from Do_Core().
+    //
+    VALUE_FLAG_EVALUATED = 1 << (GENERAL_VALUE_BIT + 6)
+};
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  TRACK payload (not a value type, only in DEBUG)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// `struct Reb_Track` is the value payload in debug builds for any REBVAL
+// whose VAL_TYPE() doesn't need any information beyond the header.  This
+// offers a chance to inject some information into the payload to help
+// know where the value originated.  It is used by voids (and void trash),
+// NONE!, LOGIC!, and BAR!.
+//
+// In addition to the file and line number where the assignment was made,
+// the "tick count" of the DO loop is also saved.  This means that it can
+// be possible in a repro case to find out which evaluation step produced
+// the value--and at what place in the source.  Repro cases can be set to
+// break on that tick count, if it is deterministic.
+//
+
+#if !defined(NDEBUG)
+    struct Reb_Track {
+        const char *filename;
+        int line;
+        REBUPT count;
+    };
+#endif
+
+struct Reb_Datatype {
+    enum Reb_Kind kind;
+    REBARR *spec;
+};
+
+struct Reb_Integer {
+    //
+    // On 32-bit platforms, this payload structure begins after a 32-bit
+    // header...hence not a 64-bit aligned location.  Since a REBUPT is
+    // 32-bits on 32-bit platforms and 64-bit on 64-bit, putting one here
+    // right after the header ensures `value` will be on a 64-bit boundary.
+    //
+    // (At time of writing, this is necessary for the "C-to-Javascript"
+    // emscripten build to work.  It's also likely preferred by x86.)
+    //
+    REBUPT padding;
+
+    REBI64 i64;
+};
+
+struct Reb_Decimal {
+    //
+    // See notes on Reb_Integer for why this is needed (handles case of when
+    // `value` is 64-bit, and the platform is 32-bit.)
+    //
+    REBUPT padding;
+
+    REBDEC dec;
+};
+
+struct Reb_Money {
+    deci amount;
+};
+
+typedef struct reb_ymdz {
+#ifdef ENDIAN_LITTLE
+    REBINT zone:7; // +/-15:00 res: 0:15
+    REBCNT day:5;
+    REBCNT month:4;
+    REBCNT year:16;
+#else
+    REBCNT year:16;
+    REBCNT month:4;
+    REBCNT day:5;
+    REBINT zone:7; // +/-15:00 res: 0:15
+#endif
+} REBYMD;
+
+typedef union reb_date {
+    REBYMD date;
+    REBCNT bits;
+} REBDAT;
+
+struct Reb_Time {
+    REBI64 nanoseconds;
+    REBDAT date;
+};
+
+typedef struct Reb_Tuple {
+    REBYTE tuple[12];
+} REBTUP;
+
+union Reb_Binding_Target {
+    REBFUN *relative; // for VALUE_FLAG_RELATIVE
+    REBCTX *specific; // for !VALUE_FLAG_RELATIVE
+};
+
+struct Reb_Any_Series {
+    //
+    // `specifier` is used in ANY-ARRAY! payloads.  It is a pointer to a FRAME!
+    // context which indicates where relatively-bound ANY-WORD! values which
+    // are in the series data can be looked up to get their variable values.
+    // If the array does not contain any relatively bound words then it is
+    // okay for this to be NULL.
+    //
+    union Reb_Binding_Target target;
+
+    // `series` represents the actual physical underlying data, which is
+    // essentially a vector of equal-sized items.  The length of the item
+    // (the series "width") is kept within the REBSER abstraction.  See the
+    // file %sys-series.h for notes.
+    //
+    REBSER *series;
+
+    // `index` is the 0-based position into the series represented by this
+    // ANY-VALUE! (so if it is 0 then that means a Rebol index of 1).
+    //
+    // It is possible that the index could be to a point beyond the range of
+    // the series.  This is intrinsic, because the series can be modified
+    // through other values and not update the others referring to it.  Hence
+    // VAL_INDEX() must be checked, or the routine called with it must.
+    //
+    // !!! Review that it doesn't seem like these checks are being done
+    // in a systemic way.  VAL_LEN_AT() bounds the length at the index
+    // position by the physical length, but VAL_ARRAY_AT() doesn't check.
+    //
+    REBCNT index;
+};
+
+//
+// Rebol Symbol
+//
+// !!! Historically Rebol used an unsigned 32-bit integer as a "symbol ID".
+// These symbols did not participate in garbage collection and had to be
+// looked up in a table to get their values.  Ren-C is moving toward adapting
+// REBSERs to be able to store words and canon words, as well as GC them.
+// This starts moving the types to be the size of a platform pointer.
+//
+
+typedef REBUPT REBSYM;
+
+struct Reb_Symbol {
+    REBCNT canon; // Index of the canonical (first) word
+    REBCNT alias; // Index to next alias form
+    REBCNT name; // Index into PG_Word_Names string
+};
+
+struct Reb_Typeset {
+    REBSYM sym; // Symbol (if a key of object or function param)
+
+    // Note: `sym` is first so that the value's 32-bit Reb_Flags header plus
+    // the 32-bit REBCNT will pad `bits` to a REBU64 alignment boundary
+
+    REBU64 bits; // One bit for each DATATYPE! (use with FLAGIT_64)
+};
+
+struct Reb_Binding {
+    //
+    // The context to look in to find the word's value.  It is valid if the
+    // word has been bound, and null otherwise.
+    //
+    // Note that if the ANY-CONTEXT! to which this word is bound is a FRAME!,
+    // then that frame may no longer be on the stack.  Hence the space for
+    // the variable is no longer allocated.  Tracking mechanisms must be used
+    // to make sure the word can keep track of this fact.
+    //
+    // !!! Tracking mechanism is currently under development.
+    //
+    // Also note that the expense involved in doing a lookup to a context
+    // that is a FRAME! is greater than one that is not (such as an OBJECT!)
+    // This is because in the current implementation, the stack must be
+    // walked to find the required frame.
+    //
+    union Reb_Binding_Target target;
+
+    // Index of word in context (if word is bound, e.g. `context` is not NULL)
+    //
+    // !!! Intended logic is that if the index is positive, then the word
+    // is looked for in the context's pooled memory data pointer.  If the
+    // index is negative or 0, then it's assumed to be a stack variable,
+    // and looked up in the call's `stackvars` data.
+    //
+    // But now there are no examples of contexts which have both pooled
+    // and stack memory, and the general issue of mapping the numbers has
+    // not been solved.  However, both pointers are available to a context
+    // so it's awaiting some solution for a reasonably-performing way to
+    // do the mapping from [1 2 3 4 5 6] to [-3 -2 -1 0 1 2] (or whatever)
+    //
+    REBINT index;
+};
+
+union Reb_Any_Word_Place {
+    struct Reb_Binding binding;
+
+    // The order in which refinements are defined in a function spec may
+    // not match the order in which they are mentioned on a path.  As an
+    // efficiency trick, a word on the data stack representing a refinement
+    // usage request is able to store the pointer to its `param` and `arg`
+    // positions, so that they may be returned to after the later-defined
+    // refinement has had its chance to take the earlier fulfillments.
+    //
+    struct {
+        const RELVAL *param;
+        REBVAL *arg;
+    } pickup;
+};
+
+struct Reb_Any_Word {
+    union Reb_Any_Word_Place place;
+
+    // Index of the word's symbol
+    //
+    // Note: Future expansion plans are to have symbol entries tracked by
+    // pointer and garbage collected, likely as series nodes.  A full pointer
+    // sized value is required here.
+    //
+    REBSYM sym;
+};
+
+// enums in C have no guaranteed size, yet Rebol wants to use known size
+// types in its interfaces.  Hence REB_R is a REBCNT from reb-c.h (and not
+// this enumerated type containing its legal values).
+enum {
+    R_OUT = 0,
+
+    // See comments on OPT_VALUE_THROWN about the migration of "thrownness"
+    // from being a property signaled to the evaluator.
+    //
+    // R_OUT_IS_THROWN is a test of that signaling mechanism.  It is currently
+    // being kept in parallel with the THROWN() bit and ensured as matching.
+    // Being in the state of doing a stack unwind will likely be knowable
+    // through other mechanisms even once the thrown bit on the value is
+    // gone...so it may not be the case that natives are asked to do their
+    // own separate indication, so this may wind up replaced with R_OUT.  For
+    // the moment it is good as a double-check.
+    //
+    R_OUT_IS_THROWN,
+
+    // This is a return value in service of the /? functions.  Since all
+    // dispatchers receive an END marker in the f->out slot (a.k.a. D_OUT)
+    // then it can be used to tell if the output has been written "in band"
+    // by a legal value or void.  This returns TRUE if D_OUT is not END,
+    // and FALSE if it still is.
+    //
+    R_OUT_TRUE_IF_WRITTEN,
+
+    // Similar to R_OUT_WRITTEN_Q, this converts an illegal END marker return
+    // value in R_OUT to simply a void.
+    //
+    R_OUT_VOID_IF_UNWRITTEN,
+
+    // !!! These R_ values are somewhat superfluous...and actually inefficient
+    // because they have to be checked by the caller in a switch statement
+    // to take the equivalent action.  They have a slight advantage in
+    // hand-written C code for making it more clear that if you have used
+    // the D_OUT return slot for temporary work that you explicitly want
+    // to specify another result...this cannot be caught by the REB_TRASH
+    // trick for detecting an unwritten D_OUT.
+    //
+    R_VOID, // => SET_VOID(D_OUT); return R_OUT;
+    R_BLANK, // => SET_BLANK(D_OUT); return R_OUT;
+    R_TRUE, // => SET_TRUE(D_OUT); return R_OUT;
+    R_FALSE, // => SET_FALSE(D_OUT); return R_OUT;
+
+    // If Do_Core gets back an R_REDO from a dispatcher, it will re-execute
+    // the f->func in the frame.  This function may be changed by the
+    // dispatcher from what was originally called.
+    //
+    R_REDO
+};
+typedef REBCNT REB_R;
+
+// Convenience function for getting the "/?" behavior if it is enabled, and
+// doing the default thing--assuming END is being left in the D_OUT slot
+//
+inline static REB_R R_OUT_Q(REBOOL q) {
+    if (q) return R_OUT_TRUE_IF_WRITTEN;
+    return R_OUT_VOID_IF_UNWRITTEN;
+}
+
+// NATIVE! function
+typedef REB_R (*REBNAT)(struct Reb_Frame *frame_);
+#define REBNATIVE(n) \
+    REB_R N_##n(struct Reb_Frame *frame_)
+
+// ACTION! function (one per each DATATYPE!)
+typedef REB_R (*REBACT)(struct Reb_Frame *frame_, REBCNT a);
+#define REBTYPE(n) \
+    REB_R T_##n(struct Reb_Frame *frame_, REBCNT action)
+
+// PORT!-action function
+typedef REB_R (*REBPAF)(struct Reb_Frame *frame_, REBCTX *p, REBCNT a);
+
+// COMMAND! function
+typedef REB_R (*CMD_FUNC)(REBCNT n, REBSER *args);
+
+typedef struct Reb_Routine_Info REBRIN;
+
+struct Reb_Function {
+    //
+    // Definitionally-scoped returns introduced the idea of there being a
+    // unique property on a per-REBVAL instance for the natives RETURN and
+    // LEAVE, in order to identify that instance of the "archetypal" natives
+    // relative to a specific frame or function.  This idea has overlap with
+    // the Reb_Binding_Target, and may be unified for this common cell slot.
+    //
+    REBARR *exit_from;
+
+    // `paramlist` is a Rebol Array whose 1..NUM_PARAMS values are all
+    // TYPESET! values, with an embedded symbol (a.k.a. a "param") as well
+    // as other bits, including the parameter class (PARAM_CLASS).  This
+    // is the list that is processed to produce WORDS-OF and which is
+    // consulted during invocation to fulfill the arguments.
+    //
+    // In addition, its [0]th element contains a FUNCTION! value which is
+    // self-referentially the function itself.  This means that the paramlist
+    // can be passed around as a single pointer from which a whole REBVAL
+    // for the function can be found.
+    //
+    // The `misc` field of the function series is `spec`, which contains data
+    // passed to MAKE FUNCTION! to create the `paramlist`.  After the
+    // paramlist has been generated, it is not generally processed by the
+    // code and remains mostly to be scanned by user mode code to make HELP.
+    // As "metadata" it is not kept in the canon value itself so it can be
+    // updated or augmented by functions like `redescribe` without worrying
+    // about all the Reb_Function REBVALs that are extant.
+    //
+    REBFUN *func; // !!! TBD: change to REBARR*, rename as paramlist
+
+    // `body` is always a REBARR--even an optimized "singular" one that is
+    // only the size of one REBSER.  This is because the information for a
+    // function body is an array in the majority of function instances, and
+    // also because it can standardize the native dispatcher code in the
+    // REBARR's series "misc" field.  This gives two benefits: no need for
+    // a switch on the function's type to figure out the dispatcher, and also
+    // to move the dispatcher out of the REBVAL itself into something that
+    // can be revectored or "hooked" for all instances of the function.
+    //
+    // PLAIN FUNCTIONS: body array is... the body of the function, obviously
+    // NATIVES: body is "equivalent code for native" (if any) in help
+    // ACTIONS: body is a 1-element array containing an INTEGER!
+    // SPECIALIZATIONS: body is a 1-element array containing a FRAME!
+    // CALLBACKS: body is a 1-element array with a HANDLE! (REBRIN*)
+    // ROUTINES: body is a 1-element array with a HANDLE! (REBRIN*)
+    //
+    REBARR *body;
+};
+
+struct Reb_Any_Context {
+    //
+    // Unless it copies the keylist, a context cannot uniquely describe a
+    // "special" instance of an archetype function it is bound to.  This
+    // field needs to be combined with the FUNC_VALUE of a frame context
+    // to get the full definition.
+    //
+    REBARR *exit_from;
+
+    // `varlist` is a Rebol Array that from 1..NUM_VARS contains REBVALs
+    // representing the stored values in the context.
+    //
+    // As with the `paramlist` of a FUNCTION!, the varlist uses the [0]th
+    // element specially.  It stores a copy of the ANY-CONTEXT! value that
+    // refers to itself.
+    //
+    // The `keylist` is held in the varlist's Reb_Series.misc field, and it
+    // may be shared with an arbitrary number of other contexts.  Changing
+    // the keylist involves making a copy if it is shared.
+    //
+    // REB_MODULE depends on a property stored in the "meta" miscellaneous
+    // field of the keylist, which is another object's-worth of data *about*
+    // the module's contents (e.g. the processed header)
+    //
+    REBCTX *context; // !!! TBD: change to REBARR*, rename as varlist
+
+    union {
+        REBCTX *spec; // used by REB_MODULE
+
+        // Used by REB_FRAME.  This is the call that corresponded to the
+        // FRAME! at the time it was created.  The pointer becomes invalid if
+        // the call ends, so the flags on the context must be consulted to
+        // see if it indicates the stack is over before using.
+        //
+        // Note: This is technically just a cache, as the stack could be
+        // walked to find it given the frame.
+        //
+        struct Reb_Frame *frame;
+    } more;
+};
+
+struct Reb_Varargs {
+    //
+    // This is a FRAME! which was on the stack at the time when the VARARGS!
+    // was created.  However it may no longer be on the stack--and once it is
+    // not, it cannot respond to requests to be advanced.  The frame keeps
+    // a flag to test for this as long as this VARARGS! is GC-managed.
+    //
+    // Note that this frame reuses its EVAL slot to hold a value for any
+    // "sub-varargs" that is being processed, so that is the first place it
+    // looks to get the next item.
+    //
+    union {
+        REBARR *varlist; // might be an in-progress varlist if not managed
+
+        REBARR *array1; // for MAKE VARARGS! to share a reference on an array
+    } feed;
+
+    // For as long as the VARARGS! can be used, the function it is applying
+    // will be alive.  Assume that the locked paramlist won't move in memory
+    // (evaluation would break if so, anyway) and hold onto the TYPESET!
+    // describing the parameter.  Each time a value is fetched from the EVAL
+    // then type check it for convenience.  Use ANY-VALUE! if not wanted.
+    //
+    // Note: could be a parameter index in the worst case scenario that the
+    // array grew, revisit the rules on holding pointers into paramlists.
+    //
+    const RELVAL *param;
+
+    // Similar to the param, the arg is only good for the lifetime of the
+    // FRAME!...but even less so, because VARARGS! can (currently) be
+    // overwritten with another value in the function frame at any point.
+    // Despite this, we proxy the VALUE_FLAG_EVALUATED from the last TAKE
+    // onto the argument to reflect its *argument* status.
+    //
+    REBVAL *arg;
+};
+
+struct Reb_Handle {
+    union {
+        CFUNC *code;
+        void *data;
+        REBUPT number;
+    } thing;
+};
+
+typedef struct Reb_Library_Handle {
+    void * fd;
+    REBUPT flags;
+} REBLHL; // sizeof(REBLHL) % 8 must equal 0 on both 64-bit and 32-bit builds
+
+struct Reb_Library {
+    REBLHL *handle;
+    REBARR *spec;
+};
+
+typedef struct Reb_Struct {
+    REBARR *spec;
+    REBSER *fields;    // fields definition
+    REBSER *data;
+} REBSTU;
+
+struct Reb_Routine_Info {
+    union {
+        struct {
+            REBLHL  *lib;
+            CFUNC *funcptr;
+        } rot;
+        struct {
+            void *closure;
+            REBFUN *func;
+            void *dispatcher;
+        } cb;
+    } info;
+    void *cif;
+    REBSER *arg_types; // index 0 is the return type
+    REBARR *fixed_args;
+    REBARR *all_args;
+    REBARR *arg_structs; // for struct arguments
+    REBSER *extra_mem; // extra memory that needs to be freed
+    REBCNT flags; // !!! 32-bit...should it use REBFLGS for 64-bit on 64-bit?
+    REBINT abi;
+
+    REBUPT padding; // sizeof(Reb_Routine_Info) % 8 must be 0 for Make_Node()
+};
+
+typedef REBFUN REBROT;
+
+#pragma pack() // set back to default (was set to 4 at start of file)
+    #include "reb-gob.h"
+#pragma pack(4) // resume packing with 4
+
+struct Reb_Gob {
+    REBGOB *gob;
+    REBCNT index;
+};
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  VALUE PAYLOAD DEFINITION (`struct Reb_Value`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The value is defined to have the header first, and then the value.  Having
+// the header come first is taken advantage of by the trick for allowing
+// a single REBUPT-sized value (32-bit on 32 bit builds, 64-bit on 64-bit
+// builds) be examined to determine if a value is an END marker or not.
+//
+// One aspect of having the header before the payload is that on 32-bit
+// platforms, this means that the starting address of the payload is not on
+// a 64-bit alignment boundary.  This means placing a quantity that needs
+// 64-bit alignment at the start of a payload can cause problems on some
+// platforms with strict alignment requirements.
+//
+// (Note: The reason why this can happen at all is due to the #pragma pack(4)
+// that is put in effect at the top of this file.)
+//
+// See Reb_Integer, Reb_Decimal, and Reb_Typeset for examples where the 64-bit
+// quantity is padded by a pointer or pointer-sized-REBUPT to compensate.
+//
+
+// Reb_All is a structure type designed specifically for getting at
+// the underlying bits of whichever union member is in effect inside
+// the Reb_Value_Data.  This is not actually legal, although if types
+// line up in unions it could be possibly be made "more legal":
+//
+//     http://stackoverflow.com/questions/11639947/
+//
+struct Reb_All {
+#if defined(__LP64__) || defined(__LLP64__)
+    REBCNT bits[6];
+#else
+    REBCNT bits[3];
+#endif
+};
+
+#define VAL_ALL_BITS(v) ((v)->payload.all.bits)
+
+union Reb_Value_Payload {
+
+#if !defined(NDEBUG)
+    struct Reb_Track track; // debug only (for void/trash, NONE!, LOGIC!, BAR!)
+#endif
+
+    REBUNI character; // It's CHAR! (for now), but 'char' is a C keyword
+
+    struct Reb_Integer integer;
+    struct Reb_Decimal decimal;
+
+    struct Reb_Pair pair;
+    struct Reb_Money money;
+    struct Reb_Handle handle;
+    struct Reb_Time time;
+    struct Reb_Tuple tuple;
+    struct Reb_Datatype datatype;
+    struct Reb_Typeset typeset;
+
+    // Both Any_Word and Any_Series have a Reb_Binding_Target as the first
+    // item in their payloads.  Since Reb_Value_Payload is a union, C permits
+    // the *reading* of common leading elements from another union member,
+    // even if that wasn't the last union written.  While this has been a
+    // longstanding informal assumption in C, the standard has adopted it:
+    //
+    //     http://stackoverflow.com/a/11996970/211160
+    //
+    // So `any_target` can be used to read the binding target out of either
+    // an ANY-WORD! or ANY-SERIES! payload.  To be on the safe side, *writing*
+    // should likely be specifically through `any_word` or `any_series`.
+    //
+    union Reb_Binding_Target any_target;
+        struct Reb_Any_Word any_word;
+        struct Reb_Any_Series any_series;
+
+    struct Reb_Any_Context any_context;
+
+    struct Reb_Function function;
+
+    struct Reb_Varargs varargs;
+
+    struct Reb_Library library;
+    struct Reb_Struct structure; // It's STRUCT!, but 'struct' is a C keyword
+
+    struct Reb_Event event;
+    struct Reb_Gob gob;
+
+    struct Reb_Symbol symbol; // internal
+
+    struct Reb_All all;
+};
+
+struct Reb_Value
+{
+    struct Reb_Value_Header header;
+    union Reb_Value_Payload payload;
+};
+
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  END marker (not a value type, only writes `struct Reb_Value_Flags`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Historically Rebol arrays were always one value longer than their maximum
+// content, and this final slot was used for a special REBVAL called END!.
+// Like a null terminator in a C string, it was possible to start from one
+// point in the series and traverse to find the end marker without needing
+// to maintain a count.  Rebol series store their length also--but it's
+// faster and more general to use the terminator.
+//
+// Ren-C changed this so that end is not a data type, but rather seeing a
+// header slot with the lowest bit set to 0.  (See NOT_END_MASK for
+// an explanation of this choice.)  The upshot is that a data structure
+// designed to hold Rebol arrays is able to terminate an array at full
+// capacity with a pointer-sized integer with the lowest 2 bits clear, and
+// use the rest of the bits for other purposes.  (See WRITABLE_MASK_DEBUG
+// for why it's the low 2 bits and not just the lowest bit.)
+//
+// This means not only is a full REBVAL not needed to terminate, the sunk cost
+// of an existing 32-bit or 64-bit number (depending on platform) can be used
+// to avoid needing even 1/4 of a REBVAL for a header to terminate.  (See the
+// `size` field in `struct Reb_Chunk` from %sys-stack.h for a simple example
+// of the technique.)
+//
+// !!! Because Rebol Arrays (REBARR) have both a length and a terminator, it
+// is important to keep these in sync.  R3-Alpha sought to give code the
+// freedom to work with unterminated arrays if the cost of writing terminators
+// was not necessary.  Ren-C pushed back against this to try and be more
+// uniform to get the invariants under control.  A formal balance is still
+// being sought of when terminators will be required and when they will not.
+//
+// The debug build puts REB_MAX in the type slot of a REB_END, to help to
+// distinguish it from the 0 that signifies an unset TRASH.  This means that
+// any writable value can be checked to ensure it is an actual END marker
+// and not "uninitialized".  This trick can only be used so long as REB_MAX
+// is 63 or smaller (ensured by an assertion at startup ATM.
+//
+
+#define END_CELL \
+    c_cast(const REBVAL*, &PG_End_Cell)
+
+#define IS_END_MACRO(v) \
+    LOGICAL((v)->header.bits % 2 == 0) // == NOT(bits & NOT_END_MASK)
+
+#ifdef NDEBUG
+    #define IS_END(v) \
+        IS_END_MACRO(v)
+
+    inline static void SET_END(RELVAL *v) {
+        v->header.bits = 0;
+    }
+#else
+    // Note: These must be macros (that don't need IS_END_Debug or
+    // SET_END_Debug defined until used at a callsite) because %tmp-funcs.h
+    // cannot be included until after REBSER and other definitions that
+    // depend on %sys-rebval.h have been defined.  (Or they could be manually
+    // forward-declared here.)
+    //
+    #define IS_END(v) \
+        IS_END_Debug((v), __FILE__, __LINE__)
+
+    #define SET_END(v) \
+        SET_END_Debug((v), __FILE__, __LINE__)
+#endif
+
+#define NOT_END(v) \
+    NOT(IS_END(v))
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  REBVAL ("fully specified" value) and RELVAL ("possibly relative" value)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// A relative value is the identical struct to Reb_Value, but is allowed to
+// have the relative bit set.  Hence a relative value pointer can point to a
+// specific value, but a relative word or array cannot be pointed to by a
+// plain REBVAL*.  The RELVAL-vs-REBVAL distinction is purely commentary
+// in the C build, but the C++ build makes REBVAL a type derived from RELVAL.
+//
+// RELVAL exists to help quarantine the bit patterns for relative words into
+// the deep-copied-body of the function they are for.  To actually look them
+// up, they must be paired with a FRAME! matching the actual instance of the
+// running function on the stack they correspond to.  Once made specific,
+// a word may then be freely copied into any REBVAL slot.
+//
+// In addition to ANY-WORD!, an ANY-ARRAY! can also be relative, if it is
+// part of the deep-copied function body.  The reason that arrays must be
+// relative too is in case they contain relative words.  If they do, then
+// recursion into them must carry forward the resolving "specifier" pointer
+// to be combined with any relative words that are seen later.
+//
+
+#ifdef __cplusplus
+    struct Reb_Specific_Value : public Reb_Value {
+    #if !defined(NDEBUG)
+        //
+        // In C++11, it is now formally legal to add constructors to types
+        // without interfering with their "standard layout" properties, or
+        // making them uncopyable with memcpy(), etc.  For the rules, see:
+        //
+        //     http://stackoverflow.com/a/7189821/211160
+        //
+        // In the debug C++ build there is an extra check of writability. This
+        // makes sure that stack variables holding REBVAL are marked with that.
+        // It also means that the check can only be performed by the C++ build,
+        // otherwise there would need to be a manual set of this bit on every
+        // stack variable.
+        //
+        Reb_Specific_Value () {
+            header.bits = WRITABLE_MASK_DEBUG;
+        }
+    #endif
+    };
+#endif
+
+inline static REBOOL IS_RELATIVE(const RELVAL *v) {
+    return LOGICAL(v->header.bits & VALUE_FLAG_RELATIVE);
+}
+
+#if defined(__cplusplus)
+    //
+    // Take special advantage of the fact that C++ can help catch when we are
+    // trying to see if a REBVAL is specific or relative (it will always
+    // be specific, so the call is likely in error).  In the C build, they
+    // are the same type so there will be no error.
+    //
+    REBOOL IS_RELATIVE(const REBVAL *v);
+#endif
+
+#define IS_SPECIFIC(v) \
+    NOT(IS_RELATIVE(v))
+
+inline static REBFUN *VAL_RELATIVE(const RELVAL *v) {
+    assert(IS_RELATIVE(v));
+    return v->payload.any_target.relative; // any_target is read-only, see note
+}
+
+#define VAL_SPECIFIC_MACRO(v) \
+    ((v)->payload.any_target.specific) // any_target is read-only, see note
+
+#ifdef NDEBUG
+    #define VAL_SPECIFIC(v) \
+        VAL_SPECIFIC_MACRO(v)
+#else
+    #define VAL_SPECIFIC(v) \
+        VAL_SPECIFIC_Debug(v)
+#endif
+
+// When you have a RELVAL* (e.g. from a REBARR) that you "know" to be specific,
+// the KNOWN macro can be used for that.  Checks to make sure in debug build.
+//
+// Use for: "invalid conversion from 'Reb_Value*' to 'Reb_Specific_Value*'"
+
+inline static const REBVAL *const_KNOWN(const RELVAL *value) {
+    assert(IS_SPECIFIC(value));
+    return cast(const REBVAL*, value); // we asserted it's actually specific
+}
+
+inline static REBVAL *KNOWN(RELVAL *value) {
+    assert(IS_SPECIFIC(value));
+    return cast(REBVAL*, value); // we asserted it's actually specific
+}
+
+inline static const RELVAL *const_REL(const REBVAL *v) {
+    return cast(const RELVAL*, v); // cast w/input restricted to REBVAL
+}
+
+inline static RELVAL *REL(REBVAL *v) {
+    return cast(RELVAL*, v); // cast w/input restricted to REBVAL
+}
+
+#ifdef NDEBUG
+    #define SPECIFIED NULL
+#else
+    #define SPECIFIED \
+        cast(REBCTX*, 0xF10F10F1) // helps catch uninitialized locations
+#endif
+
+// !!! temporary - used to document any sites where one is not sure if the
+// value is specific, to aid in finding them to review
+//
+#define GUESSED SPECIFIED
+
+
+// This can be used to turn a RELVAL into a REBVAL.  If the RELVAL is
+// indeed relative and needs to be made specific to be put into the
+// REBVAL, then the specifier is used to do that.  Debug builds assert
+// that the function in the specifier indeed matches the target in
+// the relative value (because relative values in an array may only
+// be relative to the function that deep copied them, and that is the
+// only kind of specifier you can use with them).
+//
+// NOTE: The reason this is written to specifically intialize the `specific`
+// through the union member of the remaining type is to stay on the right
+// side of the standard.  While *reading* a common leading field out of
+// different union members is legal regardless of who wrote it last,
+// *writing* a common leading field will invalidate the ensuing fields of
+// other union types besides the one it was written through (!)  See notes
+// in Reb_Value's structure definition.
+//
+inline static void COPY_VALUE_CORE(
+    REBVAL *dest,
+    const RELVAL *src,
+    REBCTX *specifier
+) {
+    if (src->header.bits & VALUE_FLAG_RELATIVE) {
+        dest->header.bits = src->header.bits & ~VALUE_FLAG_RELATIVE;
+        if (src->header.bits & VALUE_FLAG_ARRAY) {
+            dest->payload.any_series.target.specific = specifier;
+            dest->payload.any_series.series
+                = src->payload.any_series.series;
+            dest->payload.any_series.index
+                = src->payload.any_series.index;
+        }
+        else { // must be ANY-WORD! (checked by COPY_VALUE_Debug)
+            dest->payload.any_word.place.binding.target.specific
+                = specifier;
+            dest->payload.any_word.place.binding.index
+                = src->payload.any_word.place.binding.index;
+            dest->payload.any_word.sym = src->payload.any_word.sym;
+        }
+    }
+    else {
+        dest->header = src->header;
+        dest->payload = src->payload;
+    }
+}
+
+
+#ifdef NDEBUG
+    #define COPY_VALUE(dest,src,specifier) \
+        COPY_VALUE_CORE(SINK(dest),(src),(specifier))
+#else
+    #define COPY_VALUE(dest,src,specifier) \
+        COPY_VALUE_Debug(SINK(dest),(src),(specifier))
+#endif
+
+#ifdef NDEBUG
+    #define ASSERT_NO_RELATIVE(array,deep) NOOP
+#else
+    #define ASSERT_NO_RELATIVE(array,deep) \
+        Assert_No_Relative((array),(deep))
+#endif
+
+#pragma pack() // set back to default (was set to 4 at start of file)

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -7,7 +7,7 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // Copyright 2012 REBOL Technologies
-// Copyright 2012-2015 Rebol Open Source Contributors
+// Copyright 2012-2016 Rebol Open Source Contributors
 // REBOL is a trademark of REBOL Technologies
 //
 // See README.md and CREDITS.md for more information
@@ -31,7 +31,7 @@
 //
 // * The internal system datatype, also known as a REBSER.  It's a low-level
 //   implementation of something similar to a vector or an array in other
-//   languages.  It is an abstraction which represens a contiguous region
+//   languages.  It is an abstraction which represents a contiguous region
 //   of memory containing equally-sized elements.
 //
 // * The user-level value type ANY-SERIES!.  This might be more accurately
@@ -73,374 +73,32 @@
 // operations would not require casting...but this is C.)  The subclasses
 // are explained where they are defined.
 //
+// Notes:
+//
+// * For the struct definition of REBSER, see %sys-rebser.h
+//
 
-//
-// Note: Forward declarations are in %reb-defs.h
-//
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  REBSER (a.k.a. `struct Reb_Series`)
+//  DEBUG PANIC
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// This structure is a small descriptor for a series, and contains information
-// about its content and flags.  Every string and block in REBOL has one.
-//
-// The REBSER is fixed-size, and is allocated as a "node" from a memory pool.
-// That pool quickly grants and releases memory ranges that are sizeof(REBSER)
-// without needing to use malloc() and free() for each individual allocation.
-// These nodes can also be enumerated in the pool without needing the series
-// to be tracked via a linked list or other structure.  The garbage collector
-// is one example of code that performs such an enumeration.
-//
-// A REBSER node pointer will remain valid as long as outstanding references
-// to the series exist in values visible to the GC.  On the other hand, the
-// series's data pointer may be freed and reallocated to respond to the needs
-// of resizing.  (In the future, it may be reallocated just as an idle task
-// by the GC to reclaim or optimize space.)  Hence pointers into data in a
-// managed series *must not be held onto across evaluations*.
-//
-// If the data requirements of a series are small, then rather than using the
-// space in the REBSER to track a dynamic allocation, the data is included
-// directly in the node itself.  The capacity is chosen to be exactly enough
-// to store a single REBVAL so that length 0 or 1 series can be represented.
-// However, that same amount of capacity may be used by arbitrary series (such
-// as strings) if they too are small enough to fit.
-//
-
-// Series Flags
-//
-enum {
-    // `SERIES_FLAG_0_IS_FALSE` represents the lowest bit and should always
-    // be set to zero.  This is because it means that when Reb_Series_Content
-    // is interpreted as a REBVAL's worth of data, then the info bits are in
-    // a location where they do double-duty serving as an END marker.  For a
-    // description of the method see notes on NOT_END_MASK.
-    //
-    SERIES_FLAG_0_IS_FALSE = 1 << 0,
-
-    // `SERIES_FLAG_1_IS_FALSE` is the second lowest bit, and is set to zero
-    // as a safety precaution.  In the debug build this is checked by value
-    // writes to ensure that when the info flags are serving double duty
-    // as an END marker, they do not get overwritten by rogue code that
-    // thought a REBVAL* pointing at the memory had a full value's worth
-    // of memory to write into.  See WRITABLE_MASK_DEBUG.
-    //
-    SERIES_FLAG_1_IS_FALSE = 1 << 1,
-
-    // `SERIES_FLAG_HAS_DYNAMIC` indicates that this series has a dynamically
-    // allocated portion.  If it does not, then its data pointer is the
-    // address of the embedded value inside of it (marked terminated by
-    // the SERIES_FLAG_0_IS_ZERO if it has an element in it)
-    //
-    SERIES_FLAG_HAS_DYNAMIC = 1 << 2,
-
-    // `SERIES_FLAG_MARK` is used in the "mark and sweep" method of garbage
-    // collection.  It is also used for other purposes which need to go
-    // through and set a generic bit, e.g. to protect against loops in
-    // the transitive closure ("if you hit a SER_MARK, then you've already
-    // processed this series").
-    //
-    // Because of the dual purpose, it's important to be sure to not run
-    // garbage collection while one of these alternate uses is in effect.
-    // It's also important to reset the bit when done, as GC assumes when
-    // it starts that all bits are cleared.  (The GC itself clears all
-    // the bits by enumerating every series in the series pool during the
-    // sweeping phase.)
-    //
-    // !!! With more series bits now available, the dual purpose is something
-    // that should be reexamined--so long as bits are free, why reuse if it
-    // creates more risk?
-    //
-    SERIES_FLAG_MARK = 1 << 3,
-
-    // `SERIES_FLAG_MANAGED` indicates that a series is managed by garbage
-    // collection.  If this bit is not set, then during the GC's sweeping
-    // phase the simple fact that it hasn't been SER_MARK'd won't be enough
-    // to let it be considered for freeing.
-    //
-    // See MANAGE_SERIES for details on the lifecycle of a series (how it
-    // starts out manually managed, and then must either become managed or be
-    // freed before the evaluation that created it ends).
-    //
-    SERIES_FLAG_MANAGED = 1 << 4,
-
-    // `SERIES_FLAG_ARRAY` indicates that this is a series of REBVAL values,
-    // and suitable for using as the payload of an ANY-ARRAY! value.  When a
-    // series carries this bit, that means that if it is also SER_MANAGED
-    // then the garbage collector will process its transitive closure to
-    // make sure all the values it contains (and the values its references
-    // contain) do not have series GC'd out from under them.
-    //
-    // (In R3-Alpha, whether a series was an array or not was tested by if
-    // its width was sizeof(REBVAL).  The Ren-C approach allows for the
-    // creation of series that contain items that incidentally happen to be
-    // the same size as a REBVAL, while not actually being REBVALs.)
-    //
-    SERIES_FLAG_ARRAY = 1 << 5,
-
-    // `ARRAY_FLAG_CONTEXT_VARLIST` indicates this series represents the
-    // "varlist" of a context.  A second series can be reached from it via
-    // the `->misc` field in the series node, which is a second array known
-    // as a "keylist".
-    //
-    // See notes on REBCTX for further details about what a context is.
-    //
-    ARRAY_FLAG_CONTEXT_VARLIST = 1 << 6,
-
-    // `SERIES_FLAG_LOCKED` indicates that the series size or values cannot
-    // be modified.  This check is honored by some layers of abstraction, but
-    // if one manages to get a raw pointer into a value in the series data
-    // then by that point it cannot be enforced.
-    //
-    // !!! Could the 'writable' flag be used for this in the debug build,
-    // if the locking process went through and cleared writability...then
-    // put it back if the series were unlocked?
-    //
-    // This is related to the feature in PROTECT (OPT_TYPESET_LOCKED) which
-    // protects a certain variable in a context from being changed.  Yet
-    // it is distinct as it's a protection on a series itself--which ends
-    // up affecting all variable content with that series in the payload.
-    //
-    SERIES_FLAG_LOCKED = 1 << 7,
-
-    // `SERIES_FLAG_FIXED_SIZE` indicates the size is fixed, and the series
-    // cannot be expanded or contracted.  Values within the series are still
-    // writable, assuming SERIES_FLAG_LOCKED isn't set.
-    //
-    // !!! Is there checking in all paths?  Do series contractions check this?
-    //
-    // One important reason for ensuring a series is fixed size is to avoid
-    // the possibility of the data pointer being reallocated.  This allows
-    // code to ignore the usual rule that it is unsafe to hold a pointer to
-    // a value inside the series data.
-    //
-    // !!! Strictly speaking, SERIES_FLAG_NO_RELOCATE could be different
-    // from fixed size... if there would be a reason to reallocate besides
-    // changing size (such as memory compaction).
-    //
-    SERIES_FLAG_FIXED_SIZE  = 1 << 8,
-
-    // `SERIES_FLAG_POWER_OF_2` is set when an allocation size was rounded to
-    // a power of 2.  This flag was introduced in Ren-C when accounting was
-    // added to make sure the system's notion of how much memory allocation
-    // was outstanding would balance out to zero by the time of exiting the
-    // interpreter.
-    //
-    // The problem was that the allocation size was measured in terms of the
-    // number of elements.  If the elements themselves were not the size of
-    // a power of 2, then to get an even power-of-2 size of memory allocated
-    // the memory block would not be an even multiple of the element size.
-    // Rather than track the actual memory allocation size as a 32-bit number,
-    // a single bit flag remembering that the allocation was a power of 2
-    // was enough to recreate the number to balance accounting at free time.
-    //
-    // !!! The rationale for why series were ever allocated to a power of 2
-    // should be revisited.  Current conventional wisdom suggests that asking
-    // for the amount of memory you need and not using powers of 2 is
-    // generally a better idea:
-    //
-    // http://stackoverflow.com/questions/3190146/
-    //
-    SERIES_FLAG_POWER_OF_2  = 1 << 9,
-
-    // `SERIES_FLAG_EXTERNAL` indicates that when the series was created, the
-    // `->data` pointer was poked in by the creator.  It takes responsibility
-    // for freeing it, so don't free() on GC.
-    //
-    // !!! It's not clear what the lifetime management of data used in this
-    // way is.  If the external system receives no notice when Rebol is done
-    // with the data and GC's the series, how does it know when it's safe
-    // to free the data or not?  The feature is not used by the core or
-    // Ren-Cpp, but by relatively old extensions...so there may be no good
-    // answer in the case of those clients (likely either leaks or crashes).
-    //
-    SERIES_FLAG_EXTERNAL = 1 << 10,
-
-    // `SERIES_FLAG_ACCESSIBLE` indicates that the external memory pointed by
-    // `->data` is accessible. This is not checked at every access to the
-    // `->data` for the performance consideration, only on those that are
-    // known to have possible external memory storage.  Currently this is
-    // used for STRUCT! and to note when a CONTEXT_FLAG_STACK series has its
-    // stack level popped (there's no data to lookup for words bound to it)
-    //
-    SERIES_FLAG_ACCESSIBLE = 1 << 11,
-
-    // `CONTEXT_FLAG_STACK` indicates that varlist data lives on the stack.
-    // This is a work in progress to unify objects and function call frames
-    // as a prelude to unifying FUNCTION! and CLOSURE!.
-    //
-    // !!! Ultimately this flag may be unnecessary because stack-based and
-    // dynamic series will "hybridize" so that they may have some stack
-    // fields and some fields in dynamic memory.  The foundation already
-    // exists, and both can be stored in the same REBSER.  It's just a problem
-    // of mapping index numbers in the function paramlist into either the
-    // stack array or the dynamic array during binding in an efficient way.
-    //
-    CONTEXT_FLAG_STACK = 1 << 12,
-
-    // `KEYLIST_FLAG_SHARED` is indicated on the keylist array of a context
-    // when that same array is the keylist for another object.  If this flag
-    // is set, then modifying an object using that keylist (such as by adding
-    // a key/value pair) will require that object to make its own copy.
-    //
-    // (Note: This flag did not exist in R3-Alpha, so all expansions would
-    // copy--even if expanding the same object by 1 item 100 times with no
-    // sharing of the keylist.  That would make 100 copies of an arbitrary
-    // long keylist that the GC would have to clean up.)
-    //
-    KEYLIST_FLAG_SHARED = 1 << 13,
-
-    // `ARRAY_FLAG_VOIDS_LEGAL` identifies arrays in which it is legal to
-    // have void elements.  This is used for instance on reified C va_list()s
-    // which were being used for unevaluated applies.  When those va_lists
-    // need to be put into arrays for the purposes of GC protection, they may
-    // contain voids which they need to track.
-    //
-    // Note: ARRAY_FLAG_CONTEXT_VARLIST also implies legality of voids, which
-    // are used to represent unset variables.
-    //
-    ARRAY_FLAG_VOIDS_LEGAL = 1 << 14,
-
-    // `SERIES_FLAG_LEGACY` is a flag which is marked at the root set of the
-    // body of legacy functions.  It can be used in a dynamic examination of
-    // a call to see if it "originates from legacy code".  This is a vague
-    // concept given the ability to create blocks and run them--so functions
-    // like COPY would have to propagate the flag to make it "more accurate".
-    // But it's good enough for casual compatibility in many cases.
-    //
-#if !defined NDEBUG
-    SERIES_FLAG_LEGACY = 1 << 15,
-#endif
-
-    SERIES_FLAG_NO_COMMA_NEEDED = 0 // solves dangling comma from above
-};
-
-struct Reb_Series_Dynamic {
-    //
-    // `data` is the "head" of the series data.  It may not point directly at
-    // the memory location that was returned from the allocator if it has
-    // bias included in it.
-    //
-    REBYTE *data;
-
-    // `len` is one past end of useful data.
-    //
-    REBCNT len;
-
-    // `rest` is the total number of units from bias to end.  Having a
-    // slightly weird name draws attention to the idea that it's not really
-    // the "capacity", just the "rest of the capacity after the bias".
-    //
-    REBCNT rest;
-
-    // This is the 4th pointer on 32-bit platforms which could be used for
-    // something when a series is dynamic.  Previously the bias was not
-    // a full REBCNT but was limited in range to 16 bits or so.  This means
-    // 16 info bits are likely available if needed for dynamic series.
-    //
-    REBCNT bias;
-
-#if defined(__LP64__) || defined(__LLP64__)
-    //
-    // The Reb_Series_Dynamic is used in Reb_Series inside of a union with a
-    // REBVAL.  On 64-bit machines this will leave one unused 32-bit slot
-    // (which will couple with the previous REBCNT) and one naturally aligned
-    // 64-bit pointer.  These could be used for some enhancement that would
-    // be available per-dynamic-REBSER on 64-bit architectures.
-    //
-    REBCNT unused_32;
-    void *unused_64;
-#endif
-
-};
-
-struct Reb_Series {
-
-    union {
-        //
-        // If the series does not fit into the REBSER node, then it must be
-        // dynamically allocated.  This is the tracking structure for that
-        // dynamic data allocation.
-        //
-        struct Reb_Series_Dynamic dynamic;
-
-        // If not SERIES_FLAG_HAS_DYNAMIC, 0 or 1 length arrays can be held
-        // directly in the series node.  The SERIES_FLAG_0_IS_FALSE bit is set
-        // to zero and signals an IS_END().
-        //
-        // It is thus an "array" of effectively up to length two.  Either the
-        // [0] full element is IS_END(), or the [0] element is another value
-        // and the [1] element is read-only and passes IS_END() to terminate
-        // (but can't have any other value written, as the info bits are
-        // marked as unwritable by SERIES_FLAG_1_IS_FALSE...this protects the
-        // rest of the bits in the debug build as it is checked whenver a
-        // REBVAL tries to write a new header.)
-        //
-        RELVAL values[1];
-    } content;
-
-    // `info` is the information about the series which needs to be known
-    // even if it is not using a dynamic allocation.  So even if the alloc
-    // size, length, and bias aren't relevant...the series flags need to
-    // be known...including the flag of whether this is a dynamic series
-    // node or not!
-    //
-    // The lowest 2 bits of info are required to be 0 when used with the trick
-    // of implicitly terminating series data.  See SERIES_FLAG_0_IS_FALSE and
-    // SERIES_FLAG_1_IS_FALSE for more information.
-    //
-    // !!! Only the low 32-bits are used on 64-bit platforms.  There could
-    // be some interesting added caching feature or otherwise that would use
-    // it, while not making any feature specifically require a 64-bit CPU.
-    //
-    struct Reb_Value_Header info;
-
-    // The `misc` field is an extra pointer-sized piece of data which is
-    // resident in the series node, and hence visible to all REBVALs that
-    // might be referring to the series.
-    //
-    union {
-        REBNAT dispatch; // native dispatcher code, see Reb_Function's body
-        REBCNT len; // length of non-arrays when !SERIES_FLAG_HAS_DYNAMIC
-        REBCNT size;    // used for vectors and bitsets
-        REBSER *hashlist; // MAP datatype uses this
-        REBARR *keylist; // used by CONTEXT
-        struct {
-            REBCNT wide:16;
-            REBCNT high:16;
-        } area;
-        REBOOL negated; // for bitsets (must be shared, can't be in REBVAL)
-        REBARR *subfeed; // for *non-frame* VARARGS! ("array1") shared feed
-        REBCTX *meta; // paramlists and keylists can store a "meta" object
-    } misc;
-
-#if !defined(NDEBUG)
-    int *guard; // intentionally alloc'd and freed for use by Panic_Series
-    REBUPT do_count; // also maintains sizeof(REBSER) % sizeof(REBI64) == 0
-#endif
-};
-
 // "Series Panics" will (hopefully) trigger an alert under memory tools
 // like address sanitizer and valgrind that indicate the call stack at the
 // moment of allocation of a series.  Then you should have TWO stacks: the
 // one at the call of the Panic, and one where that series was alloc'd.
 //
-//    THIS FEATURE IS MENTIONED UP TOP BECAUSE IT IS VERY, VERY USEFUL!
-//
+
 #if !defined(NDEBUG)
     #define Panic_Series(s) \
         Panic_Series_Debug((s), __FILE__, __LINE__);
 #endif
 
-#define SER_WIDE(s) \
-    cast(REBYTE, ((s)->info.bits >> 16) & 0xff)
 
 //
 // Series flags
-//
-// !!! These should be renamed to the more readable SET_SER_FLAG, etc.
 //
 
 #define SET_SER_FLAG(s,f) \
@@ -475,52 +133,62 @@ struct Reb_Series {
 // the presence or absence of an END marker in the first slot.
 //
 
-#define SER_LEN(s) \
-    (GET_SER_FLAG((s), SERIES_FLAG_HAS_DYNAMIC) \
-        ? ((s)->content.dynamic.len) \
-        : GET_SER_FLAG((s), SERIES_FLAG_ARRAY) \
-            ? (IS_END(cast(REBVAL*, &(s)->content.values[0])) ? 0 : 1) \
-            : (s)->misc.len)
+#define SER_WIDE(s) \
+    cast(REBYTE, ((s)->info.bits >> 16) & 0xff)
 
-#define SET_SERIES_LEN(s,l) \
-    (assert(!GET_SER_FLAG((s), CONTEXT_FLAG_STACK)), \
-        GET_SER_FLAG((s), SERIES_FLAG_HAS_DYNAMIC) \
-        ? ((s)->content.dynamic.len = (l)) \
-        : GET_SER_FLAG((s), SERIES_FLAG_ARRAY) \
-            ? 1337 /* trust the END marker? */ \
-            : ((s)->misc.len = (l)))
+inline static REBCNT SER_LEN(REBSER *s) {
+    if (GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC))
+        return s->content.dynamic.len;
 
-#define SER_REST(s) \
-    (GET_SER_FLAG((s), SERIES_FLAG_HAS_DYNAMIC) \
-        ? ((s)->content.dynamic.rest) \
-        : GET_SER_FLAG((s), SERIES_FLAG_ARRAY) \
-            ? 2 /* includes trick "terminator" in info bits */ \
-            : sizeof(REBVAL))
+    if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+        return IS_END(&s->content.values[0]) ? 0 : 1;
 
+    return s->misc.len;
+}
+
+inline static void SET_SERIES_LEN(REBSER *s, REBCNT len) {
+    assert(!GET_SER_FLAG(s, CONTEXT_FLAG_STACK));
+
+    if (GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)) {
+        s->content.dynamic.len = len;
+    }
+    else if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+        assert(FALSE);
+    else {
+        s->misc.len = len;
+    }
+}
+
+inline static REBCNT SER_REST(REBSER *s) {
+    if (GET_SER_FLAG((s), SERIES_FLAG_HAS_DYNAMIC))
+        return s->content.dynamic.rest;
+
+    if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+        return 2; // includes info bits acting as trick "terminator"
+
+    return sizeof(s->content);
+}
 
 // Raw access does not demand that the caller know the contained type.  So
 // for instance a generic debugging routine might just want a byte pointer
 // but have no element type pointer to pass in.
 //
-#define SER_DATA_RAW(s) \
-    (GET_SER_FLAG((s), SERIES_FLAG_HAS_DYNAMIC) \
-        ? (s)->content.dynamic.data \
-        : cast(REBYTE*, &(s)->content.values[0]))
+inline static REBYTE *SER_DATA_RAW(REBSER *s) {
+    return GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)
+        ? s->content.dynamic.data
+        : cast(REBYTE*, &s->content.values[0]);
+}
 
-#define SER_AT_RAW_MACRO(w,s,i) \
-    (SER_DATA_RAW(s) + ((w) * (i)))
+inline static REBYTE *SER_AT_RAW(size_t w, REBSER *s, REBCNT i) {
+    assert(w == SER_WIDE(s));
+    return SER_DATA_RAW(s) + ((w) * (i));
+}
 
-#ifdef NDEBUG
-    #define SER_AT_RAW(w,s,i) \
-        SER_AT_RAW_MACRO((w),(s),(i))
-#else
-    #define SER_AT_RAW(w,s,i) \
-        SER_AT_RAW_Debug((w),(s),(i))
-#endif
+inline static void SER_SET_EXTERNAL_DATA(REBSER *s, void *p) {
+    SET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC);
+    s->content.dynamic.data = cast(REBYTE*, p);
+}
 
-#define SER_SET_EXTERNAL_DATA(s,p) \
-    (SET_SER_FLAG((s), SERIES_FLAG_HAS_DYNAMIC), \
-        (s)->content.dynamic.data = cast(REBYTE*, (p)))
 
 //
 // In general, requesting a pointer into the series data requires passing in
@@ -537,11 +205,20 @@ struct Reb_Series {
 #define SER_HEAD(t,s) \
     SER_AT(t, (s), 0)
 
+inline static REBYTE *SER_TAIL_RAW(size_t w, REBSER *s) {
+    return SER_AT_RAW(w, s, SER_LEN(s));
+}
+
 #define SER_TAIL(t,s) \
-    SER_AT(t, (s), SER_LEN(s))
+    cast(t*, SER_TAIL_RAW(sizeof(t), (s)))
+
+inline static REBYTE *SER_LAST_RAW(size_t w, REBSER *s) {
+    assert(SER_LEN(s) != 0);
+    return SER_AT_RAW(w, s, SER_LEN(s) - 1);
+}
 
 #define SER_LAST(t,s) \
-    (assert(SER_LEN(s) != 0), SER_AT(t, (s), SER_LEN(s) - 1))
+    cast(t*, SER_LAST_RAW(sizeof(t), (s)))
 
 //
 // Series size measurements:
@@ -551,25 +228,30 @@ struct Reb_Series {
 // SER_USED - bytes being used, including terminator
 //
 
-#define SER_TOTAL(s) \
-    ((SER_REST(s) + SER_BIAS(s)) * SER_WIDE(s))
+inline static size_t SER_SPACE(REBSER *s) {
+    return SER_REST(s) * SER_WIDE(s);
+}
 
-#define SER_SPACE(s) \
-    (SER_REST(s) * SER_WIDE(s))
+inline static size_t SER_USED(REBSER *s) {
+    return (SER_LEN(s) + 1) * SER_WIDE(s);
+}
 
-#define SER_USED(s) \
-    ((SER_LEN(s) + 1) * SER_WIDE(s))
+#define SER_FULL(s) \
+    (SER_LEN(s) + 1 >= SER_REST(s))
 
-// Returns space that a series has available (less terminator):
-#define SER_FULL(s) (SER_LEN(s) + 1 >= SER_REST(s))
-#define SER_AVAIL(s) (SER_REST(s) - (SER_LEN(s) + 1))
-#define SER_FITS(s,n) ((SER_LEN(s) + (n) + 1) <= SER_REST(s))
+#define SER_AVAIL(s) \
+    (SER_REST(s) - (SER_LEN(s) + 1)) // space available (minus terminator)
 
+#define SER_FITS(s,n) \
+    ((SER_LEN(s) + (n) + 1) <= SER_REST(s))
 
-#define Is_Array_Series(s) GET_SER_FLAG((s), SERIES_FLAG_ARRAY)
+#define Is_Array_Series(s) \
+    GET_SER_FLAG((s), SERIES_FLAG_ARRAY)
 
-#define FAIL_IF_LOCKED_SERIES(s) \
-    if (GET_SER_FLAG(s, SERIES_FLAG_LOCKED)) fail (Error(RE_LOCKED))
+inline static void FAIL_IF_LOCKED_SERIES(REBSER *s) {
+    if (GET_SER_FLAG(s, SERIES_FLAG_LOCKED))
+        fail (Error(RE_LOCKED));
+}
 
 //
 // Series external data accessible
@@ -581,64 +263,51 @@ struct Reb_Series {
 // Optimized expand when at tail (but, does not reterminate)
 //
 
-#define EXPAND_SERIES_TAIL(s,l) \
-    do { \
-        if (SER_FITS((s), (l))) (s)->content.dynamic.len += (l); \
-        else Expand_Series((s), SER_LEN(s), (l)); \
-    } while (0)
+inline static void EXPAND_SERIES_TAIL(REBSER *s, REBCNT delta) {
+    if (SER_FITS(s, delta))
+        (s)->content.dynamic.len += delta;
+    else
+        Expand_Series(s, SER_LEN(s), delta);
+}
 
-#define RESIZE_SERIES(s,l) \
-    do { \
-        (s)->content.dynamic.len = 0; \
-        if (!SER_FITS((s), (l))) Expand_Series((s), SER_LEN(s), (l)); \
-        (s)->content.dynamic.len = 0; \
-    } while (0)
+inline static void RESIZE_SERIES(REBSER *s, REBCNT len) {
+    s->content.dynamic.len = 0;
+    if (!SER_FITS(s, len))
+        Expand_Series(s, SER_LEN(s), len);
+    s->content.dynamic.len = 0;
+}
 
 //
 // Termination
 //
 
-#define RESET_SERIES(s) \
-    ((s)->content.dynamic.len = 0, TERM_SERIES(s))
-
-#define RESET_TAIL(s) \
-    ((s)->content.dynamic.len = 0)
+inline static void RESET_TAIL(REBSER *s) {
+    s->content.dynamic.len = 0;
+}
 
 // Clear all and clear to tail:
 //
-#define CLEAR_SEQUENCE(s) \
-    do { \
-        assert(!Is_Array_Series(s)); \
-        CLEAR(SER_DATA_RAW(s), SER_SPACE(s)); \
-    } while (0)
+inline static void CLEAR_SEQUENCE(REBSER *s) {
+    assert(!Is_Array_Series(s));
+    CLEAR(SER_DATA_RAW(s), SER_SPACE(s));
+}
 
-#define TERM_SEQUENCE(s) \
-    do { \
-        assert(!Is_Array_Series(s)); \
-        memset(SER_AT_RAW(SER_WIDE(s), (s), SER_LEN(s)), 0, SER_WIDE(s)); \
-    } while (0)
+inline static void TERM_SEQUENCE(REBSER *s) {
+    assert(!Is_Array_Series(s));
+    memset(SER_AT_RAW(SER_WIDE(s), s, SER_LEN(s)), 0, SER_WIDE(s));
+}
 
 #ifdef NDEBUG
-    #define ASSERT_SERIES_TERM(s) NOOP
+    #define ASSERT_SERIES_TERM(s) \
+        NOOP
 #else
-    #define ASSERT_SERIES_TERM(s) Assert_Series_Term_Core(s)
+    #define ASSERT_SERIES_TERM(s) \
+        Assert_Series_Term_Core(s)
 #endif
 
 // Just a No-Op note to point out when a series may-or-may-not be terminated
 //
 #define NOTE_SERIES_MAYBE_TERM(s) NOOP
-
-#ifdef NDEBUG
-    #define ASSERT_SERIES(s) NOOP
-#else
-    #define ASSERT_SERIES(s) \
-        do { \
-            if (Is_Array_Series(s)) \
-                Assert_Array_Core(AS_ARRAY(s)); \
-            else \
-                Assert_Series_Core(s); \
-        } while (0)
-#endif
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -672,10 +341,10 @@ struct Reb_Series {
 #define MANAGE_SERIES(s) \
     Manage_Series(s)
 
-#define ENSURE_SERIES_MANAGED(s) \
-    (GET_SER_FLAG((s), SERIES_FLAG_MANAGED) \
-        ? NOOP \
-        : MANAGE_SERIES(s))
+inline static void ENSURE_SERIES_MANAGED(REBSER *s) {
+    if (NOT(GET_SER_FLAG((s), SERIES_FLAG_MANAGED)))
+        MANAGE_SERIES(s);
+}
 
 #ifdef NDEBUG
     #define ASSERT_SERIES_MANAGED(s) \
@@ -684,11 +353,10 @@ struct Reb_Series {
     #define ASSERT_VALUE_MANAGED(v) \
         NOOP
 #else
-    #define ASSERT_SERIES_MANAGED(s) \
-        do { \
-            if (!GET_SER_FLAG((s), SERIES_FLAG_MANAGED)) \
-                Panic_Series(s); \
-        } while (0)
+    inline static void ASSERT_SERIES_MANAGED(REBSER *s) {
+        if (NOT(GET_SER_FLAG((s), SERIES_FLAG_MANAGED)))
+            Panic_Series(s);
+    }
 
     #define ASSERT_VALUE_MANAGED(v) \
         assert(Is_Value_Managed(v))
@@ -723,13 +391,10 @@ struct Reb_Series {
 #define PUSH_GUARD_SERIES(s) \
     Guard_Series_Core(s)
 
-#define DROP_GUARD_SERIES(s) \
-    do { \
-        GC_Series_Guard->content.dynamic.len--; \
-        assert((s) == \
-            *SER_AT(REBSER*, GC_Series_Guard, SER_LEN(GC_Series_Guard)) \
-        ); \
-    } while (0)
+inline static void DROP_GUARD_SERIES(REBSER *s) {
+    assert(s == *SER_LAST(REBSER*, GC_Series_Guard));
+    GC_Series_Guard->content.dynamic.len--;
+}
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -779,51 +444,78 @@ struct Reb_Series {
 // size is not odd was added to Make_Series; reconsider if this becomes an
 // issue at some point.
 //
-#define BYTE_SIZE(s)    LOGICAL(((s)->info.bits) & (1 << 16))
+#define BYTE_SIZE(s) \
+    LOGICAL(((s)->info.bits) & (1 << 16))
 
 //
 // BIN_XXX: Binary or byte-size string seres macros
 //
 
-#define BIN_AT(s,n)     SER_AT(REBYTE, (s), (n))
-#define BIN_HEAD(s)     SER_HEAD(REBYTE, (s))
-#define BIN_TAIL(s)     SER_TAIL(REBYTE, (s))
-#define BIN_LAST(s)     SER_LAST(REBYTE, (s))
+#define BIN_AT(s,n) \
+    SER_AT(REBYTE, (s), (n))
 
-#define BIN_LEN(s)      (assert(BYTE_SIZE(s)), SER_LEN(s))
+#define BIN_HEAD(s) \
+    SER_HEAD(REBYTE, (s))
 
-#define SET_BIN_END(s,n) (*BIN_AT(s,n) = 0)
+#define BIN_TAIL(s) \
+    SER_TAIL(REBYTE, (s))
+
+#define BIN_LAST(s) \
+    SER_LAST(REBYTE, (s))
+
+inline static REBCNT BIN_LEN(REBSER *s) {
+    assert(BYTE_SIZE(s));
+    return SER_LEN(s);
+}
+
+inline static void SET_BIN_END(REBSER *s, REBCNT n) {
+    *BIN_AT(s, n) = 0;
+}
 
 //
 // UNI_XXX: Unicode string series macros
 //
 
-#define UNI_LEN(s) \
-    (assert(SER_WIDE(s) == sizeof(REBUNI)), SER_LEN(s))
+inline static REBCNT UNI_LEN(REBSER *s) {
+    assert(SER_WIDE(s) == sizeof(REBUNI));
+    return SER_LEN(s);
+}
 
-#define SET_UNI_LEN(s,l) \
-    (assert(SER_WIDE(s) == sizeof(REBUNI)), SET_SERIES_LEN((s), (l)))
+inline static void SET_UNI_LEN(REBSER *s, REBCNT len) {
+    assert(SER_WIDE(s) == sizeof(REBUNI));
+    SET_SERIES_LEN(s, len);
+}
 
-#define UNI_AT(s,n)     SER_AT(REBUNI, (s), (n))
-#define UNI_HEAD(s)     SER_HEAD(REBUNI, (s))
-#define UNI_TAIL(s)     SER_TAIL(REBUNI, (s))
-#define UNI_LAST(s)     SER_LAST(REBUNI, (s))
+#define UNI_AT(s,n) \
+    SER_AT(REBUNI, (s), (n))
 
-#define UNI_TERM(s)     (*UNI_TAIL(s) = 0)
-#define UNI_RESET(s)    (UNI_HEAD(s)[(s)->tail = 0] = 0)
+#define UNI_HEAD(s) \
+    SER_HEAD(REBUNI, (s))
+
+#define UNI_TAIL(s) \
+    SER_TAIL(REBUNI, (s))
+
+#define UNI_LAST(s) \
+    SER_LAST(REBUNI, (s))
+
+inline static void UNI_TERM(REBSER *s) {
+    *UNI_TAIL(s) = 0;
+}
 
 //
 // Get a char, from either byte or unicode string:
 //
 
-#define GET_ANY_CHAR(s,n) \
-    cast(REBUNI, BYTE_SIZE(s) ? BIN_HEAD(s)[n] : UNI_HEAD(s)[n])
+inline static REBUNI GET_ANY_CHAR(REBSER *s, REBCNT n) {
+    return BYTE_SIZE(s) ? BIN_HEAD(s)[n] : UNI_HEAD(s)[n];
+}
 
-#define SET_ANY_CHAR(s,n,c) \
-    (BYTE_SIZE(s) \
-        ? (BIN_HEAD(s)[n]=(cast(REBYTE, (c)))) \
-        : (UNI_HEAD(s)[n]=(cast(REBUNI, (c)))) \
-    )
+inline static void SET_ANY_CHAR(REBSER *s, REBCNT n, REBYTE c) {
+    if BYTE_SIZE(s)
+        BIN_HEAD(s)[n] = c;
+    else
+        UNI_HEAD(s)[n] = c;
+}
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -852,8 +544,11 @@ struct Reb_Array {
 // done.  But also see the note that it's something that could just be
 // disabled by making arrays and series synonyms in "non-type-check" builds.
 //
-#define AS_ARRAY(s)         (cast(REBARR*, (s)))
-#define ARR_SERIES(a)     (&(a)->series)
+#define AS_ARRAY(s) \
+    (cast(REBARR*, (s)))
+
+#define ARR_SERIES(a) \
+    (&(a)->series)
 
 // HEAD, TAIL, and LAST refer to specific value pointers in the array.  An
 // empty array should have an END marker in its head slot, and since it has
@@ -869,21 +564,31 @@ struct Reb_Array {
 // a relative value, but it cannot be copied without a "specifier" FRAME!
 // context (which is also required to do a GET_VAR lookup).
 
-#define ARR_AT(a, n)        SER_AT(RELVAL, ARR_SERIES(a), (n))
-#define ARR_HEAD(a)         SER_HEAD(RELVAL, ARR_SERIES(a))
-#define ARR_TAIL(a)         SER_TAIL(RELVAL, ARR_SERIES(a))
-#define ARR_LAST(a)         SER_LAST(RELVAL, ARR_SERIES(a))
+#define ARR_AT(a, n) \
+    SER_AT(RELVAL, ARR_SERIES(a), (n))
+
+#define ARR_HEAD(a) \
+    SER_HEAD(RELVAL, ARR_SERIES(a))
+
+#define ARR_TAIL(a) \
+    SER_TAIL(RELVAL, ARR_SERIES(a))
+
+#define ARR_LAST(a) \
+    SER_LAST(RELVAL, ARR_SERIES(a))
 
 // As with an ordinary REBSER, a REBARR has separate management of its length
 // and its terminator.  Many routines seek to control these independently for
 // performance reasons (for better or worse).
 //
-#define ARR_LEN(a) \
-    (assert(Is_Array_Series(ARR_SERIES(a))), SER_LEN(ARR_SERIES(a)))
+inline static REBCNT ARR_LEN(REBARR *a) {
+    assert(Is_Array_Series(ARR_SERIES(a)));
+    return SER_LEN(ARR_SERIES(a));
+}
 
-#define SET_ARRAY_LEN(a,l) \
-    (assert(Is_Array_Series(ARR_SERIES(a))), \
-        SET_SERIES_LEN(ARR_SERIES(a), (l)))
+inline static void SET_ARRAY_LEN(REBARR *a, REBCNT len) {
+    assert(Is_Array_Series(ARR_SERIES(a)));
+    SET_SERIES_LEN(ARR_SERIES(a), len);
+}
 
 //
 // !!! Write more about termination in series documentation.
@@ -892,20 +597,34 @@ struct Reb_Array {
 #define TERM_ARRAY(a) \
     SET_END(ARR_TAIL(a))
 
-#define RESET_ARRAY(a) \
-    (SET_ARRAY_LEN((a), 0), TERM_ARRAY(a))
+inline static void RESET_ARRAY(REBARR *a) {
+    SET_ARRAY_LEN(a, 0);
+    TERM_ARRAY(a);
+}
 
-#define TERM_SERIES(s) \
-    Is_Array_Series(s) \
-        ? (void)TERM_ARRAY(AS_ARRAY(s)) \
-        : (void)memset(SER_AT_RAW(SER_WIDE(s), s, SER_LEN(s)), 0, SER_WIDE(s))
+inline static void TERM_SERIES(REBSER *s) {
+    if (Is_Array_Series(s))
+        TERM_ARRAY(AS_ARRAY(s));
+    else
+        memset(SER_AT_RAW(SER_WIDE(s), s, SER_LEN(s)), 0, SER_WIDE(s));
+}
+
+inline static void RESET_SERIES(REBSER *s) {
+    s->content.dynamic.len = 0;
+    TERM_SERIES(s);
+}
 
 // Setting and getting array flags is common enough to want a macro for it
 // vs. having to extract the ARR_SERIES to do it each time.
 //
-#define SET_ARR_FLAG(a,f)     SET_SER_FLAG(ARR_SERIES(a), (f))
-#define CLEAR_ARR_FLAG(a,f)     CLEAR_SER_FLAG(ARR_SERIES(a), (f))
-#define GET_ARR_FLAG(a,f)     GET_SER_FLAG(ARR_SERIES(a), (f))
+#define SET_ARR_FLAG(a,f) \
+    SET_SER_FLAG(ARR_SERIES(a), (f))
+
+#define CLEAR_ARR_FLAG(a,f) \
+    CLEAR_SER_FLAG(ARR_SERIES(a), (f))
+
+#define GET_ARR_FLAG(a,f) \
+    GET_SER_FLAG(ARR_SERIES(a), (f))
 
 #define FAIL_IF_LOCKED_ARRAY(a) \
     FAIL_IF_LOCKED_SERIES(ARR_SERIES(a))
@@ -954,12 +673,17 @@ struct Reb_Array {
     Free_Series(ARR_SERIES(a))
 
 #ifdef NDEBUG
-    #define ASSERT_ARRAY(s) cast(void, 0)
+    #define ASSERT_ARRAY(s) \
+        NOOP
 
     #define ASSERT_ARRAY_MANAGED(array) \
         NOOP
+
+    #define ASSERT_SERIES(s) \
+        NOOP
 #else
-    #define ASSERT_ARRAY(s) Assert_Array_Core(s)
+    #define ASSERT_ARRAY(s) \
+        Assert_Array_Core(s)
 
     #define ASSERT_ARRAY_MANAGED(array) \
         ASSERT_SERIES_MANAGED(ARR_SERIES(array))
@@ -969,6 +693,13 @@ struct Reb_Array {
 
     #define Debug_Array(a) \
         Debug_Series(ARR_SERIES(a))
+
+    static inline void ASSERT_SERIES(REBSER *s) {
+        if (Is_Array_Series(s))
+            Assert_Array_Core(AS_ARRAY(s));
+        else
+            Assert_Series_Core(s);
+    }
 #endif
 
 
@@ -1021,6 +752,17 @@ struct Reb_Context {
 #define CTX_VARLIST(c) \
     (&(c)->varlist)
 
+// It's convenient to not have to extract the array just to check/set flags
+//
+#define SET_CTX_FLAG(c,f) \
+    SET_ARR_FLAG(CTX_VARLIST(c), (f))
+
+#define CLEAR_CTX_FLAG(c,f) \
+    CLEAR_ARR_FLAG(CTX_VARLIST(c), (f))
+
+#define GET_CTX_FLAG(c,f) \
+    GET_ARR_FLAG(CTX_VARLIST(c), (f))
+
 // If you want to talk generically about a context just for the purposes of
 // setting its series flags (for instance) and not to access the "varlist"
 // data, then use CTX_SERIES(), as actual var access is hybridized
@@ -1036,13 +778,32 @@ struct Reb_Context {
 #define CTX_KEYLIST(c) \
     (ARR_SERIES(CTX_VARLIST(c))->misc.keylist)
 
-#define INIT_CTX_KEYLIST_SHARED(c,k) \
-    (SET_ARR_FLAG((k), KEYLIST_FLAG_SHARED), \
-        ARR_SERIES(CTX_VARLIST(c))->misc.keylist = (k))
+static inline void INIT_CTX_KEYLIST_SHARED(REBCTX *c, REBARR *keylist) {
+    SET_ARR_FLAG(keylist, KEYLIST_FLAG_SHARED);
+    ARR_SERIES(CTX_VARLIST(c))->misc.keylist = keylist;
+}
 
-#define INIT_CTX_KEYLIST_UNIQUE(c,k) \
-    (assert(!GET_ARR_FLAG((k), KEYLIST_FLAG_SHARED)), \
-        ARR_SERIES(CTX_VARLIST(c))->misc.keylist = (k))
+static inline void INIT_CTX_KEYLIST_UNIQUE(REBCTX *c, REBARR *keylist) {
+    assert(NOT(GET_ARR_FLAG(keylist, KEYLIST_FLAG_SHARED)));
+    ARR_SERIES(CTX_VARLIST(c))->misc.keylist = keylist;
+}
+
+// Navigate from context to context components.  Note that the context's
+// "length" does not count the [0] cell of either the varlist or the keylist.
+// Hence it must subtract 1.  Internally to the context building code, the
+// real length of the two series must be accounted for...so the 1 gets put
+// back in, but most clients are only interested in the number of keys/values
+// (and getting an answer for the length back that was the same as the length
+// requested in context creation).
+//
+#define CTX_LEN(c) \
+    (ARR_LEN(CTX_KEYLIST(c)) - 1)
+
+#define CTX_ROOTKEY(c) \
+    SER_HEAD(REBVAL, ARR_SERIES(CTX_KEYLIST(c)))
+
+#define CTX_TYPE(c) \
+    VAL_TYPE(CTX_VALUE(c))
 
 // The keys and vars are accessed by positive integers starting at 1.  If
 // indexed access is used then the debug build will check to be sure that
@@ -1054,75 +815,68 @@ struct Reb_Context {
 // not live in function body arrays--hence they can't hold relative words.
 // Keys can't hold relative values either.
 //
-#define CTX_KEYS_HEAD(c)    SER_AT(REBVAL, ARR_SERIES(CTX_KEYLIST(c)), 1)
-#define CTX_VARS_HEAD(c) \
-    (GET_CTX_FLAG((c), CONTEXT_FLAG_STACK) \
-        ? VAL_CONTEXT_STACKVARS(CTX_VALUE(c)) \
-        : SER_AT(REBVAL, ARR_SERIES(CTX_VARLIST(c)), 1))
-
-#ifdef NDEBUG
-    #define CTX_KEY(c,n)    (CTX_KEYS_HEAD(c) + (n) - 1)
-    #define CTX_VAR(c,n)    (CTX_VARS_HEAD(c) + (n) - 1)
-#else
-    #define CTX_KEY(c,n)    CTX_KEY_Debug((c), (n))
-    #define CTX_VAR(c,n)    CTX_VAR_Debug((c), (n))
-#endif
-#define CTX_KEY_SYM(c,n)    VAL_TYPESET_SYM(CTX_KEY((c), (n)))
-#define CTX_KEY_CANON(c,n)  VAL_TYPESET_CANON(CTX_KEY((c), (n)))
+#define CTX_KEYS_HEAD(c) \
+    SER_AT(REBVAL, ARR_SERIES(CTX_KEYLIST(c)), 1)
 
 // There may not be any dynamic or stack allocation available for a stack
 // allocated context, and in that case it will have to come out of the
 // REBSER node data itself.
 //
-#define CTX_VALUE(c) \
-    (GET_CTX_FLAG((c), CONTEXT_FLAG_STACK) \
-        ? KNOWN(&ARR_SERIES(CTX_VARLIST(c))->content.values[0]) \
-        : SER_HEAD(REBVAL, ARR_SERIES(CTX_VARLIST(c)))) // not a RELVAL
+inline static REBVAL *CTX_VALUE(REBCTX *c) {
+    return GET_CTX_FLAG(c, CONTEXT_FLAG_STACK)
+        ? KNOWN(&ARR_SERIES(CTX_VARLIST(c))->content.values[0])
+        : KNOWN(ARR_HEAD(CTX_VARLIST(c))); // not a RELVAL
+}
 
-// Navigate from context to context components.  Note that the context's
-// "length" does not count the [0] cell of either the varlist or the keylist.
-// Hence it must subtract 1.  Internally to the context building code, the
-// real length of the two series must be accounted for...so the 1 gets put
-// back in, but most clients are only interested in the number of keys/values
-// (and getting an answer for the length back that was the same as the length
-// requested in context creation).
-//
-#define CTX_LEN(c)          (ARR_LEN(CTX_KEYLIST(c)) - 1)
-#define CTX_ROOTKEY(c)      SER_HEAD(REBVAL, ARR_SERIES(CTX_KEYLIST(c)))
-#define CTX_TYPE(c)         VAL_TYPE(CTX_VALUE(c))
+#define VAL_CONTEXT_STACKVARS(v) \
+    ((v)->payload.any_context.more.frame->stackvars)
 
-#define INIT_CONTEXT_META(c,s) \
-    (VAL_CONTEXT_META(CTX_VALUE(c)) = (s))
+inline static REBVAL *CTX_VARS_HEAD(REBCTX *c) {
+    return GET_CTX_FLAG(c, CONTEXT_FLAG_STACK)
+        ? VAL_CONTEXT_STACKVARS(CTX_VALUE(c))
+        : SER_AT(REBVAL, ARR_SERIES(CTX_VARLIST(c)), 1);
+}
+
+inline static REBVAL *CTX_KEY(REBCTX *c, REBCNT n) {
+    assert(n != 0 && n <= CTX_LEN(c));
+    return CTX_KEYS_HEAD(c) + (n) - 1;
+}
+
+inline static REBVAL *CTX_VAR(REBCTX *c, REBCNT n) {
+    REBVAL *var;
+    assert(n != 0 && n <= CTX_LEN(c));
+    assert(GET_ARR_FLAG(CTX_VARLIST(c), ARRAY_FLAG_CONTEXT_VARLIST));
+
+    var = CTX_VARS_HEAD(c) + (n) - 1;
+
+    assert(NOT(var->header.bits & VALUE_FLAG_RELATIVE));
+
+    return var;
+}
+
+#define CTX_KEY_SYM(c,n) \
+    VAL_TYPESET_SYM(CTX_KEY((c), (n)))
+
+#define CTX_KEY_CANON(c,n) \
+    VAL_TYPESET_CANON(CTX_KEY((c), (n)))
 
 #define CTX_META(c) \
     (VAL_CONTEXT_META(CTX_VALUE(c)) + 0)
 
-#define INIT_CONTEXT_FRAME(c,f) \
-    (assert(IS_FRAME(CTX_VALUE(c))), \
-        VAL_CONTEXT_FRAME(CTX_VALUE(c)) = (f))
-
 #define CTX_FRAME(c) \
     (VAL_CONTEXT_FRAME(CTX_VALUE(c)) + 0)
 
-#define CTX_FRAME_FUNC_VALUE(c) \
-    (assert(IS_FUNCTION(CTX_ROOTKEY(c))), CTX_ROOTKEY(c))
+#define CTX_STACKVARS(c) \
+    VAL_CONTEXT_STACKVARS(CTX_VALUE(c))
 
-#define CTX_STACKVARS(c)    VAL_CONTEXT_STACKVARS(CTX_VALUE(c))
 
 #define FAIL_IF_LOCKED_CONTEXT(c) \
     FAIL_IF_LOCKED_ARRAY(CTX_VARLIST(c))
 
-#define FREE_CONTEXT(c) \
-    do { \
-        Free_Array(CTX_KEYLIST(c)); \
-        Free_Array(CTX_VARLIST(c)); \
-    } while (0)
-
-// It's convenient to not have to extract the array just to check/set flags
-//
-#define SET_CTX_FLAG(c,f)       SET_ARR_FLAG(CTX_VARLIST(c), (f))
-#define CLEAR_CTX_FLAG(c,f)     CLEAR_ARR_FLAG(CTX_VARLIST(c), (f))
-#define GET_CTX_FLAG(c,f)       GET_ARR_FLAG(CTX_VARLIST(c), (f))
+inline static void FREE_CONTEXT(REBCTX *c) {
+    Free_Array(CTX_KEYLIST(c));
+    Free_Array(CTX_VARLIST(c));
+}
 
 #define PUSH_GUARD_CONTEXT(c) \
     PUSH_GUARD_ARRAY(CTX_VARLIST(c)) // varlist points to/guards keylist
@@ -1154,52 +908,61 @@ struct Reb_Func {
 };
 
 #ifdef NDEBUG
-    #define AS_FUNC(s)     cast(REBFUN*, (s))
+    #define AS_FUNC(s) \
+        cast(REBFUN*, (s))
 #else
-    // Put a debug version here that asserts.
-    #define AS_FUNC(s)     cast(REBFUN*, (s))
+    #define AS_FUNC(s) \
+        cast(REBFUN*, (s)) // !!! worth it to add debug version that checks?
 #endif
 
-#define FUNC_PARAMLIST(f)       (&(f)->paramlist)
+inline static REBARR *FUNC_PARAMLIST(REBFUN *f) {
+    return &f->paramlist;
+}
 
-#define FUNC_NUM_PARAMS(f)      (ARR_LEN(FUNC_PARAMLIST(f)) - 1)
+inline static REBVAL *FUNC_VALUE(REBFUN *f) {
+    return SER_AT(REBVAL, ARR_SERIES(FUNC_PARAMLIST(f)), 0);
+}
 
-// There is no binding information in a function parameter (typeset) so a
-// REBVAL should be okay.
-//
-#define FUNC_PARAMS_HEAD(f) \
-    SER_AT(REBVAL, ARR_SERIES(FUNC_PARAMLIST(f)), 1)
+inline static REBNAT FUNC_DISPATCHER(REBFUN *f) {
+    return ARR_SERIES(FUNC_VALUE(f)->payload.function.body)->misc.dispatcher;
+}
 
-#ifdef NDEBUG
-    #define FUNC_PARAM(f,n)     (FUNC_PARAMS_HEAD(f) + (n) - 1)
-#else
-    #define FUNC_PARAM(f,n)     FUNC_PARAM_Debug((f), (n))
-#endif
+inline static RELVAL *FUNC_BODY(REBFUN *f) {
+    return ARR_HEAD(FUNC_VALUE(f)->payload.function.body);
+}
 
-#define FUNC_PARAM_SYM(f,n)     VAL_TYPESET_SYM(FUNC_PARAM((f), (n)))
+inline static REBVAL *FUNC_PARAM(REBFUN *f, REBCNT n) {
+    assert(n != 0 && n < ARR_LEN(FUNC_PARAMLIST(f)));
+    return SER_AT(REBVAL, ARR_SERIES(FUNC_PARAMLIST(f)), n);
+}
 
-#define FUNC_CLASS(f)           VAL_FUNC_CLASS(FUNC_VALUE(f))
-
-#define FUNC_VALUE(f) \
-    SER_AT(REBVAL, ARR_SERIES(FUNC_PARAMLIST(f)), 0)
+inline static REBCNT FUNC_NUM_PARAMS(REBFUN *f) {
+    return ARR_LEN(FUNC_PARAMLIST(f)) - 1;
+}
 
 #define FUNC_META(f) \
     (ARR_SERIES(FUNC_PARAMLIST(f))->misc.meta)
 
-#define FUNC_DISPATCH(f) \
-    (ARR_SERIES(FUNC_VALUE(f)->payload.function.body)->misc.dispatch)
+// Note: On Windows, FUNC_DISPATCH is already defined in the header files
+//
+#define FUNC_DISPATCHER(f) \
+    (ARR_SERIES(FUNC_VALUE(f)->payload.function.body)->misc.dispatcher)
 
-#define FUNC_BODY(f) \
-    (ARR_HEAD(FUNC_VALUE(f)->payload.function.body) + 0)
+// There is no binding information in a function parameter (typeset) so a
+// REBVAL should be okay.
+//
+inline static REBVAL *FUNC_PARAMS_HEAD(REBFUN *f) {
+    return SER_AT(REBVAL, ARR_SERIES(FUNC_PARAMLIST(f)), 1);
+}
 
-#define FUNC_ACT(f) \
-    cast(REBCNT, VAL_INT32(FUNC_BODY(f)))
+inline static REBSYM FUNC_PARAM_SYM(REBFUN *f, REBCNT n) {
+    return FUNC_PARAM((f), (n))->payload.typeset.sym;
+}
 
-#define FUNC_INFO(f) \
-    cast(REBRIN*, VAL_HANDLE_DATA(FUNC_BODY(f)))
+inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
+    return cast(REBRIN*, FUNC_BODY(f)->payload.handle.thing.data);
+}
 
-#define FUNC_EXEMPLAR(f) \
-    KNOWN(FUNC_BODY(f))
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -1220,17 +983,23 @@ struct Reb_Func {
 // they are implemented using series--and hence are in %sys-series.h, at least
 // until a better location for the definition is found.
 //
+// !!! Should there be a MAP_LEN()?  Current implementation has NONE in
+// slots that are unused, so can give a deceptive number.  But so can
+// objects with hidden fields, locals in paramlists, etc.
+//
 
 struct Reb_Map {
     struct Reb_Array pairlist; // hashlist is held in ->misc.hashlist
 };
 
-#define MAP_PAIRLIST(m)         (&(m)->pairlist)
-#define MAP_HASHLIST(m)         (ARR_SERIES(&(m)->pairlist)->misc.hashlist)
-#define MAP_HASHES(m)           SER_HEAD(MAP_HASHLIST(m))
+#define MAP_PAIRLIST(m) \
+    (&(m)->pairlist)
 
-// !!! Should there be a MAP_LEN()?  Current implementation has NONE in
-// slots that are unused, so can give a deceptive number.  But so can
-// objects with hidden fields, locals in paramlists, etc.
+#define MAP_HASHLIST(m) \
+    (ARR_SERIES(&(m)->pairlist)->misc.hashlist)
 
-#define AS_MAP(s)               cast(REBMAP*, (s))
+#define MAP_HASHES(m) \
+    SER_HEAD(MAP_HASHLIST(m))
+
+#define AS_MAP(s) \
+    cast(REBMAP*, (s))

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -98,15 +98,18 @@ typedef unsigned int REBDSP;
 
 // (D)ata (S)tack "(P)osition" is an integer index into Rebol's data stack
 //
-#define DSP DS_Index
+#define DSP \
+    DS_Index
 
 // Access value at given stack location
 //
-#define DS_AT(d) (DS_Movable_Base + (d))
+#define DS_AT(d) \
+    (DS_Movable_Base + (d))
 
 // Most recently pushed item
 //
-#define DS_TOP DS_AT(DS_Index)
+#define DS_TOP \
+    DS_AT(DS_Index)
 
 #if !defined(NDEBUG)
     #define IS_VALUE_IN_ARRAY(a,v) \
@@ -161,7 +164,8 @@ typedef unsigned int REBDSP;
 // POPPING AND "DROPPING"
 
 #ifdef NDEBUG
-    #define DS_DROP (--DS_Index, NOOP)
+    #define DS_DROP \
+        (--DS_Index, NOOP)
 #else
     #define DS_DROP \
         (SET_TRASH_SAFE(DS_TOP), --DS_Index, NOOP)

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -1,6 +1,6 @@
 //
 //  File: %sys-state.h
-//  Summary: "CPU and Interpreter State Snapshot/Restore"
+//  Summary: "Interpreter State"
 //  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
 //  Homepage: https://github.com/metaeducation/ren-c/
 //
@@ -26,97 +26,11 @@
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// Rebol is settled upon a stable and pervasive implementation baseline of
-// ANSI-C (C89).  That commitment provides certain advantages.
-//
-// One of the *disadvantages* is that there is no safe way to do non-local
-// jumps with stack unwinding (as in C++).  If you've written some code that
-// performs a raw malloc and then wants to "throw" via a `longjmp()`, that
-// will leak the malloc.
-//
-// In order to mitigate the inherent failure of trying to emulate stack
-// unwinding via longjmp, the macros in this file provide an abstraction
-// layer.  These allow Rebol to clean up after itself for some kinds of
-// "dangling" state--such as manually memory managed series that have been
-// made with Make_Series() but never passed to either Free_Series() or
-// MANAGE_SERIES().  This covers several potential leaks known-to-Rebol,
-// but custom interception code is needed for any generalized resource
-// that might be leaked in the case of a longjmp().
-//
-// The triggering of the longjmp() is done via "fail", and it's important
-// to know the distinction between a "fail" and a "throw".  In Rebol
-// terminology, a `throw` is a cooperative concept, which does *not* use
-// longjmp(), and instead must cleanly pipe the thrown value up through
-// the OUT pointer that each function call writes into.  The `throw` will
-// climb the stack until somewhere in the backtrace, one of the calls
-// chooses to intercept the thrown value instead of pass it on.
-//
-// By contrast, a `fail` is non-local control that interrupts the stack,
-// and can only be intercepted by points up the stack that have explicitly
-// registered themselves interested.  So comparing these two bits of code:
-//
-//     catch [if 1 < 2 [trap [print ["Foo" (throw "Throwing")]]]]
-//
-//     trap [if 1 < 2 [catch [print ["Foo" (fail "Failing")]]]]
-//
-// In the first case, the THROW is offered to each point up the chain as
-// a special sort of "return value" that only natives can examine.  The
-// `print` will get a chance, the `trap` will get a chance, the `if` will
-// get a chance...but only CATCH will take the opportunity.
-//
-// In the second case, the FAIL is implemented with longjmp().  So it
-// doesn't make a return value...it never reaches the return.  It offers an
-// ERROR! up the stack to native functions that have called PUSH_TRAP() in
-// advance--as a way of registering interest in intercepting failures.  For
-// IF or CATCH or PRINT to have an opportunity, they would need to be chang
-// d to include a PUSH_TRAP() call.
-//
-//=////////////////////////////////////////////////////////////////////////=//
-//
-// NOTE: If you are integrating with C++ and a longjmp crosses a constructed
-// object, abandon all hope...UNLESS you use Ren-cpp.  It is careful to
-// avoid this trap, and you don't want to redo that work.
-//
-//     http://stackoverflow.com/questions/1376085/
-//
-
-
-// "Under FreeBSD 5.2.1 and Mac OS X 10.3, setjmp and longjmp save and restore
-// the signal mask. Linux 2.4.22 and Solaris 9, however, do not do this.
-// FreeBSD and Mac OS X provide the functions _setjmp and _longjmp, which do
-// not save and restore the signal mask."
-//
-// "To allow either form of behavior, POSIX.1 does not specify the effect of
-// setjmp and longjmp on signal masks. Instead, two new functions, sigsetjmp
-// and siglongjmp, are defined by POSIX.1. These two functions should always
-// be used when branching from a signal handler."
-//
-// Note: longjmp is able to pass a value (though only an integer on 64-bit
-// platforms, and not enough to pass a pointer).  This can be used to
-// dictate the value setjmp returns in the longjmp case, though the code
-// does not currently use that feature.
-//
-// Also note: with compiler warnings on, it can tell us when values are set
-// before the setjmp and then changed before a potential longjmp:
-//
-//     http://stackoverflow.com/q/7721854/211160
-//
-// Because of this longjmp/setjmp "clobbering", it's a useful warning to
-// have enabled in.  One option for suppressing it would be to mark
-// a parameter as 'volatile', but that is implementation-defined.
-// It is best to use a new variable if you encounter such a warning.
-//
-#ifdef HAS_POSIX_SIGNAL
-    #define SET_JUMP(s) sigsetjmp((s), 1)
-    #define LONG_JUMP(s, v) siglongjmp((s), (v))
-#else
-    #define SET_JUMP(s) setjmp(s)
-    #define LONG_JUMP(s, v) longjmp((s), (v))
-#endif
-
-
 // Structure holding the information about the last point in the stack that
 // wanted to set up an opportunity to intercept a `fail (Error_XXX())`
+//
+// For operations using this structure, see %sys-trap.h
+//
 
 struct Reb_State {
     struct Reb_State *last_state;
@@ -127,9 +41,9 @@ struct Reb_State {
     REBCNT series_guard_len;
     REBCNT value_guard_len;
     REBCTX *error;
-    REBINT gc_disable;      // Count of GC_Disables at time of Push
+    REBINT gc_disable; // Count of GC_Disables at time of Push
 
-    REBCNT manuals_len;    // Where GC_Manuals was when state started
+    REBCNT manuals_len; // Where GC_Manuals was when state started
     REBCNT uni_buf_len;
     REBCNT mold_loop_tail;
 
@@ -139,130 +53,3 @@ struct Reb_State {
     jmp_buf cpu_state;
 #endif
 };
-
-
-// SNAP_STATE will record the interpreter state but not include it into
-// the chain of trapping points.  This is used by PUSH_TRAP but also by
-// debug code that just wants to record the state to make sure it balances
-// back to where it was.
-//
-#define SNAP_STATE(s) \
-    Snap_State_Core(s)
-
-
-// PUSH_TRAP is a construct which is used to catch errors that have been
-// triggered by the Fail_Core() function.  This can be triggered by a usage
-// of the `fail` pseudo-"keyword" in C code, and in Rebol user code by the
-// REBNATIVE(fail).  To call the push, you need a `struct Reb_State` to be
-// passed which it will write into--which is a black box that clients
-// shouldn't inspect.
-//
-// The routine also takes a pointer-to-a-REBCTX-pointer which represents
-// an error.  Using the tricky mechanisms of setjmp/longjmp, there will
-// be a first pass of execution where the line of code after the PUSH_TRAP
-// will see the error pointer as being NULL.  If a trap occurs during
-// code before the paired DROP_TRAP happens, then the C state will be
-// magically teleported back to the line after the PUSH_TRAP with the
-// error value now non-null and usable, including put into a REBVAL via
-// the `Val_Init_Error()` function.
-//
-#define PUSH_TRAP(e,s) \
-    PUSH_TRAP_CORE((e), (s), TRUE)
-
-
-// PUSH_UNHALTABLE_TRAP is a form of PUSH_TRAP that will receive RE_HALT in
-// the same way it would be told about other errors.  In a pure C client,
-// it would usually be only at the topmost level (e.g. console REPL loop).
-//
-// It's also necessary at C-to-C++ boundary crossings (as in Ren/C++) even
-// if they are not the topmost.  This is because C++ needs to know if *any*
-// longjmp happens, to keep it from crossing stack frames with constructed
-// objects without running their destructors.  Once it is done unwinding
-// any relevant C++ call frames, it may have to trigger another longjmp IF
-// the C++ code was called from other Rebol C code.  (This is done in the
-// exception handler found in Ren/C++'s %function.hpp)
-//
-// Note: Despite the technical needs of low-level clients, there is likely
-// no reasonable use-case for a user-exposed ability to intercept HALTs in
-// Rebol code, for instance with a "TRAP/HALT" construction.
-//
-#define PUSH_UNHALTABLE_TRAP(e,s) \
-    PUSH_TRAP_CORE((e), (s), FALSE)
-
-
-// Core implementation behind PUSH_TRAP and PUSH_UNHALTABLE_TRAP.
-//
-// Note: The implementation of this macro was chosen stylistically to
-// hide the result of the setjmp call.  That's because you really can't
-// put "setjmp" in arbitrary conditions like `setjmp(...) ? x : y`.  That's
-// against the rules.  So although the preprocessor abuse below is a bit
-// ugly, it helps establish that anyone modifying this code later not be
-// able to avoid the truth of the limitation:
-//
-//      http://stackoverflow.com/questions/30416403/
-//
-#define PUSH_TRAP_CORE(e,s,haltable) \
-    do { \
-        assert(Saved_State || (DSP == 0 && FS_TOP == NULL)); \
-        Snap_State_Core(s); \
-        (s)->last_state = Saved_State; \
-        Saved_State = (s); \
-        if (haltable) { \
-            /* the topmost TRAP must be PUSH_UNHALTABLE_TRAP */ \
-            assert((s)->last_state != NULL); \
-        } \
-        if (!SET_JUMP((s)->cpu_state)) { \
-            /* this branch will always be run */ \
-            *(e) = NULL; \
-        } \
-        else { \
-            /* this runs if before the DROP_TRAP a longjmp() happens */ \
-            if (haltable) { \
-               if (Trapped_Helper_Halted(s)) \
-                    fail ((s)->error); /* proxy the halt up the stack */ \
-                else \
-                    *(e) = (s)->error; \
-            } \
-            else { \
-               cast(void, Trapped_Helper_Halted(s)); \
-                *(e) = (s)->error; \
-            } \
-        } \
-    } while (0)
-
-
-// If either a haltable or non-haltable TRAP is PUSHed, it must be DROP'd.
-// DROP_TRAP_SAME_STACKLEVEL_AS_PUSH has a long and informative name to
-// remind you that you must DROP_TRAP from the same scope you PUSH_TRAP
-// from.  (So do not call PUSH_TRAP in a function, then return from that
-// function and DROP_TRAP at another stack level.)
-//
-//      "If the function that called setjmp has exited (whether by return
-//      or by a different longjmp higher up the stack), the behavior is
-//      undefined. In other words, only long jumps up the call stack
-//      are allowed."
-//
-//      http://en.cppreference.com/w/c/program/longjmp
-//
-// Note: There used to be more aggressive balancing-oriented asserts, making
-// this a point where outstanding manuals or guarded values and series would
-// have to be balanced.  Those seemed to be more irritating than helpful,
-// so the asserts have been left to the evaluator's bracketing.
-//
-#define DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(s) \
-    do { \
-        assert(!(s)->error); \
-        Saved_State = (s)->last_state; \
-    } while (0)
-
-
-// ASSERT_STATE_BALANCED is used to check that the situation modeled in a
-// SNAP_STATE has balanced out, without a trap (e.g. it is checked each time
-// the evaluator completes a cycle in the debug build)
-//
-#ifdef NDEBUG
-    #define ASSERT_STATE_BALANCED(s) NOOP
-#else
-    #define ASSERT_STATE_BALANCED(s) \
-        Assert_State_Balanced_Debug((s), __FILE__, __LINE__)
-#endif

--- a/src/include/sys-trap.h
+++ b/src/include/sys-trap.h
@@ -1,0 +1,255 @@
+//
+//  File: %sys-trap.h
+//  Summary: "CPU and Interpreter State Snapshot/Restore"
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2015 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Rebol is settled upon a stable and pervasive implementation baseline of
+// ANSI-C (C89).  That commitment provides certain advantages.
+//
+// One of the *disadvantages* is that there is no safe way to do non-local
+// jumps with stack unwinding (as in C++).  If you've written some code that
+// performs a raw malloc and then wants to "throw" via a `longjmp()`, that
+// will leak the malloc.
+//
+// In order to mitigate the inherent failure of trying to emulate stack
+// unwinding via longjmp, the macros in this file provide an abstraction
+// layer.  These allow Rebol to clean up after itself for some kinds of
+// "dangling" state--such as manually memory managed series that have been
+// made with Make_Series() but never passed to either Free_Series() or
+// MANAGE_SERIES().  This covers several potential leaks known-to-Rebol,
+// but custom interception code is needed for any generalized resource
+// that might be leaked in the case of a longjmp().
+//
+// The triggering of the longjmp() is done via "fail", and it's important
+// to know the distinction between a "fail" and a "throw".  In Rebol
+// terminology, a `throw` is a cooperative concept, which does *not* use
+// longjmp(), and instead must cleanly pipe the thrown value up through
+// the OUT pointer that each function call writes into.  The `throw` will
+// climb the stack until somewhere in the backtrace, one of the calls
+// chooses to intercept the thrown value instead of pass it on.
+//
+// By contrast, a `fail` is non-local control that interrupts the stack,
+// and can only be intercepted by points up the stack that have explicitly
+// registered themselves interested.  So comparing these two bits of code:
+//
+//     catch [if 1 < 2 [trap [print ["Foo" (throw "Throwing")]]]]
+//
+//     trap [if 1 < 2 [catch [print ["Foo" (fail "Failing")]]]]
+//
+// In the first case, the THROW is offered to each point up the chain as
+// a special sort of "return value" that only natives can examine.  The
+// `print` will get a chance, the `trap` will get a chance, the `if` will
+// get a chance...but only CATCH will take the opportunity.
+//
+// In the second case, the FAIL is implemented with longjmp().  So it
+// doesn't make a return value...it never reaches the return.  It offers an
+// ERROR! up the stack to native functions that have called PUSH_TRAP() in
+// advance--as a way of registering interest in intercepting failures.  For
+// IF or CATCH or PRINT to have an opportunity, they would need to be changed
+// to include a PUSH_TRAP() call.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// NOTE: If you are integrating with C++ and a longjmp crosses a constructed
+// object, abandon all hope...UNLESS you use Ren-cpp.  It is careful to
+// avoid this trap, and you don't want to redo that work.
+//
+//     http://stackoverflow.com/questions/1376085/
+//
+
+
+// "Under FreeBSD 5.2.1 and Mac OS X 10.3, setjmp and longjmp save and restore
+// the signal mask. Linux 2.4.22 and Solaris 9, however, do not do this.
+// FreeBSD and Mac OS X provide the functions _setjmp and _longjmp, which do
+// not save and restore the signal mask."
+//
+// "To allow either form of behavior, POSIX.1 does not specify the effect of
+// setjmp and longjmp on signal masks. Instead, two new functions, sigsetjmp
+// and siglongjmp, are defined by POSIX.1. These two functions should always
+// be used when branching from a signal handler."
+//
+// Note: longjmp is able to pass a value (though only an integer on 64-bit
+// platforms, and not enough to pass a pointer).  This can be used to
+// dictate the value setjmp returns in the longjmp case, though the code
+// does not currently use that feature.
+//
+// Also note: with compiler warnings on, it can tell us when values are set
+// before the setjmp and then changed before a potential longjmp:
+//
+//     http://stackoverflow.com/q/7721854/211160
+//
+// Because of this longjmp/setjmp "clobbering", it's a useful warning to
+// have enabled in.  One option for suppressing it would be to mark
+// a parameter as 'volatile', but that is implementation-defined.
+// It is best to use a new variable if you encounter such a warning.
+//
+#ifdef HAS_POSIX_SIGNAL
+    #define SET_JUMP(s) \
+        sigsetjmp((s), 1)
+
+    #define LONG_JUMP(s,v) \
+        siglongjmp((s), (v))
+#else
+    #define SET_JUMP(s) \
+        setjmp(s)
+
+    #define LONG_JUMP(s,v) \
+        longjmp((s), (v))
+#endif
+
+
+// SNAP_STATE will record the interpreter state but not include it into
+// the chain of trapping points.  This is used by PUSH_TRAP but also by
+// debug code that just wants to record the state to make sure it balances
+// back to where it was.
+//
+#define SNAP_STATE(s) \
+    Snap_State_Core(s)
+
+
+// PUSH_TRAP is a construct which is used to catch errors that have been
+// triggered by the Fail_Core() function.  This can be triggered by a usage
+// of the `fail` pseudo-"keyword" in C code, and in Rebol user code by the
+// REBNATIVE(fail).  To call the push, you need a `struct Reb_State` to be
+// passed which it will write into--which is a black box that clients
+// shouldn't inspect.
+//
+// The routine also takes a pointer-to-a-REBCTX-pointer which represents
+// an error.  Using the tricky mechanisms of setjmp/longjmp, there will
+// be a first pass of execution where the line of code after the PUSH_TRAP
+// will see the error pointer as being NULL.  If a trap occurs during
+// code before the paired DROP_TRAP happens, then the C state will be
+// magically teleported back to the line after the PUSH_TRAP with the
+// error value now non-null and usable, including put into a REBVAL via
+// the `Val_Init_Error()` function.
+//
+#define PUSH_TRAP(e,s) \
+    PUSH_TRAP_CORE((e), (s), TRUE)
+
+
+// PUSH_UNHALTABLE_TRAP is a form of PUSH_TRAP that will receive RE_HALT in
+// the same way it would be told about other errors.  In a pure C client,
+// it would usually be only at the topmost level (e.g. console REPL loop).
+//
+// It's also necessary at C-to-C++ boundary crossings (as in Ren/C++) even
+// if they are not the topmost.  This is because C++ needs to know if *any*
+// longjmp happens, to keep it from crossing stack frames with constructed
+// objects without running their destructors.  Once it is done unwinding
+// any relevant C++ call frames, it may have to trigger another longjmp IF
+// the C++ code was called from other Rebol C code.  (This is done in the
+// exception handler found in Ren/C++'s %function.hpp)
+//
+// Note: Despite the technical needs of low-level clients, there is likely
+// no reasonable use-case for a user-exposed ability to intercept HALTs in
+// Rebol code, for instance with a "TRAP/HALT" construction.
+//
+#define PUSH_UNHALTABLE_TRAP(e,s) \
+    PUSH_TRAP_CORE((e), (s), FALSE)
+
+
+// Core implementation behind PUSH_TRAP and PUSH_UNHALTABLE_TRAP.
+//
+// Note: The implementation of this macro was chosen stylistically to
+// hide the result of the setjmp call.  That's because you really can't
+// put "setjmp" in arbitrary conditions like `setjmp(...) ? x : y`.  That's
+// against the rules.  So although the preprocessor abuse below is a bit
+// ugly, it helps establish that anyone modifying this code later not be
+// able to avoid the truth of the limitation:
+//
+// http://stackoverflow.com/questions/30416403/
+//
+// !!! THIS CAN'T BE INLINED due to technical limitations of using setjmp()
+// in inline functions (at least in gcc)
+//
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=24556
+//
+// According to the developers, "This is not a bug as if you inline it, the
+// place setjmp goes to could be not where you want to goto."
+//
+#define PUSH_TRAP_CORE(e,s,haltable) \
+    do { \
+        assert(Saved_State || (DSP == 0 && FS_TOP == NULL)); \
+        Snap_State_Core(s); \
+        (s)->last_state = Saved_State; \
+        Saved_State = (s); \
+        if (haltable) { \
+            /* the topmost TRAP must be PUSH_UNHALTABLE_TRAP */ \
+            assert((s)->last_state != NULL); \
+        } \
+        if (!SET_JUMP((s)->cpu_state)) { \
+            /* this branch will always be run */ \
+            *(e) = NULL; \
+        } \
+        else { \
+            /* this runs if before the DROP_TRAP a longjmp() happens */ \
+            if (haltable) { \
+               if (Trapped_Helper_Halted(s)) \
+                    fail ((s)->error); /* proxy the halt up the stack */ \
+                else \
+                    *(e) = (s)->error; \
+            } \
+            else { \
+               cast(void, Trapped_Helper_Halted(s)); \
+                *(e) = (s)->error; \
+            } \
+        } \
+    } while (0)
+
+
+// If either a haltable or non-haltable TRAP is PUSHed, it must be DROP'd.
+// DROP_TRAP_SAME_STACKLEVEL_AS_PUSH has a long and informative name to
+// remind you that you must DROP_TRAP from the same scope you PUSH_TRAP
+// from.  (So do not call PUSH_TRAP in a function, then return from that
+// function and DROP_TRAP at another stack level.)
+//
+//      "If the function that called setjmp has exited (whether by return
+//      or by a different longjmp higher up the stack), the behavior is
+//      undefined. In other words, only long jumps up the call stack
+//      are allowed."
+//
+//      http://en.cppreference.com/w/c/program/longjmp
+//
+// Note: There used to be more aggressive balancing-oriented asserts, making
+// this a point where outstanding manuals or guarded values and series would
+// have to be balanced.  Those seemed to be more irritating than helpful,
+// so the asserts have been left to the evaluator's bracketing.
+//
+inline static void DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(struct Reb_State *s) {
+    assert(!s->error);
+    Saved_State = s->last_state;
+}
+
+
+// ASSERT_STATE_BALANCED is used to check that the situation modeled in a
+// SNAP_STATE has balanced out, without a trap (e.g. it is checked each time
+// the evaluator completes a cycle in the debug build)
+//
+#ifdef NDEBUG
+    #define ASSERT_STATE_BALANCED(s) NOOP
+#else
+    #define ASSERT_STATE_BALANCED(s) \
+        Assert_State_Balanced_Debug((s), __FILE__, __LINE__)
+#endif

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1,6 +1,6 @@
 //
 //  File: %sys-value.h
-//  Summary: {Definitions for the Rebol Value Struct (REBVAL) and Helpers}
+//  Summary: {Accessor Functions for properties of a Rebol Value}
 //  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
 //  Homepage: https://github.com/metaeducation/ren-c/
 //
@@ -26,31 +26,19 @@
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// REBVAL is the structure/union for all Rebol values. It's designed to be
-// four C pointers in size (so 16 bytes on 32-bit platforms and 32 bytes
-// on 64-bit platforms).  Operation will be most efficient with those sizes,
-// and there are checks on boot to ensure that `sizeof(REBVAL)` is the
-// correct value for the platform.  But from a mechanical standpoint, the
-// system should be *able* to work even if the size is different.
+// See notes in %sys-rebval.h for the definition of the REBVAL structure.
 //
-// Of the four 32-or-64-bit slots that each value has, the first is used for
-// the value's "Header".  This includes the data type, such as REB_INTEGER,
-// REB_BLOCK, REB_STRING, etc.  Then there are 8 flags which are for general
-// purposes that could apply equally well to any type of value (including
-// whether the value should have a new-line after it when molded out inside
-// of a block).  There are 8 bits which are custom to each type--for
-// instance whether a key in an object is hidden or not.  Then there are
-// 8 bits currently reserved for future use.
+// This file provides accessors for the various payload types.  Because these
+// accessors operate on REBVAL pointers, the inline functions cannot work
+// without having the complete struct definition available from all the types.
 //
-// The remaining content of the REBVAL struct is the "Payload".  It is the
-// size of three (void*) pointers, and is used to hold whatever bits that
-// are needed for the value type to represent itself.  Perhaps obviously,
-// an arbitrarily long string will not fit into 3*32 bits, or even 3*64 bits!
-// You can fit the data for an INTEGER or DECIMAL in that (at least until
-// they become arbitrary precision) but it's not enough for a generic BLOCK!
-// or a FUNCTION! (for instance).  So those pointers are used to point to
-// things, and often they will point to one or more Rebol Series (see
-// %sys-series.h for an explanation of REBSER, REBARR, REBCTX, and REBMAP.)
+// An attempt is made to group the accessors in sections.  Some functions are
+// defined in %c-value.c for the sake of the grouping.
+//
+// !!! R3-Alpha only used macros.  This had the advantage of only needing
+// the definitions available at the *callsite* vs at the point of the accessor
+// definition.  Yet macros may have undesirable properties (especially if
+// macro arguments are used more than once).
 //
 // While some REBVALs are in C stack variables, most reside in the allocated
 // memory block for a Rebol series.  The memory block for a series can be
@@ -73,361 +61,40 @@
 // accessed via ARG() will be stable as long as the function is running.
 //
 
-//
-// Note: Forward declarations are in %reb-defs.h
-//
-
-#ifndef VALUE_H
-#define VALUE_H
-
-// The definition of the REBVAL struct has a header followed by a payload.
-// On 32-bit platforms the header is 32 bits, and on 64-bit platforms it is
-// 64-bits.  However, even on 32-bit platforms, some payloads contain 64-bit
-// quantities (doubles or 64-bit integers).  By default, the compiler would
-// pad a payload with one 64-bit quantity and one 32-bit quantity to 128-bits,
-// which would not leave room for the header (if REBVALs are to be 128-bits).
-//
-// So since R3-Alpha, a `#pragma pack` of 4 is requested for this file:
-//
-//     http://stackoverflow.com/questions/3318410/
-//
-// It is restored to the default via `#pragma pack()` at the end of the file.
-// (Note that pack(push) and pack(pop) are not supported by older compilers.)
-//
-// Compilers are free to ignore pragmas (or error on them).  Also, this
-// packing subverts the automatic alignment handling of the compiler.  So if
-// the manually packed structures do not position 64-bit values on 64-bit
-// alignments, there can be problems.  On x86 this is generally just slower
-// reads and writes, but on more esoteric platforms (like the C-to-Javascript
-// translator "emscripten") some instances do not work at all.
-//
-// Hence REBVAL payloads that contain quantities that need 64-bit alignment
-// put those *after* a platform-pointer sized field, even if that field is
-// just padding.  On 32-bit platforms this will pair with the header to make
-// enough space to get to a 64-bit alignment
-//
-// If #pragma pack is disabled, a REBVAL will wind up being 160 bits.  This
-// won't give ideal performance, and will trigger an assertion in
-// Assert_Basics.  But the code *should* be able to work otherwise if that
-// assertion is removed.
-//
-#pragma pack(4)
-
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  VALUE HEADER (`struct Reb_Value_Header`)
+//  DEBUG PROBE AND PANIC
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// The layout of the header corresponds to the following bitfield
-// structure on big endian machines:
+// The PROBE macro can be used in debug builds to mold a REBVAL much like the
+// Rebol `probe` operation.  PROBE_MSG can add a message:
 //
-//    unsigned specific:16;     // flags that can apply to any REBVAL kind
-//    unsigned general:8;       // flags that can apply to any kind of REBVAL
-//    unsigned kind:6;          // underlying system datatype (64 kinds)
-//    unsigned settable:1;      // for debug build only--"formatted" to write
-//    unsigned not_end:1;       // not an end marker
+//     REBVAL *v = Some_Value_Pointer();
 //
-// Due to a desire to be able to assign all the header bits in one go
-// with a native-platform-sized int, this is done with bit masking.
-// Using bitfields would bring in questions of how smart the
-// optimizer is, as well as the endianness of the underlyling machine.
+//     PROBE(v);
+//     PROBE_MSG(v, "the v value debug dump label");
 //
-// We use REBUPT (Rebol's pre-C99 compatibility type for uintptr_t,
-// which is just uintptr_t from C99 on).  Only the low 32 bits are used
-// on 64-bit machines in order to make sure all the features work on
-// 32-bit machines...but could be used for some optimization or caching
-// purpose to enhance the 64-bit build.  No such uses implemented yet.
+// In order to make it easier to find out where a piece of debug spew is
+// coming from, the file and line number will be output as well.
+//
+// PANIC_VALUE causes a crash on a value, while trying to provide information
+// that could identify where that value was assigned.  If it is resident
+// in a series and you are using Address Sanitizer or Valgrind, then it should
+// cause a crash that pinpoints the stack where that array was allocated.
 //
 
-struct Reb_Value_Header {
-    REBUPT bits;
-};
+#if !defined(NDEBUG)
+    #define PROBE(v) \
+        Probe_Core_Debug(NULL, __FILE__, __LINE__, (v))
 
-// `NOT_END_MASK`
-//
-// If set, it means this is *not* an end marker.  The bit has been picked
-// strategically to be in the negative sense, and in the lowest bit position.
-// This means that any even-valued unsigned integer REBUPT value can be used
-// to implicitly signal an end.
-//
-// If this bit is 0, it means that *no other header bits are valid*, as it
-// may contain arbitrary data used for non-REBVAL purposes.
-//
-// Note that the value doing double duty as a number for one purpose and an
-// END marker as another *must* be another REBUPT.  It cannot be a pointer
-// (despite being guaranteed-REBUPT-sized, and despite having a value that
-// is 0 when you mod it by 2.  So-called "type-punning" is unsafe with a
-// likelihood of invoking "undefined behavior", while it's the compiler's
-// responsibility to guarantee that pointers to memory of the same type of
-// data be compatibly read-and-written.
-//
-#define NOT_END_MASK cast(REBUPT, 0x01)
+    #define PROBE_MSG(v, m) \
+        Probe_Core_Debug((m), __FILE__, __LINE__, (v))
 
-#define GENERAL_VALUE_BIT 8
-#define TYPE_SPECIFIC_BIT 16
-
-// `WRITABLE_MASK_DEBUG`
-//
-// This is for the debug build, to make it safer to use the implementation
-// trick of NOT_END_MASK.  It indicates the slot is "REBVAL sized", and can
-// be written into--including to be written with SET_END().
-//
-// It's again a strategic choice--the 2nd lowest bit and in the negative.
-// This means any REBUPT value whose % 4 within a container doing
-// double-duty as an implicit terminator for the contained values can
-// trigger an alert if the values try to overwrite it.
-//
-#if defined(__cplusplus) && !defined(NDEBUG)
-    //
-    // We want to be assured that we are not trying to take the type of a
-    // value that is actually an END marker, because end markers chew out only
-    // one bit--the rest of the REBUPT bits besides the bottom two may be
-    // anything necessary for the purpose.
-    //
-    // Only the C++ build honors the writability mask, because REBVAL is
-    // defined to a struct with a constructor that initializes the cell.
-    // If the C build wanted to also get the debug check, every REBVAL
-    // stack initialization would have to set it explicitly:
-    //
-    //     REBVAL value;
-    //     VAL_INIT_WRITABLE_DEBUG(&value); // C++ REBVAL does in constructor
-    //     SET_BLANK(value);
-    //
-    // In practice this was too unwieldy, so enhanced debugging of "mystery
-    // bugs" from stray writes should likely be done in a C++ build.
-    //
-    #define WRITABLE_MASK_DEBUG \
-        cast(REBUPT, 0x02)
-#else
-    //
-    // Though in the abstract it is desirable to have a way to protect an
-    // individual value from writing even in the release build, this is
-    // a debug-only check...it makes every value header initialization have
-    // to do two writes instead of one (one to format, then later to write
-    // and check that it is properly formatted space)
-    //
-    // !!! We define the WRITABLE_MASK_DEBUG as 0 for the C build, though the
-    // specific-binding branch is organized to not have it at all
-    //
-    #define WRITABLE_MASK_DEBUG \
-        cast(REBUPT, 0x00)
+    #define PANIC_VALUE(v) \
+        Panic_Value_Debug((v), __FILE__, __LINE__)
 #endif
-
-// The type mask comes up a bit and it's a fairly obvious constant, so this
-// hardcodes it for obviousness.  High 6 bits of the lowest byte.
-//
-#define HEADER_TYPE_MASK cast(REBUPT, 0xFC)
-
-
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  END marker (not a value type, only writes `struct Reb_Value_Flags`)
-//
-//=////////////////////////////////////////////////////////////////////////=//
-//
-// Historically Rebol arrays were always one value longer than their maximum
-// content, and this final slot was used for a special REBVAL called END!.
-// Like a null terminator in a C string, it was possible to start from one
-// point in the series and traverse to find the end marker without needing
-// to maintain a count.  Rebol series store their length also--but it's
-// faster and more general to use the terminator.
-//
-// Ren-C changed this so that end is not a data type, but rather seeing a
-// header slot with the lowest bit set to 0.  (See NOT_END_MASK for
-// an explanation of this choice.)  The upshot is that a data structure
-// designed to hold Rebol arrays is able to terminate an array at full
-// capacity with a pointer-sized integer with the lowest 2 bits clear, and
-// use the rest of the bits for other purposes.  (See WRITABLE_MASK_DEBUG
-// for why it's the low 2 bits and not just the lowest bit.)
-//
-// This means not only is a full REBVAL not needed to terminate, the sunk cost
-// of an existing 32-bit or 64-bit number (depending on platform) can be used
-// to avoid needing even 1/4 of a REBVAL for a header to terminate.  (See the
-// `size` field in `struct Reb_Chunk` from %sys-stack.h for a simple example
-// of the technique.)
-//
-// !!! Because Rebol Arrays (REBARR) have both a length and a terminator, it
-// is important to keep these in sync.  R3-Alpha sought to give code the
-// freedom to work with unterminated arrays if the cost of writing terminators
-// was not necessary.  Ren-C pushed back against this to try and be more
-// uniform to get the invariants under control.  A formal balance is still
-// being sought of when terminators will be required and when they will not.
-//
-
-#define IS_END_MACRO(v) \
-    LOGICAL((v)->header.bits % 2 == 0)
-
-#ifdef NDEBUG
-    #define IS_END(v)       IS_END_MACRO(v)
-#else
-    #define IS_END(v)       IS_END_Debug((v), __FILE__, __LINE__)
-#endif
-
-#define NOT_END(v)          NOT(IS_END(v))
-
-#ifdef NDEBUG
-    #define SET_END(v)      ((v)->header.bits = 0)
-#else
-    //
-    // The slot we are trying to write into must have at least been formatted
-    // in the debug build INIT_CELL_WRITABLE_IF_DEBUG().  Otherwise it could be a
-    // pointer with its low bit clear, doing double-duty as an IS_END(),
-    // marker...which we cannot overwrite...not even with another END marker.
-    //
-    #define SET_END(v) \
-        (ASSERT_CELL_WRITABLE_IF_DEBUG((v), __FILE__, __LINE__), \
-            (v)->header.bits = WRITABLE_MASK_DEBUG | REB_MAX)
-#endif
-
-// Pointer to a global END marker.  Though this global value is allocated to
-// the size of a REBVAL, only the header is initialized.  This means if any
-// of the value payload is accessed, it will trip memory checkers like
-// Valgrind or Address Sanitizer to warn of the mistake.
-//
-#define END_CELL (&PG_End_Cell)
-
-
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  GENERAL FLAGS common to every REBVAL
-//
-//=////////////////////////////////////////////////////////////////////////=//
-//
-// The value option flags are 8 individual bitflags which apply to every
-// value of every type.  Due to their scarcity, they are chosen carefully.
-//
-
-enum {
-    // `VALUE_FLAG_FALSE`
-    //
-    // Both BLANK! and LOGIC!'s false state are FALSE? ("conditionally false").
-    // All other types are TRUE?.  To make checking FALSE? and TRUE? faster,
-    // this bit is set when creating NONE! or FALSE.  As a result, LOGIC!
-    // does not need to store any data in its payload... its data of being
-    // true or false is already covered by this header bit.
-    //
-    VALUE_FLAG_FALSE = 1 << (GENERAL_VALUE_BIT + 0),
-
-    // `VALUE_FLAG_LINE`
-    //
-    // If the line marker bit is 1, then when the value is molded it will put
-    // a newline before the value.  The logic is a bit more subtle than that,
-    // because an ANY-PATH! could not be LOADed back if this were allowed.
-    // The bit is set initially by what the scanner detects, and then left
-    // to the user's control after that.
-    //
-    // !!! The native `new-line` is used set this, which has a somewhat
-    // poor name considering its similarity to `newline` the line feed char.
-    //
-    VALUE_FLAG_LINE = 1 << (GENERAL_VALUE_BIT + 1),
-
-    // `VALUE_FLAG_THROWN`
-    //
-    // The thrown bit is being phased out, as the concept of a value itself
-    // being "thrown" does not make a lot of sense, compared to the idea
-    // that the evaluator itself is in a "throwing state".  If a thrown bit
-    // can get on a value, then one has to worry about that value getting
-    // copied and showing up somewhere that it doesn't make sense.
-    //
-    // Originally, R3-Alpha did not have a thrown bit on values, rather the
-    // throw itself was represented as a certain kind of ERROR! value.  Ren-C
-    // modifications extended THROW to allow a /NAME that could be a full
-    // REBVAL (instead of a selection from a limited set of words).  This
-    // made it possible to identify a throw by an object, function,
-    // fully bound word, etc.
-    //
-    // But even after the change, the "thrown-ness" was still a property
-    // of the "throw-name REBVAL".  By virtue of being a property on a
-    // value *it could be dropped on the floor and ignored*.  There were
-    // countless examples of this originating in the code.
-    //
-    // As part of the process of stamping out the idea that thrownness comes
-    // from a value, all routines that can potentially return thrown values
-    // have been adapted to return a boolean and adopt the XXX_Throws()
-    // naming convention, so one can write:
-    //
-    //     if (XXX_Throws()) {
-    //        /* handling code */
-    //     }
-    //
-    // This forced every caller to consciously have a code path dealing with
-    // potentially thrown values, reigning in the previous problems.  At
-    // time of writing, the situation is much more under control, and natives
-    // return a flag indicating that they wish to throw a value vs. return
-    // one.  This is checked redundantly against the value bit for now, but
-    // it is likely that the bit will be removed in favor of pushing the
-    // responsibility into the evaluator state.
-    //
-    VALUE_FLAG_THROWN = 1 << (GENERAL_VALUE_BIT + 2),
-
-    // `VALUE_FLAG_RELATIVE` is used to indicate a value that needs to have
-    // a specific context added into it before it can have its bits copied
-    // or used for some purposes.  An ANY-WORD! is relative if it refers to
-    // a local or argument of a function, and has its bits resident in the
-    // deep copy of that function's body.  An ANY-ARRAY! in the deep copy
-    // of a function body must be relative also to the same function if
-    // it contains any instances of such relative words.
-    //
-    // !!! The feature of specific binding is a work in progress, and only
-    // bits of the supporting implementation changes are committed into the
-    // master branch at a time.
-    //
-    VALUE_FLAG_RELATIVE = 1 << (GENERAL_VALUE_BIT + 4),
-
-    // `VALUE_FLAG_EVALUATED` is a somewhat dodgy-yet-unavoidable concept.
-    // This is that some functions wish to be sensitive to whether or not
-    // their argument came as a literal in source or as a product of an
-    // evaluation.  While all values carry the bit, it is only guaranteed
-    // to be meaningful on arguments in function frames...though it is
-    // valid on any result at the moment of taking it from Do_Core().
-    //
-    VALUE_FLAG_EVALUATED = 1 << (GENERAL_VALUE_BIT + 5)
-};
-
-// VALUE_FLAG_XXX flags are applicable to all types.  Type-specific flags are
-// named things like TYPESET_FLAG_XXX or WORD_FLAG_XXX and only apply to the
-// type that they reference.  Both use these XXX_VAL_FLAG accessors.
-//
-#ifdef NDEBUG
-    #define SET_VAL_FLAG(v,f) \
-        ((v)->header.bits |= (f))
-
-    #define GET_VAL_FLAG(v,f) \
-        LOGICAL((v)->header.bits & (f))
-
-    #define CLEAR_VAL_FLAG(v,f) \
-        ((v)->header.bits &= ~cast(REBUPT, (f)))
-#else
-    // For safety in the debug build, all the type-specific flags include
-    // their type as part of the flag.  This type is checked first, and then
-    // masked out to use the single-bit-flag value which is intended.  The
-    // check uses the bits of an exemplar type to identify the category
-    // (e.g. REB_FUNCTION for ANY-FUNCTION!, REB_OBJECT for ANY-CONTEXT!)
-
-    #define SET_VAL_FLAG(v,f) \
-        (Assert_Flags_Are_For_Value((v), (f)), \
-            (v)->header.bits |= ((f) & ~HEADER_TYPE_MASK))
-
-    #define GET_VAL_FLAG(v,f) \
-        (Assert_Flags_Are_For_Value((v), (f)), \
-            LOGICAL((v)->header.bits & ((f) & ~HEADER_TYPE_MASK)))
-
-    #define CLEAR_VAL_FLAG(v,f) \
-        (Assert_Flags_Are_For_Value((v), (f)), \
-            (v)->header.bits &= ~cast(REBUPT, (f) & ~HEADER_TYPE_MASK))
-#endif
-
-//
-// Setting and clearing multiple flags works, so these names make that "clear"
-//
-
-#define SET_VAL_FLAGS(v,f) \
-    SET_VAL_FLAG((v), (f))
-
-#define CLEAR_VAL_FLAGS(v,f) \
-    CLEAR_VAL_FLAG((v), (f))
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -442,51 +109,175 @@ enum {
 // parameter).  If there were more types, they couldn't be flagged in a
 // typeset that fit in a REBVAL under that constraint.
 //
+// The 64 basic Rebol types ("kinds" of values) are shifted left 2 bits.
+// This makes their range go from 0..251 instead of from 0..63.  Reasoning is
+// that most of the time the types are just used in comparisons, so it's
+// usually cheaper to not shift out the 2 low bits used for END and WRITABLE.
+//
+// But to index into a zero based array with 64 elements, these XXX_0 forms
+// are available to do shifting.  See also REB_MAX_0
+//
 // VAL_TYPE() should obviously not be called on uninitialized memory.  But
 // it should also not be called on an END marker, as those markers only
 // guarantee the low bit as having Rebol-readable-meaning.  In debug builds,
 // this is asserted by VAL_TYPE_Debug.
 //
 
+#define KIND_FROM_0(z) \
+    cast(enum Reb_Kind, (z) << 2)
+
+#define TO_0_FROM_KIND(k) \
+    (cast(REBCNT, (k)) >> 2)
+
+#define FLAGIT_KIND(t) \
+    (cast(REBU64, 1) << TO_0_FROM_KIND(t)) // makes a 64-bit bitflag
+
+inline static enum Reb_Kind VAL_TYPE_CORE(const RELVAL *v) {
+    return cast(enum Reb_Kind, v->header.bits & HEADER_TYPE_MASK);
+}
+
 #ifdef NDEBUG
     #define VAL_TYPE(v) \
-        cast(enum Reb_Kind, (v)->header.bits & HEADER_TYPE_MASK)
+        VAL_TYPE_CORE(v)
 #else
+    inline static enum Reb_Kind VAL_TYPE_Debug(
+        const RELVAL *v, const char *file, int line
+    ){
+        if (IS_END(v)) {
+            printf("END marker or garbage (low bit 0) in VAL_TYPE()\n");
+            fflush(stdout);
+            Panic_Value_Debug(v, file, line);
+        }
+        if (IS_TRASH_DEBUG(v)) {
+            printf("Unexpected TRASH in VAL_TYPE()\n");
+            fflush(stdout);
+            Panic_Value_Debug(v, file, line);
+        }
+        return VAL_TYPE_CORE(v);
+    }
+
     #define VAL_TYPE(v) \
         VAL_TYPE_Debug((v), __FILE__, __LINE__)
 #endif
 
-// For the processor's convenience, the 64 basic Rebol types are shifted to
-// the left by 2 bits.  This makes their range go from 0..251 instead of
-// from 0..63.  The choice to do this is because most of the type the types
-// are just used in comparisons or switch statements, and it's cheaper to
-// not have to shift out the 2 low bits that are used for END and WRITABLE
-// flags in the header most of the time.
-//
-// However, to index into a zero based array with 64 elements, the shift
-// needs to be done.  If that's required these defines adjust for the shift.
-// See also REB_MAX_0
-//
-#define KIND_FROM_0(z) cast(enum Reb_Kind, (z) << 2)
-#define TO_0_FROM_KIND(k) (cast(REBCNT, (k)) >> 2)
-#define VAL_TYPE_0(v) TO_0_FROM_KIND(VAL_TYPE(v))
+#define VAL_TYPE_0(v) \
+    TO_0_FROM_KIND(VAL_TYPE(v))
 
-// SET_TYPE_BITS only sets the type, with other header bits intact.  This
-// should be used when you are sure that the new type payload is in sync with
-// the type and bits (for instance, changing from one ANY-WORD! type to
-// another, the binding needs to be in sync with the header bits)
+inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
+    //
+    // Note: Only use if you are sure the new type payload is in sync with
+    // the type and bits (e.g. changing ANY-WORD! to another ANY-WORD!).
+    // Otherwise the value-specific flags might be misinterpreted.
+    //
+    // Use VAL_RESET_HEADER() to set the type AND initialize the flags to 0.
+    //
+    assert(!IS_TRASH_DEBUG(v));
+    (v)->header.bits &= ~cast(REBUPT, HEADER_TYPE_MASK);
+    (v)->header.bits |= cast(REBUPT, kind);
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
 //
-// NOTE: The header MUST already be valid and initialized to use this!  For
-// fresh value creation, one wants to use VAL_RESET_HEADER to clear bits and
-// set the type.
+//  VALUE FLAGS
 //
-// !!! Is it worth the effort to add a debugging flag into the value to
-// disallow calling this routine if VAL_RESET_HEADER has not been run, or
-// are there too few instances to be worth it and is _BITS enough a hint?
+//=////////////////////////////////////////////////////////////////////////=//
 //
-#define VAL_SET_TYPE_BITS(v,t) \
-    ((v)->header.bits &= ~cast(REBUPT, HEADER_TYPE_MASK), \
-        (v)->header.bits |= cast(REBUPT, (t)))
+// VALUE_FLAG_XXX flags are applicable to all types.  Type-specific flags are
+// named things like TYPESET_FLAG_XXX or WORD_FLAG_XXX and only apply to the
+// type that they reference.  Both use these XXX_VAL_FLAG accessors.
+//
+// For safety in the debug build, all the type-specific flags include their
+// type as part of the flag.  This type is checked first, and then masked out
+// to use the single-bit-flag value which is intended.  The check uses the
+// an exemplar to identify the category (e.g. REB_OBJECT for ANY-CONTEXT!)
+//
+
+#ifdef NDEBUG
+    inline static void SET_VAL_FLAGS(RELVAL *v, REBUPT f) {
+        v->header.bits |= f;
+    }
+
+    #define SET_VAL_FLAG(v,f) \
+        SET_VAL_FLAGS((v), (f))
+
+    inline static REBOOL GET_VAL_FLAG(const RELVAL *v, REBUPT f) {
+        return LOGICAL(v->header.bits & f);
+    }
+
+    inline static void CLEAR_VAL_FLAGS(RELVAL *v, REBUPT f) {
+        v->header.bits &= ~f;
+    }
+
+    #define CLEAR_VAL_FLAG(v,f) \
+        CLEAR_VAL_FLAGS((v), (f))
+#else
+    inline static void SET_VAL_FLAGS(RELVAL *v, REBUPT f) {
+        Assert_Flags_Are_For_Value(v, f);
+        v->header.bits |= f & ~HEADER_TYPE_MASK;
+    }
+
+    inline static void SET_VAL_FLAG(RELVAL *v, REBUPT f) {
+        SET_VAL_FLAGS(v, f);
+        f &= ~HEADER_TYPE_MASK;
+        assert(f && f == (f & -f)); // checks that only one bit is set
+    }
+
+    inline static REBOOL GET_VAL_FLAG(const RELVAL *v, REBUPT f) {
+        Assert_Flags_Are_For_Value(v, f);
+        f &= ~HEADER_TYPE_MASK;
+        assert(f && f == (f & -f)); // checks that only one bit is set
+        return LOGICAL(v->header.bits & f);
+    }
+
+    inline static void CLEAR_VAL_FLAGS(RELVAL *v, REBUPT f) {
+        Assert_Flags_Are_For_Value(v, f);
+        v->header.bits &= ~(f & ~HEADER_TYPE_MASK);
+    }
+
+    inline static void CLEAR_VAL_FLAG(RELVAL *v, REBUPT f) {
+        CLEAR_VAL_FLAGS(v, f);
+        f &= ~HEADER_TYPE_MASK;
+        assert(f && f == (f & -f)); // checks that only one bit is set
+    }
+#endif
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  TRACKING PAYLOAD (for types that don't use their payloads)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Some datatypes like NONE! or LOGIC!, or a void cell, can be communicated
+// entirely by their header bits.  Though this "wastes" 3/4 of the space of
+// the value cell, it also means the cell can be written and tested quickly.
+//
+// The release build does not canonize the remaining bits of the payload so
+// they are left as random data.  But the debug build can take advantage of
+// it to store some tracking information about the point and moment of
+// initialization.  This data can be viewed in the debugging watchlist
+// under the `track` component of payload, and is also used by PANIC_VALUE.
+//
+
+#if !defined NDEBUG
+    inline static void Set_Track_Payload_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        v->payload.track.filename = file;
+        v->payload.track.line = line;
+        v->payload.track.count = TG_Do_Count;
+    }
+
+    inline static const char* VAL_TRACK_FILE(const RELVAL *v)
+        { return v->payload.track.filename; }
+
+    inline static int VAL_TRACK_LINE(const REBVAL *v)
+        { return v->payload.track.line; }
+
+    inline static REBUPT VAL_TRACK_COUNT(const REBVAL *v)
+        { return v->payload.track.count; }
+#endif
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -510,8 +301,9 @@ enum {
 // variable then it will have to be done before any write can happen.
 //
 
-#define VAL_RESET_HEADER_CORE(v,kind) \
-    ((v)->header.bits = NOT_END_MASK | cast(REBUPT, (kind)))
+inline static void VAL_RESET_HEADER_CORE(RELVAL *v, enum Reb_Kind kind) {
+    (v)->header.bits = NOT_END_MASK | cast(REBUPT, kind);
+}
 
 #ifdef NDEBUG
     #define ASSERT_CELL_WRITABLE_IF_DEBUG(v) \
@@ -555,91 +347,43 @@ enum {
             NOOP
     #endif
 
+    inline static void VAL_RESET_HEADER_Debug(
+        RELVAL *v, enum Reb_Kind kind, const char *file, int line
+    ){
+        ASSERT_CELL_WRITABLE_IF_DEBUG(v, file, line);
+        VAL_RESET_HEADER_CORE(v, kind);
+        v->header.bits |= WRITABLE_MASK_DEBUG;
+    }
+
     #define VAL_RESET_HEADER(v,k) \
         VAL_RESET_HEADER_Debug((v), (k), __FILE__, __LINE__)
 #endif
 
-// !!! SET_ZEROED is a macro-capture of a dodgy behavior of R3-Alpha,
-// which was to assume that clearing the payload of a value and then setting
-// the header made it the `zero?` of that type.  Review uses.
-//
-#define SET_ZEROED(v,t) \
-    (VAL_RESET_HEADER((v),(t)), \
-        CLEAR(&(v)->payload, sizeof(union Reb_Value_Payload)))
+inline static void SET_ZEROED(RELVAL *v, enum Reb_Kind kind) {
+    //
+    // !!! SET_ZEROED is a capturing of a dodgy behavior of R3-Alpha,
+    // which was to assume that clearing the payload of a value and then
+    // setting the header made it the `zero?` of that type.  Review uses.
+    //
+    VAL_RESET_HEADER(v, kind);
+    CLEAR(&v->payload, sizeof(union Reb_Value_Payload));
+}
 
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  TRACK payload (not a value type, only in DEBUG)
+//  VOID or TRASH
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// `struct Reb_Track` is the value payload in debug builds for any REBVAL
-// whose VAL_TYPE() doesn't need any information beyond the header.  This
-// offers a chance to inject some information into the payload to help
-// know where the value originated.  It is used by voids (and void trash),
-// BLANK!, LOGIC!, and BAR!.
-//
-// In addition to the file and line number where the assignment was made,
-// the "tick count" of the DO loop is also saved.  This means that it can
-// be possible in a repro case to find out which evaluation step produced
-// the value--and at what place in the source.  Repro cases can be set to
-// break on that tick count, if it is deterministic.
-//
-
-// !!! If we're not using TRACK_EMPTY_PAYLOADS, should this POISON_MEMORY()
-// on the payload to catch invalid reads?  Trash values don't hang around
-// that long, except for the values in the extra "->rest" capacity of series.
-// Would that be too many memory poisonings to handle efficiently?
-//
-#define TRACK_EMPTY_PAYLOADS
-
-#if !defined(NDEBUG)
-    #ifdef TRACK_EMPTY_PAYLOADS
-        struct Reb_Track {
-            const char *filename;
-            int line;
-            REBCNT count;
-        };
-
-        #define SET_TRACK_PAYLOAD(v) \
-            ( \
-                (v)->payload.track.filename = __FILE__, \
-                (v)->payload.track.line = __LINE__, \
-                (v)->payload.track.count = TG_Do_Count, \
-                NOOP \
-            )
-
-        #define VAL_TRACK_FILE(v)       ((v)->payload.track.filename)
-        #define VAL_TRACK_LINE(v)       ((v)->payload.track.line)
-        #define VAL_TRACK_COUNT(v)      ((v)->payload.track.count)
-    #else
-        #define SET_TRACK_PAYLOAD(v) NOOP
-    #endif
-#endif
-
-
-
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  VOID or TRASH (fits in header bits, may use `struct Reb_Track`)
-//
-//=////////////////////////////////////////////////////////////////////////=//
-//
-// Though there was an "unset! datatype" in Rebol2 and R3-Alpha, Ren-C does
-// not allow "reified values of type unset!".  Instead it has voids--which
-// are a transient product of evaluation (e.g. the result of `do []`).  The
-// bit pattern for the value is also used in the varlists of contexts like
-// OBJECT! or FRAME! to denote a variable that is not currently set, but
-// it is said that the *variable* is set or unset.
-//
-// Since they have no data payload, voids in the debug build use Reb_Track
-// as their structure to show where-and-when they were assigned.  This is
-// helpful because void is the default initialization value for several
-// constructs.
+// Voids are a transient product of evaluation (e.g. the result of `do []`).
+// They cannot be stored in blocks, and if a variable is assigned a void
+// cell then that variable is considered to be "unset".  Void is thus not
+// considered to be a "value type", but a bit pattern used to mark cells
+// as not containing any value at all.
 //
 // In the debug build, there is a special flag that if it is not set, the
-// unset is assumed to be "trash".  This is what's used to fill memory that
+// cell is assumed to be "trash".  This is what's used to fill memory that
 // in the release build would be uninitialized data.  To prevent it from being
 // inspected while it's in an invalid state, VAL_TYPE used on a trash value
 // will assert in the debug build.
@@ -648,119 +392,136 @@ enum {
 // The macros for setting trash will compile in both debug and release builds,
 // though an unsafe trash will be a NOOP in release builds.  (So the "trash"
 // will be uninitialized memory, in that case.)  A safe trash set turns into
-// a regular unset in release builds.
+// a regular void in release builds.
+//
+// Doesn't need payload...so the debug build adds information in Reb_Track
+// which can be viewed in the debug watchlist (or shown by PANIC_VALUE)
 //
 
+#define VOID_CELL \
+    c_cast(const REBVAL*, &PG_Void_Cell[0])
+
+inline static REBOOL IS_VOID(const RELVAL *v)
+    { return LOGICAL(VAL_TYPE(v) == REB_0); } // not a "type", so no IS_0 test
+
 #ifdef NDEBUG
-    #define SET_VOID(v) \
-        VAL_RESET_HEADER((v), REB_0)
-
-    #define SET_TRASH_IF_DEBUG(v) NOOP
-
-    #define SET_TRASH_SAFE(v) SET_VOID(v)
-
-    #define SINK(v) cast(REBVAL*, (v))
-#else
-    enum {
-        VOID_FLAG_NOT_TRASH = (1 << TYPE_SPECIFIC_BIT) | REB_0,
-
-        // By default, the garbage collector will alert if a "trash unset"
-        // is not overwritten by the time it sees it.  But some cases work with
-        // GC-visible locations and want the GC to ignore a transitional trash.
-        // For these cases use SET_TRASH_GC_SAFE().
-        //
-        VOID_FLAG_SAFE_TRASH = (2 << TYPE_SPECIFIC_BIT) | REB_0
-    };
-
-    #define SET_VOID(v) \
-        (VAL_RESET_HEADER((v), REB_0), \
-        SET_VAL_FLAG((v), VOID_FLAG_NOT_TRASH), \
-        SET_TRACK_PAYLOAD(v))
-
-    // Special type check...we don't want to use VAL_TYPE() here directly
-    // because VAL_TYPE is supposed to assert on trash
-    //
-    #define IS_TRASH_DEBUG(v) \
-        (((v)->header.bits & HEADER_TYPE_MASK) == REB_0 \
-        && !(((v)->header.bits & VOID_FLAG_NOT_TRASH)))
+    inline static void SET_VOID(RELVAL *v)
+        { VAL_RESET_HEADER(v, REB_0); }
 
     #define SET_TRASH_IF_DEBUG(v) \
-        ( \
-            VAL_RESET_HEADER((v), REB_0), /* don't set NOT_TRASH flag */ \
-            SET_TRACK_PAYLOAD(v) \
-        )
+        NOOP
 
     #define SET_TRASH_SAFE(v) \
-        ( \
-            VAL_RESET_HEADER((v), REB_0), \
-            SET_VAL_FLAG((v), VOID_FLAG_SAFE_TRASH), \
-            SET_TRACK_PAYLOAD(v) \
-        )
+        SET_VOID(v)
+
+    #define IS_VOID_OR_SAFE_TRASH(v) \
+        IS_VOID(v)
+
+    inline static REBVAL *SINK(RELVAL *v) {
+        return cast(REBVAL*, v);
+    }
+#else
+    enum {
+        VOID_FLAG_NOT_TRASH = (1 << TYPE_SPECIFIC_BIT),
+        VOID_FLAG_SAFE_TRASH = (2 << TYPE_SPECIFIC_BIT)
+    };
+
+    inline static void Set_Void_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        VAL_RESET_HEADER(v, REB_0);
+        SET_VAL_FLAG(v, VOID_FLAG_NOT_TRASH);
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
+    inline static void Set_Trash_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        VAL_RESET_HEADER(v, REB_0); // we don't set VOID_FLAG_NOT_TRASH
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
+    inline static void Set_Trash_Safe_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        VAL_RESET_HEADER(v, REB_0);
+        SET_VAL_FLAG(v, VOID_FLAG_SAFE_TRASH);
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
+    #define SET_VOID(v) \
+        Set_Void_Debug((v), __FILE__, __LINE__)
+
+    #define SET_TRASH_IF_DEBUG(v) \
+        Set_Trash_Debug((v), __FILE__, __LINE__)
+
+    #define SET_TRASH_SAFE(v) \
+        Set_Trash_Safe_Debug((v), __FILE__, __LINE__)
+
+    inline static REBOOL IS_VOID_OR_SAFE_TRASH(const RELVAL *v) {
+        if (IS_TRASH_DEBUG(v) && GET_VAL_FLAG(v, VOID_FLAG_SAFE_TRASH))
+            return TRUE; // only the GC should treat "safe" trash as void
+        if (IS_VOID(v))
+            return TRUE;
+        return FALSE;
+    }
+
+    inline static REBVAL *Sink_Debug(RELVAL *v, const char *file, int line) {
+        Set_Trash_Debug(v, file, line);
+        return cast(REBVAL*, v);
+    }
 
     #define SINK(v) \
         Sink_Debug((v), __FILE__, __LINE__)
 #endif
 
-// To help avoid confusion which might suggest there is a VOID! datatype, the
-// name of the REB_XXX type is REB_0, and the test is special.
-//
-#define IS_VOID(v) LOGICAL(VAL_TYPE(v) == REB_0)
-
-// Pointer to a global protected void cell that can be used when a read-only
-// "absence of value" bit pattern is needed.
-//
-#define VOID_CELL (&PG_Void_Cell[0])
-
-// The debug build has a concept of "safe trash" which is really just an
-// unset that is meant to be overwritten before it is ever read.  Only the
-// GC is willing to tolerate them, but they will trigger an alarm if any
-// other code sees them (error during VAL_TYPE or IS_XXX)
-//
-#ifdef NDEBUG
-    #define IS_VOID_OR_SAFE_TRASH(v) \
-        IS_VOID(v)
-#else
-    #define IS_VOID_OR_SAFE_TRASH(v) \
-        ((IS_TRASH_DEBUG(v) && GET_VAL_FLAG((v), VOID_FLAG_SAFE_TRASH)) \
-        || IS_VOID(v))
-#endif
-
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  BAR! and LIT-BAR! (fits in header bits, may use `struct Reb_Track`)
+//  BAR! and LIT-BAR!
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// The "expression barrier" is denoted by a lone vertical bar `|`, and it
-// has the special property of being rejected for argument fulfillment, but
-// ignored at interstitial positions.  So:
+// The "expression barrier" is denoted by a lone vertical bar `|`.  It
+// has the special property that literals used directly will be rejected
+// as a source for argument fulfillment.  BAR! that comes from evaluations
+// can be passed as a parameter, however:
 //
 //     append [a b c] | [d e f] print "Hello"   ;-- will cause an error
 //     append [a b c] [d e f] | print "Hello"   ;-- is legal
+//     append [a b c] (|)                       ;-- is legal
+//     append [a b c] '|                        ;-- is legal
 //
-// This makes it similar to an void in behavior, but given its specialized
-// purpose unlikely to conflict as being needed to be passed as an actual
-// parameter.  Literal unsets in source are treated differently by the
-// evaluator than unsets in variables or coming from the result of a function
-// call, so that `append [a b c] something-that-returns-a-bar` is legal.
-//
-// The other loophole for making barriers is the LIT-BAR!, which can allow
-// passing a BAR! by value.  So `append [a b c] '|` would work.
+// Doesn't need payload...so the debug build adds information in Reb_Track
+// which can be viewed in the debug watchlist (or shown by PANIC_VALUE)
 //
 
 #ifdef NDEBUG
-    #define SET_BAR(v) \
-        VAL_RESET_HEADER((v), REB_BAR)
+    inline static void SET_BAR(RELVAL *v)
+        { VAL_RESET_HEADER(v, REB_BAR); }
 
-    #define SET_LIT_BAR(v) \
-        VAL_RESET_HEADER((v), REB_LIT_BAR)
+    inline static void SET_LIT_BAR(RELVAL *v)
+        { VAL_RESET_HEADER(v, REB_LIT_BAR); }
 #else
+    inline static void SET_BAR_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        VAL_RESET_HEADER(v, REB_BAR);
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
+    inline static void SET_LIT_BAR_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        VAL_RESET_HEADER(v, REB_LIT_BAR);
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
     #define SET_BAR(v) \
-        (VAL_RESET_HEADER((v), REB_BAR), SET_TRACK_PAYLOAD(v))
+        SET_BAR_Debug((v), __FILE__, __LINE__)
 
     #define SET_LIT_BAR(v) \
-        (VAL_RESET_HEADER((v), REB_LIT_BAR), SET_TRACK_PAYLOAD(v))
+        SET_LIT_BAR_Debug((v), __FILE__, __LINE__)
 #endif
 
 #define BAR_VALUE (&PG_Bar_Value[0])
@@ -782,28 +543,37 @@ enum {
 // type, BLANK! also carries a header bit that can be checked for conditional
 // falsehood, to save on needing to separately test the type.
 //
-// Though having tracking information for a blank is less frequently useful
-// than for a void, it's there in debug builds just in case it ever serves a
-// purpose, as the REBVAL payload is not being used.
+// Doesn't need payload...so the debug build adds information in Reb_Track
+// which can be viewed in the debug watchlist (or shown by PANIC_VALUE)
 //
+
+inline static void SET_BLANK_CORE(RELVAL *v) {
+    v->header.bits = VALUE_FLAG_FALSE | NOT_END_MASK | REB_BLANK;
+}
 
 #ifdef NDEBUG
     #define SET_BLANK(v) \
-        ((v)->header.bits = VALUE_FLAG_FALSE | NOT_END_MASK | REB_BLANK)
+        SET_BLANK_CORE(v)
 #else
+    inline static void SET_BLANK_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        ASSERT_CELL_WRITABLE_IF_DEBUG(v, file, line);
+        SET_BLANK_CORE(v);
+        MARK_CELL_WRITABLE_IF_DEBUG(v);
+        Set_Track_Payload_Debug(v, file, line);
+    }
     #define SET_BLANK(v) \
-        (ASSERT_CELL_WRITABLE_IF_DEBUG((v), __FILE__, __LINE__), \
-            (v)->header.bits = VALUE_FLAG_FALSE | \
-            NOT_END_MASK | WRITABLE_MASK_DEBUG | REB_BLANK, \
-        SET_TRACK_PAYLOAD(v))
+        SET_BLANK_Debug((v), __FILE__, __LINE__)
 #endif
 
-#define BLANK_VALUE (&PG_Blank_Value[0])
+#define BLANK_VALUE \
+    (&PG_Blank_Value[0])
 
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  LOGIC! (type and value fits in header bits, may use `struct Reb_Track`)
+//  LOGIC! AND "CONDITIONAL TRUTH"
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
@@ -813,450 +583,531 @@ enum {
 // that a single check can test for both BLANK! and logic false.
 //
 // Conditional truth and falsehood allows an interpretation where a NONE!
-// is a "falsey" value as well as logic false.  Unsets are neither
+// is a "falsey" value as well as logic false.  Voids are neither
 // conditionally true nor conditionally false, and so debug builds will
 // complain if you try to determine which it is.  (It likely means a mistake
 // was made in skipping a formal decision-point regarding whether an unset
 // should represent an "opt out" or an error.)
 //
-// Due to no need for payload, it goes ahead and includes a TRACK payload
-// in debug builds.
+// Doesn't need payload...so the debug build adds information in Reb_Track
+// which can be viewed in the debug watchlist (or shown by PANIC_VALUE)
 //
+
+#define FALSE_VALUE \
+    c_cast(const REBVAL*, &PG_False_Value[0])
+
+#define TRUE_VALUE \
+    c_cast(const REBVAL*, &PG_True_Value[0])
+
+#define SET_TRUE_MACRO(v) \
+    ((v)->header.bits = REB_LOGIC | NOT_END_MASK)
+
+#define SET_FALSE_MACRO(v) \
+    ((v)->header.bits = REB_LOGIC | NOT_END_MASK | VALUE_FLAG_FALSE)
+
+#define IS_CONDITIONAL_FALSE_MACRO(v) \
+    GET_VAL_FLAG((v), VALUE_FLAG_FALSE)
 
 #ifdef NDEBUG
     #define SET_TRUE(v) \
-        ((v)->header.bits = REB_LOGIC | NOT_END_MASK)
+        SET_TRUE_MACRO(v)
 
     #define SET_FALSE(v) \
-        ((v)->header.bits = REB_LOGIC | NOT_END_MASK \
-            | VALUE_FLAG_FALSE)
+        SET_FALSE_MACRO(v)
+
+    inline static void SET_LOGIC(RELVAL *v, REBOOL b) {
+        if (b)
+            SET_TRUE(v);
+        else
+            SET_FALSE(v);
+    }
+
+    #define IS_CONDITIONAL_FALSE(v) \
+        IS_CONDITIONAL_FALSE_MACRO(v)
 #else
+    inline static void SET_TRUE_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        ASSERT_CELL_WRITABLE_IF_DEBUG(v, file, line);
+        SET_TRUE_MACRO(v);
+        MARK_CELL_WRITABLE_IF_DEBUG(v);
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
+    inline static void SET_FALSE_Debug(
+        RELVAL *v, const char *file, int line
+    ){
+        ASSERT_CELL_WRITABLE_IF_DEBUG(v, file, line);
+        SET_FALSE_MACRO(v);
+        MARK_CELL_WRITABLE_IF_DEBUG(v);
+        Set_Track_Payload_Debug(v, file, line);
+    }
+
+    inline static void SET_LOGIC_Debug(
+        RELVAL *v, REBOOL b, const char *file, int line
+    ){
+        if (b)
+            SET_TRUE_Debug(v, file, line);
+        else
+            SET_FALSE_Debug(v, file, line);
+    }
+
+    inline static REBOOL IS_CONDITIONAL_FALSE_Debug(
+        const RELVAL *v, const char *file, int line
+    ){
+        if (IS_VOID(v)) {
+            printf("Conditional true/false test on void\n");
+            fflush(stdout);
+            Panic_Value_Debug(v, file, line);
+        }
+        return IS_CONDITIONAL_FALSE_MACRO(v);
+    }
+
     #define SET_TRUE(v) \
-        (ASSERT_CELL_WRITABLE_IF_DEBUG((v), __FILE__, __LINE__), \
-            (v)->header.bits = REB_LOGIC | NOT_END_MASK \
-                | WRITABLE_MASK_DEBUG, \
-         SET_TRACK_PAYLOAD(v)) // compound
+        SET_TRUE_Debug((v), __FILE__, __LINE__)
 
     #define SET_FALSE(v) \
-        (ASSERT_CELL_WRITABLE_IF_DEBUG((v), __FILE__, __LINE__), \
-            (v)->header.bits = REB_LOGIC | NOT_END_MASK \
-            | WRITABLE_MASK_DEBUG | VALUE_FLAG_FALSE, \
-         SET_TRACK_PAYLOAD(v))  // compound
+        SET_FALSE_Debug((v), __FILE__, __LINE__)
+
+    #define SET_LOGIC(v,b) \
+        SET_LOGIC_Debug((v), (b), __FILE__, __LINE__)
+
+    #define IS_CONDITIONAL_FALSE(v) \
+        IS_CONDITIONAL_FALSE_Debug((v), __FILE__, __LINE__)
 #endif
 
-#define SET_LOGIC(v,n)  ((n) ? SET_TRUE(v) : SET_FALSE(v))
-#define VAL_LOGIC(v)    NOT(GET_VAL_FLAG((v), VALUE_FLAG_FALSE))
+#define IS_CONDITIONAL_TRUE(v) \
+    NOT(IS_CONDITIONAL_FALSE(v)) // macro gets file + line # in debug build
 
-#ifdef NDEBUG
-    #define IS_CONDITIONAL_FALSE(v) \
-        GET_VAL_FLAG((v), VALUE_FLAG_FALSE)
-#else
-    // In a debug build, we want to make sure that void cells are never asked
-    // about their conditional truth or falsehood; they are neither.
-    //
-    #define IS_CONDITIONAL_FALSE(v) \
-        IS_CONDITIONAL_FALSE_Debug(v)
-#endif
-
-#define IS_CONDITIONAL_TRUE(v) NOT(IS_CONDITIONAL_FALSE(v))
-
-#define FALSE_VALUE (&PG_False_Value[0])
-#define TRUE_VALUE (&PG_True_Value[0])
+inline static REBOOL VAL_LOGIC(const RELVAL *v) {
+    assert(IS_LOGIC(v));
+    return NOT(GET_VAL_FLAG((v), VALUE_FLAG_FALSE));
+}
 
 
+//=////////////////////////////////////////////////////////////////////////=//
 //
-// Rebol Symbol
+//  DATATYPE!
 //
-// !!! Historically Rebol used an unsigned 32-bit integer as a "symbol ID".
-// These symbols did not participate in garbage collection and had to be
-// looked up in a table to get their values.  Ren-C is moving toward adapting
-// REBSERs to be able to store words and canon words, as well as GC them.
-// This starts moving the types to be the size of a platform pointer.
+//=////////////////////////////////////////////////////////////////////////=//
 //
-
-typedef REBUPT REBSYM;
-
-
-/***********************************************************************
-**
-**  DATATYPE - Datatype or pseudo-datatype
-**
-**  !!! Consider rename to TYPE! once legacy TYPE? calls have been
-**  converted to TYPE-OF.  Also consider a model where there are
-**  user types, and hence TYPE? may be able to return more than just
-**  one out of a set of 64 things.
-**
-***********************************************************************/
-
-struct Reb_Datatype {
-    enum Reb_Kind kind;
-    REBARR  *spec;
-//  REBINT  min_type;
-//  REBINT  max_type;
-};
-
-#define VAL_TYPE_KIND(v)    ((v)->payload.datatype.kind)
-#define VAL_TYPE_KIND_0(v)  TO_0_FROM_KIND(VAL_TYPE_KIND(v))
-
-#define VAL_TYPE_SPEC(v)    ((v)->payload.datatype.spec)
-
+// Note: R3-Alpha's notion of a datatype has not been revisited very much in
+// Ren-C.  The unimplemented UTYPE! user-defined type concept was removed
+// for simplification, pending a broader review of what was needed.
+//
 // %words.r is arranged so that symbols for types are at the start
 // Although REB_0 is 0 and the 0 REBCNT used for symbol IDs is reserved
 // for "no symbol"...this is okay, because void is not a value type and
 // should not have a symbol.
 //
-#define IS_KIND_SYM(s)      ((s) < REB_MAX_0)
-#define KIND_FROM_SYM(s)    cast(enum Reb_Kind, KIND_FROM_0(s))
+// !!! Consider the naming once all legacy TYPE? calls have been converted
+// to TYPE-OF.  TYPE! may be a better name, though possibly KIND! would be
+// better if user types suggest that TYPE-OF can potentially return some
+// kind of context (might TYPE! be an ANY-CONTEXT!, with properties like
+// MIN-VALUE and MAX-VALUE, for instance).
+//
+
+#define VAL_TYPE_KIND(v) \
+    ((v)->payload.datatype.kind)
+
+#define VAL_TYPE_KIND_0(v) \
+    TO_0_FROM_KIND(VAL_TYPE_KIND(v))
+
+#define VAL_TYPE_SPEC(v) \
+    ((v)->payload.datatype.spec)
+
+#define IS_KIND_SYM(s) \
+    ((s) < REB_MAX_0)
+
+#define KIND_FROM_SYM(s) \
+    cast(enum Reb_Kind, KIND_FROM_0(s))
+
 #define SYM_FROM_KIND(k) \
     cast(REBSYM, TO_0_FROM_KIND(k))
-#define VAL_TYPE_SYM(v)     SYM_FROM_KIND((v)->payload.datatype.kind)
 
-//#define   VAL_MIN_TYPE(v) ((v)->payload.datatype.min_type)
-//#define   VAL_MAX_TYPE(v) ((v)->payload.datatype.max_type)
+#define VAL_TYPE_SYM(v) \
+    SYM_FROM_KIND((v)->payload.datatype.kind)
 
 
-/***********************************************************************
-**
-**  NUMBERS - Integer and other simple scalars
-**
-***********************************************************************/
-
-struct Reb_Integer {
-    //
-    // On 32-bit platforms, this payload structure begins after a 32-bit
-    // header...hence not a 64-bit aligned location.  Since a REBUPT is
-    // 32-bits on 32-bit platforms and 64-bit on 64-bit, putting one here
-    // right after the header ensures `value` will be on a 64-bit boundary.
-    //
-    // (At time of writing, this is necessary for the "C-to-Javascript"
-    // emscripten build to work.  It's also likely preferred by x86.)
-    //
-    REBUPT padding;
-
-    REBI64 i64;
-};
-
-// !!! Add checking
+//=////////////////////////////////////////////////////////////////////////=//
 //
-#define VAL_INT32(v)    cast(REBINT, (v)->payload.integer.i64)
-#define VAL_UNT32(v)    cast(REBCNT, (v)->payload.integer.i64)
+//  CHAR!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+
+#define MAX_CHAR 0xffff
+
+#define VAL_CHAR(v) \
+    ((v)->payload.character)
+
+inline static void SET_CHAR(RELVAL *v, REBUNI uni) {
+    VAL_RESET_HEADER(v, REB_CHAR);
+    VAL_CHAR(v) = uni;
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  INTEGER!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Integers in Rebol were standardized to use a compiler-provided 64-bit
+// value.  This was formally added to the spec in C99, but many compilers
+// supported it before that.
+//
+// !!! 64-bit extensions were added by the "rebolsource" fork, with much of
+// the code still written to operate on 32-bit values.  Since the standard
+// unit of indexing and block length counts remains 32-bit in that 64-bit
+// build at the moment, many lingering references were left that operated
+// on 32-bit values.  To make this clearer, the macros have been renamed
+// to indicate which kind of integer they retrieve.  However, there should
+// be a general review for reasoning, and error handling + overflow logic
+// for these cases.
+//
 
 #ifdef NDEBUG
-    #define VAL_INT64(v)    ((v)->payload.integer.i64)
+    #define VAL_INT64(v) \
+        ((v)->payload.integer.i64)
 #else
-    #define VAL_INT64(v)    (*VAL_INT64_Ptr_Debug(v))
+    inline static REBI64 *VAL_INT64_Ptr_Debug(const RELVAL *value) {
+        assert(IS_INTEGER(value));
+        return &m_cast(REBVAL*, const_KNOWN(value))->payload.integer.i64;
+    }
+
+    #define VAL_INT64(v) \
+        (*VAL_INT64_Ptr_Debug(v)) // allows lvalue: `VAL_INT64(x) = xxx`
 #endif
 
-#define SET_INTEGER(v,n) \
-    (VAL_RESET_HEADER(v, REB_INTEGER), (v)->payload.integer.i64 = (n))
+inline static void SET_INTEGER(RELVAL *v, REBI64 i64) {
+    VAL_RESET_HEADER(v, REB_INTEGER);
+    v->payload.integer.i64 = i64;
+}
 
-#define MAX_CHAR        0xffff
-#define VAL_CHAR(v)     ((v)->payload.character)
-#define SET_CHAR(v,n) \
-    (VAL_RESET_HEADER((v), REB_CHAR), VAL_CHAR(v) = (n), NOOP)
+#define VAL_INT32(v) \
+    cast(REBINT, VAL_INT64(v))
 
-#define IS_NUMBER(v) \
-    (VAL_TYPE(v) == REB_INTEGER || VAL_TYPE(v) == REB_DECIMAL)
+#define VAL_UNT32(v) \
+    cast(REBCNT, VAL_INT64(v))
 
 
-/***********************************************************************
-**
-**  DECIMAL -- Implementation-wise, a 'double'-precision floating
-**  point number in C (typically 64-bit).
-**
-***********************************************************************/
-
-struct Reb_Decimal {
-    //
-    // See notes on Reb_Integer for why this is needed (handles case of when
-    // `value` is 64-bit, and the platform is 32-bit.)
-    //
-    REBUPT padding;
-
-    REBDEC dec;
-};
-
-#ifdef NDEBUG
-    #define VAL_DECIMAL(v)  ((v)->payload.decimal.dec)
-#else
-    #define VAL_DECIMAL(v)  (*VAL_DECIMAL_Ptr_Debug(v))
-#endif
-
-// !!! Several parts of the code want to access the decimal as "bits", where
-// those bits are cast as a 64-bit integer.  This uses casting, which is bad,
-// but even worse was that it used to use the disengaged integer state of
-// the union.  (so it was calling VAL_INTEGER() on a MONEY! or a DECIMAL!).
-// This at least makes it clear what's happening.
+//=////////////////////////////////////////////////////////////////////////=//
 //
+//  DECIMAL! and PERCENT!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Implementation-wise, the decimal type is a `double`-precision floating
+// point number in C (typically 64-bit).  The percent type uses the same
+// payload, and is currently extracted with VAL_DECIMAL() as well.
+//
+// !!! Calling a floating point type "decimal" appears based on Rebol's
+// original desire to use familiar words and avoid jargon.  It has however
+// drawn criticism from those who don't think it correctly conveys floating
+// point behavior, expecting something else.  Red has renamed the type
+// FLOAT! which may be a good idea.
+//
+
 #ifdef NDEBUG
-    #define VAL_DECIMAL_BITS(v) (*cast(REBI64*, &(v)->payload.decimal.dec))
+    #define VAL_DECIMAL(v) \
+        ((v)->payload.decimal.dec)
+
+    #define VAL_DECIMAL_BITS(v) \
+        (*cast(REBI64*, &(v)->payload.decimal.dec))
 #else
+    inline static REBDEC *VAL_DECIMAL_Ptr_Debug(const RELVAL *value) {
+        assert(IS_DECIMAL(value) || IS_PERCENT(value));
+        return &m_cast(REBVAL*, const_KNOWN(value))->payload.decimal.dec;
+    }
+    #define VAL_DECIMAL(v) \
+        (*VAL_DECIMAL_Ptr_Debug(v)) // allows lvalue: `VAL_DECIMAL(v) = xxx`
+
+    // !!! Several parts of the code wanted to access the decimal as
+    // "bits" through reinterpreting the bits as a 64-bit integer.  In
+    // the general case this is undefined behavior, and should be
+    // changed!  (It's better than it was, because it used to use the
+    // disengaged integer state of the payload union...calling VAL_INT64()
+    // on a MONEY! or a DECIMAL!  This at least points out the problem.)
+    //
     #define VAL_DECIMAL_BITS(v) \
         (*cast(REBI64*, VAL_DECIMAL_Ptr_Debug(v)))
 #endif
 
-#define SET_DECIMAL(v,n) \
-    (VAL_RESET_HEADER(v, REB_DECIMAL), (v)->payload.decimal.dec = (n))
+inline static void SET_DECIMAL(RELVAL *v, REBDEC n) {
+    VAL_RESET_HEADER(v, REB_DECIMAL);
+    v->payload.decimal.dec = n;
+}
 
-#define SET_PERCENT(v,n) \
-    (VAL_RESET_HEADER(v, REB_PERCENT), (v)->payload.decimal.dec = (n))
-
-
-/***********************************************************************
-**
-**  MONEY -- Includes denomination and amount
-**
-**  !!! The naming of "deci" used by MONEY! as "decimal" is a very
-**  bad overlap with DECIMAL! and also not very descriptive of what
-**  the properties of a "deci" are.  Also, to be a useful money
-**  abstraction it should store the currency type, e.g. the three
-**  character ISO 4217 code (~15 bits to store)
-**
-**      https://en.wikipedia.org/wiki/ISO_4217
-**
-***********************************************************************/
-
-struct Reb_Money {
-    deci amount;
-};
-
-#define VAL_MONEY_AMOUNT(v)     ((v)->payload.money.amount)
-#define SET_MONEY_AMOUNT(v,n) \
-    (VAL_RESET_HEADER((v), REB_MONEY), VAL_MONEY_AMOUNT(v) = (n), NOOP)
+inline static void SET_PERCENT(RELVAL *v, REBDEC n) {
+    VAL_RESET_HEADER(v, REB_PERCENT);
+    v->payload.decimal.dec = n;
+}
 
 
-/***********************************************************************
-**
-**  DATE and TIME
-**
-***********************************************************************/
+// !!! There was an IS_NUMBER() macro defined in R3-Alpha which only covered
+// REB_INTEGER and REB_DECIMAL.  But ANY-NUMBER! the typeset included PERCENT!
+// so this adds that and gets rid of IS_NUMBER()
+//
+inline static REBOOL ANY_NUMBER(const RELVAL *v) {
+    return LOGICAL(
+        VAL_TYPE(v) == REB_INTEGER
+        || VAL_TYPE(v) == REB_DECIMAL
+        || VAL_TYPE(v) == REB_PERCENT
+    );
+}
 
-typedef struct reb_ymdz {
-#ifdef ENDIAN_LITTLE
-    REBINT zone:7;  // +/-15:00 res: 0:15
-    REBCNT day:5;
-    REBCNT month:4;
-    REBCNT year:16;
-#else
-    REBCNT year:16;
-    REBCNT month:4;
-    REBCNT day:5;
-    REBINT zone:7;  // +/-15:00 res: 0:15
-#endif
-} REBYMD;
 
-typedef union reb_date {
-    REBYMD date;
-    REBCNT bits;
-} REBDAT;
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  MONEY!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// R3-Alpha's MONEY! type is "unitless" currency, such that $10/$10 = $1
+// (and not 1).  This is because the feature in Rebol2 of being able to
+// store the ISO 4217 code (~15 bits) was not included:
+//
+// https://en.wikipedia.org/wiki/ISO_4217
+//
+// According to @Ladislav:
+//
+// "The money datatype is neither a bignum, nor a fixpoint arithmetic.
+//  It actually is unnormalized decimal floating point."
+//
+// !!! The naming of "deci" used by MONEY! as "decimal" is a confusing overlap
+// with DECIMAL!, although that name may be changing also.
+//
 
-struct Reb_Time {
-    REBI64 time;    // time in nanoseconds
-    REBDAT date;
-};
+#define VAL_MONEY_AMOUNT(v) \
+    ((v)->payload.money.amount)
 
-#define VAL_TIME(v) ((v)->payload.time.time)
-#define TIME_SEC(n) ((REBI64)(n) * 1000000000L)
+inline static void SET_MONEY(RELVAL *v, deci amount) {
+    VAL_RESET_HEADER(v, REB_MONEY);
+    v->payload.money.amount = amount;
+}
 
-#define MAX_SECONDS (((i64)1<<31)-1)
-#define MAX_HOUR    (MAX_SECONDS / 3600)
-#define MAX_TIME    ((REBI64)MAX_HOUR * HR_SEC)
 
-#define NANO        1.0e-9
-#define SEC_SEC     ((REBI64)1000000000L)
-#define MIN_SEC     (60 * SEC_SEC)
-#define HR_SEC      (60 * 60 * SEC_SEC)
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  TIME!
+//
+//=////////////////////////////////////////////////////////////////////////=//
 
-#define SEC_TIME(n)  ((n) * SEC_SEC)
-#define MIN_TIME(n)  ((n) * MIN_SEC)
-#define HOUR_TIME(n) ((n) * HR_SEC)
+#define VAL_TIME(v) \
+    ((v)->payload.time.nanoseconds)
 
-#define SECS_IN(n) ((n) / SEC_SEC)
-#define VAL_SECS(n) (VAL_TIME(n) / SEC_SEC)
+#define TIME_SEC(n) \
+    (cast(REBI64, n) * 1000000000L)
 
-#define DEC_TO_SECS(n) (i64)(((n) + 5.0e-10) * SEC_SEC)
+#define MAX_SECONDS \
+    ((cast(REBI64, 1) << 31) - 1)
+
+#define MAX_HOUR \
+    (MAX_SECONDS / 3600)
+
+#define MAX_TIME \
+    (cast(REBI64, MAX_HOUR) * HR_SEC)
+
+#define NANO 1.0e-9
+
+#define SEC_SEC \
+    cast(REBI64, 1000000000L)
+
+#define MIN_SEC \
+    (60 * SEC_SEC)
+
+#define HR_SEC \
+    (60 * 60 * SEC_SEC)
+
+#define SEC_TIME(n) \
+    ((n) * SEC_SEC)
+
+#define MIN_TIME(n) \
+    ((n) * MIN_SEC)
+
+#define HOUR_TIME(n) \
+    ((n) * HR_SEC)
+
+#define SECS_IN(n) \
+    ((n) / SEC_SEC)
+
+#define VAL_SECS(n) \
+    (VAL_TIME(n) / SEC_SEC)
+
+#define DEC_TO_SECS(n) \
+    cast(REBI64, ((n) + 5.0e-10) * SEC_SEC)
 
 #define SECS_IN_DAY 86400
-#define TIME_IN_DAY (SEC_TIME((i64)SECS_IN_DAY))
 
-#define NO_TIME     MIN_I64
+#define TIME_IN_DAY \
+    SEC_TIME(cast(REBI64, SECS_IN_DAY))
 
-#define MAX_YEAR        0x3fff
+#define NO_TIME MIN_I64
 
-#define VAL_DATE(v)     ((v)->payload.time.date)
-#define VAL_YEAR(v)     ((v)->payload.time.date.date.year)
-#define VAL_MONTH(v)    ((v)->payload.time.date.date.month)
-#define VAL_DAY(v)      ((v)->payload.time.date.date.day)
-#define VAL_ZONE(v)     ((v)->payload.time.date.date.zone)
+inline static void SET_TIME(RELVAL *v, REBI64 nanoseconds) {
+    VAL_RESET_HEADER(v, REB_TIME);
+    VAL_TIME(v) = nanoseconds;
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  DATE!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+
+#define VAL_DATE(v) \
+    ((v)->payload.time.date)
+
+#define MAX_YEAR 0x3fff
+
+#define VAL_YEAR(v) \
+    ((v)->payload.time.date.date.year)
+
+#define VAL_MONTH(v) \
+    ((v)->payload.time.date.date.month)
+
+#define VAL_DAY(v) \
+    ((v)->payload.time.date.date.day)
+
+#define VAL_ZONE(v) \
+    ((v)->payload.time.date.date.zone)
 
 #define ZONE_MINS 15
-#define ZONE_SECS (ZONE_MINS*60)
-#define MAX_ZONE (15 * (60/ZONE_MINS))
 
-#define SET_TIME(v, t) \
-    (VAL_RESET_HEADER(v, REB_TIME), VAL_TIME(v)=(t))
+#define ZONE_SECS \
+    (ZONE_MINS * 60)
 
-/***********************************************************************
-**
-**  TUPLE
-**
-***********************************************************************/
+#define MAX_ZONE \
+    (15 * (60 / ZONE_MINS))
 
-typedef struct Reb_Tuple {
-    REBYTE tuple[12];
-} REBTUP;
 
-#define VAL_TUPLE(v)        ((v)->payload.tuple.tuple + 1)
-#define VAL_TUPLE_LEN(v)    ((v)->payload.tuple.tuple[0])
-#define VAL_TUPLE_DATA(v)   ((v)->payload.tuple.tuple)
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  TUPLE!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// TUPLE! is a Rebol2/R3-Alpha concept to fit up to 10 byte-sized integers
+// directly into a value payload without needing to make a series allocation.
+// At source level they would be numbers separated by dots, like `1.2.3.4.5`.
+// This was mainly applied for IP addresses and RGB/RGBA constants, and
+// considered to be a "lightweight"...it would allow PICK and POKE like a
+// series, but did not behave like one due to not having a position.
+//
+// !!! Ren-C challenges the value of the TUPLE! type as defined.  Color
+// literals are often hexadecimal (where BINARY! would do) and IPv6 addresses
+// have a different notation.  It may be that `.` could be used for a more
+// generalized partner to PATH!, where `a.b.1` would be like a/b/1
+//
+
 #define MAX_TUPLE 10
-#define SET_TUPLE(v, t) \
-    (VAL_RESET_HEADER(v, REB_TIME), \
-    memcpy(VAL_TUPLE_DATA(v), t, sizeof(VAL_TUPLE_DATA(v))))
+
+#define VAL_TUPLE(v) \
+    ((v)->payload.tuple.tuple + 1)
+
+#define VAL_TUPLE_LEN(v) \
+    ((v)->payload.tuple.tuple[0])
+
+#define VAL_TUPLE_DATA(v) \
+    ((v)->payload.tuple.tuple)
+
+inline static void SET_TUPLE(RELVAL *v, const void *data) {
+    VAL_RESET_HEADER(v, REB_TUPLE);
+    memcpy(VAL_TUPLE_DATA(v), data, sizeof(VAL_TUPLE_DATA(v)));
+}
 
 
-
-/***********************************************************************
-**
-**  PAIR
-**
-***********************************************************************/
-
-#define VAL_PAIR(v)     ((v)->payload.pair)
-#define VAL_PAIR_X(v)   ((v)->payload.pair.x)
-#define VAL_PAIR_Y(v)   ((v)->payload.pair.y)
-#define VAL_PAIR_X_INT(v) ROUND_TO_INT((v)->payload.pair.x)
-#define VAL_PAIR_Y_INT(v) ROUND_TO_INT((v)->payload.pair.y)
-
-#define SET_PAIR(v,x,y) \
-    (VAL_RESET_HEADER(v, REB_PAIR),VAL_PAIR_X(v)=(x),VAL_PAIR_Y(v)=(y))
-
-
-/****************************************************************************
-**
-**  ANY-SERIES!
-**
-*****************************************************************************/
-
-union Reb_Binding_Target {
-    REBFUN *relative; // for VALUE_FLAG_RELATIVE
-    REBCTX *specific; // for !VALUE_FLAG_RELATIVE
-};
-
-#define IS_RELATIVE(v) \
-    GET_VAL_FLAG((v), VALUE_FLAG_RELATIVE)
-
-#define IS_SPECIFIC(v) \
-    NOT(IS_RELATIVE(v))
-
+//=////////////////////////////////////////////////////////////////////////=//
 //
-// Only read VAL_RELATIVE and VAL_SPECIFIC through the generic `any_target`.
-// Write via the main payload types (see the notes in Reb_Value_Payload)
+//  PAIR!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// !!! A pair contains two floating point values.  This makes it
+// uncomfortably not able to store two arbitrary INTEGER!s, nor two
+// arbitrary DECIMAL!s.
+//
+#define VAL_PAIR(v) \
+    ((v)->payload.pair)
+
+#define VAL_PAIR_X(v) \
+    ((v)->payload.pair.x)
+
+#define VAL_PAIR_Y(v) \
+    ((v)->payload.pair.y)
+
+#define VAL_PAIR_X_INT(v) \
+    ROUND_TO_INT((v)->payload.pair.x)
+
+#define VAL_PAIR_Y_INT(v) \
+    ROUND_TO_INT((v)->payload.pair.y)
+
+inline static void SET_PAIR(RELVAL *v, float x, float y) {
+    VAL_RESET_HEADER(v, REB_PAIR);
+    VAL_PAIR_X(v) = x;
+    VAL_PAIR_Y(v) = y;
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  BITSET!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// !!! As written, bitsets use the Any_Series structure in their
+// implementation, but are not considered to be an ANY-SERIES! type.
 //
 
-#define VAL_RELATIVE(v) \
-    (assert(IS_RELATIVE(v)), \
-        (v)->payload.any_target.relative)
+#define VAL_BITSET(v) \
+    VAL_SERIES(v)
 
-#ifdef NDEBUG
-    #define VAL_SPECIFIC(v)     ((v)->payload.any_target.specific)
-#else
-    #define VAL_SPECIFIC(v)     VAL_SPECIFIC_Debug(v)
-#endif
+#define Val_Init_Bitset(v,s) \
+    Val_Init_Series((v), REB_BITSET, (s))
 
 
-struct Reb_Any_Series {
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  ANY-SERIES!
+//
+//=////////////////////////////////////////////////////////////////////////=//
+
+inline static REBSER *VAL_SERIES(const RELVAL *v) {
+    assert(ANY_SERIES(v) || IS_MAP(v) || IS_VECTOR(v) || IS_IMAGE(v));
+    return v->payload.any_series.series;
+}
+
+inline static void INIT_VAL_SERIES(RELVAL *v, REBSER *s) {
+    assert(!Is_Array_Series(s));
+    v->payload.any_series.series = s;
+}
+
+#define VAL_INDEX(v) \
+    ((v)->payload.any_series.index)
+
+#define VAL_LEN_HEAD(v) \
+    SER_LEN(VAL_SERIES(v))
+
+inline static REBCNT VAL_LEN_AT(const RELVAL *v) {
+    if (VAL_INDEX(v) >= VAL_LEN_HEAD(v))
+        return 0; // avoid negative index
+    return VAL_LEN_HEAD(v) - VAL_INDEX(v); // take current index into account
+}
+
+inline static REBYTE *VAL_RAW_DATA_AT(const RELVAL *v) {
+    return SER_AT_RAW(SER_WIDE(VAL_SERIES(v)), VAL_SERIES(v), VAL_INDEX(v));
+}
+
+inline static REBMAP *VAL_MAP(const RELVAL *v) {
+    assert(IS_MAP(v));
+
+    // Ren-C introduced const REBVAL* usage, but propagating const vs non
+    // const REBSER pointers didn't show enough benefit to be worth the
+    // work in supporting them (at this time).  Mutability cast needed.
     //
-    // `specifier` is used in ANY-ARRAY! payloads.  It is a pointer to a FRAME!
-    // context which indicates where relatively-bound ANY-WORD! values which
-    // are in the series data can be looked up to get their variable values.
-    // If the array does not contain any relatively bound words then it is
-    // okay for this to be NULL.
-    //
-    union Reb_Binding_Target target;
-
-    // `series` represents the actual physical underlying data, which is
-    // essentially a vector of equal-sized items.  The length of the item
-    // (the series "width") is kept within the REBSER abstraction.  See the
-    // file %sys-series.h for notes.
-    //
-    REBSER *series;
-
-    // `index` is the 0-based position into the series represented by this
-    // ANY-VALUE! (so if it is 0 then that means a Rebol index of 1).
-    //
-    // It is possible that the index could be to a point beyond the range of
-    // the series.  This is intrinsic, because the series can be modified
-    // through other values and not update the others referring to it.  Hence
-    // VAL_INDEX() must be checked, or the routine called with it must.
-    //
-    // !!! Review that it doesn't seem like these checks are being done
-    // in a systemic way.  VAL_LEN_AT() bounds the length at the index
-    // position by the physical length, but VAL_ARRAY_AT() doesn't check.
-    //
-    REBCNT index;
-};
-
-#define VAL_SPECIFIER(v) \
-    (assert(ANY_ARRAY(v)), VAL_SPECIFIC(v))
-
-#define INIT_ARRAY_SPECIFIC(v,context) \
-    (assert(IS_SPECIFIC(v)), \
-        (v)->payload.any_series.target.specific = (context))
-
-#define INIT_ARRAY_RELATIVE(v,func) \
-    (assert(IS_RELATIVE(v)), \
-        (v)->payload.any_series.target.relative = (func))
-
-#ifdef NDEBUG
-    #define VAL_SERIES(v)   ((v)->payload.any_series.series)
-#else
-    #define VAL_SERIES(v)   VAL_SERIES_Debug(v)
-#endif
-
-#define INIT_VAL_SERIES(v,s) \
-    (assert(!Is_Array_Series(s)), (v)->payload.any_series.series = (s))
-
-#define INIT_VAL_ARRAY(v,s) \
-    ((v)->payload.any_series.target.specific = SPECIFIED, \
-    (v)->payload.any_series.series = ARR_SERIES(s))
-
-#define VAL_INDEX(v)        ((v)->payload.any_series.index)
-#define VAL_LEN_HEAD(v)     SER_LEN(VAL_SERIES(v))
-#define VAL_LEN_AT(v)       (Val_Series_Len_At(v))
-
-#define IS_EMPTY(v)         (VAL_INDEX(v) >= VAL_LEN_HEAD(v))
-
-#define VAL_RAW_DATA_AT(v) \
-    SER_AT_RAW(SER_WIDE(VAL_SERIES(v)), VAL_SERIES(v), VAL_INDEX(v))
-
-// Ren-C introduced const REBVAL* usage, but propagating const vs non
-// const REBSER pointers didn't show enough benefit to be worth the
-// work in supporting them (at this time).  Mutability cast needed.
-//
-#define VAL_MAP(v) \
-    (assert(IS_MAP(v)), \
-        AS_MAP(m_cast(REBSER*, (v)->payload.any_series.series)))
-
-// Note: These macros represent things that used to sometimes be functions,
-// and sometimes were not.  They could be done without a function call, but
-// that would then make them unsafe to use with side-effects:
-//
-//     Val_Init_Block(Alloc_Tail_Array(parent), child);
-//
-// The repetitition of the value parameter would lead to the allocation
-// running multiple times.  Hence we Caps_Words_With_Underscore to name
-// these macros to indicate they are safe by not duplicating their args.
-// If erring on the side of caution and making a function call turns out
-// to be a problem in profiling, then on a case-by-case basis those
-// bottlenecks can be replaced with something more like:
-//
-//     VAL_RESET_HEADER(value, REB_XXX);
-//     ENSURE_SERIES_MANAGED(series);
-//     VAL_SERIES(value) = series;
-//     VAL_INDEX(value) = index;
-//
-// (Or perhaps just use proper inlining and support it in those builds.)
+    return AS_MAP(m_cast(RELVAL*, v)->payload.any_series.series);
+}
 
 #define Val_Init_Series_Index(v,t,s,i) \
     Val_Init_Series_Index_Core(SINK(v), (t), (s), (i), SPECIFIED)
@@ -1265,35 +1116,43 @@ struct Reb_Any_Series {
     Val_Init_Series_Index((v), (t), (s), 0)
 
 
-/***********************************************************************
-**
-**  BINARY! (uses `struct Reb_Any_Series`)
-**
-***********************************************************************/
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  BINARY! (uses `struct Reb_Any_Series`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
 
-#define VAL_BIN(v)              BIN_HEAD(VAL_SERIES(v))
-#define VAL_BIN_HEAD(v)         BIN_HEAD(VAL_SERIES(v))
-#define VAL_BIN_AT(v)           BIN_AT(VAL_SERIES(v), VAL_INDEX(v))
-#define VAL_BIN_TAIL(v)         BIN_AT(VAL_SERIES(v), VAL_SERIES(v)->tail)
+#define VAL_BIN(v) \
+    BIN_HEAD(VAL_SERIES(v))
+
+#define VAL_BIN_HEAD(v) \
+    BIN_HEAD(VAL_SERIES(v))
+
+inline static REBYTE *VAL_BIN_AT(const RELVAL *v) {
+    return BIN_AT(VAL_SERIES(v), VAL_INDEX(v));
+}
+
+inline static REBYTE *VAL_BIN_TAIL(const RELVAL *v) {
+    return SER_TAIL(REBYTE, VAL_SERIES(v));
+}
 
 // !!! RE: VAL_BIN_AT_HEAD() see remarks on VAL_ARRAY_AT_HEAD()
 //
-#define VAL_BIN_AT_HEAD(v,n)    BIN_AT(VAL_SERIES(v), (n))
+#define VAL_BIN_AT_HEAD(v,n) \
+    BIN_AT(VAL_SERIES(v), (n))
 
-#define VAL_BYTE_SIZE(v) (BYTE_SIZE(VAL_SERIES(v)))
+#define VAL_BYTE_SIZE(v) \
+    BYTE_SIZE(VAL_SERIES(v))
 
 #define Val_Init_Binary(v,s) \
     Val_Init_Series((v), REB_BINARY, (s))
 
 
-/***********************************************************************
-**
-**  ANY-STRING! (uses `struct Reb_Any_Series`)
-**
-***********************************************************************/
-
-#define VAL_STR_IS_ASCII(v) \
-    (VAL_BYTE_SIZE(v) && All_Bytes_ASCII(VAL_BIN_AT(v), VAL_LEN_AT(v)))
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  ANY-STRING! (uses `struct Reb_Any_Series`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
 
 #define Val_Init_String(v,s) \
     Val_Init_Series((v), REB_STRING, (s))
@@ -1304,38 +1163,80 @@ struct Reb_Any_Series {
 #define Val_Init_Tag(v,s) \
     Val_Init_Series((v), REB_TAG, (s))
 
-// Arg is a unicode value:
-#define VAL_UNI(v)      UNI_HEAD(VAL_SERIES(v))
-#define VAL_UNI_HEAD(v) UNI_HEAD(VAL_SERIES(v))
-#define VAL_UNI_AT(v)   UNI_AT(VAL_SERIES(v), VAL_INDEX(v))
+#define VAL_UNI(v) \
+    UNI_HEAD(VAL_SERIES(v))
 
-#define VAL_ANY_CHAR(v) GET_ANY_CHAR(VAL_SERIES(v), VAL_INDEX(v))
+#define VAL_UNI_HEAD(v) \
+    UNI_HEAD(VAL_SERIES(v))
+
+#define VAL_UNI_AT(v) \
+    UNI_AT(VAL_SERIES(v), VAL_INDEX(v))
+
+#define VAL_ANY_CHAR(v) \
+    GET_ANY_CHAR(VAL_SERIES(v), VAL_INDEX(v))
 
 
-/***********************************************************************
-**
-**  ANY-ARRAY! (uses `struct Reb_Any_Series`)
-**
-***********************************************************************/
-
-// These operations do not need to take the value's index position into
-// account; they strictly operate on the array series
+//=////////////////////////////////////////////////////////////////////////=//
 //
-// Must use `(old_style)cast_here` because we may-or-may-not be casting away
-// constness in the process, e.g. a series extracted from a const REBVAL.
+//  ANY-ARRAY! (uses `struct Reb_Any_Series`)
 //
-#define VAL_ARRAY(v) \
-    (assert(ANY_ARRAY(v)), AS_ARRAY((v)->payload.any_series.series))
+//=////////////////////////////////////////////////////////////////////////=//
 
-#define VAL_ARRAY_HEAD(v)       ARR_HEAD(VAL_ARRAY(v))
-#define VAL_ARRAY_TAIL(v)       ARR_AT(VAL_ARRAY(v), VAL_ARRAY_LEN_AT(v))
+#define EMPTY_BLOCK \
+    ROOT_EMPTY_BLOCK
+
+#define EMPTY_ARRAY \
+    VAL_ARRAY(ROOT_EMPTY_BLOCK)
+
+#define EMPTY_STRING \
+    ROOT_EMPTY_STRING
+
+inline static REBCTX *VAL_SPECIFIER(const REBVAL *v) {
+    assert(ANY_ARRAY(v));
+    return VAL_SPECIFIC(v);
+}
+
+inline static void INIT_ARRAY_SPECIFIC(RELVAL *v, REBCTX *context) {
+    assert(NOT(GET_VAL_FLAG(v, VALUE_FLAG_RELATIVE)));
+    v->payload.any_series.target.specific = context;
+}
+
+inline static void INIT_ARRAY_RELATIVE(RELVAL *v, REBFUN *func) {
+    assert(GET_VAL_FLAG(v, VALUE_FLAG_RELATIVE));
+    v->payload.any_series.target.relative = func;
+}
+
+inline static void INIT_VAL_ARRAY(RELVAL *v, REBARR *a) {
+    SET_VAL_FLAG(v, VALUE_FLAG_ARRAY);
+    v->payload.any_series.target.specific = SPECIFIED;
+    v->payload.any_series.series = ARR_SERIES(a);
+}
 
 // These array operations take the index position into account.  The use
 // of the word AT with a missing index is a hint that the index is coming
 // from the VAL_INDEX() of the value itself.
 //
-#define VAL_ARRAY_AT(v)         ARR_AT(VAL_ARRAY(v), VAL_INDEX(v))
-#define VAL_ARRAY_LEN_AT(v)     VAL_LEN_AT(v)
+#define VAL_ARRAY_AT(v) \
+    ARR_AT(VAL_ARRAY(v), VAL_INDEX(v))
+
+#define VAL_ARRAY_LEN_AT(v) \
+    VAL_LEN_AT(v)
+
+// These operations do not need to take the value's index position into
+// account; they strictly operate on the array series
+//
+inline static REBARR *VAL_ARRAY(const RELVAL *v) {
+    assert(ANY_ARRAY(v));
+    return AS_ARRAY(v->payload.any_series.series);
+}
+
+#define VAL_ARRAY_HEAD(v) \
+    ARR_HEAD(VAL_ARRAY(v))
+
+inline static RELVAL *VAL_ARRAY_TAIL(const RELVAL *v) {
+    return ARR_AT(VAL_ARRAY(v), VAL_ARRAY_LEN_AT(v));
+}
+
 
 // !!! VAL_ARRAY_AT_HEAD() is a leftover from the old definition of
 // VAL_ARRAY_AT().  Unlike SKIP in Rebol, this definition did *not* take
@@ -1351,7 +1252,8 @@ struct Reb_Any_Series {
 #define VAL_ARRAY_AT_HEAD(v,n) \
     ARR_AT(VAL_ARRAY(v), (n))
 
-#define VAL_TERM_ARRAY(v)       TERM_ARRAY(VAL_ARRAY(v))
+#define VAL_TERM_ARRAY(v) \
+    TERM_ARRAY(VAL_ARRAY(v))
 
 #define Val_Init_Array_Index(v,t,a,i) \
     Val_Init_Series_Index((v), (t), ARR_SERIES(a), (i))
@@ -1365,258 +1267,40 @@ struct Reb_Any_Series {
 #define Val_Init_Block(v,s) \
     Val_Init_Block_Index((v), (s), 0)
 
-#define EMPTY_BLOCK     ROOT_EMPTY_BLOCK
-#define EMPTY_ARRAY     VAL_ARRAY(ROOT_EMPTY_BLOCK)
 
-#define EMPTY_STRING \
-    ROOT_EMPTY_STRING
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  SYMBOLS (Used only for symbol tables)
+//
+//=////////////////////////////////////////////////////////////////////////=//
 
-/***********************************************************************
-**
-**  IMAGES, QUADS - RGBA
-**
-***********************************************************************/
+#define VAL_SYM_NINDEX(v) \
+    ((v)->payload.symbol.name)
 
-#define QUAD_LEN(s)         SER_LEN(s)
+#define VAL_SYM_NAME(v) \
+    (BIN_HEAD(PG_Word_Names) + VAL_SYM_NINDEX(v))
 
-#define QUAD_HEAD(s)        SER_DATA_RAW(s)
-#define QUAD_SKIP(s,n)      (QUAD_HEAD(s) + ((n) * 4))
-#define QUAD_TAIL(s)        (QUAD_HEAD(s) + (QUAD_LEN(s) * 4))
+#define VAL_SYM_CANON(v) \
+    ((v)->payload.symbol.canon)
 
-#define IMG_SIZE(s)         ((s)->misc.size)
-#define IMG_WIDE(s)         ((s)->misc.area.wide)
-#define IMG_HIGH(s)         ((s)->misc.area.high)
-#define IMG_DATA(s)         SER_DATA_RAW(s)
+#define VAL_SYM_ALIAS(v) \
+    ((v)->payload.symbol.alias)
 
-#define VAL_IMAGE_HEAD(v)   QUAD_HEAD(VAL_SERIES(v))
-#define VAL_IMAGE_TAIL(v)   QUAD_SKIP(VAL_SERIES(v), VAL_LEN_HEAD(v))
-#define VAL_IMAGE_DATA(v)   QUAD_SKIP(VAL_SERIES(v), VAL_INDEX(v))
-#define VAL_IMAGE_BITS(v)   cast(REBCNT*, VAL_IMAGE_HEAD(v))
-#define VAL_IMAGE_WIDE(v)   (IMG_WIDE(VAL_SERIES(v)))
-#define VAL_IMAGE_HIGH(v)   (IMG_HIGH(VAL_SERIES(v)))
-#define VAL_IMAGE_LEN(v)    VAL_LEN_AT(v)
-
-#define Val_Init_Image(v,s) \
-    Val_Init_Series((v), REB_IMAGE, (s));
-
-//tuple to image! pixel order bytes
-#define TO_PIXEL_TUPLE(t) \
-    TO_PIXEL_COLOR(VAL_TUPLE(t)[0], VAL_TUPLE(t)[1], VAL_TUPLE(t)[2], \
-        VAL_TUPLE_LEN(t) > 3 ? VAL_TUPLE(t)[3] : 0xff)
-
-//tuple to RGBA bytes
-#define TO_COLOR_TUPLE(t) \
-    TO_RGBA_COLOR(VAL_TUPLE(t)[0], VAL_TUPLE(t)[1], VAL_TUPLE(t)[2], \
-        VAL_TUPLE_LEN(t) > 3 ? VAL_TUPLE(t)[3] : 0xff)
-
-
-/***********************************************************************
-**
-**  BIT_SET -- Bit sets
-**
-***********************************************************************/
-
-#define VAL_BITSET(v)   VAL_SERIES(v)
-
-#define VAL_BIT_DATA(v) VAL_BIN(v)
-
-#define SET_BIT(d,n)    ((d)[(n) >> 3] |= (1 << ((n) & 7)))
-#define CLR_BIT(d,n)    ((d)[(n) >> 3] &= ~(1 << ((n) & 7)))
-#define IS_BIT(d,n)     LOGICAL((d)[(n) >> 3] & (1 << ((n) & 7)))
-
-#define Val_Init_Bitset(v,s) \
-    Val_Init_Series((v), REB_BITSET, (s))
-
-
-/***********************************************************************
-**
-**  SYMBOLS -- Used only for symbol tables
-**
-***********************************************************************/
-
-struct Reb_Symbol {
-    REBCNT  canon;  // Index of the canonical (first) word
-    REBCNT  alias;  // Index to next alias form
-    REBCNT  name;   // Index into PG_Word_Names string
-};
-
-// Arg is value:
-#define VAL_SYM_NINDEX(v)   ((v)->payload.symbol.name)
-#define VAL_SYM_NAME(v)     (BIN_HEAD(PG_Word_Names) + VAL_SYM_NINDEX(v))
-#define VAL_SYM_CANON(v)    ((v)->payload.symbol.canon)
-#define VAL_SYM_ALIAS(v)    ((v)->payload.symbol.alias)
-
-// Return the CANON value for a symbol number:
 #define SYMBOL_TO_CANON(sym) \
     VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, sym))
 
-// Return the CANON value for a word value:
 #define WORD_TO_CANON(w) \
     VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, VAL_WORD_SYM(w)))
 
-// Is it the same symbol? Quick check, then canon check:
-#define SAME_SYM(s1,s2) \
-    ((s1) == (s2) \
-    || ( \
-        VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, (s1))) \
-        == VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, (s2))) \
-    ))
+inline static REBOOL SAME_SYM(REBSYM s1, REBSYM s2) {
+    if (s1 == s2)
+        return TRUE; // quick check
 
-
-/***********************************************************************
-**
-**  WORDS -- All word related types
-**
-***********************************************************************/
-
-#ifdef NDEBUG
-    #define WORD_FLAG_X 0
-#else
-    #define WORD_FLAG_X REB_WORD // interpreted to mean ANY-WORD!
-#endif
-
-enum {
-    // `WORD_FLAG_BOUND` answers whether a word is bound, but it may be
-    // relatively bound if `VALUE_FLAG_RELATIVE` is set.  In that case, it
-    // does not have a context pointer but rather a function pointer, that
-    // must be combined with more information to get the FRAME! where the
-    // word should actually be looked up.
-    //
-    // If VALUE_FLAG_RELATIVE is set, then WORD_FLAG_BOUND must also be set.
-    //
-    WORD_FLAG_BOUND = (1 << (TYPE_SPECIFIC_BIT + 0)) | WORD_FLAG_X,
-
-    // A special kind of word is used during argument fulfillment to hold
-    // a refinement's word on the data stack, augmented with its param
-    // and argument location.  This helps fulfill "out-of-order" refinement
-    // usages more quickly without having to do two full arglist walks.
-    //
-    WORD_FLAG_PICKUP = (1 << (TYPE_SPECIFIC_BIT + 1)) | WORD_FLAG_X
-};
-
-struct Reb_Binding {
-    //
-    // The context to look in to find the word's value.  It is valid if the
-    // word has been bound, and null otherwise.
-    //
-    // Note that if the ANY-CONTEXT! to which this word is bound is a FRAME!,
-    // then that frame may no longer be on the stack.  Hence the space for
-    // the variable is no longer allocated.  Tracking mechanisms must be used
-    // to make sure the word can keep track of this fact.
-    //
-    // !!! Tracking mechanism is currently under development.
-    //
-    // Also note that the expense involved in doing a lookup to a context
-    // that is a FRAME! is greater than one that is not (such as an OBJECT!)
-    // This is because in the current implementation, the stack must be
-    // walked to find the required frame.
-    //
-    union Reb_Binding_Target target;
-
-    // Index of word in context (if word is bound, e.g. `context` is not NULL)
-    //
-    // !!! Intended logic is that if the index is positive, then the word
-    // is looked for in the context's pooled memory data pointer.  If the
-    // index is negative or 0, then it's assumed to be a stack variable,
-    // and looked up in the call's `stackvars` data.
-    //
-    // But now there are no examples of contexts which have both pooled
-    // and stack memory, and the general issue of mapping the numbers has
-    // not been solved.  However, both pointers are available to a context
-    // so it's awaiting some solution for a reasonably-performing way to
-    // do the mapping from [1 2 3 4 5 6] to [-3 -2 -1 0 1 2] (or whatever)
-    //
-    REBINT index;
-};
-
-union Reb_Any_Word_Place {
-    struct Reb_Binding binding;
-
-    // The order in which refinements are defined in a function spec may
-    // not match the order in which they are mentioned on a path.  As an
-    // efficiency trick, a word on the data stack representing a refinement
-    // usage request is able to store the pointer to its `param` and `arg`
-    // positions, so that they may be returned to after the later-defined
-    // refinement has had its chance to take the earlier fulfillments.
-    //
-    struct {
-        const RELVAL *param;
-        REBVAL *arg;
-    } pickup;
-};
-
-struct Reb_Any_Word {
-    union Reb_Any_Word_Place place;
-
-    // Index of the word's symbol
-    //
-    // Note: Future expansion plans are to have symbol entries tracked by
-    // pointer and garbage collected, likely as series nodes.  A full pointer
-    // sized value is required here.
-    //
-    REBSYM sym;
-};
-
-#define IS_WORD_BOUND(v) \
-    GET_VAL_FLAG((v), WORD_FLAG_BOUND)
-
-#define IS_WORD_UNBOUND(v) \
-    NOT(IS_WORD_BOUND(v))
-
-#define VAL_WORD_SYM(v) \
-    (assert(ANY_WORD(v)), (v)->payload.any_word.sym)
-#define INIT_WORD_SYM(v,s) \
-    (assert(ANY_WORD(v)), (v)->payload.any_word.sym = (s))
-
-#define VAL_WORD_INDEX(v) \
-    (assert(ANY_WORD(v)), (v)->payload.any_word.place.binding.index)
-
-#ifdef NDEBUG
-    #define INIT_WORD_INDEX(v,i) \
-        ((v)->payload.any_word.place.binding.index = (i))
-#else
-    #define INIT_WORD_INDEX(v,i) \
-        INIT_WORD_INDEX_Debug((v),(i))
-#endif
-
-#define VAL_WORD_CONTEXT(v) \
-    (assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND)), VAL_SPECIFIC(v))
-
-#define INIT_WORD_CONTEXT(v,context) \
-    (assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND) && context != SPECIFIED), \
-        ENSURE_SERIES_MANAGED(CTX_SERIES(context)), \
-        assert(GET_ARR_FLAG(CTX_KEYLIST(context), SERIES_FLAG_MANAGED)), \
-        (v)->payload.any_word.place.binding.target.specific = (context))
-
-#define INIT_WORD_FUNC(v,func) \
-    (assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND)), \
-        (v)->payload.any_word.place.binding.target.relative = (func))
-
-#define VAL_WORD_FUNC(v) \
-    (assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND)), VAL_RELATIVE(v))
-
-#define IS_SAME_WORD(v, n) \
-    (IS_WORD(v) && VAL_WORD_CANON(v) == n)
-
-#ifdef NDEBUG
-    #define UNBIND_WORD(v) \
-        CLEAR_VAL_FLAGS((v), WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE)
-#else
-    #define UNBIND_WORD(v) \
-        (CLEAR_VAL_FLAGS((v), WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE), \
-        (v)->payload.any_word.place.binding.index = 0)
-#endif
-
-#define VAL_WORD_CANON(v) \
-    VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, VAL_WORD_SYM(v)))
-
-#define VAL_WORD_NAME(v) \
-    VAL_SYM_NAME(ARR_AT(PG_Word_Table.array, VAL_WORD_SYM(v)))
-
-#define VAL_WORD_NAME_STR(v)    BIN_HEAD(VAL_WORD_NAME(v))
-
-#define Val_Init_Word(out,kind,sym) \
-    Val_Init_Word_Core((out), (kind), (sym))
+    return LOGICAL(
+        VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, s1))
+        == VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, (s2)))
+    ); // canon check
+}
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -1728,9 +1412,10 @@ enum Reb_Param_Class {
     PARAM_CLASS_MAX
 };
 
-#define PCLASS_ANY_QUOTE_MASK = 0x02
+#define PCLASS_ANY_QUOTE_MASK 0x02
 
-#define PCLASS_MASK (cast(REBUPT, 0x07) << TYPE_SPECIFIC_BIT)
+#define PCLASS_MASK \
+    (cast(REBUPT, 0x07) << TYPE_SPECIFIC_BIT)
 
 
 #ifdef NDEBUG
@@ -1808,15 +1493,6 @@ enum {
     TYPESET_FLAG_LOOKBACK = (1 << (TYPE_SPECIFIC_BIT + 9)) | TYPESET_FLAG_X
 };
 
-struct Reb_Typeset {
-    REBSYM sym;         // Symbol (if a key of object or function param)
-
-    // Note: `sym` is first so that the value's 32-bit Reb_Flags header plus
-    // the 32-bit REBCNT will pad `bits` to a REBU64 alignment boundary
-
-    REBU64 bits;        // One bit for each DATATYPE! (use with FLAGIT_64)
-};
-
 // Operations when typeset is done with a bitset (currently all typesets)
 
 #define VAL_TYPESET_BITS(v) ((v)->payload.typeset.bits)
@@ -1833,7 +1509,15 @@ struct Reb_Typeset {
 
 // Symbol is SYM_0 unless typeset in object keylist or func paramlist
 
-#define VAL_TYPESET_SYM(v) ((v)->payload.typeset.sym)
+inline static REBSYM VAL_TYPESET_SYM(const RELVAL *typeset) {
+    assert(IS_TYPESET(typeset));
+    return typeset->payload.typeset.sym;
+}
+
+inline static void VAL_TYPESET_SYM_INIT(RELVAL *typeset, REBSYM sym) {
+    assert(IS_TYPESET(typeset));
+    typeset->payload.typeset.sym = sym;
+}
 
 #define VAL_TYPESET_CANON(v) \
     VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, VAL_TYPESET_SYM(v)))
@@ -1845,19 +1529,248 @@ struct Reb_Typeset {
 #define WORDS_LAST(w) \
     (WORDS_HEAD(w) + SER_LEN(w) - 1) // (tail never zero)
 
-// Useful variation of FLAGIT_64 for marking a type, as they now involve
-// shifting and possible abstraction vs. simply being 0..63
+inline static enum Reb_Param_Class VAL_PARAM_CLASS(const RELVAL *v) {
+    assert(IS_TYPESET(v));
+    return cast(
+        enum Reb_Param_Class,
+        (v->header.bits & PCLASS_MASK) >> TYPE_SPECIFIC_BIT
+    );
+}
+
+inline static void INIT_VAL_PARAM_CLASS(RELVAL *v, enum Reb_Param_Class c) {
+    v->header.bits &= ~PCLASS_MASK;
+    v->header.bits |= (c << TYPE_SPECIFIC_BIT);
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
 //
-#define FLAGIT_KIND(t)          (cast(REBU64, 1) << TO_0_FROM_KIND(t))
+//  ANY-WORD! (`struct Reb_Any_Word`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+
+#ifdef NDEBUG
+    #define WORD_FLAG_X 0
+#else
+    #define WORD_FLAG_X REB_WORD // interpreted to mean ANY-WORD!
+#endif
+
+enum {
+    // `WORD_FLAG_BOUND` answers whether a word is bound, but it may be
+    // relatively bound if `VALUE_FLAG_RELATIVE` is set.  In that case, it
+    // does not have a context pointer but rather a function pointer, that
+    // must be combined with more information to get the FRAME! where the
+    // word should actually be looked up.
+    //
+    // If VALUE_FLAG_RELATIVE is set, then WORD_FLAG_BOUND must also be set.
+    //
+    WORD_FLAG_BOUND = (1 << (TYPE_SPECIFIC_BIT + 0)) | WORD_FLAG_X,
+
+    // A special kind of word is used during argument fulfillment to hold
+    // a refinement's word on the data stack, augmented with its param
+    // and argument location.  This helps fulfill "out-of-order" refinement
+    // usages more quickly without having to do two full arglist walks.
+    //
+    WORD_FLAG_PICKUP = (1 << (TYPE_SPECIFIC_BIT + 1)) | WORD_FLAG_X
+};
+
+#define IS_WORD_BOUND(v) \
+    GET_VAL_FLAG((v), WORD_FLAG_BOUND)
+
+#define IS_WORD_UNBOUND(v) \
+    NOT(IS_WORD_BOUND(v))
+
+inline static REBSYM VAL_WORD_SYM(const RELVAL *v) {
+    assert(ANY_WORD(v));
+    return v->payload.any_word.sym;
+}
+
+inline static void INIT_WORD_SYM(RELVAL *v, REBSYM sym) {
+    assert(ANY_WORD(v));
+    v->payload.any_word.sym = sym;
+}
+
+inline static void INIT_WORD_CONTEXT(RELVAL *v, REBCTX *context) {
+    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND) && context != SPECIFIED);
+    ENSURE_SERIES_MANAGED(CTX_SERIES(context));
+    assert(GET_ARR_FLAG(CTX_KEYLIST(context), SERIES_FLAG_MANAGED));
+    v->payload.any_word.place.binding.target.specific = context;
+}
+
+inline static REBCTX *VAL_WORD_CONTEXT(const REBVAL *v) {
+    assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
+    return VAL_SPECIFIC(v);
+}
+
+inline static void INIT_WORD_FUNC(RELVAL *v, REBFUN *func) {
+    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND));
+    v->payload.any_word.place.binding.target.relative = func;
+}
+
+inline static REBFUN *VAL_WORD_FUNC(const RELVAL *v) {
+    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND));
+    return VAL_RELATIVE(v);
+}
+
+inline static void INIT_WORD_INDEX(RELVAL *v, REBCNT i) {
+    assert(ANY_WORD(v));
+    assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
+    assert(SAME_SYM(
+        VAL_WORD_SYM(v),
+        IS_RELATIVE(v)
+            ? VAL_TYPESET_SYM(FUNC_PARAM(VAL_WORD_FUNC(v), i))
+            : CTX_KEY_SYM(VAL_WORD_CONTEXT(KNOWN(v)), i)
+    ));
+    v->payload.any_word.place.binding.index = i;
+}
+
+inline static REBCNT VAL_WORD_INDEX(const RELVAL *v) {
+    assert(ANY_WORD(v));
+    return v->payload.any_word.place.binding.index;
+}
+
+inline static void UNBIND_WORD(RELVAL *v) {
+    CLEAR_VAL_FLAGS(v, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
+#if !defined(NDEBUG)
+    v->payload.any_word.place.binding.index = 0;
+#endif
+}
+
+#define VAL_WORD_CANON(v) \
+    VAL_SYM_CANON(ARR_AT(PG_Word_Table.array, VAL_WORD_SYM(v)))
+
+#define VAL_WORD_NAME(v) \
+    VAL_SYM_NAME(ARR_AT(PG_Word_Table.array, VAL_WORD_SYM(v)))
+
+#define VAL_WORD_NAME_STR(v) \
+    BIN_HEAD(VAL_WORD_NAME(v))
+
+#define Val_Init_Word(out,kind,sym) \
+    Val_Init_Word_Core((out), (kind), (sym))
 
 
-#define VAL_PARAM_CLASS(v) \
-    (assert(IS_TYPESET(v)), cast(enum Reb_Param_Class, \
-        ((v)->header.bits & PCLASS_MASK) >> TYPE_SPECIFIC_BIT))
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  FUNCTION! (`struct Reb_Function`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
 
-#define INIT_VAL_PARAM_CLASS(v,c) \
-    ((v)->header.bits &= ~PCLASS_MASK, \
-    (v)->header.bits |= ((c) << TYPE_SPECIFIC_BIT))
+#ifdef NDEBUG
+    #define FUNC_FLAG_X 0
+#else
+    #define FUNC_FLAG_X REB_FUNCTION
+#endif
+
+enum {
+    // RETURN will always be in the last paramlist slot (if present)
+    //
+    FUNC_FLAG_RETURN = (1 << (TYPE_SPECIFIC_BIT + 0)) | FUNC_FLAG_X,
+
+    // LEAVE will always be in the last paramlist slot (if present)
+    //
+    FUNC_FLAG_LEAVE = (1 << (TYPE_SPECIFIC_BIT + 1)) | FUNC_FLAG_X,
+
+    // A function may act as a barrier on its left (so that it cannot act
+    // as an input argument to another function).
+    //
+    // Given the "greedy" nature of infix, a function with arguments cannot
+    // be stopped from infix consumption on its right--because the arguments
+    // would consume them.  Only a function with no arguments is able to
+    // trigger an error when used as a left argument.  This is the ability
+    // given to lookback 0 arity functions, known as "punctuators".
+    //
+    FUNC_FLAG_PUNCTUATES = (1 << (TYPE_SPECIFIC_BIT + 2)) | FUNC_FLAG_X,
+
+#if !defined(NDEBUG)
+    //
+    // TRUE-valued refinements, NONE! for unused args
+    //
+    FUNC_FLAG_LEGACY = (1 << (TYPE_SPECIFIC_BIT + 3)) | FUNC_FLAG_X,
+#endif
+
+    FUNC_FLAG_NO_COMMA // needed for proper comma termination of this list
+};
+
+#ifdef NDEBUG
+    #define VAL_FUNC(v) \
+        ((v)->payload.function.func + 0)
+#else
+    #define VAL_FUNC(v) \
+        VAL_FUNC_Debug(v)
+#endif
+
+inline static REBARR *VAL_FUNC_PARAMLIST(const RELVAL *v)
+    { return FUNC_PARAMLIST(VAL_FUNC(v)); }
+
+inline static REBCNT VAL_FUNC_NUM_PARAMS(const RELVAL *v)
+    { return FUNC_NUM_PARAMS(VAL_FUNC(v)); }
+
+inline static REBVAL *VAL_FUNC_PARAMS_HEAD(const RELVAL *v)
+    { return FUNC_PARAMS_HEAD(VAL_FUNC(v)); }
+
+inline static const REBVAL *VAL_FUNC_PARAM(const RELVAL *v, REBCNT n)
+    { return FUNC_PARAM(VAL_FUNC(v), n); }
+
+inline static RELVAL *VAL_FUNC_BODY(const RELVAL *v)
+    { return ARR_HEAD(v->payload.function.body); }
+
+inline static REBNAT VAL_FUNC_DISPATCHER(const RELVAL *v)
+    { return ARR_SERIES(v->payload.function.body)->misc.dispatcher; }
+
+#define VAL_FUNC_META(v) \
+    (ARR_SERIES(FUNC_PARAMLIST((v)->payload.function.func))->misc.meta)
+
+inline static REBOOL IS_FUNCTION_PLAIN(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Plain_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_ACTION(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Action_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_COMMAND(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Command_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_SPECIALIZER(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Specializer_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_CHAINER(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Chainer_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_ADAPTER(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Adapter_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_RIN(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Routine_Dispatcher); }
+
+inline static REBOOL IS_FUNCTION_HIJACKER(const RELVAL *v)
+    { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Hijacker_Dispatcher); }
+
+inline static REBRIN *VAL_FUNC_ROUTINE(const RELVAL *v) {
+    return cast(REBRIN*, VAL_FUNC_BODY(v)->payload.handle.thing.data);
+}
+
+inline static REBARR *VAL_FUNC_EXIT_FROM(const RELVAL *v)
+    { return v->payload.function.exit_from; }
+
+// !!! At the moment functions are "all durable" or "none durable" w.r.t. the
+// survival of their arguments and locals after the call.
+//
+inline static REBOOL IS_FUNC_DURABLE(REBFUN *f) {
+    return LOGICAL(
+        FUNC_NUM_PARAMS(f) != 0
+        && GET_VAL_FLAG(FUNC_PARAM(f, 1), TYPESET_FLAG_DURABLE)
+    );
+}
+
+// Native values are stored in an array at boot time.  This is a convenience
+// accessor for getting the "FUNC" portion of the native--e.g. the paramlist.
+// It should compile to be as efficient as fetching any global pointer.
+
+#define NAT_VALUE(name) \
+    (&Natives[N_##name##_ID])
+
+#define NAT_FUNC(name) \
+    (NAT_VALUE(name)->payload.function.func)
+
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -1895,50 +1808,27 @@ struct Reb_Typeset {
 // entire REBVAL if it is needed.
 //
 
-struct Reb_Any_Context {
-    //
-    // Unless it copies the keylist, a context cannot uniquely describe a
-    // "special" instance of an archetype function it is bound to.  This
-    // field needs to be combined with the FUNC_VALUE of a frame context
-    // to get the full definition.
-    //
-    REBARR *exit_from;
-
-    // `varlist` is a Rebol Array that from 1..NUM_VARS contains REBVALs
-    // representing the stored values in the context.
-    //
-    // As with the `paramlist` of a FUNCTION!, the varlist uses the [0]th
-    // element specially.  It stores a copy of the ANY-CONTEXT! value that
-    // refers to itself.
-    //
-    // The `keylist` is held in the varlist's Reb_Series.misc field, and it
-    // may be shared with an arbitrary number of other contexts.  Changing
-    // the keylist involves making a copy if it is shared.
-    //
-    // REB_MODULE depends on a property stored in the "meta" miscellaneous
-    // field of the keylist, which is another object's-worth of data *about*
-    // the module's contents (e.g. the processed header)
-    //
-    REBCTX *context; // !!! TBD: change to REBARR*, rename as varlist
-
-    union {
-        // Used by REB_FRAME.  This is the call that corresponded to the
-        // FRAME! at the time it was created.  The pointer becomes invalid if
-        // the call ends, so the flags on the context must be consulted to
-        // see if it indicates the stack is over before using.
-        //
-        // Note: This is technically just a cache, as the stack could be
-        // walked to find it given the frame.
-        //
-        struct Reb_Frame *frame;
-    } more;
-};
-
-#define VAL_CONTEXT(v) \
-    (assert(ANY_CONTEXT(v)), (v)->payload.any_context.context)
+inline static REBCTX *VAL_CONTEXT(const RELVAL *v) {
+    assert(ANY_CONTEXT(v));
+    return v->payload.any_context.context;
+}
 
 #define INIT_VAL_CONTEXT(v,c) \
     ((v)->payload.any_context.context = (c))
+
+#define VAL_CONTEXT_SPEC(v) \
+    ((v)->payload.any_context.more.spec)
+
+#define VAL_CONTEXT_FRAME(v) \
+    ((v)->payload.any_context.more.frame)
+
+// Convenience macros to speak in terms of object values instead of the context
+//
+#define VAL_CONTEXT_VAR(v,n) \
+    CTX_VAR(VAL_CONTEXT(v), (n))
+
+#define VAL_CONTEXT_KEY(v,n) \
+    CTX_KEY(VAL_CONTEXT(v), (n))
 
 #define VAL_CONTEXT_META(v) \
     (ARR_SERIES(CTX_KEYLIST((v)->payload.any_context.context))->misc.meta)
@@ -1946,20 +1836,31 @@ struct Reb_Any_Context {
 #define VAL_CONTEXT_EXIT_FROM(v) \
     ((v)->payload.any_context.exit_from)
 
-#define VAL_CONTEXT_STACKVARS(v) \
-    cast(REBVAL*, (v)->payload.any_context.more.frame->stackvars)
+inline static REBCNT VAL_CONTEXT_STACKVARS_LEN(const RELVAL *v) {
+    assert(ANY_CONTEXT(v));
+    return CHUNK_LEN_FROM_VALUES(VAL_CONTEXT_STACKVARS(v));
+}
 
-#define VAL_CONTEXT_STACKVARS_LEN(v) \
-    (assert(ANY_CONTEXT(v)), \
-        CHUNK_LEN_FROM_VALUES(VAL_CONTEXT_STACKVARS(v)))
+#define VAL_CONTEXT_KEY_SYM(v,n) \
+    CTX_KEY_SYM(VAL_CONTEXT(v), (n))
 
-#define VAL_CONTEXT_FRAME(v)        ((v)->payload.any_context.more.frame)
+inline static void INIT_CONTEXT_SPEC(REBCTX *c, REBCTX *spec) {
+    assert(!IS_FRAME(CTX_VALUE(c)));
+    VAL_CONTEXT_SPEC(CTX_VALUE(c)) = spec;
+}
 
-// Convenience macros to speak in terms of object values instead of the context
-//
-#define VAL_CONTEXT_VAR(v,n)        CTX_VAR(VAL_CONTEXT(v), (n))
-#define VAL_CONTEXT_KEY(v,n)        CTX_KEY(VAL_CONTEXT(v), (n))
-#define VAL_CONTEXT_KEY_SYM(v,n)    CTX_KEY_SYM(VAL_CONTEXT(v), (n))
+inline static void INIT_CONTEXT_FRAME(REBCTX *c, struct Reb_Frame *frame) {
+    assert(IS_FRAME(CTX_VALUE(c)));
+    VAL_CONTEXT_FRAME(CTX_VALUE(c)) = frame;
+}
+
+#define INIT_CONTEXT_META(c,s) \
+    (VAL_CONTEXT_META(CTX_VALUE(c)) = (s))
+
+inline static REBVAL *CTX_FRAME_FUNC_VALUE(const REBCTX *c) {
+    assert(IS_FUNCTION(CTX_ROOTKEY(c)));
+    return CTX_ROOTKEY(c);
+}
 
 // The movement of the SELF word into the domain of the object generators
 // means that an object may wind up having a hidden SELF key (and it may not).
@@ -1975,20 +1876,14 @@ struct Reb_Any_Context {
 // and which do not remains to be seen, so this macro helps review the + 1
 // more easily than if it were left as just + 1.
 //
-#define SELFISH(n) (n + 1)
+#define SELFISH(n) \
+    ((n) + 1)
 
 #define Val_Init_Context(out,kind,context) \
     Val_Init_Context_Core(SINK(out), (kind), (context))
 
 #define Val_Init_Object(v,c) \
     Val_Init_Context((v), REB_OBJECT, (c))
-
-
-/***********************************************************************
-**
-**  PORTS - External series interface
-**
-***********************************************************************/
 
 #define Val_Init_Port(v,c) \
     Val_Init_Context((v), REB_PORT, (c))
@@ -2015,271 +1910,25 @@ struct Reb_Any_Context {
 // `fail()` C macro inside the source, and the various routines in %c-error.c
 //
 
-#define ERR_VARS(e)     cast(ERROR_VARS*, CTX_VARS_HEAD(e))
-#define ERR_NUM(e)      cast(REBCNT, VAL_INT32(&ERR_VARS(e)->code))
+#define ERR_VARS(e) \
+    cast(ERROR_VARS*, CTX_VARS_HEAD(e))
 
-#define VAL_ERR_VARS(v)     ERR_VARS(VAL_CONTEXT(v))
-#define VAL_ERR_NUM(v)      ERR_NUM(VAL_CONTEXT(v))
+#define ERR_NUM(e) \
+    cast(REBCNT, VAL_INT32(&ERR_VARS(e)->code))
+
+#define VAL_ERR_VARS(v) \
+    ERR_VARS(VAL_CONTEXT(v))
+
+#define VAL_ERR_NUM(v) \
+    ERR_NUM(VAL_CONTEXT(v))
 
 #define Val_Init_Error(v,c) \
     Val_Init_Context((v), REB_ERROR, (c))
 
 
-/***********************************************************************
-**
-**  FUNCTIONS - Natives, actions, operators, and user functions
-**
-**  NOTE: make-headers.r will skip specs with the "REBNATIVE(" in them
-**  REBTYPE macros are used and expanded in tmp-funcs.h
-**
-***********************************************************************/
-
-#ifdef NDEBUG
-    #define FUNC_FLAG_X 0
-#else
-    #define FUNC_FLAG_X REB_FUNCTION // interpreted to mean ANY-FUNCTION!
-#endif
-
-enum {
-    // RETURN will always be in the last paramlist slot (if present)
-    //
-    FUNC_FLAG_RETURN = (1 << (TYPE_SPECIFIC_BIT + 0)) | FUNC_FLAG_X,
-
-    // LEAVE will always be in the last paramlist slot (if present)
-    //
-    FUNC_FLAG_LEAVE = (1 << (TYPE_SPECIFIC_BIT + 1)) | FUNC_FLAG_X,
-
-    // A function may act as a barrier on its left (so that it cannot act
-    // as an input argument to another function).
-    //
-    // Given the "greedy" nature of infix, a function with arguments cannot
-    // be stopped from infix consumption on its right--because the arguments
-    // would consume them.  Only a function with no arguments is able to
-    // trigger an error when used as a left argument.  This is the ability
-    // given to lookback 0 arity functions, known as "punctuators".
-    //
-    FUNC_FLAG_PUNCTUATES = (1 << (TYPE_SPECIFIC_BIT + 2)) | FUNC_FLAG_X,
-
-#if !defined(NDEBUG)
-    //
-    // TRUE-valued refinements, NONE! for unused args
-    //
-    FUNC_FLAG_LEGACY = (1 << (TYPE_SPECIFIC_BIT + 3)) | FUNC_FLAG_X,
-#endif
-
-    FUNC_FLAG_NO_COMMA // needed for proper comma termination of this list
-};
-
-
-// enums in C have no guaranteed size, yet Rebol wants to use known size
-// types in its interfaces.  Hence REB_R is a REBCNT from reb-c.h (and not
-// this enumerated type containing its legal values).
-enum {
-    R_OUT = 0,
-
-    // See comments on OPT_VALUE_THROWN about the migration of "thrownness"
-    // from being a property signaled to the evaluator.
-    //
-    // R_OUT_IS_THROWN is a test of that signaling mechanism.  It is currently
-    // being kept in parallel with the THROWN() bit and ensured as matching.
-    // Being in the state of doing a stack unwind will likely be knowable
-    // through other mechanisms even once the thrown bit on the value is
-    // gone...so it may not be the case that natives are asked to do their
-    // own separate indication, so this may wind up replaced with R_OUT.  For
-    // the moment it is good as a double-check.
-    //
-    R_OUT_IS_THROWN,
-
-    // This is a return value in service of the /? functions.  Since all
-    // dispatchers receive an END marker in the f->out slot (a.k.a. D_OUT)
-    // then it can be used to tell if the output has been written "in band"
-    // by a legal value or void.  This returns TRUE if D_OUT is not END,
-    // and FALSE if it still is.
-    //
-    R_OUT_TRUE_IF_WRITTEN,
-
-    // Similar to R_OUT_WRITTEN_Q, this converts an illegal END marker return
-    // value in R_OUT to simply a void.
-    //
-    R_OUT_VOID_IF_UNWRITTEN,
-
-    // !!! These R_ values are somewhat superfluous...and actually inefficient
-    // because they have to be checked by the caller in a switch statement
-    // to take the equivalent action.  They have a slight advantage in
-    // hand-written C code for making it more clear that if you have used
-    // the D_OUT return slot for temporary work that you explicitly want
-    // to specify another result...this cannot be caught by the REB_TRASH
-    // trick for detecting an unwritten D_OUT.
-    //
-    R_VOID, // => SET_VOID(D_OUT); return R_OUT;
-    R_BLANK, // => SET_BLANK(D_OUT); return R_OUT;
-    R_TRUE, // => SET_TRUE(D_OUT); return R_OUT;
-    R_FALSE, // => SET_FALSE(D_OUT); return R_OUT;
-
-    // If Do_Core gets back an R_REDO from a dispatcher, it will re-execute
-    // the f->func in the frame.  This function may be changed by the
-    // dispatcher from what was originally called.
-    //
-    R_REDO
-};
-typedef REBCNT REB_R;
-
-// Convenience function for getting the "/?" behavior if it is enabled, and
-// doing the default thing--assuming END is being left in the D_OUT slot
-//
-inline static REB_R R_OUT_Q(REBOOL q) {
-    if (q) return R_OUT_TRUE_IF_WRITTEN;
-    return R_OUT_VOID_IF_UNWRITTEN;
-}
-
-
-// NATIVE! function
-typedef REB_R (*REBNAT)(struct Reb_Frame *frame_);
-#define REBNATIVE(n) \
-    REB_R N_##n(struct Reb_Frame *frame_)
-
-// ACTION! function (one per each DATATYPE!)
-typedef REB_R (*REBACT)(struct Reb_Frame *frame_, REBCNT a);
-#define REBTYPE(n) \
-    REB_R T_##n(struct Reb_Frame *frame_, REBCNT action)
-
-// PORT!-action function
-typedef REB_R (*REBPAF)(struct Reb_Frame *frame_, REBCTX *p, REBCNT a);
-
-// COMMAND! function
-typedef REB_R (*CMD_FUNC)(REBCNT n, REBSER *args);
-
-typedef struct Reb_Routine_Info REBRIN;
-
-struct Reb_Function {
-    //
-    // Definitionally-scoped returns introduced the idea of there being a
-    // unique property on a per-REBVAL instance for the natives RETURN and
-    // LEAVE, in order to identify that instance of the "archetypal" natives
-    // relative to a specific frame or function.  This idea has overlap with
-    // the Reb_Binding_Target, and may be unified for this common cell slot.
-    //
-    REBARR *exit_from;
-
-    // `paramlist` is a Rebol Array whose 1..NUM_PARAMS values are all
-    // TYPESET! values, with an embedded symbol (a.k.a. a "param") as well
-    // as other bits, including the parameter class (PARAM_CLASS).  This
-    // is the list that is processed to produce WORDS-OF and which is
-    // consulted during invocation to fulfill the arguments.
-    //
-    // In addition, its [0]th element contains a FUNCTION! value which is
-    // self-referentially the function itself.  This means that the paramlist
-    // can be passed around as a single pointer from which a whole REBVAL
-    // for the function can be found.
-    //
-    // The `misc` field of the function series is `spec`, which contains data
-    // passed to MAKE FUNCTION! to create the `paramlist`.  After the
-    // paramlist has been generated, it is not generally processed by the
-    // code and remains mostly to be scanned by user mode code to make HELP.
-    // As "metadata" it is not kept in the canon value itself so it can be
-    // updated or augmented by functions like `redescribe` without worrying
-    // about all the Reb_Function REBVALs that are extant.
-    //
-    REBFUN *func; // !!! TBD: change to REBARR*, rename as paramlist
-
-    // `body` is always a REBARR--even an optimized "singular" one that is
-    // only the size of one REBSER.  This is because the information for a
-    // function body is an array in the majority of function instances, and
-    // also because it can standardize the native dispatcher code in the
-    // REBARR's series "misc" field.  This gives two benefits: no need for
-    // a switch on the function's type to figure out the dispatcher, and also
-    // to move the dispatcher out of the REBVAL itself into something that
-    // can be revectored or "hooked" for all instances of the function.
-    //
-    // PLAIN FUNCTIONS: body array is... the body of the function, obviously
-    // NATIVES: body is "equivalent code for native" (if any) in help
-    // ACTIONS: body is a 1-element array containing an INTEGER!
-    // SPECIALIZATIONS: body is a 1-element array containing a FRAME!
-    // CALLBACKS: body is a 1-element array with a HANDLE! (REBRIN*)
-    // ROUTINES: body is a 1-element array with a HANDLE! (REBRIN*)
-    //
-    REBARR *body;
-};
-
-/* argument is of type REBVAL* */
-#ifdef NDEBUG
-    #define VAL_FUNC(v)             ((v)->payload.function.func + 0)
-#else
-    #define VAL_FUNC(v)             VAL_FUNC_Debug(v)
-#endif
-
-#define VAL_FUNC_PARAMLIST(v)       FUNC_PARAMLIST(VAL_FUNC(v))
-#define VAL_FUNC_META(v) \
-    (ARR_SERIES(FUNC_PARAMLIST((v)->payload.function.func))->misc.meta)
-
-#define VAL_FUNC_NUM_PARAMS(v)      FUNC_NUM_PARAMS(VAL_FUNC(v))
-#define VAL_FUNC_PARAMS_HEAD(v)     FUNC_PARAMS_HEAD(VAL_FUNC(v))
-#define VAL_FUNC_PARAM(v,p)         FUNC_PARAM(VAL_FUNC(v), (p))
-
-#define VAL_FUNC_DISPATCH(v) \
-    cast(REBNAT, ARR_SERIES((v)->payload.function.body)->misc.dispatch)
-
-#define IS_FUNCTION_PLAIN(v) \
-    (VAL_FUNC_DISPATCH(v) == &Plain_Dispatcher)
-
-#define IS_FUNCTION_ACTION(v) \
-    (VAL_FUNC_DISPATCH(v) == &Action_Dispatcher)
-
-#define IS_FUNCTION_COMMAND(v) \
-    (VAL_FUNC_DISPATCH(v) == &Command_Dispatcher)
-
-#define IS_FUNCTION_SPECIALIZER(v) \
-    (VAL_FUNC_DISPATCH(v) == &Specializer_Dispatcher)
-
-#define IS_FUNCTION_ADAPTER(v) \
-    (VAL_FUNC_DISPATCH(v) == &Adapter_Dispatcher)
-
-#define IS_FUNCTION_CHAINER(v) \
-    (VAL_FUNC_DISPATCH(v) == &Chainer_Dispatcher)
-
-#define IS_FUNCTION_RIN(v) \
-    (VAL_FUNC_DISPATCH(v) == &Routine_Dispatcher)
-
-#define IS_FUNCTION_HIJACKER(v) \
-    (VAL_FUNC_DISPATCH(v) == &Hijacker_Dispatcher)
-
-#define VAL_FUNC_BODY(v) \
-    (ARR_HEAD((v)->payload.function.body) + 0)
-
-#define VAL_FUNC_ACT(v) \
-    cast(REBCNT, VAL_INT32(VAL_FUNC_BODY(v)))
-
-#define VAL_FUNC_INFO(v) \
-    cast(REBRIN*, VAL_HANDLE_DATA(VAL_FUNC_BODY(v)))
-
-#define VAL_FUNC_EXEMPLAR(v) \
-    KNOWN(VAL_FUNC_BODY(v))
-
-#define VAL_FUNC_EXIT_FROM(v) ((v)->payload.function.exit_from)
-
-// !!! At the moment functions are "all durable" or "none durable" w.r.t. the
-// survival of their arguments and locals after the call.  This corresponds
-// to the CLOSURE! and FUNCTION! distinction for the moment, and brings
-// about two things: specific binding *and* durability.
-//
-#define IS_FUNC_DURABLE(f) \
-    LOGICAL(VAL_FUNC_NUM_PARAMS(f) != 0 \
-        && GET_VAL_FLAG(VAL_FUNC_PARAM((f), 1), TYPESET_FLAG_DURABLE))
-
-// Native values are stored in an array at boot time.  This is a convenience
-// accessor for getting the "FUNC" portion of the native--e.g. the paramlist.
-// It should compile to be as efficient as fetching any global pointer.
-
-#define NAT_VALUE(name) \
-    (&Natives[N_##name##_ID])
-
-#define NAT_FUNC(name) \
-    (NAT_VALUE(name)->payload.function.func)
-
-
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// VARARGS! (`struct Reb_Varargs`)
+//  VARARGS! (`struct Reb_Varargs`)
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
@@ -2316,52 +1965,22 @@ enum {
     VARARGS_FLAG_NO_FRAME = (1 << (TYPE_SPECIFIC_BIT + 0)) | VARARGS_FLAG_X
 };
 
-struct Reb_Varargs {
-    //
-    // This is a FRAME! which was on the stack at the time when the VARARGS!
-    // was created.  However it may no longer be on the stack--and once it is
-    // not, it cannot respond to requests to be advanced.  The frame keeps
-    // a flag to test for this as long as this VARARGS! is GC-managed.
-    //
-    // Note that this frame reuses its EVAL slot to hold a value for any
-    // "sub-varargs" that is being processed, so that is the first place it
-    // looks to get the next item.
-    //
-    union {
-        REBARR *varlist; // might be an in-progress varlist if not managed
+inline static const RELVAL *VAL_VARARGS_PARAM(const RELVAL *v)
+    { return v->payload.varargs.param; }
 
-        REBARR *array1; // for MAKE VARARGS! to share a reference on an array
-    } feed;
+inline static REBVAL *VAL_VARARGS_ARG(const RELVAL *v)
+    { return v->payload.varargs.arg; }
 
-    // For as long as the VARARGS! can be used, the function it is applying
-    // will be alive.  Assume that the locked paramlist won't move in memory
-    // (evaluation would break if so, anyway) and hold onto the TYPESET!
-    // describing the parameter.  Each time a value is fetched from the EVAL
-    // then type check it for convenience.  Use ANY-VALUE! if not wanted.
-    //
-    // Note: could be a parameter index in the worst case scenario that the
-    // array grew, revisit the rules on holding pointers into paramlists.
-    //
-    const RELVAL *param;
+inline static REBCTX *VAL_VARARGS_FRAME_CTX(const RELVAL *v) {
+    assert(
+        GET_ARR_FLAG((v)->payload.varargs.feed.varlist, SERIES_FLAG_MANAGED)
+    );
+    return AS_CONTEXT((v)->payload.varargs.feed.varlist);
+}
 
-    // Similar to the param, the arg is only good for the lifetime of the
-    // FRAME!...but even less so, because VARARGS! can (currently) be
-    // overwritten with another value in the function frame at any point.
-    // Despite this, we proxy the VALUE_FLAG_EVALUATED from the last TAKE
-    // onto the argument to reflect its *argument* status.
-    //
-    REBVAL *arg;
-};
+inline static REBARR *VAL_VARARGS_ARRAY1(const RELVAL *v)
+    { return v->payload.varargs.feed.array1; }
 
-#define VAL_VARARGS_FRAME_CTX(v) \
-    (assert(GET_ARR_FLAG( \
-        (v)->payload.varargs.feed.varlist, SERIES_FLAG_MANAGED)), \
-    AS_CONTEXT((v)->payload.varargs.feed.varlist))
-
-#define VAL_VARARGS_ARRAY1(v) ((v)->payload.varargs.feed.array1)
-
-#define VAL_VARARGS_PARAM(v) ((v)->payload.varargs.param)
-#define VAL_VARARGS_ARG(v) ((v)->payload.varargs.arg)
 
 // The subfeed is either the varlist of the frame of another varargs that is
 // being chained at the moment, or the `array1` of another varargs.  To
@@ -2369,30 +1988,25 @@ struct Reb_Varargs {
 // payload bits--so it's in the `eval` slot of a frame or the misc slot
 // of the array1.
 //
-#define SUBFEED_ADDR_OF_FEED(a) \
-    (GET_ARR_FLAG((a), ARRAY_FLAG_CONTEXT_VARLIST) \
-        ? &CTX_FRAME(AS_CONTEXT(a))->cell.subfeed \
-        : &ARR_SERIES(a)->misc.subfeed)
+inline static REBARR **SUBFEED_ADDR_OF_FEED(REBARR *a) {
+    return GET_ARR_FLAG(a, ARRAY_FLAG_CONTEXT_VARLIST)
+        ? &CTX_FRAME(AS_CONTEXT(a))->cell.subfeed
+        : &ARR_SERIES(a)->misc.subfeed;
+}
 
 
-/***********************************************************************
-**
-**  HANDLE
-**
-**  Type for holding an arbitrary code or data pointer inside
-**  of a Rebol data value.  What kind of function or data is not
-**  known to the garbage collector, so it ignores it.
-**
-**  !!! Review usages of this type where they occur
-**
-***********************************************************************/
-
-struct Reb_Handle {
-    union {
-        CFUNC *code;
-        void *data;
-    } thing;
-};
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  HANDLE! (`struct Reb_Handle`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Type for holding an arbitrary code or data pointer inside of a Rebol data
+// value.  What kind of function or data is not known to the garbage collector,
+// so it ignores it.
+//
+// !!! Review usages of this type where they occur.
+//
 
 #define VAL_HANDLE_CODE(v) \
     ((v)->payload.handle.thing.code)
@@ -2400,33 +2014,39 @@ struct Reb_Handle {
 #define VAL_HANDLE_DATA(v) \
     ((v)->payload.handle.thing.data)
 
-#define SET_HANDLE_CODE(v,c) \
-    (VAL_RESET_HEADER((v), REB_HANDLE), VAL_HANDLE_CODE(v) = (c))
+#define VAL_HANDLE_NUMBER(v) \
+    ((v)->payload.handle.thing.number)
 
-#define SET_HANDLE_DATA(v,d) \
-    (VAL_RESET_HEADER((v), REB_HANDLE), VAL_HANDLE_DATA(v) = (d))
+inline static void SET_HANDLE_CODE(RELVAL *v, CFUNC *code) {
+    VAL_RESET_HEADER(v, REB_HANDLE);
+    VAL_HANDLE_CODE(v) = code;
+}
 
-// !!! The logic used to be an I32 but now it's folded in as a value flag
-// Usages of this should be reviewed.
+inline static void SET_HANDLE_DATA(RELVAL *v, void *data) {
+    VAL_RESET_HEADER(v, REB_HANDLE);
+    VAL_HANDLE_DATA(v) = data;
+}
+
+inline static void SET_HANDLE_NUMBER(RELVAL *v, REBUPT number) {
+    VAL_RESET_HEADER(v, REB_HANDLE);
+    VAL_HANDLE_NUMBER(v) = number;
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
 //
-#define VAL_I32(v) ((v)->payload.rebcnt)
-
-
-/***********************************************************************
-**
-**  LIBRARY -- External library management structures
-**
-***********************************************************************/
-
-typedef struct Reb_Library_Handle {
-    void * fd;
-    REBUPT flags;
-} REBLHL; // sizeof(REBLHL) % 8 must equal 0 on both 64-bit and 32-bit builds
-
-struct Reb_Library {
-    REBLHL *handle;
-    REBARR *spec;
-};
+//  LIBRARY! (`struct Reb_Library`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// A library represents a loaded .DLL or .so file.  This contains native
+// code, which can be executed either through the "COMMAND" method (Rebol
+// extensions) or the FFI interface.
+//
+// !!! The COMMAND method of extension is being deprecated by Ren-C, instead
+// leaning on the idea of writing new natives using the same API that
+// the system uses internally.
+//
 
 #define LIB_FD(v)           ((v)->fd)
 #define LIB_FLAGS(v)        ((v)->flags)
@@ -2459,55 +2079,59 @@ enum {
 #define CLOSE_LIB(s)        LIB_SET_FLAG(s, LIB_CLOSED)
 #define OPEN_LIB(s)         LIB_CLR_FLAG(s, LIB_CLOSED)
 
-/***********************************************************************
-**
-**  STRUCT -- C Structures
-**
-***********************************************************************/
 
-typedef struct Reb_Struct {
-    REBARR  *spec;
-    REBSER  *fields;    // fields definition
-    REBSER  *data;
-} REBSTU;
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  STRUCT! (`struct Reb_Struct`)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Struct is used by the FFI code to describe the layout of a C `struct`,
+// so that Rebol data can be proxied to a C function call.
+//
+// !!! Atronix added the struct type to get coverage in the FFI, and it is
+// possible to make and extract structure data even if one is not calling
+// a routine at all.  This might not be necessary, in that the struct
+// description could be an ordinary OBJECT! which is used in FFI specs
+// and tells how to map data into a Rebol object used as a target.
+//
 
-#define VAL_STRUCT(v)           ((v)->payload.structure)
-#define VAL_STRUCT_SPEC(v)      ((v)->payload.structure.spec)
-#define VAL_STRUCT_FIELDS(v)    ((v)->payload.structure.fields)
-#define VAL_STRUCT_DATA(v)      ((v)->payload.structure.data)
-#define VAL_STRUCT_DP(v)        (BIN_HEAD(VAL_STRUCT_DATA(v)))
+#define VAL_STRUCT(v) \
+    ((v)->payload.structure)
+
+#define VAL_STRUCT_SPEC(v) \
+    ((v)->payload.structure.spec)
+
+#define VAL_STRUCT_FIELDS(v) \
+    ((v)->payload.structure.fields)
+
+#define VAL_STRUCT_DATA(v) \
+    ((v)->payload.structure.data)
+
+#define VAL_STRUCT_DP(v) \
+    BIN_HEAD(VAL_STRUCT_DATA(v))
 
 
-/***********************************************************************
-**
-**  ROUTINE -- External library routine structures
-**
-***********************************************************************/
-struct Reb_Routine_Info {
-    union {
-        struct {
-            REBLHL  *lib;
-            CFUNC *funcptr;
-        } rot;
-        struct {
-            void *closure;
-            REBFUN *func;
-            void *dispatcher;
-        } cb;
-    } info;
-    void    *cif;
-    REBSER  *arg_types; /* index 0 is the return type, */
-    REBARR  *fixed_args;
-    REBARR  *all_args;
-    REBARR  *arg_structs; /* for struct arguments */
-    REBSER  *extra_mem; /* extra memory that needs to be free'ed */
-    REBCNT  flags; // !!! 32-bit...should it use REBFLGS for 64-bit on 64-bit?
-    REBINT  abi;
-
-    REBUPT padding; // sizeof(Reb_Routine_Info) % 8 must be 0 for Make_Node()
-};
-
-typedef REBFUN REBROT;
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  ROUTINE SUPPORT
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// A routine is an interface to calling a C function, which uses the libffi
+// library.
+//
+// !!! Previously, ROUTINE! was an ANY-FUNCTION! category (like NATIVE!,
+// COMMAND!, ACTION!, etc.)  Ren-C unified these under a single FUNCTION!
+// type for the purposes of interface (included in the elimination of the
+// CLOSURE! vs. FUNCTION! distinction).
+//
+// Since MAKE ROUTINE! wouldn't work (without some hacks in the compatibility
+// layer), MAKE-ROUTINE was introduced as a native that returns a FUNCTION!.
+// This opens the door to having MAKE-ROUTINE be a user function which then
+// generates another user function which calls a simpler native to dispatch
+// its work.  That review is pending.
+//
 
 enum {
     ROUTINE_MARK = 1,       // routine was found during GC mark scan.
@@ -2516,33 +2140,38 @@ enum {
     ROUTINE_VARIADIC = 1 << 3 //this is a FFI function with a va_list interface
 };
 
-/* argument is REBFCN */
-
-#define ROUTINE_META(v)             FUNC_META(v)
-#define ROUTINE_INFO(v)             FUNC_INFO(v)
-#define ROUTINE_PARAMLIST(v)        FUNC_PARAMLIST(v)
-#define ROUTINE_FUNCPTR(v)          (ROUTINE_INFO(v)->info.rot.funcptr)
-#define ROUTINE_LIB(v)              (ROUTINE_INFO(v)->info.rot.lib)
-#define ROUTINE_ABI(v)              (ROUTINE_INFO(v)->abi)
-#define ROUTINE_FFI_ARG_TYPES(v)    (ROUTINE_INFO(v)->arg_types)
-#define ROUTINE_FIXED_ARGS(v)       (ROUTINE_INFO(v)->fixed_args)
-#define ROUTINE_ALL_ARGS(v)         (ROUTINE_INFO(v)->all_args)
-#define ROUTINE_FFI_ARG_STRUCTS(v)  (ROUTINE_INFO(v)->arg_structs)
-#define ROUTINE_EXTRA_MEM(v)        (ROUTINE_INFO(v)->extra_mem)
-#define ROUTINE_CIF(v)              (ROUTINE_INFO(v)->cif)
-#define ROUTINE_RVALUE(v)           VAL_STRUCT(ARR_HEAD(ROUTINE_FFI_ARG_STRUCTS(v)))
-#define ROUTINE_CLOSURE(v)          (ROUTINE_INFO(v)->info.cb.closure)
-#define ROUTINE_DISPATCHER(v)       (ROUTINE_INFO(v)->info.cb.dispatcher)
-#define CALLBACK_FUNC(v)            (ROUTINE_INFO(v)->info.cb.func)
-
 /* argument is REBRIN */
 
-#define RIN_FUNCPTR(v)              ((v)->info.rot.funcptr)
-#define RIN_LIB(v)                  ((v)->info.rot.lib)
-#define RIN_CLOSURE(v)              ((v)->info.cb.closure)
-#define RIN_FUNC(v)                 ((v)->info.cb.func)
-#define RIN_ARGS_STRUCTS(v)         ((v)->arg_structs)
-#define RIN_RVALUE(v)               VAL_STRUCT(ARR_HEAD(RIN_ARGS_STRUCTS(v)))
+#define RIN_FUNCPTR(r)          ((r)->info.rot.funcptr)
+#define RIN_LIB(r)              ((r)->info.rot.lib)
+#define RIN_ABI(r)              ((r)->abi)
+#define RIN_FFI_ARG_TYPES(r)    ((r)->arg_types)
+#define RIN_FIXED_ARGS(r)       ((r)->fixed_args)
+#define RIN_ALL_ARGS(r)         ((r)->all_args)
+#define RIN_ARGS_STRUCTS(r)     ((r)->arg_structs)
+#define RIN_EXTRA_MEM(r)        ((r)->extra_mem)
+#define RIN_CIF(r)              ((r)->cif)
+#define RIN_RVALUE(r)           VAL_STRUCT(ARR_HEAD(RIN_ARGS_STRUCTS(r)))
+#define RIN_CLOSURE(r)          ((r)->info.cb.closure)
+#define RIN_DISPATCHER(r)       ((r)->info.cb.dispatcher)
+#define RIN_CALLBACK_FUNC(r)    ((r)->info.cb.func)
+
+
+/* argument is REBFUN */
+
+#define ROUTINE_FUNCPTR(v)          (FUNC_ROUTINE(v)->info.rot.funcptr)
+#define ROUTINE_LIB(v)              (FUNC_ROUTINE(v)->info.rot.lib)
+#define ROUTINE_ABI(v)              (FUNC_ROUTINE(v)->abi)
+#define ROUTINE_FFI_ARG_TYPES(v)    (FUNC_ROUTINE(v)->arg_types)
+#define ROUTINE_FIXED_ARGS(v)       (FUNC_ROUTINE(v)->fixed_args)
+#define ROUTINE_ALL_ARGS(v)         (FUNC_ROUTINE(v)->all_args)
+#define ROUTINE_FFI_ARG_STRUCTS(v)  (FUNC_ROUTINE(v)->arg_structs)
+#define ROUTINE_EXTRA_MEM(v)        (FUNC_ROUTINE(v)->extra_mem)
+#define ROUTINE_CIF(v)              (FUNC_ROUTINE(v)->cif)
+#define ROUTINE_RVALUE(v)           VAL_STRUCT(ARR_HEAD(ROUTINE_FFI_ARG_STRUCTS(v)))
+#define ROUTINE_CLOSURE(v)          (FUNC_ROUTINE(v)->info.cb.closure)
+#define ROUTINE_DISPATCHER(v)       (FUNC_ROUTINE(v)->info.cb.dispatcher)
+#define CALLBACK_FUNC(v)            (FUNC_ROUTINE(v)->info.cb.func)
 
 #define ROUTINE_FLAGS(s)       ((s)->flags)
 #define ROUTINE_SET_FLAG(s, f) (ROUTINE_FLAGS(s) |= (f))
@@ -2552,311 +2181,172 @@ enum {
 #define IS_CALLBACK_ROUTINE(s) ROUTINE_GET_FLAG(s, ROUTINE_CALLBACK)
 
 /* argument is REBVAL */
-#define VAL_ROUTINE(v)              VAL_FUNC(v)
-#define VAL_ROUTINE_META(v)         VAL_FUNC_META(v)
-#define VAL_ROUTINE_INFO(v)         VAL_FUNC_INFO(v)
-#define VAL_ROUTINE_PARAMLIST(v)    VAL_FUNC_PARAMLIST(v)
-#define VAL_ROUTINE_FUNCPTR(v)      (VAL_ROUTINE_INFO(v)->info.rot.funcptr)
-#define VAL_ROUTINE_LIB(v)          (VAL_ROUTINE_INFO(v)->info.rot.lib)
-#define VAL_ROUTINE_ABI(v)          (VAL_ROUTINE_INFO(v)->abi)
-#define VAL_ROUTINE_FFI_ARG_TYPES(v)    (VAL_ROUTINE_INFO(v)->arg_types)
-#define VAL_ROUTINE_FIXED_ARGS(v)   (VAL_ROUTINE_INFO(v)->fixed_args)
-#define VAL_ROUTINE_ALL_ARGS(v)     (VAL_ROUTINE_INFO(v)->all_args)
-#define VAL_ROUTINE_FFI_ARG_STRUCTS(v)  (VAL_ROUTINE_INFO(v)->arg_structs)
-#define VAL_ROUTINE_EXTRA_MEM(v)    (VAL_ROUTINE_INFO(v)->extra_mem)
-#define VAL_ROUTINE_CIF(v)          (VAL_ROUTINE_INFO(v)->cif)
+#define VAL_ROUTINE_FUNCPTR(v)      (VAL_FUNC_ROUTINE(v)->info.rot.funcptr)
+#define VAL_ROUTINE_LIB(v)          (VAL_FUNC_ROUTINE(v)->info.rot.lib)
+#define VAL_ROUTINE_ABI(v)          (VAL_FUNC_ROUTINE(v)->abi)
+#define VAL_ROUTINE_FFI_ARG_TYPES(v)    (VAL_FUNC_ROUTINE(v)->arg_types)
+#define VAL_ROUTINE_FIXED_ARGS(v)   (VAL_FUNC_ROUTINE(v)->fixed_args)
+#define VAL_ROUTINE_ALL_ARGS(v)     (VAL_FUNC_ROUTINE(v)->all_args)
+#define VAL_ROUTINE_FFI_ARG_STRUCTS(v)  (VAL_FUNC_ROUTINE(v)->arg_structs)
+#define VAL_ROUTINE_EXTRA_MEM(v)    (VAL_FUNC_ROUTINE(v)->extra_mem)
+#define VAL_ROUTINE_CIF(v)          (VAL_FUNC_ROUTINE(v)->cif)
 
 #define VAL_ROUTINE_RVALUE(v) \
-    VAL_STRUCT(ARR_HEAD(VAL_ROUTINE_INFO(v)->arg_structs))
+    VAL_STRUCT(ARR_HEAD(VAL_FUNC_ROUTINE(v)->arg_structs))
 
-#define VAL_ROUTINE_CLOSURE(v)      (VAL_ROUTINE_INFO(v)->info.cb.closure)
-#define VAL_ROUTINE_DISPATCHER(v)   (VAL_ROUTINE_INFO(v)->info.cb.dispatcher)
-#define VAL_CALLBACK_FUNC(v)        (VAL_ROUTINE_INFO(v)->info.cb.func)
-
-
-/***********************************************************************
-**
-**  EVENT
-**
-***********************************************************************/
-
-#define VAL_EVENT_TYPE(v)   ((v)->payload.event.type)  //(VAL_EVENT_INFO(v) & 0xff)
-#define VAL_EVENT_FLAGS(v)  ((v)->payload.event.flags) //((VAL_EVENT_INFO(v) >> 16) & 0xff)
-#define VAL_EVENT_WIN(v)    ((v)->payload.event.win)   //((VAL_EVENT_INFO(v) >> 24) & 0xff)
-#define VAL_EVENT_MODEL(v)  ((v)->payload.event.model)
-#define VAL_EVENT_DATA(v)   ((v)->payload.event.data)
-#define VAL_EVENT_TIME(v)   ((v)->payload.event.time)
-#define VAL_EVENT_REQ(v)    ((v)->payload.event.eventee.req)
-
-#define VAL_EVENT_SER(v)    ((v)->payload.event.eventee.ser)
-
-#define IS_EVENT_MODEL(v,f) (VAL_EVENT_MODEL(v) == (f))
-
-#define SET_EVENT_INFO(val, type, flags, win) \
-    VAL_EVENT_TYPE(val)=type, VAL_EVENT_FLAGS(val)=flags, VAL_EVENT_WIN(val)=win
-    //VAL_EVENT_INFO(val) = (type | (flags << 16) | (win << 24))
-
-#define VAL_EVENT_X(v)      ((REBINT) (short) (VAL_EVENT_DATA(v) & 0xffff))
-#define VAL_EVENT_Y(v)      ((REBINT) (short) ((VAL_EVENT_DATA(v) >> 16) & 0xffff))
-#define VAL_EVENT_XY(v)     (VAL_EVENT_DATA(v))
-#define SET_EVENT_XY(v,x,y) VAL_EVENT_DATA(v) = ((y << 16) | (x & 0xffff))
-
-#define VAL_EVENT_KEY(v)    (VAL_EVENT_DATA(v) & 0xffff)
-#define VAL_EVENT_KCODE(v)  ((VAL_EVENT_DATA(v) >> 16) & 0xffff)
-#define SET_EVENT_KEY(v,k,c) VAL_EVENT_DATA(v) = ((c << 16) + k)
-
-#define IS_KEY_EVENT(type)  0
-
-
-/***********************************************************************
-**
-**  GOBS - Graphic Objects
-**
-***********************************************************************/
-
-#pragma pack() // set back to default (was set to 4 at start of file)
-    #include "reb-gob.h"
-#pragma pack(4) // resume packing with 4
-
-struct Reb_Gob {
-    REBGOB *gob;
-    REBCNT index;
-};
-
-#define VAL_GOB(v)          ((v)->payload.gob.gob)
-#define VAL_GOB_INDEX(v)    ((v)->payload.gob.index)
-#define SET_GOB(v,g) \
-    (VAL_RESET_HEADER(v, REB_GOB), VAL_GOB(v) = g, VAL_GOB_INDEX(v) = 0)
+#define VAL_ROUTINE_CLOSURE(v)      (VAL_FUNC_ROUTINE(v)->info.cb.closure)
+#define VAL_ROUTINE_DISPATCHER(v)   (VAL_FUNC_ROUTINE(v)->info.cb.dispatcher)
+#define VAL_CALLBACK_FUNC(v)        (VAL_FUNC_ROUTINE(v)->info.cb.func)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  VALUE PAYLOAD DEFINITION (`struct Reb_Value`)
+//  EVENT!
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// The value is defined to have the header first, and then the value.  Having
-// the header come first is taken advantage of by the trick for allowing
-// a single REBUPT-sized value (32-bit on 32 bit builds, 64-bit on 64-bit
-// builds) be examined to determine if a value is an END marker or not.
+// Rebol's events are used for the GUI and for network and I/O.  They are
+// essentially just a union of some structures which are packed so they can
+// fit into a REBVAL's payload size.
 //
-// One aspect of having the header before the payload is that on 32-bit
-// platforms, this means that the starting address of the payload is not on
-// a 64-bit alignment boundary.  This means placing a quantity that needs
-// 64-bit alignment at the start of a payload can cause problems on some
-// platforms with strict alignment requirements.
+// The available event models are:
 //
-// (Note: The reason why this can happen at all is due to the #pragma pack(4)
-// that is put in effect at the top of this file.)
-//
-// See Reb_Integer, Reb_Decimal, and Reb_Typeset for examples where the 64-bit
-// quantity is padded by a pointer or pointer-sized-REBUPT to compensate.
+// * EVM_PORT
+// * EVM_OBJECT
+// * EVM_DEVICE
+// * EVM_CALLBACK
+// * EVM_GUI
 //
 
-// Reb_All is a structure type designed specifically for getting at
-// the underlying bits of whichever union member is in effect inside
-// the Reb_Value_Data.  This is not actually legal, although if types
-// line up in unions it could be possibly be made "more legal":
-//
-//     http://stackoverflow.com/questions/11639947/
-//
-struct Reb_All {
-#if defined(__LP64__) || defined(__LLP64__)
-    REBCNT bits[6];
-#else
-    REBCNT bits[3];
-#endif
-};
+#define VAL_EVENT_TYPE(v) \
+    ((v)->payload.event.type)
 
-#define VAL_ALL_BITS(v) ((v)->payload.all.bits)
+#define VAL_EVENT_FLAGS(v) \
+    ((v)->payload.event.flags)
 
-union Reb_Value_Payload {
-    struct Reb_All all;
+#define VAL_EVENT_WIN(v) \
+    ((v)->payload.event.win)
 
-    REBUNI character; // It's CHAR! (for now), but 'char' is a C keyword
+#define VAL_EVENT_MODEL(v) \
+    ((v)->payload.event.model)
 
-    struct Reb_Integer integer;
-    struct Reb_Decimal decimal;
+#define VAL_EVENT_DATA(v) \
+    ((v)->payload.event.data)
 
-    struct Reb_Pair pair;
-    struct Reb_Money money;
-    struct Reb_Handle handle;
-    struct Reb_Time time;
-    struct Reb_Tuple tuple;
-    struct Reb_Datatype datatype;
-    struct Reb_Typeset typeset;
+#define VAL_EVENT_TIME(v) \
+    ((v)->payload.event.time)
 
-    // Both Any_Word and Any_Series have a Reb_Binding_Target as the first
-    // item in their payloads.  Since Reb_Value_Payload is a union, C permits
-    // the *reading* of common leading elements from another union member,
-    // even if that wasn't the last union written.  While this has been a
-    // longstanding informal assumption in C, the standard has adopted it:
-    //
-    //     http://stackoverflow.com/a/11996970/211160
-    //
-    // So `any_target` can be used to read the binding target out of either
-    // an ANY-WORD! or ANY-SERIES! payload.  To be on the safe side, *writing*
-    // should likely be specifically through `any_word` or `any_series`.
-    //
-    union Reb_Binding_Target any_target;
-        struct Reb_Any_Word any_word;
-        struct Reb_Any_Series any_series;
+#define VAL_EVENT_REQ(v) \
+    ((v)->payload.event.eventee.req)
 
-    struct Reb_Any_Context any_context;
+#define VAL_EVENT_SER(v) \
+    ((v)->payload.event.eventee.ser)
 
-    struct Reb_Function function;
+#define IS_EVENT_MODEL(v,f) \
+    (VAL_EVENT_MODEL(v) == (f))
 
-    struct Reb_Varargs varargs;
+inline static void SET_EVENT_INFO(RELVAL *val, u8 type, u8 flags, u8 win) {
+    VAL_EVENT_TYPE(val) = type;
+    VAL_EVENT_FLAGS(val) = flags;
+    VAL_EVENT_WIN(val) = win;
+}
 
-    REBCNT rebcnt; // !!! used by extensions, review
-    struct Reb_Library library;
-    struct Reb_Struct structure; // It's STRUCT!, but 'struct' is a C keyword
+// Position event data
 
-    struct Reb_Event event;
-    struct Reb_Gob gob;
+#define VAL_EVENT_X(v) \
+    cast(REBINT, cast(short, VAL_EVENT_DATA(v) & 0xffff))
 
-    struct Reb_Symbol symbol; // internal
+#define VAL_EVENT_Y(v) \
+    cast(REBINT, cast(short, (VAL_EVENT_DATA(v) >> 16) & 0xffff))
 
-#if !defined(NDEBUG) && defined(TRACK_EMPTY_PAYLOADS)
-    struct Reb_Track track; // debug only (for void/trash, NONE!, LOGIC!, BAR!)
-#endif
-};
+#define VAL_EVENT_XY(v) \
+    (VAL_EVENT_DATA(v))
 
-struct Reb_Value
-{
-    struct Reb_Value_Header header;
-    union Reb_Value_Payload payload;
-};
+inline static void SET_EVENT_XY(RELVAL *v, REBINT x, REBINT y) {
+    VAL_EVENT_DATA(v) = ((y << 16) | (x & 0xffff));
+}
 
-#pragma pack() // set back to default (was set to 4 at start of file)
+// Key event data
 
+#define VAL_EVENT_KEY(v) \
+    (VAL_EVENT_DATA(v) & 0xffff)
 
-#ifdef __cplusplus
-    struct Reb_Specific_Value : public Reb_Value {
-    #if !defined(NDEBUG)
-        //
-        // In C++11, it is now formally legal to add constructors to types
-        // without interfering with their "standard layout" properties, or
-        // making them uncopyable with memcpy(), etc.  For the rules, see:
-        //
-        //     http://stackoverflow.com/a/7189821/211160
-        //
-        // In the debug C++ build there is an extra check of writability. This
-        // makes sure that stack variables holding REBVAL are marked with that.
-        // It also means that the check can only be performed by the C++ build,
-        // otherwise there would need to be a manual set of this bit on every
-        // stack variable.
-        //
-        Reb_Specific_Value () {
-            header.bits = WRITABLE_MASK_DEBUG;
-        }
-    #endif
-    };
-#endif
+#define VAL_EVENT_KCODE(v) \
+    ((VAL_EVENT_DATA(v) >> 16) & 0xffff)
+
+inline static void SET_EVENT_KEY(RELVAL *v, REBCNT k, REBCNT c) {
+    VAL_EVENT_DATA(v) = ((c << 16) + k);
+}
 
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  REBVAL ("fully specified" value) and RELVAL ("possibly relative" value)
+//  IMAGE!
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// RELVAL exists to help quarantine the bit patterns for relative words into
-// the deep-copied-body of the function they are for.  To actually look them
-// up, they must be paired with a FRAME! matching the actual instance of the
-// running function on the stack they correspond to.  Once made specific,
-// a word may then be freely copied into any REBVAL slot.
-//
-// In addition to ANY-WORD!, an ANY-ARRAY! can also be relative, if it is
-// part of the deep-copied function body.  The reason that arrays must be
-// relative too is in case they contain relative words.  If they do, then
-// recursion into them must carry forward the resolving "specifier" pointer
-// to be combined with any relative words that are seen later.
-//
-// A relative value pointer is allowed to point to a specific value, but a
-// relative word or array cannot be pointed to by a REBVAL*.
+// !!! Ren-C's primary goals are to research and pin down fundamentals, where
+// things like IMAGE! would be an extension through a user-defined type
+// vs. being in the core.  The R3-Alpha code has been kept compiling here
+// due to its usage in R3-GUI.
 //
 
-// When you have a RELVAL* (e.g. from a REBARR) that you "know" to be specific,
-// this macro can be used for that.  Checks to make sure in debug build.
-//
-// Use for: "invalid conversion from 'Reb_Value*' to 'Reb_Specific_Value*'"
-//
-#ifdef NDEBUG
-    #define const_KNOWN(v)      cast(const REBVAL*, (v))
-    #define KNOWN(v)            cast(REBVAL*, (v))
-#else
-    #define const_KNOWN(v)      const_KNOWN_Debug(v)
-    #define KNOWN(v)            KNOWN_Debug(v)
-#endif
+// QUAD=(Red, Green, Blue, Alpha)
 
-// To make it easier to look for places that think they aren't dealing
-// with any relative values, pass this as the specifier instead of NULL.
-//
-#define SPECIFIED cast(REBCTX*, 0xF10F10F1)
-#define GUESSED SPECIFIED // document sites where you're not sure it's specific
+#define QUAD_LEN(s) \
+    SER_LEN(s)
 
-// A very small subset of code wants to be able to work with a relative
-// function body in an unbound way.  If it were not able to, then the debug
-// dumping of a relativized function body's values would have to copy (which
-// would undermine the debug operation by doing a complex operation) or
-// the system would have to be generally tolerant of "lying" specifiers.
-// Instead, you can combine the array with ARCHETYPED.
-//
-// !!! Review this and if it can be made debug build only.
-//
-#define ARCHETYPED cast(REBCTX*, 0xB10B10B1)
+#define QUAD_HEAD(s) \
+    SER_DATA_RAW(s)
 
-// This can be used to turn a RELVAL into a REBVAL.  If the RELVAL is
-// indeed relative and needs to be made specific to be put into the
-// REBVAL, then the specifier is used to do that.  Debug builds assert
-// that the function in the specifier indeed matches the target in
-// the relative value (because relative values in an array may only
-// be relative to the function that deep copied them, and that is the
-// only kind of specifier you can use with them).
-//
-#define COPY_VALUE_MACRO(dest,src,specifier) \
-    do { \
-        if (IS_RELATIVE(src)) { \
-            (dest)->header.bits = (src)->header.bits & ~VALUE_FLAG_RELATIVE; \
-            if (ANY_ARRAY(src)) { \
-                (dest)->payload.any_series.target.specific = (specifier); \
-                (dest)->payload.any_series.series \
-                    = (src)->payload.any_series.series; \
-                (dest)->payload.any_series.index \
-                    = (src)->payload.any_series.index; \
-            } \
-            else { \
-                assert(ANY_WORD(src)); \
-                (dest)->payload.any_word.place.binding.target.specific \
-                    = (specifier); \
-                (dest)->payload.any_word.place.binding.index \
-                    = (src)->payload.any_word.place.binding.index; \
-                (dest)->payload.any_word.sym = (src)->payload.any_word.sym; \
-            } \
-        } \
-        else { \
-            (dest)->header = (src)->header; \
-            (dest)->payload = (src)->payload; \
-        } \
-    } while (0)
+#define QUAD_SKIP(s,n) \
+    (QUAD_HEAD(s) + ((n) * 4))
 
+#define QUAD_TAIL(s) \
+    (QUAD_HEAD(s) + (QUAD_LEN(s) * 4))
 
-#ifdef NDEBUG
-    #define COPY_VALUE(dest,src,specifier) \
-        COPY_VALUE_Release(SINK(dest),(src),(specifier))
-#else
-    #define COPY_VALUE(dest,src,specifier) \
-        COPY_VALUE_Debug(SINK(dest),(src),(specifier))
-#endif
+#define IMG_WIDE(s) \
+    ((s)->misc.area.wide)
 
-#ifdef NDEBUG
-    #define ASSERT_NO_RELATIVE(array,deep) \
-        NOOP
-#else
-    #define ASSERT_NO_RELATIVE(array,deep) \
-        Assert_No_Relative((array),(deep))
-#endif
+#define IMG_HIGH(s) \
+    ((s)->misc.area.high)
+
+#define IMG_DATA(s) \
+    SER_DATA_RAW(s)
+
+#define VAL_IMAGE_HEAD(v) \
+    QUAD_HEAD(VAL_SERIES(v))
+
+#define VAL_IMAGE_TAIL(v) \
+    QUAD_SKIP(VAL_SERIES(v), VAL_LEN_HEAD(v))
+
+#define VAL_IMAGE_DATA(v) \
+    QUAD_SKIP(VAL_SERIES(v), VAL_INDEX(v))
+
+#define VAL_IMAGE_BITS(v) \
+    cast(REBCNT*, VAL_IMAGE_HEAD(v))
+
+#define VAL_IMAGE_WIDE(v) \
+    (IMG_WIDE(VAL_SERIES(v)))
+
+#define VAL_IMAGE_HIGH(v) \
+    (IMG_HIGH(VAL_SERIES(v)))
+
+#define VAL_IMAGE_LEN(v) \
+    VAL_LEN_AT(v)
+
+#define Val_Init_Image(v,s) \
+    Val_Init_Series((v), REB_IMAGE, (s));
+
+//tuple to image! pixel order bytes
+#define TO_PIXEL_TUPLE(t) \
+    TO_PIXEL_COLOR(VAL_TUPLE(t)[0], VAL_TUPLE(t)[1], VAL_TUPLE(t)[2], \
+        VAL_TUPLE_LEN(t) > 3 ? VAL_TUPLE(t)[3] : 0xff)
+
+//tuple to RGBA bytes
+#define TO_COLOR_TUPLE(t) \
+    TO_RGBA_COLOR(VAL_TUPLE(t)[0], VAL_TUPLE(t)[1], VAL_TUPLE(t)[2], \
+        VAL_TUPLE_LEN(t) > 3 ? VAL_TUPLE(t)[3] : 0xff)
 
 
 // In the C++ build, defining this overload that takes a REBVAL* instead of
@@ -2869,37 +2359,33 @@ void COPY_VALUE_Debug(REBVAL *dest, const REBVAL *src, REBCTX *specifier);
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  DEBUG PROBE AND PANIC
+//  GOB! Graphic Object
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// The PROBE macro can be used in debug builds to mold a REBVAL much like the
-// Rebol `probe` operation.  PROBE_MSG can add a message:
+// !!! The GOB! is a datatype specific to R3-View.  Its data is a small
+// fixed-size object.  It is linked together by series containing more
+// GOBs and values, and participates in the garbage collection process.
 //
-//     REBVAL *v = Some_Value_Pointer();
-//
-//     PROBE(v);
-//     PROBE_MSG(v, "the v value debug dump label");
-//
-// In order to make it easier to find out where a piece of debug spew is
-// coming from, the file and line number will be output as well.
-//
-// PANIC_VALUE causes a crash on a value, while trying to provide information
-// that could identify where that value was assigned.  If it is resident
-// in a series and you are using Address Sanitizer or Valgrind, then it should
-// cause a crash that pinpoints the stack where that array was allocated.
+// The monolithic structure of Rebol had made it desirable to take advantage
+// of the memory pooling to quickly allocate, free, and garbage collect
+// these.  If the GOB! is to become part of an extension mechanism for
+// user-defined types (and hence not present in minimalist configurations)
+// then this would require either exporting the memory pools as part of
+// the service or expecting clients to use malloc or do their own pooling.
 //
 
-#if !defined(NDEBUG)
-    #define PROBE(v) \
-        Probe_Core_Debug(NULL, __FILE__, __LINE__, (v))
+#define VAL_GOB(v) \
+    ((v)->payload.gob.gob)
 
-    #define PROBE_MSG(v, m) \
-        Probe_Core_Debug((m), __FILE__, __LINE__, (v))
+#define VAL_GOB_INDEX(v) \
+    ((v)->payload.gob.index)
 
-    #define PANIC_VALUE(v) \
-        Panic_Value_Debug((v), __FILE__, __LINE__)
-#endif
+inline static void SET_GOB(RELVAL *v, REBGOB *g) {
+    VAL_RESET_HEADER(v, REB_GOB);
+    VAL_GOB(v) = g;
+    VAL_GOB_INDEX(v) = 0;
+}
 
 #define Panic_Value(v) \
     PANIC_VALUE(v)
@@ -2920,14 +2406,7 @@ void COPY_VALUE_Debug(REBVAL *dest, const REBVAL *src, REBCTX *specifier);
 #define PUSH_GUARD_VALUE(v) \
     Guard_Value_Core(v)
 
-#define DROP_GUARD_VALUE(v) \
-    do { \
-        GC_Value_Guard->content.dynamic.len--; \
-        assert((v) == cast(RELVAL **, \
-            GC_Value_Guard->content.dynamic.data)[ \
-                GC_Value_Guard->content.dynamic.len \
-            ]); \
-    } while (0)
-
-
-#endif // %sys-value.h
+inline static void DROP_GUARD_VALUE(RELVAL *v) {
+    assert(v == *SER_LAST(RELVAL*, GC_Value_Guard));
+    GC_Value_Guard->content.dynamic.len--;
+}

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -85,9 +85,17 @@ make-action: func [
     ; COLLECT-WORDS interface to efficiently give this result.
     ;
     spec: copy spec
+
+    ; Insert <durable> into the spec if not already there.  This is
+    ; based on the belief that indefinite duration is a fair user expectation
+    ; without having to ask.  Consider the legitimacy of:
+    ;
+    ;    foo: function [x] [y: x * 2 | return func [z] [x + y + z]
+    ;
     unless find spec <durable> [
         insert spec <durable>
     ]
+
     for-next words [
         append spec to set-word! words/1
     ]

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -557,8 +557,13 @@ emit {
 #define ANY_BINSTR(v) \
     LOGICAL(VAL_TYPE(v) >= REB_BINARY && VAL_TYPE(v) <= REB_TAG)
 
+// Accelerated by a value flag
+//
+// #define ANY_ARRAY(v)
+//   LOGICAL(VAL_TYPE(v) >= REB_BLOCK && VAL_TYPE(v) <= REB_LIT_PATH)
+
 #define ANY_ARRAY(v) \
-    LOGICAL(VAL_TYPE(v) >= REB_BLOCK && VAL_TYPE(v) <= REB_LIT_PATH)
+    GET_VAL_FLAG((v), VALUE_FLAG_ARRAY)
 
 #define ANY_WORD(v) \
     LOGICAL(VAL_TYPE(v) >= REB_WORD && VAL_TYPE(v) <= REB_ISSUE)
@@ -572,7 +577,6 @@ emit {
 #define ANY_CONTEXT(v) \
     LOGICAL(VAL_TYPE(v) >= REB_OBJECT && VAL_TYPE(v) <= REB_PORT)
 }
-
 
 emit {
 /***********************************************************************
@@ -1024,7 +1028,6 @@ write inc/reb-evtypes.h out
 emit-head "Error Structure and Constants" %errnums.h
 
 emit {
-#ifdef VAL_TYPE
 /***********************************************************************
 **
 */  typedef struct REBOL_Error_Vars
@@ -1039,7 +1042,6 @@ for-each word words-of ob/standard/error [
     emit-line/code "REBVAL " word ";"
 ]
 emit {^} ERROR_VARS;
-#endif
 }
 
 emit {

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -121,7 +121,7 @@ extern "C" ^{
 // are included in a system-wide header in order to allow recognizing a
 // given native by identity in the C code, e.g.:
 //
-//     if (VAL_FUNC_DISPATCH(native) == &N_parse) { ... }
+//     if (VAL_FUNC_DISPATCHER(native) == &N_parse) { ... }
 //
 }
 


### PR DESCRIPTION
This is basically a top-to bottom vetting of the macros, switching
the ones that used an argument more than once over to using an inline
function.  Because `inline static` is used on these definitions, it
means that `inline` could be defined to nothing and they would be
compiled as if a separate copy were statically included in each
header that used it--hence retaining C89 compatibility.

The previous macros did not require the types they worked with to be
defined at the point the macro was defined.  It was only when a macro
was used at a callsite that the definitions would need to be available.
The inline functions however needed much more to be defined.  As a
consequence, this required splitting out the REBVAL and REBSER and
`struct Reb_Frame` definitions into separate headers included earlier
in the ordering of %sys-core.h.  Once all the structures were defined,
the inline functions could be made in a certain ordering.

Since basically every line of %sys-value.h and %sys-series.h needed to
be touched in this change, the opportunity was taken to do some amount
of cleanup in the process.  However, %sys-core.h was reordered in
something of a trial-and-error process to get this to compile.  With
the reorganization strategy now started and working, it now needs
another going-over and review.