### PR TITLE
Set-Words/paths pushed, lookahead in lookback operations

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -158,6 +158,7 @@ options: construct [] [  ; Options supplied to REBOL during startup
     get-will-get-anything: false
     no-reduce-nested-print: false
     arg1-arg2-arg3-error: false
+    no-infix-lookahead: false
 
     ; These option will only apply if the function which is currently executing
     ; was created after legacy mode was enabled, and if refinements-blank is
@@ -165,15 +166,6 @@ options: construct [] [  ; Options supplied to REBOL during startup
     ;
     no-switch-evals: false
     no-switch-fallthrough: false
-
-    ; Legacy Options that *cannot* be enabled (due to mezzanine dependency
-    ; on the new behavior).  The points are retained in the code for purpose
-    ; of instruction to those curious about where such a decision is made, or
-    ; even if a motivated individual wanted to change the behavior.  That
-    ; would mean adapting the mezzanine (or finding a way to mark a routine
-    ; as not being in the mezzanine and following a different rule.)
-
-    set-word-void-is-error: false
 ]
 
 script: construct [] [

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -187,7 +187,7 @@ static void Do_Core_Shared_Checks_Debug(REBFRM *f) {
 
     /* ASSERT_STATE_BALANCED(&f->state);*/
     assert(f == FS_TOP);
-    assert(DSP == f->dsp_orig);
+    /* assert(DSP == f->dsp_orig); */ // !!! not true now with push SET-WORD!
 
     if (f->flags & DO_FLAG_VA_LIST)
         assert(f->index == TRASHED_INDEX);

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -622,9 +622,6 @@ static void Mark_Frame_Stack_Deep(void)
             // while evaluating the group it has no anchor anywhere in the
             // root set and could be GC'd.  The Reb_Frame's array ref is it.
             //
-            // !!! Consider the ->param field for SET-WORD! and SET-PATH!,
-            // these require protection too (!)
-            //
             continue;
         }
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -640,6 +640,7 @@ set 'r3-legacy* func [<local> if-flags] [
     system/options/paren-instead-of-group: true
     system/options/get-will-get-anything: true
     system/options/no-reduce-nested-print: true
+    system/options/no-infix-lookahead: true
 
     append system/contexts/user compose [
 

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -34,30 +34,32 @@ REBOL [
     )
 ]
 
-mod: func [
+mod: function [
     "Compute a nonnegative remainder of A divided by B."
-    ; In fact the function tries to find the remainder,
-    ; that is "almost non-negative"
+    a [any-number! money! time!]
+    b [any-number! money! time!]
+        "Must be nonzero."
+][
+    ; This function tries to find the remainder that is "almost non-negative"
     ; Example: 0.15 - 0.05 - 0.1 // 0.1 is negative,
     ; but it is "almost" zero, i.e. "almost non-negative"
-    a [any-number! money! time!]
-    b [any-number! money! time!] "Must be nonzero."
-    /local r
-] [
+
     ; Compute the smallest non-negative remainder
-    all [negative? r: a // b   r: r + b]
+    all [negative? r: a // b | r: r + b]
     ; Use abs a for comparisons
     a: abs a
     ; If r is "almost" b (i.e. negligible compared to b), the
     ; result will be r - b. Otherwise the result will be r
-    either all [a + r = (a + b)  positive? r + r - b] [r - b] [r]
+    either all [(a + r) = (a + b) | positive? (r + r) - b] [r - b] [r]
 ]
 
-modulo: func [
-    {Wrapper for MOD that handles errors like REMAINDER. Negligible values (compared to A and B) are rounded to zero.}
+modulo: function [
+    {Wrapper for MOD that handles errors like REMAINDER.}
+    return:
+        {Negligible values (compared to A and B) are rounded to zero}
     a [any-number! money! time!]
-    b [any-number! money! time!] "Absolute value will be used"
-    /local r
+    b [any-number! money! time!]
+        "Absolute value will be used"
 ] [
     ; Coerce B to a type compatible with A
     any [any-number? a  b: make a b]
@@ -66,7 +68,7 @@ modulo: func [
     ; If the MOD result is "near zero", w.r.t. A and B,
     ; return 0--the "expected" result, in human terms.
     ; Otherwise, return the result we got from MOD.
-    either any [a - r = a   r + b = b] [make r 0] [r]
+    either any [(a - r) = a | (r + b) = b] [make r 0] [r]
 ]
 
 sign-of: func [

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -5645,7 +5645,7 @@
 [
     o: make object! [a: 0]
     b: eval/only (quote o/a:) 1 + 2
-    all [o/a = 1 b = 3]
+    all [o/a = 3 | b = 3] ;-- above acts as `b: (eval/only (quote o/a:) 1) + 2`
 ]
 [
     a: func [b c :d] [reduce [b c d]]
@@ -6324,9 +6324,9 @@
     num: 0
     for i 1 10 1 [
         num: num + 1
-        success: i = num and* success
+        success: (i = num) and* success
     ]
-    10 = num and* success
+    (10 = num) and* success
 ]
 ; cycle return value
 [false = for i 1 1 1 [false]]
@@ -6989,9 +6989,9 @@
     num: 0
     repeat i 10 [
         num: num + 1
-        success: i = num and* success
+        success: (i = num) and* success
     ]
-    10 = num and* success
+    (10 = num) and* success
 ]
 ; cycle return value
 [false = repeat i 1 [false]]
@@ -7770,94 +7770,94 @@
 [0.0.255 = add 0.0.255 0.0.1]
 [0.0.255 = add 0.0.255 0.0.255]
 ; functions/math/and.r
-[true and* true = true]
-[true and* false = false]
-[false and* true = false]
-[false and* false = false]
+[true = true and* true]
+[false = true and* false]
+[false = false and* true]
+[false = false and* false]
 ; integer
-[1 and* 1 = 1]
-[1 and* 0 = 0]
-[0 and* 1 = 0]
-[0 and* 0 = 0]
-[1 and* 2 = 0]
-[2 and* 1 = 0]
-[2 and* 2 = 2]
+[1 = 1 and* 1]
+[0 = 1 and* 0]
+[0 = 0 and* 1]
+[0 = 0 and* 0]
+[0 = 1 and* 2]
+[0 = 2 and* 1]
+[2 = 2 and* 2]
 ; char
-[#"^(00)" and* #"^(00)" = #"^(00)"]
-[#"^(01)" and* #"^(00)" = #"^(00)"]
-[#"^(00)" and* #"^(01)" = #"^(00)"]
-[#"^(01)" and* #"^(01)" = #"^(01)"]
-[#"^(01)" and* #"^(02)" = #"^(00)"]
-[#"^(02)" and* #"^(02)" = #"^(02)"]
+[#"^(00)" = #"^(00)" and* #"^(00)"]
+[#"^(00)" = #"^(01)" and* #"^(00)"]
+[#"^(00)" = #"^(00)" and* #"^(01)"]
+[#"^(01)" = #"^(01)" and* #"^(01)"]
+[#"^(00)" = #"^(01)" and* #"^(02)"]
+[#"^(02)" = #"^(02)" and* #"^(02)"]
 ; tuple
-[0.0.0 and* 0.0.0 = 0.0.0]
-[1.0.0 and* 1.0.0 = 1.0.0]
-[2.0.0 and* 2.0.0 = 2.0.0]
-[255.255.255 and* 255.255.255 = 255.255.255]
+[0.0.0 = 0.0.0 and* 0.0.0]
+[1.0.0 = 1.0.0 and* 1.0.0]
+[2.0.0 = 2.0.0 and* 2.0.0]
+[255.255.255 = 255.255.255 and* 255.255.255]
 ; binary
-[#{030000} and* #{020000} = #{020000}]
+[#{020000} = #{030000} and* #{020000}]
 [0 = arccosine 1]
 [0 = arccosine/radians 1]
 [30 = arccosine (square-root 3) / 2]
-[pi / 6 = arccosine/radians (square-root 3) / 2]
+[(pi / 6) = arccosine/radians (square-root 3) / 2]
 [45 = arccosine (square-root 2) / 2]
-[pi / 4 = arccosine/radians (square-root 2) / 2]
+[(pi / 4) = arccosine/radians (square-root 2) / 2]
 [60 = arccosine 0.5]
-[pi / 3 = arccosine/radians 0.5]
+[(pi / 3) = arccosine/radians 0.5]
 [90 = arccosine 0]
-[pi / 2 = arccosine/radians 0]
+[(pi / 2) = arccosine/radians 0]
 [180 = arccosine -1]
 [pi = arccosine/radians -1]
 [150 = arccosine (square-root 3) / -2]
-[pi * 5 / 6 = arccosine/radians (square-root 3) / -2]
+[((pi * 5) / 6) = arccosine/radians (square-root 3) / -2]
 [135 = arccosine (square-root 2) / -2]
-[pi * 3 / 4 = arccosine/radians (square-root 2) / -2]
+[((pi * 3) / 4) = arccosine/radians (square-root 2) / -2]
 [120 = arccosine -0.5]
-[pi * 2 / 3 = arccosine/radians -0.5]
+[((pi * 2) / 3) = arccosine/radians -0.5]
 [error? try [arccosine 1.1]]
 [error? try [arccosine -1.1]]
 ; functions/math/arcsine.r
 [0 = arcsine 0]
 [0 = arcsine/radians 0]
 [30 = arcsine 0.5]
-[pi / 6 = arcsine/radians 0.5]
+[(pi / 6) = arcsine/radians 0.5]
 [45 = arcsine (square-root 2) / 2]
-[pi / 4 = arcsine/radians (square-root 2) / 2]
+[(pi / 4) = arcsine/radians (square-root 2) / 2]
 [60 = arcsine (square-root 3) / 2]
-[pi / 3 = arcsine/radians (square-root 3) / 2]
+[(pi / 3) = arcsine/radians (square-root 3) / 2]
 [90 = arcsine 1]
-[pi / 2 = arcsine/radians 1]
+[(pi / 2) = arcsine/radians 1]
 [-30 = arcsine -0.5]
-[pi / -6 = arcsine/radians -0.5]
+[(pi / -6) = arcsine/radians -0.5]
 [-45 = arcsine (square-root 2) / -2]
-[pi / -4 = arcsine/radians (square-root 2) / -2]
+[(pi / -4) = arcsine/radians (square-root 2) / -2]
 [-60 = arcsine (square-root 3) / -2]
-[pi / -3 = arcsine/radians (square-root 3) / -2]
+[(pi / -3) = arcsine/radians (square-root 3) / -2]
 [-90 = arcsine -1]
-[pi / -2 = arcsine/radians -1]
-[1e-12 / (arcsine 1e-12) = (pi / 180)]
-[1e-9 / (arcsine/radians 1e-9) = 1.0]
+[(pi / -2) = arcsine/radians -1]
+[(1e-12 / (arcsine 1e-12)) = (pi / 180)]
+[(1e-9 / (arcsine/radians 1e-9)) = 1.0]
 [error? try [arcsine 1.1]]
 [error? try [arcsine -1.1]]
 ; functions/math/arctangent.r
 [-90 = arctangent -1e16]
-[pi / -2 = arctangent/radians -1e16]
+[(pi / -2) = arctangent/radians -1e16]
 [-60 = arctangent negate square-root 3]
-[pi / -3 = arctangent/radians negate square-root 3]
+[(pi / -3) = arctangent/radians negate square-root 3]
 [-45 = arctangent -1]
-[pi / -4 = arctangent/radians -1]
+[(pi / -4) = arctangent/radians -1]
 [-30 = arctangent (square-root 3) / -3]
-[pi / -6 = arctangent/radians (square-root 3) / -3]
+[(pi / -6) = arctangent/radians (square-root 3) / -3]
 [0 = arctangent 0]
 [0 = arctangent/radians 0]
 [30 = arctangent (square-root 3) / 3]
-[pi / 6 = arctangent/radians (square-root 3) / 3]
+[(pi / 6) = arctangent/radians (square-root 3) / 3]
 [45 = arctangent 1]
-[pi / 4 = arctangent/radians 1]
+[(pi / 4) = arctangent/radians 1]
 [60 = arctangent square-root 3]
-[pi / 3 = arctangent/radians square-root 3]
+[(pi / 3) = arctangent/radians square-root 3]
 [90 = arctangent 1e16]
-[pi / 2 = arctangent/radians 1e16]
+[(pi / 2) = arctangent/radians 1e16]
 ; functions/math/complement.r
 ; bug#849
 [false = complement true]
@@ -7890,20 +7890,20 @@
 ; functions/math/cosine.r
 [1 = cosine 0]
 [1 = cosine/radians 0]
-[(square-root 3) / 2 = cosine 30]
-[(square-root 3) / 2 = cosine/radians pi / 6]
-[(square-root 2) / 2 = cosine 45]
-[(square-root 2) / 2 = cosine/radians pi / 4]
+[((square-root 3) / 2) = cosine 30]
+[((square-root 3) / 2) = cosine/radians pi / 6]
+[((square-root 2) / 2) = cosine 45]
+[((square-root 2) / 2) = cosine/radians pi / 4]
 [0.5 = cosine 60]
 [0.5 = cosine/radians pi / 3]
 [0 = cosine 90]
 [0 = cosine/radians pi / 2]
 [-1 = cosine 180]
 [-1 = cosine/radians pi]
-[(square-root 3) / -2 = cosine 150]
-[(square-root 3) / -2 = cosine/radians pi * 5 / 6]
-[(square-root 2) / -2 = cosine 135]
-[(square-root 2) / -2 = cosine/radians pi * 3 / 4]
+[((square-root 3) / -2) = cosine 150]
+[((square-root 3) / -2) = cosine/radians pi * 5 / 6]
+[((square-root 2) / -2) = cosine 135]
+[((square-root 2) / -2) = cosine/radians pi * 3 / 4]
 [-0.5 = cosine 120]
 [-0.5 = cosine/radians pi * 2 / 3]
 ; functions/math/difference.r
@@ -8026,9 +8026,9 @@
 ; functions/math/exp.r
 [1 = exp 0]
 [2.718281828459045 = exp 1]
-[2.718281828459045 * 2.718281828459045 = exp 2]
+[(2.718281828459045 * 2.718281828459045) = exp 2]
 [(square-root 2.718281828459045) = exp 0.5]
-[1 / 2.718281828459045 = exp -1]
+[(1 / 2.718281828459045) = exp -1]
 ; functions/math/log-10.r
 [0 = log-10 1]
 [0.5 = log-10 square-root 10]
@@ -9208,26 +9208,26 @@
 [0 = sine/radians 0]
 [0.5 = sine 30]
 [0.5 = sine/radians pi / 6]
-[(square-root 2) / 2 = sine 45]
-[(square-root 2) / 2 = sine/radians pi / 4]
-[(square-root 3) / 2 = sine 60]
-[(square-root 3) / 2 = sine/radians pi / 3]
+[((square-root 2) / 2) = sine 45]
+[((square-root 2) / 2) = sine/radians pi / 4]
+[((square-root 3) / 2) = sine 60]
+[((square-root 3) / 2) = sine/radians pi / 3]
 [1 = sine 90]
 [1 = sine/radians pi / 2]
 [0 = sine 180]
 [0 = sine/radians pi]
 [-0.5 = sine -30]
 [-0.5 = sine/radians pi / -6]
-[(square-root 2) / -2 = sine -45]
-[(square-root 2) / -2 = sine/radians pi / -4]
-[(square-root 3) / -2 = sine -60]
-[(square-root 3) / -2 = sine/radians pi / -3]
+[((square-root 2) / -2) = sine -45]
+[((square-root 2) / -2) = sine/radians pi / -4]
+[((square-root 3) / -2) = sine -60]
+[((square-root 3) / -2) = sine/radians pi / -3]
 [-1 = sine -90]
 [-1 = sine/radians pi / -2]
 [0 = sine -180]
 [0 = sine/radians negate pi]
-[(sine 1e-12) / 1e-12 = (pi / 180)]
-[(sine/radians 1e-9) / 1e-9 = 1.0]
+[((sine 1e-12) / 1e-12) = (pi / 180)]
+[((sine/radians 1e-9) / 1e-9) = 1.0]
 ; #bug#852
 ; Flint Hills test
 [
@@ -9236,7 +9236,7 @@
     repeat l n [
         k: to decimal! l
         ks: sine/radians k
-        s4: 1.0 / (k * k * k * ks * ks) + s4
+        s4: (1.0 / (k * k * k * ks * ks)) + s4
     ]
     30.314520404 = round/to s4 1e-9
 ]
@@ -9474,12 +9474,12 @@
 [(negate square-root 3) = tangent/radians pi / -3]
 [-1 = tangent -45]
 [-1 = tangent/radians pi / -4]
-[(square-root 3) / -3 = tangent -30]
-[(square-root 3) / -3 = tangent/radians pi / -6]
+[((square-root 3) / -3) = tangent -30]
+[((square-root 3) / -3) = tangent/radians pi / -6]
 [0 = tangent 0]
 [0 = tangent/radians 0]
-[(square-root 3) / 3 = tangent 30]
-[(square-root 3) / 3 = tangent/radians pi / 6]
+[((square-root 3) / 3) = tangent 30]
+[((square-root 3) / 3) = tangent/radians pi / 6]
 [1 = tangent 45]
 [1 = tangent/radians pi / 4]
 [(square-root 3) = tangent 60]
@@ -9493,7 +9493,7 @@
     repeat l n [
         k: to decimal! l
         kt: tangent/radians k
-        s4t: 1.0 / (kt * kt) + 1.0 / (k * k * k) + s4t
+        s4t: (((1.0 / (kt * kt)) + 1.0) / (k * k * k)) + s4t
     ]
     30.314520404 = round/to s4t 1e-9
 ]


### PR DESCRIPTION
(Note: r3-legacy compatibility switch as `no-infix-lookahead`)

Typically the evaluator is "greedy", so here it sees 10, then sees an
= operation whose first argument gets 10, and then as much is consumed
as possible...so `add 5 5` is processed:

    >> 10 = add 5 5
    == true

This greediness leads to errors if one doesn't see that an expression
is actually incomplete, e.g. before doing an equality test:

    >> add 5 5 = 10
    ** Script error: expected logic! not integer!`

There it's the case that for the second argument to add, 5 keeps looking
and turns into the logic expression (5 = 10) as the second argument.

It's a simple and longstanding rule.  But R3-Alpha had a strange infix
"feature" that twisted it the other way:

    >> 5 + 5 = 10
    true

    >> 10 = 5 + 5
    ** Script error: expected logic! not integer!

After long wishing to make this behavior go away unless there was a
*really* good reason for it, this commit finally excises the idea.  The
straw breaking the camel's back in this case was what it did to
an attempt to shift SET-WORD! and SET-PATH! to be processed without
making a new frame.  Instead they would be pushed to a pending state
on the data stack, and flushed at a convenient time.

This showed these troubling variations in R3-Alpha's behavior:

    >> 10 = probe 5 + 5
    == true

    >> 10 = x: 5 + 5
    == true

The addition or removal of a PROBE or SET-WORD! doesn't seem like it
should transform what was previously an erroring case into a correct
one.  Or vice-versa; removing the probe and the x: from the above code
does not seem like it should cause an error.

Despite the compatibility issues, the balance is in favor of fixing the
behavior.  Parentheses can be used to stylize code in such a way that
it would work before or after the rule change, which is at least some
benefit to those trying to write code that would work under either rule.