### PR TITLE
GC word symbols and pave way for UTF-8 everywhere (major)

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -152,7 +152,7 @@ void Reify_Va_To_Array_In_Frame(struct Reb_Frame *f, REBOOL truncated)
 
     if (truncated) {
         REBVAL temp;
-        Val_Init_Word(&temp, REB_WORD, SYM___OPTIMIZED_OUT__);
+        Val_Init_Word(&temp, REB_WORD, Canon(SYM___OPTIMIZED_OUT__));
 
         DS_PUSH(&temp);
     }

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -188,7 +188,7 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
 //
 REBOOL Do_Path_Throws_Core(
     REBVAL *out,
-    REBSYM *label_sym,
+    REBSTR **label_out,
     const RELVAL *path,
     REBCTX *specifier,
     REBVAL *opt_setval
@@ -326,7 +326,7 @@ REBOOL Do_Path_Throws_Core(
         return FALSE;
     }
 
-    if (label_sym) {
+    if (label_out) {
         REBVAL refinement;
 
         // When a function is hit, path processing stops as soon as the
@@ -335,7 +335,7 @@ REBOOL Do_Path_Throws_Core(
         // this last component in the sub-path is a word naming the function.
         //
         if (IS_WORD(pvs.item)) {
-            *label_sym = VAL_WORD_SYM(pvs.item);
+            *label_out = VAL_WORD_SPELLING(pvs.item);
         }
         else {
             // In rarer cases, the final component (completing the sub-path to
@@ -359,7 +359,7 @@ REBOOL Do_Path_Throws_Core(
             // was ROOT_NONAME, and another was to be the type of the function
             // being executed.  None are fantastic, we do the type for now.
 
-            *label_sym = SYM_FROM_KIND(VAL_TYPE(pvs.value));
+            *label_out = Canon(SYM_FROM_KIND(VAL_TYPE(pvs.value)));
         }
 
         // Move on to the refinements (if any)
@@ -430,7 +430,7 @@ REBOOL Do_Path_Throws_Core(
             // Go ahead and canonize the word symbol so we don't have to
             // do it each time in order to get a case-insenstive compare
             //
-            INIT_WORD_SYM(DS_TOP, SYMBOL_TO_CANON(VAL_WORD_SYM(DS_TOP)));
+            INIT_WORD_SPELLING(DS_TOP, VAL_WORD_CANON(DS_TOP));
         }
 
         // To make things easier for processing, reverse the refinements on
@@ -623,8 +623,8 @@ REBCTX *Resolve_Path(const REBVAL *path, REBCNT *index_out)
         return NULL; // !!! does not handle single-element paths
 
     while (ANY_CONTEXT(var) && IS_WORD(selector)) {
-        i = Find_Word_In_Context(
-            VAL_CONTEXT(var), VAL_WORD_SYM(selector), FALSE
+        i = Find_Canon_In_Context(
+            VAL_CONTEXT(var), VAL_WORD_CANON(selector), FALSE
         );
         ++selector;
         if (IS_END(selector)) {

--- a/src/core/c-signal.c
+++ b/src/core/c-signal.c
@@ -76,7 +76,7 @@ REBOOL Do_Signals_Throws(REBVAL *out)
         Eval_Cycles += Eval_Dose - Eval_Count;
         Eval_Count = Eval_Dose;
         if (Eval_Limit != 0 && Eval_Cycles > Eval_Limit)
-            Check_Security(SYM_EVAL, POL_EXEC, 0);
+            Check_Security(Canon(SYM_EVAL), POL_EXEC, 0);
     }
 
     if (!(Eval_Signals & Eval_Sigmask)) {

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -232,13 +232,15 @@ void INIT_WORD_INDEX_Debug(RELVAL *v, REBCNT i)
     assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
     if (IS_RELATIVE(v))
         assert(
-            SAME_SYM(VAL_WORD_SYM(v), FUNC_PARAM_SYM(VAL_WORD_FUNC(v), i))
+            VAL_WORD_CANON(v)
+            == VAL_PARAM_CANON(FUNC_PARAM(VAL_WORD_FUNC(v), i))
         );
     else
-        assert(SAME_SYM(
-            VAL_WORD_SYM(v), CTX_KEY_SYM(VAL_WORD_CONTEXT(KNOWN(v)), i))
+        assert(
+            VAL_WORD_CANON(v)
+            == CTX_KEY_CANON(VAL_WORD_CONTEXT(KNOWN(v)), i)
         );
-    (v)->payload.any_word.index = (i);
+    v->payload.any_word.index = i;
 }
 
 

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -106,26 +106,17 @@ REBINT Get_Hash_Prime(REBCNT size)
 }
 
 
+// Removals from linear probing lists can be complex, because the same
+// overflow slot may be visited through different initial hashes:
 //
-//  Expand_Hash: C
-// 
-// Expand hash series. Clear it but set its tail.
+// http://stackoverflow.com/a/279812/211160
 //
-void Expand_Hash(REBSER *ser)
-{
-    REBINT pnum = Get_Hash_Prime(SER_LEN(ser) + 1);
-    if (!pnum) {
-        REBVAL temp;
-        SET_INTEGER(&temp, SER_LEN(ser) + 1);
-        fail (Error(RE_SIZE_LIMIT, &temp));
-    }
-
-    assert(!Is_Array_Series(ser));
-    Remake_Series(ser, pnum + 1, SER_WIDE(ser), MKS_POWER_OF_2);
-
-    Clear_Series(ser);
-    SET_SERIES_LEN(ser, pnum);
-}
+// Since it's not enough to simply NULL out the spot when an interned string
+// is GC'd, a special pointer signaling "deletedness" is used.  It does not
+// cause a linear probe to terminate, but it is reused on insertions.
+//
+static REBSTR PG_Deleted_Canon;
+#define DELETED_CANON &PG_Deleted_Canon
 
 
 //
@@ -137,163 +128,342 @@ void Expand_Hash(REBSER *ser)
 //
 static void Expand_Word_Table(void)
 {
-    REBCNT *hashes;
-    RELVAL *word;
-    REBINT hash;
-    REBCNT size;
-    REBINT skip;
-    REBCNT n;
+    // The only full list of canon words available is the old hash table.
+    // Hold onto it while creating the new hash table.
 
-    // Allocate a new hash table:
-    Expand_Hash(PG_Word_Table.hashes);
-    // Debug_Fmt("WORD-TABLE: expanded (%d symbols, %d slots)", PG_Word_Table.array->tail, PG_Word_Table.hashes->tail);
+    REBCNT old_size = SER_LEN(PG_Canons_By_Hash);
+    REBSTR* *old_canons_by_hash = SER_HEAD(REBSER*, PG_Canons_By_Hash);
+
+    REBCNT new_size = Get_Hash_Prime(old_size + 1);
+    if (new_size == 0) {
+        REBVAL temp;
+        SET_INTEGER(&temp, old_size + 1);
+        fail (Error(RE_SIZE_LIMIT, &temp));
+    }
+
+    assert(SER_WIDE(PG_Canons_By_Hash) == sizeof(REBSTR*));
+
+    REBSER *ser = Make_Series(new_size, sizeof(REBSTR*), MKS_POWER_OF_2);
+    Clear_Series(ser);
+    SET_SERIES_LEN(ser, new_size);
 
     // Rehash all the symbols:
-    word = ARR_AT(PG_Word_Table.array, 1);
-    hashes = SER_HEAD(REBCNT, PG_Word_Table.hashes);
-    size = SER_LEN(PG_Word_Table.hashes);
 
-    for (n = 1; n < ARR_LEN(PG_Word_Table.array); n++, word++) {
-        const REBYTE *name = VAL_SYM_NAME(word);
-        hash = Hash_Word(name, LEN_BYTES(name));
+    REBSTR **new_canons_by_hash = SER_HEAD(REBSER*, ser);
 
-        skip = (hash & 0x0000FFFF) % size;
-        if (skip == 0) skip = 1;
+    REBCNT n;
+    for (n = 0; n < old_size; ++n) {
+        REBSTR *canon = old_canons_by_hash[n];
 
-        hash = (hash & 0x00FFFF00) % size;
-        while (hashes[hash]) {
-            hash += skip;
-            if (hash >= cast(REBINT, size))
-                hash -= size;
+        if (canon == NULL) continue;
+
+        if (canon == DELETED_CANON) { // clean out any deleted canon entries
+            --PG_Num_Canon_Slots_In_Use;
+        #if !defined(NDEBUG)
+            --PG_Num_Canon_Deleteds; // keep track for shutdown assert
+        #endif
+            continue;
         }
-        hashes[hash] = n;
+
+        REBINT hash = Hash_Word(STR_HEAD(canon), LEN_BYTES(STR_HEAD(canon)));
+        REBINT skip = (hash & 0x0000FFFF) % new_size;
+        if (skip == 0) skip = 1;
+        hash = (hash & 0x00FFFF00) % new_size;
+
+        while (new_canons_by_hash[hash] != NULL) {
+            hash += skip;
+            if (hash >= cast(REBINT, new_size))
+                hash -= new_size;
+        }
+        new_canons_by_hash[hash] = canon;
     }
+
+    Free_Series(PG_Canons_By_Hash);
+    PG_Canons_By_Hash = ser;
 }
 
 
 //
-//  Make_Word_Name: C
-// 
-// Allocates and copies the text string of the word.
+//  Intern_UTF8_Managed: C
 //
-static REBCNT Make_Word_Name(const REBYTE *str, REBCNT len)
+// This will "intern" a UTF-8 string, which is to store only one copy of each
+// distinct string value:
+//
+// https://en.wikipedia.org/wiki/String_interning
+//
+// The interning is case-sensitive.  But a relationship is set up between
+// instances that are just differently upper-or-lower-"cased".  This allows
+// those instances to agree on a single "canon" interning that can be used for
+// fast comparison between them.
+//
+// Interned UTF8 strings are stored as series, and are implicitly managed
+// by the GC (because they are shared).  Individual synonyms can be GC'd,
+// including canon forms--in which case the agreed-upon canon for the
+// group will get bumped to one of the other synonyms.
+//
+REBSTR *Intern_UTF8_Managed(const REBYTE *utf8, REBCNT len)
 {
-    REBCNT pos = SER_LEN(PG_Word_Names);
-
-    Append_Mem_Extra(PG_Word_Names, str, len, 1); // so we can do next line...
-
-    // keep terminator for each string
-    SET_SERIES_LEN(PG_Word_Names, SER_LEN(PG_Word_Names) + 1);
-
-    return pos;
-}
-
-
-//
-//  Make_Word: C
-// 
-// Given a string and its length, compute its hash value,
-// search for a match, and if not found, add it to the table.
-// Return the table index for the word (whether found or new).
-//
-REBCNT Make_Word(const REBYTE *str, REBCNT len)
-{
-    REBINT hash;
-    REBINT size;
-    REBINT skip;
-    REBINT n;
-    REBCNT h;
-    REBCNT *hashes;
-    RELVAL *words;
-    RELVAL *w;
-
-    //REBYTE *sss = Get_Sym_Name(1);    // (Debugging method)
-
-    // Prior convention was to assume zero termination if length was zero,
-    // but that creates problems.  Caller should use LEN_BYTES for that.
-
-    assert(len != 0);
-
-    // !!! ...but should the zero length word be a valid word?
-
-    // If hash part of word table is too dense, expand it:
-    if (
-        ARR_LEN(PG_Word_Table.array) > SER_LEN(PG_Word_Table.hashes) / 2
-    ) {
+    // The hashing technique used is called "linear probing":
+    //
+    // https://en.wikipedia.org/wiki/Linear_probing
+    //
+    // For the hash search to be guaranteed to terminate, the table must be
+    // large enough that we are able to find a NULL if there's a miss.  (It's
+    // actually kept larger than that, but to be on the right side of theory,
+    // the table is always checked for expansion needs *before* the search.)
+    //
+    REBCNT size = SER_LEN(PG_Canons_By_Hash);
+    if (PG_Num_Canon_Slots_In_Use > size / 2) {
         Expand_Word_Table();
+        size = SER_LEN(PG_Canons_By_Hash); // got larger
     }
 
-    assert(ARR_LEN(PG_Word_Table.array) == SER_LEN(Bind_Table));
+    REBSTR* *canons_by_hash = SER_HEAD(REBSER*, PG_Canons_By_Hash);
 
-    // If word symbol part of word table is full, expand it:
-    if (SER_FULL(ARR_SERIES(PG_Word_Table.array))) {
-        Extend_Series(ARR_SERIES(PG_Word_Table.array), 256);
-    }
-    if (SER_FULL(Bind_Table)) {
-        Extend_Series(Bind_Table, 256);
-        CLEAR_SEQUENCE(Bind_Table);
-    }
-
-    size = cast(REBINT, SER_LEN(PG_Word_Table.hashes));
-    words = ARR_HEAD(PG_Word_Table.array);
-    hashes = SER_HEAD(REBCNT, PG_Word_Table.hashes);
-
-    // Hash the word, including a skip factor for lookup:
-    hash  = Hash_Word(str, len);
-    skip  = (hash & 0x0000FFFF) % size;
+    // Calculate the starting hash slot to try--and the amount to skip to by
+    // each time a slot is found that is occupied by a non-match.
+    //
+    REBCNT hash = Hash_Word(utf8, len);
+    REBCNT skip = (hash & 0x0000FFFF) % size;
     if (skip == 0) skip = 1;
     hash = (hash & 0x00FFFF00) % size;
-    //Debug_Fmt("%s hash %d skip %d", str, hash, skip);
 
-    // Search hash table for word match:
-    while ((h = hashes[hash])) {
-        while ((n = Compare_UTF8(VAL_SYM_NAME(words+h), str, len)) >= 0) {
-            //if (Match_String("script", str, len))
-            //  Debug_Fmt("---- %s %d %d\n", VAL_SYM_NAME(&words[h]), n, h);
-            if (n == 0) return h; // direct hit
-            if (VAL_SYM_ALIAS(words+h)) h = VAL_SYM_ALIAS(words+h);
-            else goto make_sym; // Create new alias for word
+    REBSTR **deleted_slot = NULL;
+
+    // The hash table only indexes the canon form of each spelling.  So when
+    // testing a slot to see if it's a match (or a collision that needs to
+    // be skipped to try again) the search uses a comparison that is
+    // case-insensitive...and returns a value > 0 for a match.
+    //
+    // However, the result also indicates whether it was an *exact* match, by
+    // returning 0 if it is.
+    //
+    REBSTR* canon;
+    while ((canon = canons_by_hash[hash]) != NULL) {
+        if (canon == DELETED_CANON) {
+            deleted_slot = &canons_by_hash[hash];
+            hash += skip;
+            if (hash >= size) hash -= size;
+            continue;
         }
+
+        assert(GET_SER_FLAG(canon, STRING_FLAG_CANON));
+
+        // Compare_UTF8 returns 0 when the spelling is a case-sensitive match,
+        // and is the exact interning to return.
+        //
+        REBINT cmp = Compare_UTF8(STR_HEAD(canon), utf8, len);
+        if (cmp == 0) return canon;
+
+        if (cmp < 0) {
+            //
+            // Compare_UTF8 returns less than zero when the canon value in the
+            // slot isn't the same at all.  Since it's not a match, skip ahead
+            // to the next candidate slot--wrapping around if necessary
+            //
+            hash += skip;
+            if (hash >= size) hash -= size;
+            continue;
+        }
+
+        // The > 0 result means that the canon word that was found is an
+        // alternate casing ("synonym") for the string we're interning.  The
+        // synonyms are attached to the canon form with a circularly linked
+        // list.  Walk the list to see if any of the synonyms are a match.
+        //
+        REBSTR *synonym = canon->link.synonym;
+        while (synonym != canon) {
+            assert(synonym->misc.canon == canon);
+            assert(!GET_SER_FLAG(synonym, STRING_FLAG_CANON));
+
+            // Exact match for a synonym also means no new allocation needed.
+            //
+            cmp = Compare_UTF8(STR_HEAD(synonym), utf8, len);
+            if (cmp == 0) return synonym;
+
+            // Comparison should at least be a synonym, if in this list.
+            // Keep checking for an exact match until a cycle is found.
+            //
+            assert(cmp > 0);
+            synonym = synonym->link.synonym;
+        }
+
+        // If none of the synonyms matched, then this case variation needs
+        // to get its own interning, and point to the canon found.
+
+        /*assert(canon != NULL);*/
+        goto new_interning; // break loop, make a new synonym
+    }
+
+    // normal loop fallthrough at canon == NULL - make a new canon form
+    /*assert(canon == NULL)*/
+
+new_interning: ; // semicolon needed for statement
+
+    // If possible, try to fit the data into the REBSER node without doing a
+    // separate dynamic allocation.
+    //
+    REBSTR *intern;
+    if (len + 1 > sizeof(intern->content)) {
+        intern = Make_Series(len + 1, sizeof(REBYTE), MKS_NONE);
+        SET_SERIES_LEN(intern, len);
+    }
+    else {
+        intern = Make_Series(
+            1, // !!! no length stored--size measured by LEN_BYTES(data)
+            sizeof(REBYTE),
+            MKS_NO_DYNAMIC // don't alloc (or free) any data, trust us
+        );
+    }
+    memcpy(BIN_HEAD(intern), utf8, len);
+
+    // The incoming string isn't always null terminated, e.g. if you are
+    // interning `foo` in `foo: bar + 1` it would be colon-terminated.
+    //
+    BIN_HEAD(intern)[len] = '\0';
+
+    SET_SER_FLAGS(intern, SERIES_FLAG_STRING | SERIES_FLAG_FIXED_SIZE);
+
+    assert(intern->header.bits == 0); // SYM_XXX (if any) winds up in high bits
+
+    if (canon == NULL) {
+        //
+        // There was no canon symbol found, so this interning will be canon.
+        // Add it to the hash table and mark it, reuse deleted slot (if any)
+        //
+        if (deleted_slot) {
+            *deleted_slot = intern; // slot "usage" count stays constant
+
+        #if !defined(NDEBUG)
+            --PG_Num_Canon_Deleteds;
+        #endif
+        }
+        else {
+            canons_by_hash[hash] = intern;
+            ++PG_Num_Canon_Slots_In_Use;
+        }
+
+        SET_SER_FLAG(intern, STRING_FLAG_CANON);
+
+        intern->link.synonym = intern; // circularly linked list, empty state
+
+        // Canon symbols don't need to cache a canon pointer to themselves.
+        // So instead that slot is reserved for tracking associated information
+        // for the canon word, e.g. the current bind index.  Because this
+        // may be used by several threads, it would likely have to be an
+        // atomic pointer that would "pop out" to a structure, but for now
+        // it is just randomized to keep its information in high bits or low
+        // bits as a poor-man's demo that there is an infrastructure in place
+        // for sharing (start with 2, grow to N based on the functions for
+        // 2 being in place)
+        //
+        intern->misc.bind_index.high = 0;
+        intern->misc.bind_index.low = 0;
+
+        // leave header.bits as 0 for SYM_0 as answer to VAL_WORD_SYM()
+        // Init_Symbols() tags values from %words.r after the fact.
+    }
+    else {
+        // This is a synonym for an existing canon.  Link it into the synonyms
+        // circularly linked list, and direct link the canon form.
+        //
+        intern->misc.canon = canon;
+        intern->link.synonym = canon->link.synonym;
+        canon->link.synonym = intern;
+
+        // If the canon form had a SYM_XXX for quick comparison of %words.r
+        // words in C switch statements, the synonym inherits that number.
+        //
+        intern->header.bits |= ((canon->header.bits >> 16) << 16);
+    }
+
+    // Created series must be managed, because if they were not there could
+    // be no clear contract on the return result--as it wouldn't be possible
+    // to know if a shared instance had been managed by someone else or not.
+    //
+    MANAGE_SERIES(intern);
+    return intern;
+}
+
+
+//
+//  GC_Kill_Interning: C
+//
+void GC_Kill_Interning(REBSTR *intern)
+{
+    REBSER *synonym = intern->link.synonym;
+
+    // We need to unlink this spelling out of the circularly linked list of
+    // synonyms.  Further, if it happens to be canon, we need to re-point
+    // everything in the chain to a new entry.  Choose the synonym if so.
+    // (Note synonym and intern may be the same here.)
+    //
+    REBSER *temp = synonym;
+    while (temp->link.synonym != intern) {
+        if (GET_SER_FLAG(intern, STRING_FLAG_CANON))
+            temp->misc.canon = synonym;
+        temp = temp->link.synonym;
+    }
+    temp->link.synonym = synonym; // cut intern out of chain (or no-op)
+
+    if (!GET_SER_FLAG(intern, STRING_FLAG_CANON))
+        return; // for non-canon forms, removing from chain is all you need
+
+    assert(intern->misc.bind_index.high == 0); // shouldn't GC during binds?
+    assert(intern->misc.bind_index.low == 0);
+
+    REBCNT size = SER_LEN(PG_Canons_By_Hash);
+    REBSTR* *canons_by_hash = SER_HEAD(REBSER*, PG_Canons_By_Hash);
+    assert(canons_by_hash != NULL);
+
+    REBCNT len = LEN_BYTES(STR_HEAD(intern));
+    REBCNT hash = Hash_Word(STR_HEAD(intern), len);
+    REBCNT skip = (hash & 0x0000FFFF) % size;
+    if (skip == 0) skip = 1;
+    hash = (hash & 0x00FFFF00) % size;
+
+    // We *will* find the canon form in the hash table.
+    //
+    while (canons_by_hash[hash] != intern) {
         hash += skip;
         if (hash >= size) hash -= size;
     }
 
-make_sym:
-    n = ARR_LEN(PG_Word_Table.array);
-    w = words + n;
-    if (h) {
-        // Alias word (h = canon word)
-        VAL_SYM_ALIAS(words+h) = n;
-        VAL_SYM_CANON(w) = VAL_SYM_CANON(words+h);
-    } else {
-        // Canon (base version of) word (h == 0)
-        hashes[hash] = n;
-        VAL_SYM_CANON(w) = n;
+    if (synonym != intern) {
+        //
+        // If there was a synonym in the circularly linked list distinct from
+        // the canon form, then it gets a promotion to being the canon form.
+        // It should hash the same, and be able to take over the hash slot.
+        //
+        /*assert(hash == Hash_Word(STR_HEAD(synonym)));*/
+        canons_by_hash[hash] = synonym;
+        SET_SER_FLAG(synonym, STRING_FLAG_CANON);
+        synonym->misc.bind_index.low = 0;
+        synonym->misc.bind_index.high = 0;
     }
-    VAL_SYM_ALIAS(w) = 0;
-    VAL_SYM_NINDEX(w) = Make_Word_Name(str, len);
-    VAL_RESET_HEADER(w, REB_HANDLE);
+    else {
+        // This canon form must be removed from the hash table.  Ripple the
+        // collision slots back until a NULL is found, to reduce search times.
+        //
+        REBCNT previous_hash = hash;
+        while (canons_by_hash[hash] != NULL) {
+            hash += skip;
+            if (hash >= size) hash -= size;
+            canons_by_hash[previous_hash] = canons_by_hash[hash];
+        }
 
-    // These are allowed because of the SER_FULL checks above which
-    // add one extra to the TAIL check comparision. However, their
-    // termination values (nulls) will be missing.
-    SET_ARRAY_LEN(PG_Word_Table.array, ARR_LEN(PG_Word_Table.array) + 1);
-    SET_SERIES_LEN(Bind_Table, SER_LEN(Bind_Table) + 1);
+        // Signal that the hash slot is "deleted" via a special pointer.
+        // See notes on DELETED_SLOT for why the final slot in the collision
+        // chain can't just be left NULL:
+        //
+        // http://stackoverflow.com/a/279812/211160
+        //
+        canons_by_hash[previous_hash] = DELETED_CANON;
 
-    assert(n != SYM_0);
-    return n;
-}
-
-
-//
-//  Last_Word_Num: C
-// 
-// Return the number of the last word created.  Used to
-// mark a range of canon-words (e.g. operators).
-//
-REBCNT Last_Word_Num(void)
-{
-    return ARR_LEN(PG_Word_Table.array) - 1;
+    #if !defined(NDEBUG)
+        ++PG_Num_Canon_Deleteds; // total use same (PG_Num_Canons_Or_Deleteds)
+    #endif
+    }
 }
 
 
@@ -305,16 +475,16 @@ REBCNT Last_Word_Num(void)
 void Val_Init_Word_Bound(
     REBVAL *out,
     enum Reb_Kind type,
-    REBSYM sym,
+    REBSTR *name,
     REBCTX *context,
     REBCNT index
 ) {
-    assert(sym != SYM_0);
+    assert(name != NULL);
     assert(context);
 
     VAL_RESET_HEADER(out, type);
     SET_VAL_FLAG(out, WORD_FLAG_BOUND);
-    INIT_WORD_SYM(out, sym);
+    INIT_WORD_SPELLING(out, name);
     INIT_WORD_CONTEXT(out, context);
     INIT_WORD_INDEX(out, index);
 
@@ -326,47 +496,11 @@ void Val_Init_Word_Bound(
 
 
 //
-//  Val_Init_Word_Core: C
-// 
-// Initialize a value as a word. Set frame as unbound--no context.  (See
-// also Val_Init_Word_Bound)
-//
-void Val_Init_Word_Core(RELVAL *out, enum Reb_Kind type, REBSYM sym)
-{
-    assert(sym != SYM_0);
-
-    VAL_RESET_HEADER(out, type);
-    INIT_WORD_SYM(out, sym);
-
-#if !defined(NDEBUG)
-    out->payload.any_word.index = 0;
-#endif
-
-    assert(ANY_WORD(out));
-    assert(IS_WORD_UNBOUND(out));
-}
-
-
-//
-//  Get_Sym_Name: C
-//
-const REBYTE *Get_Sym_Name(REBSYM sym)
-{
-    if (sym == 0 || sym >= ARR_LEN(PG_Word_Table.array)) {
-        assert(FALSE); // !!! R3-Alpha was tolerant, Ren-C is not...
-        return cb_cast("???");
-    }
-
-    return VAL_SYM_NAME(ARR_AT(PG_Word_Table.array, sym));
-}
-
-
-//
 //  Get_Type_Name: C
 //
 const REBYTE *Get_Type_Name(const REBVAL *value)
 {
-    return Get_Sym_Name(SYM_FROM_KIND(VAL_TYPE(value)));
+    return STR_HEAD(Canon(SYM_FROM_KIND(VAL_TYPE(value))));
 }
 
 
@@ -379,8 +513,8 @@ const REBYTE *Get_Type_Name(const REBVAL *value)
 //
 REBINT Compare_Word(const RELVAL *s, const RELVAL *t, REBOOL is_case)
 {
-    REBYTE *sp = VAL_WORD_NAME(s);
-    REBYTE *tp = VAL_WORD_NAME(t);
+    const REBYTE *sp = STR_HEAD(VAL_WORD_SPELLING(s));
+    const REBYTE *tp = STR_HEAD(VAL_WORD_SPELLING(t));
 
     // Use a more strict comparison than normal:
     if (is_case) return COMPARE_BYTES(sp, tp);
@@ -394,43 +528,99 @@ REBINT Compare_Word(const RELVAL *s, const RELVAL *t, REBOOL is_case)
 
 
 //
-//  Init_Words: C
-// 
-// Only flags BIND_Table creation only (for threads).
+//  Init_Symbols: C
 //
-void Init_Words(REBOOL only)
+// By this point in the boot, the canon words have already been created for
+// everything in %words.r.
+//
+// This goes through the name series for %words.r words and tags them with
+// SYM_XXX constants.  This allows the small number to be quickly extracted to
+// use with VAL_WORD_SYM() in C switch statements.  These are the only words
+// that have fixed symbol numbers--others are only managed and compared
+// through their pointers.
+//
+// It also creates a table for mapping from SYM_XXX => REBSTR series.  This
+// is used e.g. by Canon(SYM_XXX) to get the string name for a symbol.
+//
+void Init_Symbols(REBARR *words)
 {
-    REBCNT n = Get_Hash_Prime(WORD_TABLE_SIZE * 4); // extra to reduce rehashing
-
-    if (!only) {
-        // Create the hash for locating words quickly:
-        // Note that the TAIL is never changed for this series.
-        PG_Word_Table.hashes = Make_Series(n + 1, sizeof(REBCNT), MKS_NONE);
-        Clear_Series(PG_Word_Table.hashes);
-        SET_SERIES_LEN(PG_Word_Table.hashes, n);
-
-        // The word (symbol) table itself:
-        PG_Word_Table.array = Make_Array(WORD_TABLE_SIZE);
-
-        // !!! R3-Alpha would "Put a BLANK at the head" here.  Why?  It seemed
-        // to later think it needed to be able to read a symbol out of a blank,
-        // which it cannot do.  Changed to a typeset with symbol 0--which
-        // seems to work as intended, but review what the intent is.
-        //
-        Val_Init_Typeset(ARR_HEAD(PG_Word_Table.array), ALL_64, SYM_0);
-
-        SET_ARRAY_LEN(PG_Word_Table.array, 1);  // prevent the zero case
-
-        // A normal char array to hold symbol names:
-        PG_Word_Names = Make_Binary(6 * WORD_TABLE_SIZE); // average word size
-    }
-
-    // The bind table. Used to cache context indexes for given symbols.
-    Bind_Table = Make_Series(
-        SER_REST(ARR_SERIES(PG_Word_Table.array)),
-        sizeof(REBCNT),
+    PG_Symbol_Canons = Make_Series(
+        ARR_LEN(words) + 1, // extra NULL at head for SYM_0 (END maps to NULL)
+        sizeof(REBSTR*),
         MKS_NONE
     );
-    CLEAR_SEQUENCE(Bind_Table);
-    SET_SERIES_LEN(Bind_Table, ARR_LEN(PG_Word_Table.array));
+
+    REBSYM sym = SYM_0;
+    *SER_AT(REBSTR*, PG_Symbol_Canons, cast(REBCNT, sym)) = NULL; // Canon(REB_0)
+
+    RELVAL *word = ARR_HEAD(words);
+    for (; NOT_END(word); ++word) {
+        REBSTR *canon = VAL_WORD_CANON(word);
+        assert(GET_SER_FLAG(canon, STRING_FLAG_CANON));
+
+        sym = cast(REBSYM, cast(REBCNT, sym) + 1);
+        *SER_AT(REBSTR*, PG_Symbol_Canons, cast(REBCNT, sym)) = canon;
+
+        // More code was loaded than just the word list, and it might have
+        // included alternate-case forms of the %words.r words.  Walk any
+        // aliases and make sure they have the header bits too.
+
+        REBSTR *name = canon;
+        do {
+            // The low bits of the header are reserved for flags, including
+            // those common between singulars and "doubulars".  The symbol
+            // numbers are shifted by 16 bits
+            //
+            assert((name->header.bits >> 16) == 0);
+            name->header.bits |= cast(REBUPT, sym << 16);
+            name = name->link.synonym;
+        } while (name != canon); // circularly linked list, stop on a cycle
+    }
+
+    *SER_AT(REBSTR*, PG_Symbol_Canons, cast(REBCNT, sym)) = NULL; // terminate
+    sym = cast(REBSYM, cast(REBCNT, sym) + 1);
+
+    SET_SERIES_LEN(PG_Symbol_Canons, cast(REBCNT, sym));
+    assert(SER_LEN(PG_Symbol_Canons) == ARR_LEN(words) + 1);
+
+    // Do some sanity checks
+
+    if (COMPARE_BYTES(cb_cast("blank!"), STR_HEAD(Canon(SYM_BLANK_X))) != 0)
+        panic (Error(RE_BAD_BOOT_STRING));
+    if (COMPARE_BYTES(cb_cast("true"), STR_HEAD(Canon(SYM_TRUE))) != 0)
+        panic (Error(RE_BAD_BOOT_STRING));
+}
+
+
+//
+//  Init_Words: C
+//
+void Init_Words(void)
+{
+    PG_Num_Canon_Slots_In_Use = 0;
+#if !defined(NDEBUG)
+    PG_Num_Canon_Deleteds = 0;
+#endif
+
+    // Start hash table out at a fixed size.  When collisions occur, it
+    // causes a skipping pattern that continues until it finds the desired
+    // slot.  The method is known as linear probing:
+    //
+    // https://en.wikipedia.org/wiki/Linear_probing
+    //
+    // It must always be at least as big as the total number of words, in order
+    // for it to uniquely be able to locate each symbol pointer.  But to
+    // reduce long probing chains, it should be significantly larger than that.
+    // R3-Alpha used a heuristic of 4 times as big as the number of words.
+
+    REBCNT n;
+#if defined(NDEBUG)
+    n = Get_Hash_Prime(WORD_TABLE_SIZE * 4); // extra reduces rehashing
+#else
+    n = 1; // forces exercise of rehashing logic in debug build
+#endif
+
+    PG_Canons_By_Hash = Make_Series(n, sizeof(REBSTR*), MKS_POWER_OF_2);
+    Clear_Series(PG_Canons_By_Hash); // all slots start at NULL
+    SET_SERIES_LEN(PG_Canons_By_Hash, n);
 }

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -149,7 +149,7 @@ void Dump_Values(RELVAL *vp, REBCNT count)
         }
         n = 0;
         if (IS_WORD(val) || IS_GET_WORD(val) || IS_SET_WORD(val)) {
-            const REBYTE *name = Get_Sym_Name(VAL_WORD_SYM(val));
+            const REBYTE *name = STR_HEAD(VAL_WORD_SPELLING(val));
             n = snprintf(
                 s_cast(cp), sizeof(buf) - (cp - buf), " (%s)", cs_cast(name)
             );
@@ -235,7 +235,7 @@ void Dump_Stack(struct Reb_Frame *f, REBCNT level)
     Debug_Fmt(
         "STACK[%d](%s) - %s",
         level,
-        Get_Sym_Name(FRM_LABEL(f)),
+        STR_HEAD(FRM_LABEL(f)),
         mode_strings[f->eval_type]
     );
 
@@ -251,7 +251,7 @@ void Dump_Stack(struct Reb_Frame *f, REBCNT level)
     for (; NOT_END(param); ++param, ++arg, ++n) {
         Debug_Fmt(
             "    %s: %72r",
-            Get_Sym_Name(VAL_TYPESET_SYM(param)),
+            STR_HEAD(VAL_PARAM_SPELLING(param)),
             arg
         );
     }

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -145,8 +145,8 @@ void Do_Core_Entry_Checks_Debug(struct Reb_Frame *f)
     //
     assert(f->value);
 
-    f->label_sym = SYM_0;
-    f->label_str = NULL;
+    f->label = NULL;
+    f->label_debug = NULL;
 
     // All callers should ensure that the type isn't an END marker before
     // bothering to invoke Do_Core().
@@ -262,7 +262,7 @@ REBUPT Do_Core_Expression_Checks_Debug(struct Reb_Frame *f) {
     //
     assert(IS_TRASH_DEBUG(&TG_Thrown_Arg));
 
-    assert(f->label_sym == SYM_0 && f->label_str == NULL);
+    assert(f->label == NULL && f->label_debug == NULL);
 
     // Make sure `eval` is trash in debug build if not doing a `reevaluate`.
     // It does not have to be GC safe (for reasons explained below).  We
@@ -351,7 +351,7 @@ void Do_Core_Exit_Checks_Debug(struct Reb_Frame *f) {
     assert(VAL_TYPE(f->out) < REB_MAX); // cheap check
 
     if (NOT(THROWN(f->out))) {
-        assert(f->label_sym == SYM_0);
+        assert(f->label == NULL);
         ASSERT_VALUE_MANAGED(f->out);
     }
 }

--- a/src/core/d-legacy.c
+++ b/src/core/d-legacy.c
@@ -163,9 +163,7 @@ REBCTX *Make_Guarded_Arg123_Error(void)
 {
     REBCTX *root_error = VAL_CONTEXT(ROOT_ERROBJ);
     REBCTX *error = Copy_Context_Shallow_Extra(root_error, 3);
-    REBVAL *key;
-    REBVAL *var;
-    REBCNT n;
+
     REBCNT root_len = ARR_LEN(CTX_VARLIST(root_error));
 
     // Update the length to suppress out of bounds assert from CTX_KEY/VAL
@@ -173,11 +171,16 @@ REBCTX *Make_Guarded_Arg123_Error(void)
     SET_ARRAY_LEN(CTX_VARLIST(error), root_len + 3);
     SET_ARRAY_LEN(CTX_KEYLIST(error), root_len + 3);
 
-    key = CTX_KEY(error, CTX_LEN(root_error)) + 1;
-    var = CTX_VAR(error, CTX_LEN(root_error)) + 1;
+    REBVAL *key = CTX_KEY(error, CTX_LEN(root_error)) + 1;
+    REBVAL *var = CTX_VAR(error, CTX_LEN(root_error)) + 1;
 
+    REBCNT n;
     for (n = 0; n < 3; n++, key++, var++) {
-        Val_Init_Typeset(key, ALL_64, SYM_ARG1 + n);
+        Val_Init_Typeset(
+            key,
+            ALL_64,
+            Canon(cast(REBSYM, cast(REBCNT, SYM_ARG1) + n))
+        );
         SET_BLANK(var);
     }
 

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -387,10 +387,7 @@ void Debug_Series(REBSER *ser)
     }
     else if (SER_WIDE(ser) == sizeof(REBUNI))
         Debug_Uni(ser);
-    else if (ser == Bind_Table) {
-        // Dump bind table somehow?
-        Panic_Series(ser);
-    } else if (ser == PG_Word_Table.hashes) {
+    else if (ser == PG_Canons_By_Hash) {
         // Dump hashes somehow?
         Panic_Series(ser);
     } else if (ser == GC_Series_Guard) {
@@ -459,7 +456,7 @@ void Debug_Space(REBCNT num)
 //
 void Debug_Word(const REBVAL *word)
 {
-    Debug_Str(cs_cast(Get_Sym_Name(VAL_WORD_SYM(word))));
+    Debug_Str(cs_cast(STR_HEAD(VAL_WORD_SPELLING(word))));
 }
 
 

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -57,7 +57,7 @@ void Collapsify_Array(REBARR *array, REBCTX *specifier, REBCNT limit)
                 limit + 1
             );
 
-            Val_Init_Word(ARR_AT(copy, limit), REB_WORD, SYM_ELLIPSIS);
+            Val_Init_Word(ARR_AT(copy, limit), REB_WORD, Canon(SYM_ELLIPSIS));
 
             Collapsify_Array(
                 copy,
@@ -168,7 +168,7 @@ REBARR *Make_Where_For_Frame(struct Reb_Frame *f)
     //
     if (pending) {
         DS_PUSH_TRASH;
-        Val_Init_Word(DS_TOP, REB_WORD, SYM_ELLIPSIS);
+        Val_Init_Word(DS_TOP, REB_WORD, Canon(SYM_ELLIPSIS));
     }
 
     where = Pop_Stack_Values(dsp_start);
@@ -339,7 +339,7 @@ REBNATIVE(backtrace)
     REBARR *backtrace;
     struct Reb_Frame *frame;
 
-    Check_Security(SYM_DEBUG, POL_READ, 0);
+    Check_Security(Canon(SYM_DEBUG), POL_READ, 0);
 
     if (get_frame && (REF(limit) || REF(brief))) {
         //
@@ -491,7 +491,7 @@ REBNATIVE(backtrace)
                 // to show, then put an `+ ...` in the list and break.
                 //
                 temp = ARR_AT(backtrace, --index);
-                Val_Init_Word(temp, REB_WORD, SYM_PLUS);
+                Val_Init_Word(temp, REB_WORD, Canon(SYM_PLUS));
                 if (!REF(brief)) {
                     //
                     // In the non-/ONLY backtrace, the pairing of the ellipsis
@@ -502,7 +502,7 @@ REBNATIVE(backtrace)
                     // !!! Review arbitrary symbolic choices.
                     //
                     temp = ARR_AT(backtrace, --index);
-                    Val_Init_Word(temp, REB_WORD, SYM_ASTERISK);
+                    Val_Init_Word(temp, REB_WORD, Canon(SYM_ASTERISK));
                     SET_VAL_FLAG(temp, VALUE_FLAG_LINE); // put on own line
                 }
                 break;
@@ -560,7 +560,7 @@ REBNATIVE(backtrace)
             // dealings with the arguments, however (for instance: not having
             // to initialize not-yet-filled args could be one thing).
             //
-            Val_Init_Word(temp, REB_WORD, SYM_ASTERISK);
+            Val_Init_Word(temp, REB_WORD, Canon(SYM_ASTERISK));
         }
         else
             SET_INTEGER(temp, number);

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -144,11 +144,11 @@ void Trace_Line(struct Reb_Frame *f)
 //
 //  Trace_Func: C
 //
-void Trace_Func(REBCNT label_sym, const REBVAL *value)
+void Trace_Func(REBSTR *label, const REBVAL *value)
 {
     int depth;
     CHECK_DEPTH(depth);
-    Debug_Fmt_("--> %s", Get_Sym_Name(label_sym) /* Get_Type_Name(value) */);
+    Debug_Fmt_("--> %s", STR_HEAD(label));
     if (GET_FLAG(Trace_Flags, 1))
         Debug_Values(FRM_ARG(FS_TOP, 1), FRM_NUM_ARGS(FS_TOP), 20);
     else Debug_Line();
@@ -158,11 +158,11 @@ void Trace_Func(REBCNT label_sym, const REBVAL *value)
 //
 //  Trace_Return: C
 //
-void Trace_Return(REBCNT label_sym, const REBVAL *value)
+void Trace_Return(REBSTR *label, const REBVAL *value)
 {
     int depth;
     CHECK_DEPTH(depth);
-    Debug_Fmt_("<-- %s ==", Get_Sym_Name(label_sym));
+    Debug_Fmt_("<-- %s ==", STR_HEAD(label));
     Debug_Values(value, 1, 50);
 }
 
@@ -224,7 +224,7 @@ REBNATIVE(trace)
 {
     REBVAL *arg = D_ARG(1);
 
-    Check_Security(SYM_DEBUG, POL_READ, 0);
+    Check_Security(Canon(SYM_DEBUG), POL_READ, 0);
 
     // The /back option: ON and OFF, or INTEGER! for # of lines:
     if (D_REF(2)) { // /back

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -110,8 +110,8 @@ void Value_To_RXI(RXIARG *arg, const REBVAL *val)
     case REB_LIT_WORD:
     case REB_REFINEMENT:
     case REB_ISSUE:
-        arg->i2.int32a = VAL_WORD_CANON(val);
-        arg->i2.int32b = 0;
+        arg->sri.series = VAL_WORD_CANON(val);
+        arg->sri.index = 0;
         break;
 
     case REB_STRING:
@@ -211,27 +211,27 @@ void RXI_To_Value(REBVAL *val, const RXIARG *arg, REBRXT type)
         break;
 
     case RXT_WORD:
-        Val_Init_Word(val, REB_WORD, arg->i2.int32a);
+        Val_Init_Word(val, REB_WORD, arg->sri.series);
         break;
 
     case RXT_SET_WORD:
-        Val_Init_Word(val, REB_SET_WORD, arg->i2.int32a);
+        Val_Init_Word(val, REB_SET_WORD, arg->sri.series);
         break;
 
     case RXT_GET_WORD:
-        Val_Init_Word(val, REB_GET_WORD, arg->i2.int32a);
+        Val_Init_Word(val, REB_GET_WORD, arg->sri.series);
         break;
 
     case RXT_LIT_WORD:
-        Val_Init_Word(val, REB_LIT_WORD, arg->i2.int32a);
+        Val_Init_Word(val, REB_LIT_WORD, arg->sri.series);
         break;
 
     case RXT_REFINEMENT:
-        Val_Init_Word(val, REB_REFINEMENT, arg->i2.int32a);
+        Val_Init_Word(val, REB_REFINEMENT, arg->sri.series);
         break;
 
     case RXT_ISSUE:
-        Val_Init_Word(val, REB_ISSUE, arg->i2.int32a);
+        Val_Init_Word(val, REB_ISSUE, arg->sri.series);
         break;
 
     case RXT_BINARY:

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -46,7 +46,7 @@
 REBOOL Series_Common_Action_Returns(
     REB_R *r, // `r_out` would be slightly confusing, considering R_OUT
     struct Reb_Frame *frame_,
-    REBCNT action
+    REBSYM action
 ) {
     REBVAL *value = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -324,7 +324,7 @@ REBVAL *Type_Of_Core(const RELVAL *value)
 const REBYTE *Get_Field_Name(REBCTX *context, REBCNT index)
 {
     assert(index <= CTX_LEN(context));
-    return Get_Sym_Name(CTX_KEY_SYM(context, index));
+    return STR_HEAD(CTX_KEY_SPELLING(context, index));
 }
 
 
@@ -740,16 +740,15 @@ REBARR *Collect_Set_Words(RELVAL *val)
 {
     REBCNT count = 0;
     RELVAL *val2 = val;
-    REBARR *array;
 
     for (; NOT_END(val); val++) if (IS_SET_WORD(val)) count++;
     val = val2;
 
-    array = Make_Array(count);
+    REBARR *array = Make_Array(count);
     val2 = ARR_HEAD(array);
     for (; NOT_END(val); val++) {
         if (IS_SET_WORD(val))
-            Val_Init_Word(val2++, REB_WORD, VAL_WORD_SYM(val));
+            Val_Init_Word(val2++, REB_WORD, VAL_WORD_SPELLING(val));
     }
     SET_END(val2);
     SET_ARRAY_LEN(array, count);

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -134,7 +134,7 @@ REBNATIVE(make)
             // settings available.  Make a fake parameter that hard quotes
             // and takes any type (it will be type checked if in a chain).
             //
-            Val_Init_Typeset(&fake_param, ALL_64, SYM_ELLIPSIS);
+            Val_Init_Typeset(&fake_param, ALL_64, Canon(SYM_ELLIPSIS));
             INIT_VAL_PARAM_CLASS(&fake_param, PARAM_CLASS_HARD_QUOTE);
             vararg_param = &fake_param;
             vararg_arg = &fake_param; // doesn't matter, just gets flag set
@@ -149,7 +149,7 @@ REBNATIVE(make)
 
         do {
             REBIXO indexor = Do_Vararg_Op_Core(
-                D_OUT, feed, vararg_param, vararg_arg, SYM_0, VARARG_OP_TAKE
+                D_OUT, feed, vararg_param, vararg_arg, NULL, VARARG_OP_TAKE
             );
 
             if (indexor == THROWN_FLAG) {
@@ -1043,12 +1043,12 @@ REBNATIVE(scan_net_header)
         else break;
 
         if (*cp == ':') {
-            REBSYM sym = Make_Word(start, cp-start);
+            REBSTR *name = Intern_UTF8_Managed(start, cp-start);
             RELVAL *item;
             cp++;
             // Search if word already present:
             for (item = ARR_HEAD(result); NOT_END(item); item += 2) {
-                if (VAL_WORD_SYM(item) == sym) {
+                if (SAME_STR(VAL_WORD_SPELLING(item), name)) {
                     // Does it already use a block?
                     if (IS_BLOCK(item + 1)) {
                         // Block of values already exists:
@@ -1070,7 +1070,7 @@ REBNATIVE(scan_net_header)
             }
             if (IS_END(item)) {
                 val = Alloc_Tail_Array(result); // add new word
-                Val_Init_Word(val, REB_SET_WORD, sym);
+                Val_Init_Word(val, REB_SET_WORD, name);
                 val = Alloc_Tail_Array(result); // for new value
                 SET_BLANK(val);
             }

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -189,7 +189,7 @@ static int Protect(struct Reb_Frame *frame_, REBFLGS flags)
 
     // flags has PROT_SET bit (set or not)
 
-    Check_Security(SYM_PROTECT, POL_WRITE, value);
+    Check_Security(Canon(SYM_PROTECT), POL_WRITE, value);
 
     if (REF(deep)) SET_FLAG(flags, PROT_DEEP);
     //if (REF(words)) SET_FLAG(flags, PROT_WORD);
@@ -1066,7 +1066,7 @@ REBNATIVE(do)
 
         f->varlist = CTX_VARLIST(VAL_CONTEXT(value)); // need w/NULL def
 
-        return Apply_Frame_Core(f, SYM___ANONYMOUS__, NULL);
+        return Apply_Frame_Core(f, Canon(SYM___ANONYMOUS__), NULL);
     }
 
     case REB_TASK:

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -332,7 +332,7 @@ REBNATIVE(bind)
         // not in context, bind/new means add it if it's not.
         //
         if (REF(new) || (IS_SET_WORD(value) && REF(set))) {
-            Append_Context(context, value, SYM_0);
+            Append_Context(context, value, NULL);
             *D_OUT = *value;
             return R_OUT;
         }
@@ -664,8 +664,8 @@ REBNATIVE(in)
                 v = &safe;
                 if (IS_OBJECT(v)) {
                     context = VAL_CONTEXT(v);
-                    index = Find_Word_In_Context(
-                        context, VAL_WORD_SYM(word), FALSE
+                    index = Find_Canon_In_Context(
+                        context, VAL_WORD_CANON(word), FALSE
                     );
                     if (index != 0) {
                         CLEAR_VAL_FLAG(word, VALUE_FLAG_RELATIVE);
@@ -692,12 +692,12 @@ REBNATIVE(in)
         return R_OUT;
     }
 
-    index = Find_Word_In_Context(context, VAL_WORD_SYM(word), FALSE);
+    index = Find_Canon_In_Context(context, VAL_WORD_CANON(word), FALSE);
     if (index == 0)
         return R_BLANK;
 
     VAL_RESET_HEADER(D_OUT, VAL_TYPE(word));
-    INIT_WORD_SYM(D_OUT, VAL_WORD_SYM(word));
+    INIT_WORD_SPELLING(D_OUT, VAL_WORD_SPELLING(word));
     SET_VAL_FLAG(D_OUT, WORD_FLAG_BOUND); // header reset, so not relative
     INIT_WORD_CONTEXT(D_OUT, context);
     INIT_WORD_INDEX(D_OUT, index);
@@ -1015,7 +1015,7 @@ REBNATIVE(set)
 
             if (!REF(opt) && IS_VOID(value)) {
                 REBVAL key_name;
-                Val_Init_Word(&key_name, REB_WORD, VAL_TYPESET_SYM(key));
+                Val_Init_Word(&key_name, REB_WORD, VAL_KEY_SPELLING(key));
 
                 fail (Error(RE_NEED_VALUE, &key_name));
             }
@@ -1322,7 +1322,7 @@ REBNATIVE(punctuates_q)
 {
     PARAM(1, value);
 
-    REBSYM sym; // unused here
+    REBSTR *sym; // unused here
     Get_If_Word_Or_Path_Arg(D_OUT, &sym, ARG(value));
 
     if (!IS_FUNCTION(D_OUT))

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -641,7 +641,7 @@ REBNATIVE(change_dir)
 
         REBVAL val;
         Val_Init_String(&val, ser); // may be unicode or utf-8
-        Check_Security(SYM_FILE, POL_EXEC, &val);
+        Check_Security(Canon(SYM_FILE), POL_EXEC, &val);
 
         if (!OS_SET_CURRENT_DIR(SER_HEAD(REBCHR, ser)))
             fail (Error_Invalid_Arg(arg)); // !!! ERROR MSG
@@ -668,7 +668,7 @@ REBNATIVE(browse)
     REBCHR *url = 0;
     REBVAL *arg = D_ARG(1);
 
-    Check_Security(SYM_BROWSE, POL_EXEC, arg);
+    Check_Security(Canon(SYM_BROWSE), POL_EXEC, arg);
 
     if (IS_BLANK(arg))
         return R_VOID;
@@ -784,7 +784,7 @@ REBNATIVE(call)
 
     int exit_code = 0;
 
-    Check_Security(SYM_CALL, POL_EXEC, arg);
+    Check_Security(Canon(SYM_CALL), POL_EXEC, arg);
 
     if (D_REF(2)) flag_wait = TRUE;
     if (D_REF(3)) flag_console = TRUE;
@@ -1040,9 +1040,12 @@ REBNATIVE(call)
     if (flag_info) {
         REBCTX *info = Alloc_Context(2);
 
-        SET_INTEGER(Append_Context(info, NULL, SYM_ID), pid);
+        SET_INTEGER(Append_Context(info, NULL, Canon(SYM_ID)), pid);
         if (flag_wait)
-            SET_INTEGER(Append_Context(info, NULL, SYM_EXIT_CODE), exit_code);
+            SET_INTEGER(
+                Append_Context(info, NULL, Canon(SYM_EXIT_CODE)),
+                exit_code
+            );
 
         Val_Init_Object(D_OUT, info);
         return R_OUT;
@@ -1274,7 +1277,7 @@ REBNATIVE(get_env)
     REBCHR *buf;
     REBVAL *arg = D_ARG(1);
 
-    Check_Security(SYM_ENVR, POL_READ, arg);
+    Check_Security(Canon(SYM_ENVR), POL_READ, arg);
 
     if (ANY_WORD(arg)) Val_Init_String(arg, Copy_Form_Value(arg, 0));
 
@@ -1311,7 +1314,7 @@ REBNATIVE(set_env)
     REBVAL *arg2 = D_ARG(2);
     REBOOL success;
 
-    Check_Security(SYM_ENVR, POL_WRITE, arg1);
+    Check_Security(Canon(SYM_ENVR), POL_WRITE, arg1);
 
     if (ANY_WORD(arg1)) Val_Init_String(arg1, Copy_Form_Value(arg1, 0));
 
@@ -1383,7 +1386,7 @@ REBNATIVE(access_os)
     REBOOL set = D_REF(2);
     REBVAL *val = D_ARG(3);
 
-    switch (VAL_WORD_CANON(field)) {
+    switch (VAL_WORD_SYM(field)) {
         case SYM_UID:
             if (set) {
                 if (IS_INTEGER(val)) {

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -137,7 +137,7 @@ static REBARR *Init_Loop(
             fail (Error_Invalid_Arg_Core(item, specifier));
         }
 
-        Val_Init_Typeset(key, ALL_64, VAL_WORD_SYM(item));
+        Val_Init_Typeset(key, ALL_64, VAL_WORD_SPELLING(item));
         key++;
 
         // !!! This should likely use the unset-defaulting in Ren-C with the
@@ -518,7 +518,7 @@ static REB_R Loop_Each(struct Reb_Frame *frame_, LOOP_MODE mode)
                     Val_Init_Word_Bound(
                         var,
                         REB_WORD,
-                        VAL_TYPESET_SYM(VAL_CONTEXT_KEY(data_value, index)),
+                        CTX_KEY_SPELLING(VAL_CONTEXT(data_value), index),
                         AS_CONTEXT(series),
                         index
                     );
@@ -537,7 +537,7 @@ static REB_R Loop_Each(struct Reb_Frame *frame_, LOOP_MODE mode)
                 else {
                     // !!! Review this error (and this routine...)
                     REBVAL key_name;
-                    Val_Init_Word(&key_name, REB_WORD, VAL_TYPESET_SYM(key));
+                    Val_Init_Word(&key_name, REB_WORD, VAL_KEY_SPELLING(key));
 
                     fail (Error_Invalid_Arg(&key_name));
                 }
@@ -572,7 +572,9 @@ static REB_R Loop_Each(struct Reb_Frame *frame_, LOOP_MODE mode)
                         // !!! Review this error (and this routine...)
                         REBVAL key_name;
                         Val_Init_Word(
-                            &key_name, REB_WORD, VAL_TYPESET_SYM(key)
+                            &key_name,
+                            REB_WORD,
+                            VAL_KEY_SPELLING(key)
                         );
 
                         fail (Error_Invalid_Arg(&key_name));

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -626,7 +626,7 @@ REBNATIVE(same_q)
         //
         // ANY-WORD! must match in binding as well as be otherwise equal.
         //
-        if (VAL_WORD_SYM(value1) != VAL_WORD_SYM(value2))
+        if (VAL_WORD_SPELLING(value1) != VAL_WORD_SPELLING(value2))
             return R_FALSE;
         if (IS_WORD_BOUND(value1) != IS_WORD_BOUND(value2))
             return R_FALSE;

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -263,7 +263,7 @@ REBNATIVE(evoke)
     RELVAL *arg = ARG(chant);
     REBCNT len;
 
-    Check_Security(SYM_DEBUG, POL_READ, 0);
+    Check_Security(Canon(SYM_DEBUG), POL_READ, 0);
 
     if (IS_BLOCK(arg)) {
         len = VAL_LEN_AT(arg);
@@ -273,7 +273,7 @@ REBNATIVE(evoke)
 
     for (; len > 0; len--, arg++) {
         if (IS_WORD(arg)) {
-            switch (VAL_WORD_CANON(arg)) {
+            switch (VAL_WORD_SYM(arg)) {
             case SYM_DELECT:
                 Trace_Delect(1);
                 break;
@@ -293,16 +293,12 @@ REBNATIVE(evoke)
             switch (Int32(KNOWN(arg))) {
             case 0:
                 Check_Memory();
-                Assert_Bind_Table_Empty();
                 break;
             case 1:
                 Reb_Opts->watch_expand = TRUE;
                 break;
             case 2:
                 Check_Memory();
-                break;
-            case 3:
-                Assert_Bind_Table_Empty();
                 break;
             default:
                 Out_Str(cb_cast(evoke_help), 1);
@@ -326,9 +322,7 @@ REBNATIVE(evoke)
 //
 REBNATIVE(limit_usage)
 {
-    REBSYM sym;
-
-    sym = VAL_WORD_CANON(D_ARG(1));
+    REBSYM sym = VAL_WORD_SYM(D_ARG(1));
 
     // Only gets set once:
     if (sym == SYM_EVAL) {

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -204,5 +204,5 @@ static REB_R Clipboard_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM acti
 //
 void Init_Clipboard_Scheme(void)
 {
-    Register_Scheme(SYM_CLIPBOARD, 0, Clipboard_Actor);
+    Register_Scheme(Canon(SYM_CLIPBOARD), 0, Clipboard_Actor);
 }

--- a/src/core/p-console.c
+++ b/src/core/p-console.c
@@ -140,5 +140,5 @@ static REB_R Console_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action
 //
 void Init_Console_Scheme(void)
 {
-    Register_Scheme(SYM_CONSOLE, 0, Console_Actor);
+    Register_Scheme(Canon(SYM_CONSOLE), 0, Console_Actor);
 }

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -328,5 +328,5 @@ create:
 //
 void Init_Dir_Scheme(void)
 {
-    Register_Scheme(SYM_DIR, 0, Dir_Actor);
+    Register_Scheme(Canon(SYM_DIR), 0, Dir_Actor);
 }

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -153,5 +153,5 @@ pick:
 //
 void Init_DNS_Scheme(void)
 {
-    Register_Scheme(SYM_DNS, 0, DNS_Actor);
+    Register_Scheme(Canon(SYM_DNS), 0, DNS_Actor);
 }

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -239,9 +239,9 @@ act_blk:
 void Init_Event_Scheme(void)
 {
     req = 0; // move to port struct
-    Register_Scheme(SYM_SYSTEM, 0, Event_Actor);
-    Register_Scheme(SYM_EVENT, 0, Event_Actor);
-    Register_Scheme(SYM_CALLBACK, 0, Event_Actor);
+    Register_Scheme(Canon(SYM_SYSTEM), 0, Event_Actor);
+    Register_Scheme(Canon(SYM_EVENT), 0, Event_Actor);
+    Register_Scheme(Canon(SYM_CALLBACK), 0, Event_Actor);
 }
 
 

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -125,7 +125,7 @@ void Ret_Query_File(REBCTX *port, REBREQ *file, REBVAL *ret)
     Val_Init_Word(
         CTX_VAR(context, STD_FILE_INFO_TYPE),
         REB_WORD,
-        GET_FLAG(file->modes, RFM_DIR) ? SYM_DIR : SYM_FILE
+        GET_FLAG(file->modes, RFM_DIR) ? Canon(SYM_DIR) : Canon(SYM_FILE)
     );
     SET_INTEGER(
         CTX_VAR(context, STD_FILE_INFO_SIZE), file->special.file.size
@@ -178,7 +178,7 @@ static REBCNT Get_Mode_Id(REBVAL *word)
 {
     REBCNT id = 0;
     if (IS_WORD(word)) {
-        id = Find_Int(&Mode_Syms[0], VAL_WORD_CANON(word));
+        id = Find_Int(&Mode_Syms[0], VAL_WORD_SYM(word));
         if (id == NOT_FOUND) fail (Error_Invalid_Arg(word));
     }
     return id;
@@ -594,5 +594,5 @@ seeked:
 //
 void Init_File_Scheme(void)
 {
-    Register_Scheme(SYM_FILE, 0, File_Actor);
+    Register_Scheme(Canon(SYM_FILE), 0, File_Actor);
 }

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -114,7 +114,7 @@ static void Accept_New_Port(REBVAL *out, REBCTX *port, REBREQ *sock)
 static REB_R Transport_Actor(
     struct Reb_Frame *frame_,
     REBCTX *port,
-    REBCNT action,
+    REBSYM action,
     enum Transport_Types proto
 ) {
     REBREQ *sock;   // IO request
@@ -359,12 +359,13 @@ static REB_R UDP_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action)
 //
 void Init_TCP_Scheme(void)
 {
-    Register_Scheme(SYM_TCP, 0, TCP_Actor);
+    Register_Scheme(Canon(SYM_TCP), 0, TCP_Actor);
 }
+
 //
 //  Init_UDP_Scheme: C
 //
 void Init_UDP_Scheme(void)
 {
-    Register_Scheme(SYM_UDP, 0, UDP_Actor);
+    Register_Scheme(Canon(SYM_UDP), 0, UDP_Actor);
 }

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -114,7 +114,7 @@ static REB_R Serial_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action)
                 if (!IS_WORD(arg))
                     fail (Error(RE_INVALID_PORT_ARG, arg));
 
-                switch (VAL_WORD_CANON(arg)) {
+                switch (VAL_WORD_SYM(arg)) {
                     case SYM_ODD:
                         req->special.serial.parity = SERIAL_PARITY_ODD;
                         break;
@@ -133,7 +133,7 @@ static REB_R Serial_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action)
                 if (!IS_WORD(arg))
                     fail (Error(RE_INVALID_PORT_ARG, arg));
 
-                switch (VAL_WORD_CANON(arg)) {
+                switch (VAL_WORD_SYM(arg)) {
                     case SYM_HARDWARE:
                         req->special.serial.flow_control = SERIAL_FLOW_CONTROL_HARDWARE;
                         break;
@@ -261,5 +261,5 @@ static REB_R Serial_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action)
 //
 void Init_Serial_Scheme(void)
 {
-    Register_Scheme(SYM_SERIAL, 0, Serial_Actor);
+    Register_Scheme(Canon(SYM_SERIAL), 0, Serial_Actor);
 }

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -47,20 +47,20 @@ static void update(REBREQ *req, REBINT len, REBVAL *arg)
     for (i = 0; i < len; i ++) {
         REBCTX *obj = Alloc_Context(8);
         REBVAL *val = Append_Context(
-            obj, NULL, Make_Word(signal_no, LEN_BYTES(signal_no))
+            obj, NULL, Intern_UTF8_Managed(signal_no, LEN_BYTES(signal_no))
         );
         SET_INTEGER(val, sig[i].si_signo);
 
         val = Append_Context(
-            obj, NULL, Make_Word(code, LEN_BYTES(code))
+            obj, NULL, Intern_UTF8_Managed(code, LEN_BYTES(code))
         );
         SET_INTEGER(val, sig[i].si_code);
         val = Append_Context(
-            obj, NULL, Make_Word(source_pid, LEN_BYTES(source_pid))
+            obj, NULL, Intern_UTF8_Managed(source_pid, LEN_BYTES(source_pid))
         );
         SET_INTEGER(val, sig[i].si_pid);
         val = Append_Context(
-            obj, NULL, Make_Word(source_uid, LEN_BYTES(source_uid))
+            obj, NULL, Intern_UTF8_Managed(source_uid, LEN_BYTES(source_uid))
         );
         SET_INTEGER(val, sig[i].si_uid);
 
@@ -77,9 +77,9 @@ static void update(REBREQ *req, REBINT len, REBVAL *arg)
     req->actual = 0; /* avoid duplicate updates */
 }
 
-static int sig_word_num(REBSYM canon)
+static int sig_word_num(REBSTR *canon)
 {
-    switch (canon) {
+    switch (STR_SYMBOL(canon)) {
         case SYM_SIGALRM:
             return SIGALRM;
         case SYM_SIGABRT:
@@ -180,7 +180,7 @@ static REB_R Signal_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action)
                 for(sig = VAL_ARRAY_AT_HEAD(val, 0); NOT_END(sig); sig ++) {
                     if (IS_WORD(sig)) {
                         /* handle the special word "ALL" */
-                        if (VAL_WORD_CANON(sig) == SYM_ALL) {
+                        if (VAL_WORD_SYM(sig) == SYM_ALL) {
                             if (sigfillset(&req->special.signal.mask) < 0) {
                                 // !!! Needs better error
                                 fail (Error(RE_INVALID_SPEC, sig));
@@ -291,7 +291,7 @@ static REB_R Signal_Actor(struct Reb_Frame *frame_, REBCTX *port, REBSYM action)
 //
 void Init_Signal_Scheme(void)
 {
-    Register_Scheme(SYM_SIGNAL, 0, Signal_Actor);
+    Register_Scheme(Canon(SYM_SIGNAL), 0, Signal_Actor);
 }
 
 #endif //HAS_POSIX_SIGNAL

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -88,7 +88,11 @@ act_blk:
         *D_ARG(1) = *state;
         result = T_Block(ds, action);
         SET_FLAG(Eval_Signals, SIG_EVENT_PORT);
-        if (action == A_INSERT || action == A_APPEND || action == A_REMOVE) {
+        if (
+            action == SYM_INSERT
+            || action == SYM_APPEND
+            || action == SYM_REMOVE
+        ){
             *D_OUT = save_port;
             break;
         }

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -269,7 +269,7 @@ REBCNT Hash_Value(const RELVAL *val, REBCTX *specifier)
         fail (Error_Invalid_Type(VAL_TYPE(val)));
 
     case REB_DATATYPE:
-        name = Get_Sym_Name(VAL_TYPE_SYM(val));
+        name = STR_HEAD(Canon(VAL_TYPE_SYM(val)));
         ret = Hash_Word(name, LEN_BYTES(name));
         break;
 
@@ -290,7 +290,8 @@ REBCNT Hash_Value(const RELVAL *val, REBCTX *specifier)
     case REB_LIT_WORD:
     case REB_REFINEMENT:
     case REB_ISSUE:
-        ret = VAL_WORD_CANON(val);
+        // !!! Review
+        ret = cast(REBCNT, cast(REBUPT, VAL_WORD_CANON(val)) >> 4);
         break;
 
     case REB_FUNCTION:

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -309,7 +309,6 @@ REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
 
     REBCNT n;
     REBCNT c;
-    RELVAL *item;
 
     if (IS_CHAR(val)) {
         Set_Bit(bset, VAL_CHAR(val), set);
@@ -331,8 +330,13 @@ REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
     if (!ANY_ARRAY(val))
         fail (Error_Invalid_Type(VAL_TYPE(val)));
 
-    item = VAL_ARRAY_AT(val);
-    if (NOT_END(item) && IS_WORD(item) && VAL_WORD_CANON(item) == SYM_NOT) {
+    RELVAL *item = VAL_ARRAY_AT(val);
+
+    if (
+        NOT_END(item)
+        && IS_WORD(item)
+        && VAL_WORD_SYM(item) == SYM_NOT
+    ){
         INIT_BITS_NOT(bset, TRUE);
         item++;
     }
@@ -341,17 +345,13 @@ REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
     for (; NOT_END(item); item++) {
 
         switch (VAL_TYPE(item)) {
-
         case REB_CHAR:
             c = VAL_CHAR(item);
-
-            // !!! Modified to check for END, is the `else` actually correct?
-            //
             if (
                 NOT_END(item + 1)
                 && IS_WORD(item + 1)
-                && VAL_WORD_CANON(item + 1) == SYM_HYPHEN
-            ) {
+                && VAL_WORD_SYM(item + 1) == SYM_HYPHEN
+            ){
                 item += 2;
                 if (IS_CHAR(item)) {
                     n = VAL_CHAR(item);
@@ -368,7 +368,7 @@ span_bits:
         case REB_INTEGER:
             n = Int32s(KNOWN(item), 0);
             if (n > MAX_BITSET) return FALSE;
-            if (IS_WORD(item + 1) && VAL_WORD_CANON(item + 1) == SYM_HYPHEN) {
+            if (IS_WORD(item + 1) && VAL_WORD_SYM(item + 1) == SYM_HYPHEN) {
                 c = n;
                 item += 2;
                 if (IS_INTEGER(item)) {
@@ -393,7 +393,7 @@ span_bits:
 
         case REB_WORD:
             // Special: BITS #{000...}
-            if (!IS_WORD(item) || VAL_WORD_CANON(item) != SYM_BITS)
+            if (!IS_WORD(item) || VAL_WORD_SYM(item) != SYM_BITS)
                 return FALSE;
             item++;
             if (!IS_BINARY(item)) return FALSE;
@@ -446,7 +446,7 @@ REBOOL Check_Bits(REBSER *bset, const REBVAL *val, REBOOL uncased)
 
         case REB_CHAR:
             c = VAL_CHAR(item);
-            if (IS_WORD(item + 1) && VAL_WORD_CANON(item + 1) == SYM_HYPHEN) {
+            if (IS_WORD(item + 1) && VAL_WORD_SYM(item + 1) == SYM_HYPHEN) {
                 item += 2;
                 if (IS_CHAR(item)) {
                     n = VAL_CHAR(item);
@@ -465,7 +465,7 @@ scan_bits:
         case REB_INTEGER:
             n = Int32s(KNOWN(item), 0);
             if (n > 0xffff) return FALSE;
-            if (IS_WORD(item + 1) && VAL_WORD_CANON(item + 1) == SYM_HYPHEN) {
+            if (IS_WORD(item + 1) && VAL_WORD_SYM(item + 1) == SYM_HYPHEN) {
                 c = n;
                 item += 2;
                 if (IS_INTEGER(item)) {

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -269,7 +269,7 @@ REBCNT Find_In_Array(
         for (; index >= start && index < end; index += skip) {
             value = ARR_AT(array, index);
             if (ANY_WORD(value)) {
-                cnt = (VAL_WORD_SYM(value) == VAL_WORD_SYM(target));
+                cnt = (VAL_WORD_SPELLING(value) == VAL_WORD_SPELLING(target));
                 if (flags & AM_FIND_CASE) {
                     // Must be same type and spelling:
                     if (cnt && VAL_TYPE(value) == VAL_TYPE(target)) return index;

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -506,35 +506,27 @@ void TO_Date(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 //
 REBINT PD_Date(REBPVS *pvs)
 {
-    const REBVAL *sel = pvs->selector;
     REBVAL *value = KNOWN(pvs->value);
-    const REBVAL *setval;
-
-    REBINT i;
-    REBINT n;
-    REBI64 secs;
-    REBINT tz;
-    REBDAT date;
-    REBCNT day, month, year;
-    REBINT num;
-    REB_TIMEF time;
-
     assert(IS_DATE(value));
 
     // Extract the components of the input
     //
-    date = VAL_DATE(value);
-    day = VAL_DAY(value) - 1;
-    month = VAL_MONTH(value) - 1;
-    year = VAL_YEAR(value);
-    secs = VAL_TIME(value);
-    tz = VAL_ZONE(value);
+    REBDAT date = VAL_DATE(value);
+    REBCNT day = VAL_DAY(value) - 1;
+    REBCNT month = VAL_MONTH(value) - 1;
+    REBCNT year = VAL_YEAR(value);
 
+    REBI64 secs = VAL_TIME(value);
+    REBINT tz = VAL_ZONE(value);
+
+    REBINT i;
+
+    const REBVAL *sel = pvs->selector;
     if (IS_WORD(sel)) {
         //
         // !!! Wouldn't it be clearer if this turned indices into symbols?
         //
-        switch (VAL_WORD_CANON(sel)) {
+        switch (VAL_WORD_SYM(sel)) {
         case SYM_YEAR:  i = 0; break;
         case SYM_MONTH: i = 1; break;
         case SYM_DAY:   i = 2; break;
@@ -559,9 +551,11 @@ REBINT PD_Date(REBPVS *pvs)
     }
     else fail (Error_Bad_Path_Select(pvs));
 
+    REB_TIMEF time;
     if (i > 8) Split_Time(secs, &time);
 
-    if (!(setval = pvs->opt_setval)) {
+    const REBVAL *setval = pvs->opt_setval;
+    if (setval == NULL) {
         //
         // Adapt the date value that came in to get the return result.  Put
         // the existing value in the store, and adjust its time zone if
@@ -573,6 +567,7 @@ REBINT PD_Date(REBPVS *pvs)
 
         if (i != 8) Adjust_Date_Zone(store, FALSE);
 
+        REBINT num;
         switch(i) {
         case 0:
             num = year;
@@ -634,6 +629,8 @@ REBINT PD_Date(REBPVS *pvs)
         // Here the desire is to modify the incoming date directly.  This is
         // done by changing the components that need to change which were
         // extracted, and building a new date out of the parts.
+
+        REBINT n;
 
         if (IS_INTEGER(setval) || IS_DECIMAL(setval))
             n = Int32s(setval, 0);

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -443,9 +443,9 @@ REBTYPE(Decimal)
         case SYM_EVEN_Q:
         case SYM_ODD_Q:
             d1 = fabs(fmod(d1, 2.0));
-            return ((action != SYM_EVEN_Q) != ((d1 < 0.5) || (d1 >= 1.5)))
-                ? R_TRUE
-                : R_FALSE;
+            if ((action == SYM_ODD_Q) != ((d1 < 0.5) || (d1 >= 1.5)))
+                return R_TRUE;
+            return R_FALSE;
 
         case SYM_ROUND:
             arg = D_ARG(3);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -138,9 +138,9 @@ REBTYPE(Function)
         return R_OUT;
 
     case SYM_REFLECT: {
-        REBSYM canon = VAL_WORD_CANON(arg);
+        REBSYM sym = VAL_WORD_SYM(arg);
 
-        switch (canon) {
+        switch (sym) {
         case SYM_ADDR:
             if (
                 IS_FUNCTION_RIN(value)
@@ -225,9 +225,9 @@ REBTYPE(Function)
             param = VAL_FUNC_PARAMS_HEAD(value);
             typeset = SINK(ARR_HEAD(copy));
             for (; NOT_END(param); param++, typeset++) {
-                assert(VAL_TYPESET_SYM(param) != SYM_0);
+                assert(VAL_PARAM_SPELLING(param) != NULL);
                 *typeset = *param;
-                VAL_TYPESET_SYM_INIT(typeset, SYM_0);
+                INIT_TYPESET_NAME(typeset, NULL);
             }
             SET_END(typeset);
             SET_ARRAY_LEN(copy, VAL_FUNC_NUM_PARAMS(value));

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -1184,8 +1184,7 @@ REBINT PD_Image(REBPVS *pvs)
     else if (IS_LOGIC(sel))   n = (VAL_LOGIC(sel) ? 1 : 2);
     else if (IS_WORD(sel)) {
         if (!pvs->opt_setval) {
-            switch (VAL_WORD_CANON(sel)) {
-
+            switch (VAL_WORD_SYM(sel)) {
             case SYM_SIZE:
                 VAL_RESET_HEADER(pvs->store, REB_PAIR);
                 VAL_PAIR_X(pvs->store) = (REBD32)VAL_IMAGE_WIDE(data);
@@ -1215,8 +1214,7 @@ REBINT PD_Image(REBPVS *pvs)
             FAIL_IF_LOCKED_SERIES(series);
             setval = pvs->opt_setval;
 
-            switch (VAL_WORD_CANON(sel)) {
-
+            switch (VAL_WORD_SYM(sel)) {
             case SYM_SIZE:
                 if (!IS_PAIR(setval) || !VAL_PAIR_X(setval))
                     fail (Error_Bad_Path_Set(pvs));

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -233,7 +233,7 @@ void Value_To_Int64(REBI64 *out, const REBVAL *value, REBOOL no_sign)
         // more sense as these would be hexes likely typed in by users,
         // who rarely do 2s-complement math in their head.
 
-        const REBYTE *bp = Get_Sym_Name(VAL_WORD_SYM(value));
+        const REBYTE *bp = VAL_WORD_HEAD(value);
         REBCNT len = LEN_BYTES(bp);
 
         if (len > MAX_HEX_LEN) {

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -185,9 +185,9 @@ REBINT PD_Pair(REBPVS *pvs)
     REBD32 dec;
 
     if (IS_WORD(sel)) {
-        if (VAL_WORD_CANON(sel) == SYM_X)
+        if (VAL_WORD_SYM(sel) == SYM_X)
             n = 1;
-        else if (VAL_WORD_CANON(sel) == SYM_Y)
+        else if (VAL_WORD_SYM(sel) == SYM_Y)
             n = 2;
         else
             fail (Error_Bad_Path_Select(pvs));
@@ -338,9 +338,9 @@ REBTYPE(Pair)
         REBVAL *arg = D_ARG(2);
         REBINT n;
         if (IS_WORD(arg)) {
-            if (VAL_WORD_CANON(arg) == SYM_X)
+            if (VAL_WORD_SYM(arg) == SYM_X)
                 n = 0;
-            else if (VAL_WORD_CANON(arg) == SYM_Y)
+            else if (VAL_WORD_SYM(arg) == SYM_Y)
                 n = 1;
             else
                 fail (Error_Invalid_Arg(arg));

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -302,7 +302,7 @@ REBINT PD_Time(REBPVS *pvs)
     REB_TIMEF tf;
 
     if (IS_WORD(sel)) {
-        switch (VAL_WORD_CANON(sel)) {
+        switch (VAL_WORD_SYM(sel)) {
         case SYM_HOUR:   i = 0; break;
         case SYM_MINUTE: i = 1; break;
         case SYM_SECOND: i = 2; break;

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -107,7 +107,7 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind type, const REBVAL *arg)
 
     if (IS_ISSUE(arg)) {
         REBUNI c;
-        const REBYTE *ap = Get_Sym_Name(VAL_WORD_SYM(arg));
+        const REBYTE *ap = VAL_WORD_HEAD(arg);
         REBCNT len = LEN_BYTES(ap);  // UTF-8 len
         if (len & 1) goto bad_arg; // must have even # of chars
         len /= 2;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -85,21 +85,19 @@ REBINT CT_Typeset(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void Init_Typesets(void)
 {
-    REBVAL *value;
-    REBINT n;
-
     Set_Root_Series(ROOT_TYPESETS, ARR_SERIES(Make_Array(40)));
 
-    for (n = 0; Typesets[n].sym != SYM_0; n++) {
-        value = Alloc_Tail_Array(VAL_ARRAY(ROOT_TYPESETS));
+    REBINT n;
+    for (n = 0; Typesets[n].sym != 0; n++) {
+        REBVAL *value = Alloc_Tail_Array(VAL_ARRAY(ROOT_TYPESETS));
 
         // Note: the symbol in the typeset is not the symbol of a word holding
         // the typesets, rather an extra data field used when the typeset is
         // in a context key slot to identify that field's name
         //
-        Val_Init_Typeset(value, Typesets[n].bits, SYM_0);
+        Val_Init_Typeset(value, Typesets[n].bits, NULL);
 
-        *Append_Context(Lib_Context, NULL, Typesets[n].sym) = *value;
+        *Append_Context(Lib_Context, NULL, Canon(Typesets[n].sym)) = *value;
     }
 }
 
@@ -107,12 +105,13 @@ void Init_Typesets(void)
 //
 //  Val_Init_Typeset: C
 // 
-// Note: sym is optional, and can be SYM_0
+// Name should be set when a typeset is being used as a function parameter
+// specifier, or as a key in an object.
 //
-void Val_Init_Typeset(RELVAL *value, REBU64 bits, REBSYM sym)
+void Val_Init_Typeset(RELVAL *value, REBU64 bits, REBSTR *opt_name)
 {
     VAL_RESET_HEADER(value, REB_TYPESET);
-    VAL_TYPESET_SYM_INIT(value, sym);
+    INIT_TYPESET_NAME(value, opt_name);
     VAL_TYPESET_BITS(value) = bits;
 }
 
@@ -252,7 +251,7 @@ void MAKE_Typeset(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 
     if (!IS_BLOCK(arg)) goto bad_make;
 
-    Val_Init_Typeset(out, 0, SYM_0);
+    Val_Init_Typeset(out, 0, NULL);
     Update_Typeset_Bits_Core(
         out,
         VAL_ARRAY_AT(arg),

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -365,16 +365,18 @@ REBVAL *Make_Vector_Spec(RELVAL *bp, REBCTX *specifier, REBVAL *value)
     REBVAL *iblk = 0;
 
     // UNSIGNED
-    if (IS_WORD(bp) && VAL_WORD_CANON(bp) == SYM_UNSIGNED) {
+    if (IS_WORD(bp) && VAL_WORD_SYM(bp) == SYM_UNSIGNED) {
         sign = 1;
         bp++;
     }
 
     // INTEGER! or DECIMAL!
     if (IS_WORD(bp)) {
-        if (VAL_WORD_CANON(bp) == SYM_FROM_KIND(REB_INTEGER))
+        if (SAME_SYM_NONZERO(VAL_WORD_SYM(bp), SYM_FROM_KIND(REB_INTEGER)))
             type = 0;
-        else if (VAL_WORD_CANON(bp) == SYM_FROM_KIND(REB_DECIMAL)) {
+        else if (
+            SAME_SYM_NONZERO(VAL_WORD_SYM(bp), SYM_FROM_KIND(REB_DECIMAL))
+        ){
             type = 1;
             if (sign > 0) return 0;
         }
@@ -644,12 +646,21 @@ void Mold_Vector(const REBVAL *value, REB_MOLD *mold, REBOOL molded)
     }
 
     if (molded) {
-        REBCNT type = (bits >= VTSF08) ? REB_DECIMAL : REB_INTEGER;
+        enum Reb_Kind kind = (bits >= VTSF08) ? REB_DECIMAL : REB_INTEGER;
         Pre_Mold(value, mold);
-        if (!GET_MOPT(mold, MOPT_MOLD_ALL)) Append_Codepoint_Raw(mold->series, '[');
-        if (bits >= VTUI08 && bits <= VTUI64) Append_Unencoded(mold->series, "unsigned ");
-        Emit(mold, "N I I [", type+1, bit_sizes[bits & 3], len);
-        if (len) New_Indented_Line(mold);
+        if (!GET_MOPT(mold, MOPT_MOLD_ALL))
+            Append_Codepoint_Raw(mold->series, '[');
+        if (bits >= VTUI08 && bits <= VTUI64)
+            Append_Unencoded(mold->series, "unsigned ");
+        Emit(
+            mold,
+            "N I I [",
+            Canon(SYM_FROM_KIND(kind)),
+            bit_sizes[bits & 3],
+            len
+        );
+        if (len)
+            New_Indented_Line(mold);
     }
 
     c = 0;

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -47,7 +47,7 @@ REBINT CT_Word(const RELVAL *a, const RELVAL *b, REBINT mode)
             //
             // Symbols must be exact match, case-sensitively
             //
-            if (VAL_WORD_SYM(a) != VAL_WORD_SYM(b))
+            if (VAL_WORD_SPELLING(a) != VAL_WORD_SPELLING(b))
                 return 0;
         }
         else {
@@ -83,56 +83,55 @@ void MAKE_Word(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         return;
     }
 
-    REBSYM sym;
+    REBSTR *name;
 
     if (IS_STRING(arg)) {
-        REBYTE *bp;
         REBCNT len;
         const REBOOL allow_utf8 = TRUE;
 
-        // Set sym. Rest is set below.  If characters in the source
+        // Set name. Rest is set below.  If characters in the source
         // string are > 0x80 they will be encoded to UTF8 to be stored
         // in the symbol.
         //
-        bp = Temp_Byte_Chars_May_Fail(
+        REBYTE *bp = Temp_Byte_Chars_May_Fail(
             arg, MAX_SCAN_WORD, &len, allow_utf8
         );
 
         if (kind == REB_ISSUE)
-            sym = Scan_Issue(bp, len);
+            name = Scan_Issue(bp, len);
         else
-            sym = Scan_Word(bp, len);
+            name = Scan_Word(bp, len);
 
-        if (sym == SYM_0)
+        if (name == NULL)
             fail (Error(RE_BAD_CHAR, arg));
     }
     else if (IS_CHAR(arg)) {
         REBYTE buf[8];
-        sym = Encode_UTF8_Char(&buf[0], VAL_CHAR(arg)); //returns length
-        sym = Scan_Word(&buf[0], sym);
-        if (!sym) fail (Error(RE_BAD_CHAR, arg));
+        REBCNT len = Encode_UTF8_Char(&buf[0], VAL_CHAR(arg));
+        name = Scan_Word(&buf[0], len);
+        if (name == NULL) fail (Error(RE_BAD_CHAR, arg));
     }
     else if (IS_DATATYPE(arg)) {
     #if defined(NDEBUG)
-        sym = VAL_TYPE_SYM(arg);
+        name = Canon(VAL_TYPE_SYM(arg));
     #else
         if (
             LEGACY(OPTIONS_PAREN_INSTEAD_OF_GROUP)
             && VAL_TYPE_KIND(arg) == REB_GROUP
         ) {
-            sym = SYM_PAREN_X; // e_Xclamation point (PAREN!)
+            name = Canon(SYM_PAREN_X); // e_Xclamation point (PAREN!)
         }
         else
-            sym = VAL_TYPE_SYM(arg);
+            name = Canon(VAL_TYPE_SYM(arg));
     #endif
     }
     else if (IS_LOGIC(arg)) {
-        sym = VAL_LOGIC(arg) ? SYM_TRUE : SYM_FALSE;
+        name = VAL_LOGIC(arg) ? Canon(SYM_TRUE) : Canon(SYM_FALSE);
     }
     else
         fail (Error_Unexpected_Type(REB_WORD, VAL_TYPE(arg)));
 
-    Val_Init_Word(out, kind, sym);
+    Val_Init_Word(out, kind, name);
 }
 
 
@@ -153,7 +152,7 @@ REBTYPE(Word)
     REBVAL *val = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
     REBINT diff;
-    REBSYM sym;
+    REBSTR *sym;
 
     switch (action) {
     default:

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -56,6 +56,9 @@
     struct Reb_Series; // Rebol series node
     typedef struct Reb_Series REBSER;
 
+    // UTF-8 Everywhere series (used for WORD!s only ATM)
+    typedef REBSER REBSTR;
+
     struct Reb_Array; // REBSER containing REBVALs ("Rebol Array")
     typedef struct Reb_Array REBARR;
 
@@ -90,6 +93,8 @@
     // the binding in Ren-Cpp binary compatible regardless of whether the build
     // was done with C or C++
     //
+
+    struct Reb_Binder; // used as argument in %tmp-funcs.h, needs forward decl
 
     #define END_FLAG 0x80000000  // end of block as index
     #define THROWN_FLAG (END_FLAG - 0x75) // throw as an index
@@ -136,6 +141,7 @@
     typedef void REBSER;
     typedef void REBARR;
     typedef void REBOBJ;
+    typedef void REBSTR;
 #endif
 
 

--- a/src/include/reb-struct.h
+++ b/src/include/reb-struct.h
@@ -130,7 +130,7 @@
 struct Struct_Field {
     REBARR* spec; /* for nested struct */
     REBSER* fields; /* for nested struct */
-    REBSYM sym;
+    REBSTR *name;
 
     unsigned short type; // e.g. FFI_TYPE_XXX constants
 
@@ -372,8 +372,8 @@ inline static void* SCHEMA_FFTYPE_CORE(const RELVAL *schema) {
     assert(IS_INTEGER(schema));
 
     enum Reb_Kind kind; // dummy
-    REBSYM sym; // dummy
-    return Get_FFType_Enum_Info(&sym, &kind, VAL_INT32(schema));
+    REBSTR *name; // dummy
+    return Get_FFType_Enum_Info(&name, &kind, VAL_INT32(schema));
 }
 
 #define SCHEMA_FFTYPE(schema) \

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -1,0 +1,176 @@
+//
+//  File: %sys-bind.h
+//  Summary: "System Binding Include"
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2016 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// R3-Alpha had a per-thread "bind table"; a large and sparsely populated hash
+// into which index numbers would be placed, for what index those words would
+// have as keys or parameters.  Ren-C's strategy is that binding information
+// is wedged into REBSER nodes that represent the canon words themselves.
+//
+// This would create problems if multiple threads were trying to bind at the
+// same time.  While threading was never realized in R3-Alpha, Ren-C doesn't
+// want to have any "less of a plan".  So the Reb_Binder is used by binding
+// clients as a placeholder for whatever actual state would be used to augment
+// the information in the canon word series about which client is making a
+// request.  This could be coupled with some kind of lockfree adjustment
+// strategy whereby a word that was contentious would cause a structure to
+// "pop out" and be pointed to by some atomic thing inside the word.
+//
+// For the moment, a binder has some influence by saying whether the high 16
+// bits or low 16 bits of the canon's misc.index are used.  If the index
+// were atomic this would--for instance--allow two clients to bind at once.
+// It's just a demonstration of where more general logic using atomics
+// that could work for N clients would be.
+//
+// The debug build also adds another feature, that makes sure the clear count
+// matches the set count.
+//
+
+// Modes allowed by Bind related functions:
+enum {
+    BIND_0 = 0, // Only bind the words found in the context.
+    BIND_DEEP = 1 << 1, // Recurse into sub-blocks.
+    BIND_FUNC = 1 << 2 // Recurse into functions.
+};
+
+
+struct Reb_Binder {
+    REBOOL high;
+#if !defined(NDEBUG)
+    REBCNT count;
+#endif
+};
+
+
+inline static void INIT_BINDER(struct Reb_Binder *binder) {
+    binder->high = TRUE; //LOGICAL(SPORADICALLY(2)); sporadic?
+#if !defined(NDEBUG)
+    binder->count = 0;
+#endif
+}
+
+
+inline static void SHUTDOWN_BINDER(struct Reb_Binder *binder) {
+    assert(binder->count == 0);
+}
+
+
+// Tries to set the binder index, but return false if already there.
+//
+inline static REBOOL Try_Add_Binder_Index(
+    struct Reb_Binder *binder,
+    REBSTR *canon,
+    REBINT index
+){
+    assert(index != 0);
+    assert(GET_SER_FLAG(canon, STRING_FLAG_CANON));
+    if (binder->high) {
+        if (canon->misc.bind_index.high != 0)
+            return FALSE;
+        canon->misc.bind_index.high = index;
+    }
+    else {
+        if (canon->misc.bind_index.low != 0)
+            return FALSE;
+        canon->misc.bind_index.low = index;
+    }
+
+#if !defined(NDEBUG)
+    ++binder->count;
+#endif
+    return TRUE;
+}
+
+
+inline static void Add_Binder_Index(
+    struct Reb_Binder *binder,
+    REBSTR *canon,
+    REBINT index
+){
+    REBOOL success = Try_Add_Binder_Index(binder, canon, index);
+    assert(success);
+}
+
+
+inline static REBINT Try_Get_Binder_Index( // 0 if not present
+    struct Reb_Binder *binder,
+    REBSTR *canon
+){
+    assert(GET_SER_FLAG(canon, STRING_FLAG_CANON));
+
+    if (binder->high)
+        return canon->misc.bind_index.high;
+    else
+        return canon->misc.bind_index.low;
+}
+
+
+inline static REBINT Try_Remove_Binder_Index( // 0 if failure, else old index
+    struct Reb_Binder *binder,
+    REBSTR *canon
+){
+    assert(GET_SER_FLAG(canon, STRING_FLAG_CANON));
+
+    REBINT old_index;
+    if (binder->high) {
+        old_index = canon->misc.bind_index.high;
+        if (old_index == 0)
+            return 0;
+        canon->misc.bind_index.high = 0;
+    }
+    else {
+        old_index = canon->misc.bind_index.low;
+        if (old_index == 0)
+            return 0;
+        canon->misc.bind_index.low = 0;
+    }
+
+#if !defined(NDEBUG)
+    --binder->count;
+#endif
+    return old_index;
+}
+
+
+inline static void Remove_Binder_Index(
+    struct Reb_Binder *binder,
+    REBSTR *canon
+){
+    REBINT old_index = Try_Remove_Binder_Index(binder, canon);
+    assert(old_index != 0);
+}
+
+
+// Modes allowed by Collect keys functions:
+enum {
+    COLLECT_ONLY_SET_WORDS = 0,
+    COLLECT_ANY_WORD = 1 << 1,
+    COLLECT_DEEP = 1 << 2,
+    COLLECT_NO_DUP = 1 << 3, // Do not allow dups during collection (for specs)
+    COLLECT_ENSURE_SELF = 1 << 4 // !!! Ensure SYM_SELF in context (temp)
+};
+

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -156,6 +156,8 @@ typedef struct rebol_mem_pool REBPOL;
 
 #include "sys-deci.h"
 
+#include "tmp-bootdefs.h"
+
 #include "sys-rebval.h" // REBVAL structure definition
 #include "sys-action.h"
 #include "sys-rebser.h" // REBSER series definition (embeds REBVAL definition)
@@ -206,14 +208,6 @@ typedef struct rebol_mold {
 **  Structures
 **
 ***********************************************************************/
-
-// Word Table Structure - used to manage hashed word tables (symbol tables).
-typedef struct rebol_word_table
-{
-    REBARR  *array;     // Global block of words
-    REBSER  *hashes;    // Hash table
-//  REBCNT  count;      // Number of units used in hash table
-} WORD_TABLE;
 
 //-- Measurement Variables:
 typedef struct rebol_stats {
@@ -349,37 +343,6 @@ typedef void (*REBMRK)(void);
 // Breakpoint hook callback
 typedef REBOOL (*REBBRK)(REBVAL *instruction_out, REBOOL interrupted);
 
-// Modes allowed by Bind related functions:
-enum {
-    BIND_0 = 0, // Only bind the words found in the context.
-    BIND_DEEP = 1 << 1, // Recurse into sub-blocks.
-    BIND_FUNC = 1 << 2 // Recurse into functions.
-};
-
-// The bind table is sparsely hashed, so when it is in use only a few
-// entries get set.  It's cheaper to go through the entries that were
-// made nonzero and zero them out than to reset it.  So after every wave
-// of binding, the binds that were given non-zero values should have been
-// zeroed back out.  This can be enabled to check that invariant.
-//
-#ifdef NDEBUG
-    #define ASSERT_BIND_TABLE_EMPTY
-#else
-    #if 0
-        #define ASSERT_BIND_TABLE_EMPTY Assert_Bind_Table_Empty()
-    #else
-        #define ASSERT_BIND_TABLE_EMPTY
-    #endif
-#endif
-
-// Modes allowed by Collect keys functions:
-enum {
-    COLLECT_ONLY_SET_WORDS = 0,
-    COLLECT_ANY_WORD = 1 << 1,
-    COLLECT_DEEP = 1 << 2,
-    COLLECT_NO_DUP = 1 << 3, // Do not allow dups during collection (for specs)
-    COLLECT_ENSURE_SELF = 1 << 4 // !!! Ensure SYM_SELF in context (temp)
-};
 
 // Flags used for Protect functions
 //
@@ -643,7 +606,6 @@ enum Reb_Vararg_Op {
 //#include "reb-net.h"
 #include "tmp-strings.h"
 #include "tmp-funcargs.h"
-#include "tmp-bootdefs.h"
 #include "tmp-boot.h"
 #include "tmp-errnums.h"
 #include "tmp-sysobj.h"
@@ -669,6 +631,8 @@ enum Reb_Vararg_Op {
 #include "sys-series.h" // Series accessor routines (used by value accessors)
 
 #include "sys-value.h" // Value accessors
+
+#include "sys-bind.h"
 
 #include "reb-struct.h"
 
@@ -776,7 +740,7 @@ static inline void CATCH_THROWN(REBVAL *arg_out, REBVAL *thrown) {
 enum {
     GETVAR_READ_ONLY = 0,
     GETVAR_UNBOUND_OK = 1 << 0,
-    GETVAR_IS_SETVAR = 1 << 1, // will clear infix bit, so "always writes"!
+    GETVAR_IS_SETVAR = 1 << 1 // will clear infix bit, so "always writes"!
 };
 
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -102,18 +102,18 @@ inline static REBOOL Is_Function_Frame_Fulfilling(struct Reb_Frame *f)
 // and see a cached string for the function it's running (if there is one).
 // The release build only considers the frame symbol valid if ET_FUNCTION
 //
-inline static void SET_FRAME_SYM(struct Reb_Frame *f, REBSYM sym) {
+inline static void SET_FRAME_LABEL(struct Reb_Frame *f, REBSTR *label) {
     assert(Is_Any_Function_Frame(f));
+    f->label = label;
 #if !defined(NDEBUG)
-    f->label_sym = sym;
-    f->label_str = cast(const char*, Get_Sym_Name(sym));
+    f->label_debug = cast(const char*, STR_HEAD(label));
 #endif
 }
 
-inline static void CLEAR_FRAME_SYM(struct Reb_Frame *f) {
+inline static void CLEAR_FRAME_LABEL(struct Reb_Frame *f) {
 #if !defined(NDEBUG)
-    f->label_sym = SYM_0;
-    f->label_str = NULL;
+    f->label = NULL;
+    f->label_debug = NULL;
 #endif
 }
 
@@ -842,7 +842,7 @@ struct Native_Refine {
 
 #define FRM_OUT(f)          cast(REBVAL * const, (f)->out) // writable Lvalue
 #define FRM_PRIOR(f)        ((f)->prior)
-#define FRM_LABEL(f)        ((f)->label_sym)
+#define FRM_LABEL(f)        ((f)->label)
 
 #define FRM_FUNC(f)         ((f)->func)
 #define FRM_DSP_ORIG(f)     ((f)->dsp_orig + 0) // Lvalue

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -438,13 +438,13 @@ struct Reb_Frame {
     //
     REBARR *binding; // either a varlist of a FRAME! or function paramlist
 
-    // `label_sym`
+    // `label`
     //
     // Functions don't have "names", though they can be assigned to words.
     // The evaluator only enforces that the symbol be set during function
     // calls--in the release build, it is allowed to be garbage otherwise.
     //
-    REBUPT label_sym; // actually REBSYM
+    REBSTR *label;
 
     // `stackvars`
     //
@@ -534,13 +534,13 @@ struct Reb_Frame {
 
 #if !defined(NDEBUG)
     //
-    // `label_str` [DEBUG]
+    // `label_debug` [DEBUG]
     //
     // Knowing the label symbol is not as handy as knowing the actual string
     // of the function this call represents (if any).  It is in UTF8 format,
     // and cast to `char*` to help debuggers that have trouble with REBYTE.
     //
-    const char *label_str;
+    const char *label_debug;
 
     // `value_type`
     //

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -385,6 +385,7 @@ struct Reb_Series {
         REBARR *subfeed; // for *non-frame* VARARGS! ("array1") shared feed
         REBSER *schema; // STRUCT uses this (parallels object's keylist)
         REBCTX *meta; // paramlists and keylists can store a "meta" object
+        REBSTR *synonym; // circularly linked list of othEr-CaSed string forms
     } link;
 
     // The `misc` field is an extra pointer-sized piece of data which is
@@ -393,7 +394,6 @@ struct Reb_Series {
     //
     union {
         REBNAT dispatcher; // native dispatcher code, see Reb_Function's body
-        REBCNT len; // length of non-arrays when !SERIES_FLAG_HAS_DYNAMIC
         REBCNT size;    // used for vectors and bitsets
         struct {
             REBCNT wide:16;
@@ -403,6 +403,11 @@ struct Reb_Series {
         REBFUN *underlying; // specialization -or- final underlying function
         struct Reb_Frame *f; // for a FRAME! series, the call frame (or NULL)
         void *fd; // file descriptor for library
+        REBSTR *canon; // canon cased form of this symbol (if not canon)
+        struct {
+            REBINT high:16;
+            REBINT low:16;
+        } bind_index; // canon words hold index for binding--demo sharing 2
     } misc;
 
 #if !defined(NDEBUG)

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -328,7 +328,7 @@ enum {
     // to be meaningful on arguments in function frames...though it is
     // valid on any result at the moment of taking it from Do_Core().
     //
-    VALUE_FLAG_EVALUATED = 1 << (GENERAL_VALUE_BIT + 7),
+    VALUE_FLAG_EVALUATED = 1 << (GENERAL_VALUE_BIT + 7)
 };
 
 
@@ -404,24 +404,6 @@ typedef struct Reb_Tuple {
 } REBTUP;
 
 
-//
-// Rebol Symbol
-//
-// !!! Historically Rebol used an unsigned 32-bit integer as a "symbol ID".
-// These symbols did not participate in garbage collection and had to be
-// looked up in a table to get their values.  Ren-C is moving toward adapting
-// REBSERs to be able to store words and canon words, as well as GC them.
-// This starts moving the types to be the size of a platform pointer.
-//
-
-typedef REBUPT REBSYM;
-
-struct Reb_Symbol {
-    REBCNT alias; // Index to next alias form
-    REBCNT name; // Index into PG_Word_Names string
-};
-
-
 struct Reb_Any_Series {
     //
     // `series` represents the actual physical underlying data, which is
@@ -453,13 +435,9 @@ struct Reb_Typeset {
 
 struct Reb_Any_Word {
     //
-    // Index of the word's symbol
+    // This is the word's non-canonized spelling.  It is a UTF-8 string.
     //
-    // Note: Future expansion plans are to have symbol entries tracked by
-    // pointer and garbage collected, likely as series nodes.  A full pointer
-    // sized value is required here.
-    //
-    REBSYM sym;
+    REBSTR *spelling;
 
     // Index of word in context (if word is bound, e.g. `binding` is not NULL)
     //
@@ -706,9 +684,8 @@ union Reb_Value_Extra {
     // 64-bit alignment, then that gets the priority for being in the payload,
     // with the "Extra" pointer-sized item here.
 
-    REBSYM typeset_sym; // if typeset is key of object or function parameter
+    REBSTR *key_spelling; // if typeset is key of object or function parameter
     REBDAT date; // time's payload holds the nanoseconds, this is the date
-    REBSYM symbol_canon; // if Reb_Symbol, index of the canonical (first) word
     REBCNT struct_offset; // offset for struct in the possibly shared series
 
     // !!! Biasing Ren-C to helping solve its technical problems led the
@@ -752,8 +729,6 @@ union Reb_Value_Payload {
 
     struct Reb_Event event;
     struct Reb_Gob gob;
-
-    struct Reb_Symbol symbol; // internal
 
     // These use `specific` or `relative` in `binding`, based on IS_RELATIVE()
 

--- a/src/os/host-core.c
+++ b/src/os/host-core.c
@@ -67,7 +67,7 @@ extern "C" {
 //REBYTE *encapBuffer = NULL;
 //REBINT encapBufferLen;
 RL_LIB *RL; // Link back to reb-lib from embedded extensions
-static u32 *core_ext_words;
+static REBSTR* *core_ext_words;
 
 //
 //  RXD_Core: C
@@ -381,7 +381,8 @@ RXIEXT int RXD_Core(int cmd, RXIFRM *frm, REBCEC *data)
         case CMD_CORE_RSA:
         {
             RXIARG val;
-            u32 *words,*w;
+            REBSTR* *words;
+            REBSTR* *w;
             REBCNT type;
             REBSER *data = RXA_SERIES(frm, 1);
             REBYTE *dataBuffer = (REBYTE *)RL_SERIES(data, RXI_SER_DATA) + RXA_INDEX(frm,1);
@@ -529,7 +530,7 @@ RXIEXT int RXD_Core(int cmd, RXIFRM *frm, REBCEC *data)
             RXIARG val, priv_key, pub_key;
             REBCNT type;
             REBSER *obj = RXA_OBJECT(frm, 1);
-            u32 *words = RL_WORDS_OF_OBJECT(obj);
+            REBSTR* *words = RL_WORDS_OF_OBJECT(obj);
             REBYTE *objData;
 
             memset(&dh_ctx, 0, sizeof(dh_ctx));
@@ -603,7 +604,7 @@ RXIEXT int RXD_Core(int cmd, RXIFRM *frm, REBCEC *data)
             REBCNT type;
             REBSER *obj = RXA_OBJECT(frm, 1);
             REBSER *pub_key = RXA_SERIES(frm, 2);
-            u32 *words = RL_WORDS_OF_OBJECT(obj);
+            REBSTR* *words = RL_WORDS_OF_OBJECT(obj);
             REBYTE *objData;
             REBSER *binary;
             REBYTE *binaryBuffer;

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -871,7 +871,10 @@ add-word: func [word /skip-if-duplicate /type] [
     ; The types make a SYM_XXX entry, but they're kept in a separate block
     ; in the boot object (see `boot-types` in `sections`)
     ;
-    unless type [append boot-words word]
+    ; !!! Update--temporarily to make word numbering easier, they are
+    ; duplicated.  Consider a better way longer term.
+    ;
+    append boot-words word ;-- was `unless type [...]`
 ]
 
 for-each-record-NO-RETURN type boot-types [


### PR DESCRIPTION
Previously, when a word was "interned" into the system, it would receive
a fixed index number from a table.  This index number pointed into a
data area of UTF-8 strings, and was persistent--the system would never
reclaim a word's data from the table once it had been loaded.  Every
spelling variation--even one fleetingly used--would add another permanent
record into the table

The data was kept as UTF-8 because there was no need to decode it--the
words were immutable, and only needed to be hashed and compared.

This beings the unification of properties of strings and words, which
intends to use UTF-8 as the internal representation for strings
anyway.  In anticipation of that change, it puts words into a kind of
REBSER series node called a REBSTR.  The previous term "REBSYM" could
have meant either a canon form or arbitrary casing of a symbol, but
is repurposed to be a small integer for words known to the C code
(defined in %words.r).

Terminology was standardized and examined, so terms like "interning"
are used instead of more vague things (`Intern_Utf8` vs. `Make_Word`)
To help avoid mistakes in code in the future, the two forms of REBSTR
are extracted from words as VAL_WORD_CANON and VAL_WORD_SPELLING.
This makes it more obvious to understand the internal logic.  Also,
when it comes to the small numeric symbols not all words have,
checks in the C++ build prevent coders from writing something like:

    if (VAL_WORD_SYM(word1) == VAL_WORD_SYM(word2)) {...}

Since not all words have "SYMs", then two words that are not in %words.r
might return the same SYM_0 to indicate that fact, which would cause
a false belief these were equal (at least, that's likely what the code
would have meant).  The C build is unchecked for this, but the C++
build has trickery to notice it at compile time.

A major aspect of the change is that this removes the binding table.
Instead, space is reserved in the REBSTR node itself on the canon forms
of words--in the spot that non-canon forms use to point to the canon
form.  This is where indices are stored during a bind.

While not having a bind table and leaning on the existing hash structure
for lookups to words has benefits, the previous code had a bind table
per thread.  While there was no larger threading story, Ren-C doesn't
want to have even less of one--so the technique is augmented with
a stack-based "Binder" that demonstrates how contentions could be
resolved over the space.  This would ideally use some sort of lock-free
strategy that would dynamically build out as-needed from the contentious
REBSTR node that more than one thread (or recursion) wanted to write on.

This leverages some new-ish features, like the ability to embed small
payloads directly into REBSERs themselves.  Short UTF-8 strings that
fit into 16 bytes (on 32-bit platforms) and 32 bytes (on 64-bit
platforms) do not need a separate storage allocation

The likely trickiest part of this change is the behavior when a canon
form of a word is GC'd.  Because the accelerating hash table is done
using linear probing, it's not easy to remove a hashed item because
hash chains starting from more than one initial hash may have collided,
and leaving an empty cell in the spot could cause a false miss of an
item that is still present.  This was addressed with a special "deleted"
pointer value used, which is reclaimed on insertions and hash resizings.