### PR TITLE
<in>, <with>, <static> function specs...plus defaults

### DIFF
--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -523,18 +523,29 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         if (definitional_return == NULL) { // no RETURN: pure local explicit
             REBSTR *canon_return = Canon(SYM_RETURN);
 
-            // The types in the typeset of a "magic" definitional return are
-            // usually-prohibited typing on a local.  They hold the legal
-            // types for the return.  By default the rules are the same as
-            // for arguments...to help accidentally returning voids or
-            // functions to unsuspecting callers.
+            // !!! The current experiment for dealing with default type
+            // checking on definitional returns is to be somewhat restrictive
+            // if there are *any* documentation notes or typesets on the
+            // function.  Hence:
             //
-            // !!! This is an experiment to see what happens.
+            //     >> foo: func [x] [] ;-- no error, void return allowed
+            //     >> foo: func [{a} x] [] ;-- will error, can't return void
+            //
+            // The idea is that if any effort has been expended on documenting
+            // the interface at all, it has some "public" component...so
+            // problems like leaking arbitrary values (vs. using PROC) are
+            // more likely to be relevant.  Whereas no effort indicates a
+            // likely more ad-hoc experimentation.
+            //
+            // (A "strict" mode, selectable per module, could control this and
+            // other settings.  But the goal is to attempt to define something
+            // that is as broadly usable as possible.)
             //
             DS_PUSH_TRASH;
             Val_Init_Typeset(
                 DS_TOP,
                 (flags & MKF_ANY_VALUE)
+                || NOT(has_description || has_types || has_notes)
                     ? ALL_64
                     : ALL_64 & ~(FLAGIT_64(REB_0) | FLAGIT_64(REB_FUNCTION)),
                 canon_return

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -1060,17 +1060,34 @@ set 'r3-legacy* func [<local> if-flags] [
             ] body
         ])
 
+        ; The shift in Ren-C is to remove the refinements from FUNCTION.
+        ; Previously /WITH is now handles as the tag <in>
+        ; /EXTERN then takes over the tag <with>
+        ;
         function: (func [
             {FUNCTION <r3-legacy>}
             return: [function!]
             spec [block!]
             body [block!]
+            /with
+                {Define or use a persistent object (self)}
+            object [object! block! map!]
+                {The object or spec}
+            /extern
+                {Provide explicit list of external words}
+            words [block!]
+                {These words are not local.}
         ][
             if block? first spec [spec: next spec]
+
+            if block? object [object: has object]
 
             lib/function compose [
                 return: [<opt> any-value!]
                 (spec)
+                (if with [reduce [<in> object]])
+                (if extern [<with>])
+                (:words)
             ] body
         ])
 

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -11,10 +11,97 @@ REBOL [
     }
 ]
 
