### PR TITLE
fix about - use exit to not return a value

### DIFF
--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -335,6 +335,7 @@ about: func [
     "Information about REBOL"
 ][
     print make-banner sys/boot-banner
+    exit
 ]
 
 ;       --cgi (-c)       Load CGI utiliy module and modes


### PR DESCRIPTION
This is just a trivial fix for ABOUT which currently causes in error, because it does not have a return value.