### PR TITLE
checked RETURN: types in function specs, notes in HELP

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -164,6 +164,9 @@ Script: [
     bad-func-def:       [{invalid function definition:} :arg1]
     bad-func-arg:       [{function argument} :arg1 {is not valid}] ; can be a number
 
+    needs-return-value: [:arg1 {must return value (use PROC or RETURN: <opt>)}]
+    bad-return-type:    [:arg1 {doesn't have RETURN: enabled for} :arg2]
+
     no-refine:          [:arg1 {has no refinement called} :arg2]
     bad-refines:        {incompatible or invalid refinements}
     bad-refine:         [{incompatible or duplicate refinement:} :arg1]

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -235,6 +235,8 @@ standard: construct [] [
     ;
     function-meta: construct [] [
         description:
+        return-type:
+        return-note:
         parameter-types:
         parameter-notes:
             _

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -79,8 +79,10 @@ types
 title
 ;addr already defined
 
-; !!! See notes on FUNCTION-META in %sysobj.r
+; !!! See notes on FUNCTION-META and SPECIALIZER-META in %sysobj.r
 description
+return-type
+return-note
 parameter-types
 parameter-notes
 specializee

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -540,6 +540,8 @@ static void Init_Natives(void)
     {
         REBCTX *function_meta = Alloc_Context(3);
         Append_Context(function_meta, NULL, Canon(SYM_DESCRIPTION));
+        Append_Context(function_meta, NULL, Canon(SYM_RETURN_TYPE));
+        Append_Context(function_meta, NULL, Canon(SYM_RETURN_NOTE));
         Append_Context(function_meta, NULL, Canon(SYM_PARAMETER_TYPES));
         Append_Context(function_meta, NULL, Canon(SYM_PARAMETER_NOTES));
         REBVAL *rootvar = CTX_VALUE(function_meta);

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -505,10 +505,10 @@ void Make_Command(
         REBVAL *param = FUNC_PARAMS_HEAD(fun);
         for (; NOT_END(param); ++param) {
             if (
-                // !!! this said "not END and not UNSET (no args)"...what is
-                // it actually supposed to be doing with this 3?
-                //
-                (FLAGIT_64(REB_0) != ~VAL_TYPESET_BITS(param))
+                (
+                    VAL_TYPESET_BITS(param)
+                    != ~(FLAGIT_64(REB_0) | FLAGIT_64(REB_FUNCTION)) // default
+                )
                 && (VAL_TYPESET_BITS(param) & ~RXT_ALLOWED_TYPES)
             ) {
                 fail (Error(RE_BAD_FUNC_ARG, param));

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -734,8 +734,8 @@ REBNATIVE(in)
 //  
 //  {Returns true if both values are conditionally true (no "short-circuit")}
 //  
-//      value1
-//      value2
+//      value1 [any-value!]
+//      value2 [any-value!]
 //  ]
 //
 REBNATIVE(and_q)
@@ -752,8 +752,8 @@ REBNATIVE(and_q)
 //
 //  {Returns true if both values are conditionally false (no "short-circuit")}
 //
-//      value1
-//      value2
+//      value1 [any-value!]
+//      value2 [any-value!]
 //  ]
 //
 REBNATIVE(nor_q)
@@ -773,8 +773,8 @@ REBNATIVE(nor_q)
 //
 //  {Returns false if both values are conditionally true (no "short-circuit")}
 //
-//      value1
-//      value2
+//      value1 [any-value!]
+//      value2 [any-value!]
 //  ]
 //
 REBNATIVE(nand_q)
@@ -794,7 +794,8 @@ REBNATIVE(nand_q)
 //  
 //  "Returns the logic complement."
 //  
-//      value "(Only FALSE and NONE return TRUE)"
+//      value [any-value!]
+//          "(Only LOGIC!'s FALSE and BLANK! return TRUE)"
 //  ]
 //
 REBNATIVE(not_q)
@@ -808,8 +809,8 @@ REBNATIVE(not_q)
 //  
 //  {Returns true if either value is conditionally true (no "short-circuit")}
 //  
-//      value1
-//      value2
+//      value1 [any-value!]
+//      value2 [any-value!]
 //  ]
 //
 REBNATIVE(or_q)
@@ -826,8 +827,8 @@ REBNATIVE(or_q)
 //  
 //  {Returns true if only one of the two values is conditionally true.}
 //  
-//      value1
-//      value2
+//      value1 [any-value!]
+//      value2 [any-value!]
 //  ]
 //
 REBNATIVE(xor_q)

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -101,7 +101,7 @@ void MAKE_Function(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     // code (though round-tripping it via text is not possible in
     // general in any case due to loss of bindings.)
     //
-    REBFUN *fun = Make_Plain_Function_May_Fail(&spec, &body, MKF_NONE);
+    REBFUN *fun = Make_Plain_Function_May_Fail(&spec, &body, MKF_ANY_VALUE);
 
     *out = *FUNC_VALUE(fun);
 }

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -292,7 +292,8 @@ enum {
     MKF_RETURN      = 1 << 0,   // has definitional RETURN
     MKF_LEAVE       = 1 << 1,   // has definitional LEAVE
     MKF_PUNCTUATES  = 1 << 2,   // generated function can't be used as argument
-    MKF_KEYWORDS    = 1 << 3    // respond to words like <opt>, <no-return>
+    MKF_KEYWORDS    = 1 << 3,   // respond to words like <opt>, <no-return>
+    MKF_ANY_VALUE   = 1 << 4    // args and return are [<opt> any-value!]
 };
 
 // Modes allowed by FORM

--- a/src/mezz/base-debug.r
+++ b/src/mezz/base-debug.r
@@ -16,7 +16,7 @@ REBOL [
     }
 ]
 
-boot-print: function [
+boot-print: procedure [
     "Prints during boot when not quiet."
     data
     /eval
@@ -29,7 +29,7 @@ boot-print: function [
     ]
 ]
 
-loud-print: function [
+loud-print: procedure [
     "Prints during boot when verbose."
     data
     /eval

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -33,16 +33,11 @@ blank: _
 bar: '|
 
 
-; There is no Rebol value representing void, so it cannot be assigned as
-; a word to a literal.  This VOID function is an alternative to `()`
-
-void: func [] [] ;-- DOES not defined yet.
-
-
-eval func [
+eval proc [
     {Make type testing functions (variadic to quote "top-level" words)}
-    :set-word... [[ set-word!]]
-    /local set-word type-name
+    :set-word... [set-word! <...>]
+    <local>
+        set-word type-name
 ][
     while [? set-word: take set-word...] [
         type-name: append (head clear find (spelling-of set-word) {?}) "!"
@@ -124,6 +119,8 @@ eval func [
 ;
 probe: func [
     {Debug print a molded value and returns that same value.}
+    return: [<opt> any-value!]
+        {Same as the input value.}
     value [<opt> any-value!]
         {Value to display.}
 ][
@@ -132,14 +129,13 @@ probe: func [
 ]
 
 
-dump: func [
+dump: proc [
     {Show the name of a value (or block of expressions) with the value itself}
-    return: [<opt> any-value!]
-        {Returns void so as to conveniently "opt-out" of ANY, ALL, etc.}
     'value
-    <local> dump-one item
+    <local>
+        dump-one item
 ][
-    dump-one: func [item][
+    dump-one: proc [item][
         case [
             string? item [
                 print ["---" item "---"] ;-- label it
@@ -174,17 +170,16 @@ dump: func [
     ][
         dump-one value
     ]
-
-    return ()
 ]
 
 
-eval func [
+eval proc [
     {Make reflector functions (variadic to quote "top-level" words)}
-    :set-word... [[ set-word!]]
-    :divider... [[blank!]]
-    :categories... [[string!]]
-    /local set-word categories name
+    :set-word... [set-word! <...>]
+    :divider... [blank! <...>]
+    :categories... [string! <...>]
+    <local>
+        set-word categories name
 ][
     while [any-value? set-word: take set-word...] [
         take divider... ;-- so it doesn't look like we're setting to a string
@@ -196,7 +191,7 @@ eval func [
         set set-word make function! compose/deep [
             [
                 (ajoin [{Returns a copy of the } name { of a } categories {.}])
-                value
+                value [any-value!]
             ][
                 reflect :value (to lit-word! name)
             ]

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -20,19 +20,18 @@ REBOL [
 
 enfix: _
 
-set/lookback 'enfix function [
+set/lookback 'enfix procedure [
     "Convenience version of SET/LOOKBACK, e.g `+: enfix :add`"
     :target [set-word! set-path!]
     action [function!]
 ][
     set/lookback target :action
 
-    ; return value should never be used...the SET-WORD! or SET-PATH!
+    ; return value should never be needed/used...the SET-WORD! or SET-PATH!
     ; evaluation is converted to a GET when infix quoted on the left.
-    ; however, can't be a procedure because `x: some-proc` is illegal
 ]
 
-default: enfix function [
+default: enfix procedure [
     "Set word or path to a default value if it is not set yet or blank."
     :target [set-word! set-path!]
         "The word"
@@ -42,9 +41,8 @@ default: enfix function [
     unless all [any-value? gotten: get/opt target | not blank? gotten] [
         set target value
     ]
-    ; return value should never be used...the SET-WORD! or SET-PATH!
+    ; return value should never be needed/used...the SET-WORD! or SET-PATH!
     ; evaluation is converted to a GET when infix quoted on the left.
-    ; however, can't be a procedure because `x: some-proc` is illegal
 ]
 
 +: enfix :add

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -37,6 +37,7 @@ REBOL [
 live-asserts-map: make map! []
 
 assert-debug: function [
+    return: [<opt> any-value!]
     conditions [block!]
         {Conditions to check (or meta instructions if /META)}
     /meta
@@ -78,7 +79,7 @@ assert-debug: function [
                 conditions
             ]
         ]
-        leave
+        return ()
     ]
 
     active: true
@@ -113,7 +114,7 @@ assert-debug: function [
         conditions: pos ;-- move to next expression position and continue
     ]
 
-    () ;-- void result by default
+    return if quiet [blank] ;-- void is return default
 ]
 
 ; !!! If a debug mode were offered, you'd want to be able to put back ASSERT

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -118,6 +118,20 @@ spec-of: function [
         new-line back spec true
     ]
 
+    return-type: maybe block! any [
+        select meta 'return-type
+        select original-meta 'return-type
+    ]
+    return-note: maybe string! any [
+        select meta 'return-note
+        select original-meta 'return-note
+    ]
+    if return-type or return-note [
+        append spec quote return:
+        if return-type [append/only spec return-type]
+        if return-note [append spec return-note]
+    ]
+
     types: maybe frame! any [
         select meta 'parameter-types
         select original-meta 'parameter-types
@@ -129,8 +143,8 @@ spec-of: function [
 
     for-each param words-of :value [
         append spec param
-        if type: select types param [append/only spec type]
-        if note: select notes param [append spec note]
+        if any [type: select types param] [append/only spec type]
+        if any [note: select notes param] [append spec note]
     ]
 
     return spec
@@ -373,6 +387,8 @@ help: procedure [
     fields: dig-function-meta-fields :value
 
     description: fields/description
+    return-type: :fields/return-type
+    return-note: fields/return-note
     types: fields/parameter-types
     notes: fields/parameter-notes
 
@@ -454,6 +470,22 @@ help: procedure [
 
             if note [
                 print [[space4 space4 note]]
+            ]
+        ]
+    ]
+
+    ; Always make a note about the return value if there's no explicit
+    ; indication about it being a procedure...even to say it's undocumented.
+    ;
+    ; !!! Should it say "RETURNS: void"?  Concept is that's wasteful.
+    ;
+    unless blank? :return-type [
+        print [newline "RETURNS:" if set? 'return-type [mold return-type]]
+        either return-note [
+            print [[space4 return-note]]
+        ][
+            if not set? 'return-type [
+                print [[space4 "(undocumented)"]]
             ]
         ]
     ]

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -949,7 +949,7 @@ do-commands: func [
 
 ; TLS scheme
 
-tls-init: func [
+tls-init: proc [
     ctx [object!]
 ] [
     ctx/seq-num-r: 0

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -28,6 +28,7 @@ action: _ ; for boot only
 
 do*: function [
     {SYS: Called by system for DO on datatypes that require special handling.}
+    return: [<opt> any-value!]
     value [file! url! string! binary! tag!]
     args [logic!]
         "Positional workaround of /ARGS"

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -301,6 +301,7 @@ load-ext-module: function [
             cmd-index: 0
             command: func [
                 "Define a new command for an extension."
+                return: [function!]
                 args [integer! block!]
             ][
                 ; (contains module-local variables)

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -255,7 +255,7 @@ init-schemes: func [
 
             false ; keep waiting
         ]
-        init: func [port] [
+        init: proc [port] [
             ;;print ["Init" title]
             port/data: copy [] ; The port wake list
         ]
@@ -270,7 +270,7 @@ init-schemes: func [
         title: "File Access"
         name: 'file
         info: system/standard/file-info ; for C enums
-        init: func [port /local path] [
+        init: proc [port /local path] [
             if url? port/spec/ref [
                 parse port/spec/ref [thru #":" 0 2 slash path:]
                 append port/spec compose [path: (to file! path)]
@@ -332,7 +332,7 @@ init-schemes: func [
         title: "Serial Port"
         name: 'serial
         spec: system/standard/port-spec-serial
-        init: func [port /local path speed] [
+        init: proc [port /local path speed] [
             if url? port/spec/ref [
                 parse port/spec/ref
                     [thru #":" 0 2 slash copy path [to slash | end] skip copy speed to end]

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -199,11 +199,15 @@ binary-to-c: func [
 ; RETURN in it will return from the *caller*.  It will just wind up returning
 ; from *this loop wrapper* (in older Rebols) when the call is finished!
 ;
-for-each-record-NO-RETURN: func [
+for-each-record-NO-RETURN: proc [
     {Iterate a table with a header by creating an object for each row}
-    'record [word!] {Word to set each time to the row made into an object}
-    table [block!] {Table of values with header block as first element}
-    body [block!] {Block to evaluate each time}
+
+    'record [word!]
+        {Word to set each time to the row made into an object}
+    table [block!]
+        {Table of values with header block as first element}
+    body [block!]
+        {Block to evaluate each time}
     /local headings result spec
 ] [
     unless block? first table [

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -36,7 +36,7 @@ emit-header: func [t f] [emit-out form-header/gen t f %make-headers]
 collapse-whitespace: [some [change some white-space #" " | skip]]
 bind collapse-whitespace c.lexical/grammar
 
-emit-proto: func [proto] [
+emit-proto: proc [proto] [
 
     if find proto "()" [
         print [

--- a/src/tools/make-natives.r
+++ b/src/tools/make-natives.r
@@ -24,7 +24,7 @@ verbose: false
 
 unsorted-buffer: make string! 20000
 
-emit-proto: func [proto] [
+emit-proto: proc [proto] [
 
     if all [
         'format2015 = proto-parser/style

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -82,7 +82,7 @@ count: func [s c /local n] [
     append output-buffer ")"
 ]
 
-emit-proto: func [
+emit-proto: proc [
     proto
 ] [
 

--- a/src/tools/make-reb-lib.r
+++ b/src/tools/make-reb-lib.r
@@ -52,7 +52,7 @@ emit:  func [d] [append repend xlib-buffer d newline]
 emit-rlib: func [d] [append repend rlib-buffer d newline]
 emit-dlib: func [d] [append repend dlib-buffer d newline]
 emit-comment: func [d] [append repend comments-buffer d newline]
-emit-mlib: func [d /nol] [
+emit-mlib: proc [d /nol] [
     repend mlib-buffer d
     if not nol [append mlib-buffer newline]
 ]
@@ -120,7 +120,7 @@ pads: func [start col] [
     head insert/dup str #" " col
 ]
 
-emit-proto: func [
+emit-proto: proc [
     proto
 ] [
 
@@ -168,8 +168,8 @@ process: func [file] [
     proto-parser/process data
 ]
 
-write-if: func [file data] [
-    if data <> attempt [to string! read file][
+write-if: proc [file data] [
+    if data != attempt [to string! read file][
         print ["UPDATE:" file]
         write file data
     ]

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -48,6 +48,7 @@ REBOL [
 ;
 unless true = attempt [void? :some-undefined-thing] [
     void?: :unset?
+    void: does []
 
     ; Since it's R3-Alpha or before, go ahead and mention this...
     ;
@@ -88,6 +89,21 @@ unless set? 'blank? [
     blank!: get 'none!
     blank: get 'none
     _: none
+]
+
+unless set? 'proc? [
+    leave: does [
+        do make error! "LEAVE cannot be implemented in usermode R3-Alpha"
+    ]
+
+    ; bypass FUNCTION! return check by using raw MAKE FUNCTION!
+    ;
+    proc: make function! [[spec body][
+        make function! compose/deep [[(spec)][
+            (body)
+            void
+        ]]
+    ]]
 ]
 
 ; ANY-VALUE! is anything that isn't void.  -OPT- ANY-VALUE! is a

--- a/tests/catch-any.r
+++ b/tests/catch-any.r
@@ -16,6 +16,7 @@ Rebol [
 make object! [
     do-block: func [
         ; helper for catching BREAK, CONTINUE, THROW or QUIT
+        return: [<opt> any-value!]
         block [block!]
         exception [word!]
         /local result
@@ -52,10 +53,14 @@ make object! [
 
     set 'catch-any func [
         {catches any REBOL exception}
+        return: [<opt> any-value!]
         block [block!] {block to evaluate}
         exception [word!] {used to return the exception type}
         /local result
-    ] either rebol/version >= 2.100.0 [[
+    ][
+        ; !!! outdated comment, RETURN/REDO no longer exists, look into what
+        ; this was supposed to be for.  --HF
+
         ; catch RETURN, EXIT and RETURN/REDO
         ; using the DO-BLOCK helper call
         ; the helper call is enclosed in a block
@@ -68,34 +73,12 @@ make object! [
             catch/quit [
                 try [
                     catch [
-                        loop 1 [set/opt 'result do-block block exception]
+                        loop 1 [result: do-block block exception]
                     ]
                 ]
             ]
         ]
-        either get exception [()] [:result]
-    ]] [[
-        error? set/opt 'result catch [
-            error? set/opt 'result loop 1 [
-                error? result: try [
-                    ; RETURN or EXIT
-                    set exception 'return
-                    set/opt 'result do block
-
-                    ; no exception
-                    set exception blank
-                    return get/opt 'result
-                ]
-                ; an error was triggered
-                set exception 'error
-                return result
-            ]
-            ; BREAK
-            set exception 'break
-            return get/opt 'result
-        ]
-        ; THROW
-        set exception 'throw
-        return get/opt 'result
-    ]]
+        if get exception [return ()]
+        return :result
+    ]
 ]

--- a/tests/control/apply.test.reb
+++ b/tests/control/apply.test.reb
@@ -50,18 +50,49 @@
     [1 + 2] = (eval/only :a 1 + 2)
 ]
 
-[void? r3-alpha-apply func [x [<opt> any-value!]] [get/opt 'x] [()]]
-[void? r3-alpha-apply func ['x [<opt> any-value!]] [get/opt 'x] [()]]
-[void? r3-alpha-apply func ['x [<opt> any-value!]] [get/opt 'x] [()]]
-[void? r3-alpha-apply func [x [<opt> any-value!]] [return get/opt 'x] [()]]
-[void? r3-alpha-apply func ['x [<opt> any-value!]] [return get/opt 'x] [()]]
+[
+    void? r3-alpha-apply func [
+        return: [<opt> any-value!]
+        x [<opt> any-value!]
+    ][
+        get/opt 'x
+    ][
+        ()
+    ]
+][
+    void? r3-alpha-apply func [
+        return: [<opt> any-value!]
+        'x [<opt> any-value!]
+    ][
+        get/opt 'x
+    ][
+        ()
+    ]
+][
+    void? r3-alpha-apply func [
+        return: [<opt> any-value!]
+        x [<opt> any-value!]
+    ][
+        return get/opt 'x
+    ][
+        ()
+    ]
+][
+    void? r3-alpha-apply func [
+        return: [<opt> any-value!]
+        'x [<opt> any-value!]
+    ][
+        return get/opt 'x
+    ][
+        ()
+    ]
+]
 [error? r3-alpha-apply func ['x [<opt> any-value!]] [return get/opt 'x] [make error! ""]]
 [
     error? r3-alpha-apply/only func [x [<opt> any-value!]] [
         return get/opt 'x
     ] head insert copy [] make error! ""
-]
-[
+][
     error? r3-alpha-apply/only func ['x [<opt> any-value!]] [
         return get/opt 'x
     ] head insert copy [] make error! ""

--- a/tests/control/loop.test.reb
+++ b/tests/control/loop.test.reb
@@ -56,12 +56,14 @@
 [
     f: func [x] [
         loop 1 [
-            if x = 1 [
+            either x = 1 [
                 use [break] [
                     break: 1
                     f 2
                     1 = get/opt 'break
                 ]
+            ][
+                false
             ]
         ]
     ]

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -270,7 +270,7 @@
 [lf: func ['x] [:x] 30 == lf (10 + 20)]
 [lf: func ['x] [:x] o: context [f: 10] 10 == lf :o/f]
 ; basic test for recursive function! invocation
-[i: 0 countdown: func [n] [if n > 0 [++ i countdown n - 1]] countdown 10 i = 10]
+[i: 0 countdown: proc [n] [if n > 0 [++ i countdown n - 1]] countdown 10 i = 10]
 
 ; In Ren-C's specific binding, a function-local word that escapes the
 ; function's extent cannot be used when re-entering the same function later

--- a/tests/define/func.test.reb
+++ b/tests/define/func.test.reb
@@ -1,11 +1,13 @@
 ; functions/define/func.r
 ; recursive safety
 [
-    f: func [] [
+    f: func [return: [function!]] [
         func [x] [
-            if x = 1 [
+            either x = 1 [
                 eval f 2
                 x = 1
+            ][
+                false
             ]
         ]
     ]

--- a/tests/run-recover.r
+++ b/tests/run-recover.r
@@ -18,12 +18,9 @@ do %test-framework.r
 ; Example runner for the REBOL/Core tests which chooses
 ; appropriate flags depending on the interpreter version.
 
-do-core-tests: func [
-    <local>
-    flags result log-file summary interpreter-checksum log-file-prefix
-] [
+do-core-tests: procedure [] [
     ; Check if we run R3 or R2.
-    set 'flags pick [
+    flags: pick [
         [#64bit #r3only #r3]
         [#32bit #r2only]
     ] not blank? in system 'catalog

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -163,7 +163,7 @@ rebsource: context [
                 emit [malloc (file) (malloc)]
             ]
 
-            emit-proto: function [proto][
+            emit-proto: procedure [proto][
                 if all [
                     'format2015 = proto-parser/style
                     block? proto-parser/data

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -29,7 +29,7 @@ make object! [
             position: ["{" | {"}] (
                 ; handle string using TRANSCODE
                 success: either error? try [
-                    set/opt 'position second transcode/next position
+                    position: second transcode/next position
                 ] [
                     [end skip]
                 ] [
@@ -53,12 +53,11 @@ make object! [
         ]
     ]
 
-    set 'collect-tests func [
-        collected-tests [block!] {collect the tests here (modified)}
+    set 'collect-tests procedure [
+        collected-tests [block!]
+            {collect the tests here (modified)}
         test-file [file!]
-        /local flags position stop vector value next-position test-sources
-        current-dir
-    ] [
+    ][
         current-dir: what-dir
         print ["file:" mold test-file]
 
@@ -68,19 +67,19 @@ make object! [
                 change-dir first split-path test-file
             ]
             test-sources: read test-file
-        ] [
+        ][
             append collected-tests reduce [
                 test-file 'dialect {^/"failed, cannot read the file"^/}
             ]
             change-dir current-dir
-            return ()
-        ] [
+            leave
+        ][
             change-dir current-dir
             append collected-tests test-file
         ]
 
         flags: copy []
-        unless parse test-sources [
+        rule: [
             any [
                 some whitespace
                     |
@@ -98,7 +97,9 @@ make object! [
                     case [
                         any [
                             error? try [
-                                set/opt [value next-position] transcode/next position
+                                set [value: next-position:] (
+                                    transcode/next position
+                                )
                             ]
                             blank? next-position
                         ] [stop: [:position]]
@@ -118,7 +119,9 @@ make object! [
                     |
                 :next-position
             ]
-        ] [
+        ]
+
+        unless parse test-sources rule [
             append collected-tests reduce [
                 'dialect
                 rejoin [{^/"failed, line: } line-number? position {"^/}]
@@ -126,13 +129,13 @@ make object! [
         ]
     ]
 
-    set 'collect-logs func [
-        collected-logs [block!] {collect the logged results here (modified)}
+    set 'collect-logs function [
+        collected-logs [block!]
+            {collect the logged results here (modified)}
         log-file [file!]
-        /local log-contents last-vector stop value
-    ] [
+    ][
         if error? try [log-contents: read log-file] [
-            make error! rejoin ["Unable to read " mold log-file]
+            fail ["Unable to read " mold log-file]
         ]
 
         parse log-contents [
@@ -141,7 +144,7 @@ make object! [
                 any whitespace
                 [
                     position: "%"
-                    (set/opt [value next-position] transcode/next position)
+                    (set [value: next-position:] transcode/next position)
                     :next-position
                         |
                     ; dialect failure?
@@ -153,7 +156,7 @@ make object! [
                     [
                         end (
                             ; crash found
-                            do make error! "log incomplete!"
+                            fail "log incomplete!"
                         )
                             |
                         {"} copy value to {"} skip
@@ -168,7 +171,7 @@ make object! [
                                     |
                                 "skipped" (value: 'skipped)
                                     |
-                                (do make error! "invalid test result")
+                                (fail "invalid test result")
                             ]
                             append collected-logs reduce [
                                 last-vector
@@ -179,7 +182,7 @@ make object! [
                         |
                     "system/version:" to end (stop: _)
                         |
-                    (do make error! "log file parsing problem")
+                    (fail "log file parsing problem")
                 ] position: stop break
                     |
                 :position


### PR DESCRIPTION
This adds the long-planned feature of being able to document and check
the return types of functions.  It uses the planned notation from
R3-Alpha and Red of a RETURN: set-word in the function spec, followed
by type and description as with other parameters.

***NOTICE*** This also implements an experimental-yet-important Ren-C
"rule" that FUNC and FUNCTION must return a value unless they explicitly
say they do not.  This means that return values--like parameters--
default to not being optional.  The PROC and PROCEDURE generators are
the most likely intent behind functions that want to return voids, as
opposed to "sometimes void, sometimes not".  They also have the
advantage of suppressing values to prevent them from accidentally
"falling out" the bottom of the function body...which can be confusing
to the caller (if meaningless) or even a potential security issue.

This also implements another rule, which is that FUNCTION! is not
considered by default to be a legal parameter for function types--nor
a return type from them.  This is because like voids (already disabled
by default in R3-Alpha for function arguments), FUNCTION! values must
be handled with particular care and awareness that they are function
values.  The best way of documenting this fact is to annotate the
type to show you know that.  Similar rules apply for return types, in
that callees must be particularly prepared to handle the behaviors of
a function if that's what they receive.

Given that the generators can be adjusted to one's tastes (e.g. making
one's own FUNCTION, FUNC, PROCEDURE, PROC) then these policies are
not hard and fast rules for all coders.  But after absorbing the
initial conversion, they are likely to improve the debuggability and
coherence of the code.