-secure: function/with [
+secure: function [
     "Set security policies (use SECURE help for more information)."
+    return: [<opt> any-value!]
     'policy [<opt> word! lit-word! block!]
         "Set single or multiple policies (or HELP)"
+
+    <static>
+
+    ; Permanent values and sub-functions of SECURE:
+
+    acts ([allow ask throw quit])
+
+    assert-policy (
+        func [tst kind arg] [
+            unless tst [cause-error 'access 'security-error reduce [kind arg]]
+        ]
+    )
+
+    make-policy (function [
+        ; Build the policy tuple used by lower level code.
+        target ; "For special cases: eval, memory"
+        pol ; word number or block
+    ][
+        ; Special cases: [eval 100000]
+        if find [eval memory] target [
+            assert-policy any-number? pol target pol
+            limit-usage target pol ; pol is a number here
+            return 3.3.3 ; always quit
+        ]
+        ; The set all case: [file allow]
+        if word? pol [
+            n: find acts pol
+            assert-policy n target pol
+            return (index-of n) - 1 * 1.1.1
+        ]
+        ; Detailed case: [file [allow read throw write]]
+        flags: 0.0.0
+        assert-policy block? pol target pol
+        for-each [act perm] pol [
+            n: find acts act
+            assert-policy n target act
+            m: select [read 1.0.0 write 0.1.0 execute 0.0.1] perm
+            assert-policy m target perm
+            flags: (index-of n) - 1 * m or+ flags
+        ]
+        flags
+    ])
+
+    set-policy (function [
+        ; Set the policy as tuple or block:
+        target
+        pol
+        pol-obj
+    ][
+        case [
+            file? target [
+                val: to-local-file/full target
+                ; This string must have OS-local encoding, because
+                ; the check is done at a lower level of I/O.
+                if system/version/4 != 3 [val: to binary! val]
+                target: 'file
+            ]
+            url? target [val: target  target: 'net]
+        ]
+        old: select pol-obj target
+        assert-policy old target pol
+        either val [
+            ; Convert tuple to block if needed:
+            if tuple? old [old: reduce [target old]]
+            remove/part find old val 2  ; can be in list only once
+            insert old reduce [val pol]
+        ][
+            old: pol
+        ]
+        set in pol-obj target old
+    ])
+
+    word-policy (function [pol][
+        ; Convert lower-level policy tuples to words:
+        if all [pol/1 = pol/2 pol/2 = pol/3][
+            return pick acts 1 + pol/1
+        ]
+        blk: make block! 4
+        n: 1
+        for-each act [read write execute] [
+            repend blk [pick acts 1 + pol/:n act]
+            ++ n
+        ]
+        blk
+    ])
+
 ] append bind [
 
     "Two funcs bound to private system/state/policies with protect/hide after."
@@ -91,88 +178,8 @@ secure: function/with [
     ; ADD: check for policy level reductions!
     set-policies pol-obj
     return ()
-][
-    ; Permanent values and sub-functions of SECURE:
-
-    acts: [allow ask throw quit]
-
-    assert-policy: func [tst kind arg] [unless tst [cause-error 'access 'security-error reduce [kind arg]]]
-
-    make-policy: func [
-        ; Build the policy tuple used by lower level code.
-        target ; "For special cases: eval, memory"
-        pol ; word number or block
-        /local n m flags
-    ][
-        ; Special cases: [eval 100000]
-        if find [eval memory] target [
-            assert-policy any-number? pol target pol
-            limit-usage target pol ; pol is a number here
-            return 3.3.3 ; always quit
-        ]
-        ; The set all case: [file allow]
-        if word? pol [
-            n: find acts pol
-            assert-policy n target pol
-            return (index-of n) - 1 * 1.1.1
-        ]
-        ; Detailed case: [file [allow read throw write]]
-        flags: 0.0.0
-        assert-policy block? pol target pol
-        for-each [act perm] pol [
-            n: find acts act
-            assert-policy n target act
-            m: select [read 1.0.0 write 0.1.0 execute 0.0.1] perm
-            assert-policy m target perm
-            flags: (index-of n) - 1 * m or+ flags
-        ]
-        flags
-    ]
-
-    set-policy: func [
-        ; Set the policy as tuple or block:
-        target
-        pol
-        pol-obj
-        /local val old
-    ][
-        case [
-            file? target [
-                val: to-local-file/full target
-                ; This string must have OS-local encoding, because
-                ; the check is done at a lower level of I/O.
-                if system/version/4 != 3 [val: to binary! val]
-                target: 'file
-            ]
-            url? target [val: target  target: 'net]
-        ]
-        old: select pol-obj target
-        assert-policy old target pol
-        either val [
-            ; Convert tuple to block if needed:
-            if tuple? old [old: reduce [target old]]
-            remove/part find old val 2  ; can be in list only once
-            insert old reduce [val pol]
-        ][
-            old: pol
-        ]
-        set in pol-obj target old
-    ]
-
-    word-policy: func [pol /local blk n][
-        ; Convert lower-level policy tuples to words:
-        if all [pol/1 = pol/2 pol/2 = pol/3][
-            return pick acts 1 + pol/1
-        ]
-        blk: make block! 4
-        n: 1
-        for-each act [read write execute] [
-            repend blk [pick acts 1 + pol/:n act]
-            ++ n
-        ]
-        blk
-    ]
 ]
+
 
 unless system/options/flags/secure-min [
     ; Remove all other access to the policies:

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -96,7 +96,7 @@ mixin?: func [
 ]
 
 
-load-header: function/with [
+load-header: function [
     "Loads script header object and body binary (not loaded)."
     source [binary! string!]
         "Source code (string! will be UTF-8 encoded)"
@@ -104,6 +104,10 @@ load-header: function/with [
         "Only process header, don't decompress or checksum body"
     /required
         "Script header is required"
+
+    <static>
+
+    non-ws (make bitset! [not 1 - 32])
 ][
     ; This function decodes the script header from the script body.
     ; It checks the header 'checksum and 'compress and 'content options,
@@ -261,8 +265,6 @@ load-header: function/with [
         ensure [binary! block!] rest
         ensure binary! end
     ]
-][
-    non-ws: make bitset! [not 1 - 32]
 ]
 
 

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -331,3 +331,31 @@
     p: make o []
     not same? o/f 1 p/f 1
 ]
+
+[
+    o1: make object! [x: {x} o2: make object! [y: {y}]]
+    outer: {outer}
+    n: 20
+
+    f: function [
+        /count
+        n (2)
+        <in> o1 o1/o2
+        <with> outer
+        <static> static (10 + n)
+    ][
+        data: reduce [n x y outer static]
+        return case [
+            n = 0 [reduce [data]]
+            true [
+               append/only (f/count n - 1) data
+            ]
+        ]
+    ]
+
+    f = [
+        [0 "x" "y" "outer" 30]
+        [1 "x" "y" "outer" 30]
+        [2 "x" "y" "outer" 30]
+    ]
+]


### PR DESCRIPTION
This moves the /WITH refinement on FUNCTION as a feature to be the
<in> tag.  So instead of:

    f: function/with [spec...] [body...] obj

You can write:

    f: function [spec... <in> obj] [body...]

It also switches the block-based statics aspect of that /WITH to be a
<static> feature.  So instead of:

    f: function/with [spec...] [body...] [x: 1 y: 2]

You can write:

    f: function [spec... <static> x (1) y (2)] [body...]

The /EXTERN feature on the other hand took the "with" name, as a way
of defining the outer words you want to define as "being brought in
with" the function defintion.  So instead of:

    f: function/extern [spec...] [body...] [a b c]

You can write:

    f: function [spec... <with> a b c] [body...]

Along with these conveniences is the ability to use parentheses as a
way of providing defaults to refinement args, that will become their
value if they are not passed in (or passed in and BLANK!).  Whether
BLANK! should be overridden or not is a question up for debate.

All parenthesized expressions are invoked in the context of function
generation--not the function body--which means it only runs once
(hence good for reducing total computation if the model fits) as well
as bridging data in variables the function body won't have access to
when it runs otherwise.