### PR TITLE
MSVC 2015 Zero-Warning CMake Build

### DIFF
--- a/make/CMakeLists.txt
+++ b/make/CMakeLists.txt
@@ -1,9 +1,39 @@
 # vim: ts=2 shiftwidth=2 filetype=CMAKE
+
+#
+# Sample command lines:
+#
+#     cd make
+#     mkdir build
+#     cd build
+#     CMake .. -G "Visual Studio 14 Win64" -DR3_OS_ID=0.3.40
+#          -DR3_EXTERNAL_FFI=yes -DR3_CPP=no
+#
+
 cmake_minimum_required (VERSION 2.8)
 
 set (CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
 
 project (Rebol3 C CXX)
+
+
+# Simplify appending flags to the C build settings, C++ settings, or both
+
+macro(add_cxx_flags flags)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flags}")
+endmacro()
+
+macro(add_c_flags flags)
+    set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} ${flags}")
+endmacro()
+
+macro(add_c_and_cxx_flags flags)
+    set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} ${flags}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flags}")
+endmacro()
+
+
+
 set (TOP_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src")
 set (CORE_DIR "${TOP_SRC_DIR}/core")
 set (OS_DIR "${TOP_SRC_DIR}/os")
@@ -18,6 +48,7 @@ else()
 endif()
 
 option(R3_EXTERNAL_FFI "Build with external FFI" OFF)
+option(R3_CPP "Build C files as C++" OFF)
 
 if (NOT EXISTS ${REBOL})
     message(FATAL_ERROR "${REBOL} doesn't exist, an executable r3 is required")
@@ -102,6 +133,22 @@ endif ()
 
 if (MSVC)
     set (LINK_FLAGS /STACK:4194304)
+
+    # !!! At the moment, there are many places where in the 64-bit build, a
+    # 64-bit integer is used in places where a 32-bit integer is expected.
+    # Ren-C intends to use 64-bit series indices in 64-bit builds, but that
+    # just hasn't been done yet.
+    #
+    # (Note: /WD is "Warning Disable")
+    #
+    add_c_and_cxx_flags(/wd4244) # possible data loss in argument conversion
+    add_c_and_cxx_flags(/wd4267) # possible data loss in initialization
+
+    # MSVC complains if you use old-style functions like `strcpy` instead of
+    # `strcpy_s`.  There should be a review of these cases, but for now they
+    # are allowed as-is
+    #
+    add_c_and_cxx_flags(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 if (WIN32 OR CYGWIN)
@@ -529,7 +576,18 @@ if (WIN32)
 else ()
     target_compile_definitions(r3-core PUBLIC REB_CORE REB_EXE ${COMMON_MACROS})
 endif ()
-set_target_properties(r3-core PROPERTIES LINKER_LANGUAGE C)
+
+# Build as C by default, but there are extra checks if you build as C++
+# NOTE: The library code will not be binary compatible in -debug- builds as
+# C++, so a C++ debug client cannot be used with a C built debug Rebol
+#
+if (R3_CPP)
+    set_property(SOURCE ${CORE_SOURCE} PROPERTY LANGUAGE CXX)
+    set_property(SOURCE ${OS_SOURCE} PROPERTY LANGUAGE CXX)
+    set_property(SOURCE {GENERATED_OS_SOURCE} PROPERTY LANGUAGE CXX)
+    set_target_properties(r3-core PROPERTIES LINKER_LANGUAGE CXX)
+endif()
+
 if (DEFINED LINK_FLAGS)
     set_target_properties(r3-core PROPERTIES LINK_FLAGS ${LINK_FLAGS})
 endif()

--- a/src/codecs/png/lodepng.c
+++ b/src/codecs/png/lodepng.c
@@ -3394,7 +3394,8 @@ unsigned lodepng_convert(unsigned char* out, const unsigned char* in,
 
   if(mode_out->colortype == LCT_PALETTE)
   {
-    size_t palsize = 1 << mode_out->bitdepth;
+    // !!! Ren-C modification...add cast for bit shift, avoid warning
+    size_t palsize = ((size_t)1) << mode_out->bitdepth;
     if(mode_out->palettesize < palsize) palsize = mode_out->palettesize;
     color_tree_init(&tree);
     for(i = 0; i < palsize; i++)

--- a/src/core/a-globals.c
+++ b/src/core/a-globals.c
@@ -42,6 +42,6 @@
 #undef TVAR
 
 #define PVAR
-#define TVAR THREAD
+#define TVAR
 
 #include "sys-globals.h"

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -49,7 +49,14 @@ REBOL_HOST_LIB *Host_Lib;
 // the burden of keeping these in sync manually is for the best.
 //
 #include "reb-lib.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern const REBRXT Reb_To_RXT[REB_MAX];
+#if defined(__cplusplus)
+}
+#endif
 extern void Value_To_RXI(RXIARG *arg, const REBVAL *val); // f-extension.c
 extern void RXI_To_Value(REBVAL *val, const RXIARG *arg, REBRXT type); // f-extension.c
 extern void RXI_To_Block(RXIFRM *frm, REBVAL *out); // f-extension.c
@@ -440,7 +447,7 @@ RL_API int RL_Do_String(
         else
             DS_PUSH(last);
 
-        return -ERR_NUM(error);
+        return -cast(int, ERR_NUM(error));
     }
 
     REBARR *code = Scan_UTF8_Managed(text, LEN_BYTES(text));

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1511,7 +1511,6 @@ REB_R Plain_Dispatcher(REBFRM *f)
     RELVAL *body = FUNC_BODY(f->func);
     assert(IS_BLOCK(body) && IS_RELATIVE(body) && VAL_INDEX(body) == 0);
 
-    REB_R r;
     if (Do_At_Throws(
         f->out,
         VAL_ARRAY(body),
@@ -1537,7 +1536,6 @@ REB_R Voider_Dispatcher(REBFRM *f)
     RELVAL *body = FUNC_BODY(f->func);
     assert(IS_BLOCK(body) && IS_RELATIVE(body) && VAL_INDEX(body) == 0);
 
-    REB_R r;
     if (Do_At_Throws(
         f->out,
         VAL_ARRAY(body),
@@ -1563,7 +1561,6 @@ REB_R Returner_Dispatcher(REBFRM *f)
     RELVAL *body = FUNC_BODY(f->func);
     assert(IS_BLOCK(body) && IS_RELATIVE(body) && VAL_INDEX(body) == 0);
 
-    REB_R r;
     if (Do_At_Throws(
         f->out,
         VAL_ARRAY(body),

--- a/src/core/c-signal.c
+++ b/src/core/c-signal.c
@@ -81,9 +81,6 @@ REBOOL Do_Signals_Throws(REBVAL *out)
     REBOOL thrown = FALSE;
     SET_VOID(out);
 
-    struct Reb_State state;
-    REBCTX *error;
-
 #if !defined(NDEBUG)
     if (!Saved_State && PG_Boot_Phase >= BOOT_MEZZ) {
         printf(

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -291,19 +291,17 @@ REBUPT Do_Core_Expression_Checks_Debug(REBFRM *f) {
     // chained in via a function execution, so it's okay to put "non-GC safe"
     // trash in at this point...though by the time of that call, they must
     // hold valid values.
-    //
-    f->func = NULL;
+    
+    TRASH_POINTER_IF_DEBUG(f->param);
+    TRASH_POINTER_IF_DEBUG(f->arg);
+    TRASH_POINTER_IF_DEBUG(f->refine);
 
-    f->param = cast(const RELVAL*, 0xDECAFBAD);
-    f->arg = cast(REBVAL*, 0xDECAFBAD);
-    f->refine = cast(REBVAL*, 0xDECAFBAD);
-
-    f->args_head = cast(REBVAL*, 0xDECAFBAD);
-    f->varlist = cast(REBARR*, 0xDECAFBAD);
-
-    f->func = cast(REBFUN*, 0xDECAFBAD);
-    f->binding = cast(REBARR*, 0xDECAFBAD);
-    f->underlying = cast(REBFUN*, 0xDECAFBAD);
+    TRASH_POINTER_IF_DEBUG(f->args_head);
+    TRASH_POINTER_IF_DEBUG(f->varlist);
+  
+    TRASH_POINTER_IF_DEBUG(f->func);
+    TRASH_POINTER_IF_DEBUG(f->binding);
+    TRASH_POINTER_IF_DEBUG(f->underlying);
 
     // Mutate va_list sources into arrays at fairly random moments in the
     // debug build.  It should be able to handle it at any time.

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -918,7 +918,6 @@ pick:
 //
 void Form_Args(REB_MOLD *mo, const char *fmt, ...)
 {
-    REBYTE *result;
     va_list args;
 
     va_start(args, fmt);

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -410,7 +410,6 @@ REBNATIVE(backtrace)
     row = 0;
     number = 0;
     for (frame = FS_TOP->prior; frame != NULL; frame = frame->prior) {
-        REBCNT len;
         RELVAL *temp;
 
         // Only consider invoked or pending functions in the backtrace.

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -382,7 +382,7 @@ REBNATIVE(load_extension)
     REBEXT *ext;
     CFUNC *call; // RXICAL
     REBSER *src;
-    int Remove_after_first_run;
+
     //Check_Security(SYM_EXTENSION, POL_EXEC, val);
 
     if (!REF(dispatch)) { // No /dispatch, use the DLL file:

--- a/src/core/f-random.c
+++ b/src/core/f-random.c
@@ -58,7 +58,7 @@
 
 static REBI64 ran_x[KK];                    /* the generator state */
 
-#ifdef __STDC__
+#if defined __STDC__ || defined __cplusplus
 void ran_array(REBI64 aa[], int n)
 #else
 void ran_array(aa,n)    /* put n new random numbers in aa */

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1062,9 +1062,6 @@ void Queue_Mark_Value_Deep(const RELVAL *val)
 //
 static void Mark_Array_Deep_Core(REBARR *array)
 {
-    REBCNT len;
-    RELVAL *value;
-
 #if !defined(NDEBUG)
     //
     // We should have marked this series at queueing time to keep it from
@@ -1096,7 +1093,7 @@ static void Mark_Array_Deep_Core(REBARR *array)
     assert(!IS_FREE_NODE(ARR_SERIES(array)));
 #endif
 
-    value = ARR_HEAD(array);
+    RELVAL *value = ARR_HEAD(array);
     for (; NOT_END(value); value++) {
         if (IS_VOID_OR_SAFE_TRASH(value)) {
             //

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -174,8 +174,6 @@ void Free_Mem(void *mem, size_t size)
 
 #define POOL_MAP
 
-#define BAD_MEM_PTR ((REBYTE *)0xBAD1BAD1)
-
 #ifdef POOL_MAP
     #ifdef NDEBUG
         #define FIND_POOL(n) \
@@ -877,8 +875,8 @@ REBSER *Make_Series(REBCNT length, REBYTE wide, REBCNT flags)
     s->guard = cast(int*, malloc(sizeof(*s->guard)));
     free(s->guard);
 
-    s->link.keylist = cast(REBARR*, 0xBAD3BAD3);
-    s->misc.canon = cast(REBSTR*, 0xBAD4BAD4);
+    TRASH_POINTER_IF_DEBUG(s->link.keylist);
+    TRASH_POINTER_IF_DEBUG(s->misc.canon);
 
     // It's necessary to have another value in order to round out the size of
     // the pool node so pointer-aligned entries are given out, so might as well
@@ -1470,9 +1468,7 @@ void GC_Kill_Series(REBSER *s)
 
     s->info.bits = 0; // includes width
 
-#if !defined(NDEBUG)
-    s->link.keylist = cast(REBARR*, 0xBAD3BAD3);
-#endif
+    TRASH_POINTER_IF_DEBUG(s->link.keylist);
 
     Free_Node(SER_POOL, s);
 
@@ -1859,8 +1855,6 @@ void Dump_All(REBCNT size)
 //
 void Dump_Series_In_Pool(REBCNT pool_id)
 {
-    REBCNT count;
-
     REBSEG *seg;
     for (seg = Mem_Pools[SER_POOL].segs; seg; seg = seg->next) {
         REBSER *s = cast(REBSER*, seg + 1);

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -459,7 +459,7 @@ void Assert_Series_Term_Core(REBSER *series)
         REBCNT len = SER_LEN(series);
         REBCNT wide = SER_WIDE(series);
         REBCNT n;
-        for (n = 0; n < SER_WIDE(series); n++) {
+        for (n = 0; n < wide; n++) {
             if (0 != SER_DATA_RAW(series)[(len * wide) + n]) {
                 printf("Non-zero byte in terminator of non-block series\n");
                 fflush(stdout);

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -332,8 +332,6 @@ REBCTX *Context_For_Frame_May_Reify_Core(REBFRM *f) {
     assert(Is_Any_Function_Frame(f)); // varargs reifies while still pending
 
     REBCTX *context;
-    struct Reb_Chunk *chunk;
-
     if (f->varlist != NULL) {
         if (GET_ARR_FLAG(f->varlist, ARRAY_FLAG_VARLIST))
             return AS_CONTEXT(f->varlist); // already a context!

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -91,7 +91,7 @@
 
 
 // Table of has functions and parameters:
-static struct digest {
+static struct {
     REBYTE *(*digest)(REBYTE *, REBCNT, REBYTE *);
     void (*init)(void *);
     void (*update)(void *, REBYTE *, REBCNT);

--- a/src/core/p-console.c
+++ b/src/core/p-console.c
@@ -76,7 +76,11 @@ static REB_R Console_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         SET_SERIES_LEN(ser, 0);
         TERM_SERIES(ser);
 
-        req->common.data = BIN_HEAD(ser);
+        // !!! May be a 2-byte wide series on Windows for wide chars, in
+        // which case the length is not bytes??  (Can't use BIN_DATA here
+        // because that asserts width is 1...)
+        //
+        req->common.data = SER_DATA_RAW(ser);
         req->length = SER_AVAIL(ser);
 
 #ifdef nono

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -285,7 +285,6 @@ static void Write_File_Port(REBREQ *file, REBVAL *data, REBCNT len, REBCNT args)
 static REBCNT Set_Length(const REBREQ *file, REBI64 limit)
 {
     REBI64 len;
-    int what_if_it_changed;
 
     // Compute and bound bytes remaining:
     len = file->special.file.size - file->special.file.index; // already read

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -42,7 +42,6 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
     REBREQ *req;    // IO request
     REBVAL *spec;   // port spec
     REBVAL *arg;    // action argument value
-    REBVAL *val;    // e.g. port number value
     REBINT result;  // IO result
     REBCNT refs;    // refinement argument flags
     REBCNT len;     // generic length

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -1272,7 +1272,6 @@ REBSER *Make_UTF8_From_Any_String(
 //
 REBCNT Strlen_Uni(const REBUNI *up)
 {
-    REBCNT len;
     const char *cp = cast(const char *, up) + 1; // "C"har vs. "U"nicode
     assert(sizeof(REBUNI) == 2);
     assert(cast(REBUPT, up) % 2 == 0);

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -150,9 +150,8 @@ static REBINT Math_Arg_For_Char(REBVAL *arg, REBSYM action)
 //
 REBTYPE(Char)
 {
-    REBUNI chr = VAL_CHAR(D_ARG(1));
-    REBINT  arg;
-    REBVAL  *val;
+    REBCNT chr = VAL_CHAR(D_ARG(1)); // !!! Larger than REBCHR for math ops?
+    REBINT arg;
 
     switch (action) {
 
@@ -200,11 +199,6 @@ REBTYPE(Char)
     case SYM_XOR_T:
         arg = Math_Arg_For_Char(D_ARG(2), action);
         chr ^= cast(REBUNI, arg);
-        break;
-
-    case SYM_NEGATE:
-        arg = Math_Arg_For_Char(D_ARG(2), action);
-        chr = cast(REBUNI, -chr);
         break;
 
     case SYM_COMPLEMENT:

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -73,9 +73,7 @@ REBTYPE(Datatype)
 {
     REBVAL *value = D_ARG(1);
     REBVAL *arg = D_ARG(2);
-    REBACT act;
     enum Reb_Kind kind = VAL_TYPE_KIND(value);
-    REBINT n;
 
     switch (action) {
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -34,7 +34,7 @@
 
 const struct {
     REBSYM sym;
-    REBFLGS flags;
+    REBUPT flags;
 } Gob_Flag_Words[] = {
     {SYM_RESIZE,      GOBF_RESIZE},
     {SYM_NO_TITLE,    GOBF_NO_TITLE},
@@ -335,21 +335,25 @@ static void Set_Gob_Flag(REBGOB *gob, REBSTR *name)
             //handle mutual exclusive states
             switch (flag) {
                 case GOBF_RESTORE:
-                    CLR_GOB_FLAGS(gob, GOBF_MINIMIZE, GOBF_MAXIMIZE);
+                    CLR_GOB_FLAG(gob, GOBF_MINIMIZE);
+                    CLR_GOB_FLAG(gob, GOBF_MAXIMIZE);
                     CLR_GOB_FLAG(gob, GOBF_FULLSCREEN);
                     break;
                 case GOBF_MINIMIZE:
-                    CLR_GOB_FLAGS(gob, GOBF_MAXIMIZE, GOBF_RESTORE);
+                    CLR_GOB_FLAG(gob, GOBF_MAXIMIZE);
+                    CLR_GOB_FLAG(gob, GOBF_RESTORE);
                     CLR_GOB_FLAG(gob, GOBF_FULLSCREEN);
                     break;
                 case GOBF_MAXIMIZE:
-                    CLR_GOB_FLAGS(gob, GOBF_MINIMIZE, GOBF_RESTORE);
+                    CLR_GOB_FLAG(gob, GOBF_MINIMIZE);
+                    CLR_GOB_FLAG(gob, GOBF_RESTORE);
                     CLR_GOB_FLAG(gob, GOBF_FULLSCREEN);
                     break;
                 case GOBF_FULLSCREEN:
                     SET_GOB_FLAG(gob, GOBF_NO_TITLE);
                     SET_GOB_FLAG(gob, GOBF_NO_BORDER);
-                    CLR_GOB_FLAGS(gob, GOBF_MINIMIZE, GOBF_RESTORE);
+                    CLR_GOB_FLAG(gob, GOBF_MINIMIZE);
+                    CLR_GOB_FLAG(gob, GOBF_RESTORE);
                     CLR_GOB_FLAG(gob, GOBF_MAXIMIZE);
             }
             break;
@@ -479,7 +483,7 @@ static REBOOL Set_GOB_Var(REBGOB *gob, const REBVAL *word, const REBVAL *val)
             //clear only flags defined by words
             REBINT i;
             for (i = 0; Gob_Flag_Words[i].sym != 0; ++i)
-                CLR_FLAG(gob->header.bits, Gob_Flag_Words[i].flags);
+                CLR_GOB_FLAG(gob, Gob_Flag_Words[i].flags);
 
             RELVAL* item;
             for (item = VAL_ARRAY_HEAD(val); NOT_END(item); item++)

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -339,9 +339,6 @@ REBTYPE(Integer)
     REBCNT n;
 
     REBI64 p;
-    REBU64 a, b; // for overflow detection
-    REBCNT a1, a0, b1, b0;
-    REBOOL sgn;
     REBI64 anum;
 
     num = VAL_INT64(val);

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -577,8 +577,6 @@ REBTYPE(Context)
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
     REBCTX *context;
 
-    enum Reb_Kind target;
-
     switch (action) {
     case SYM_APPEND:
         FAIL_IF_LOCKED_CONTEXT(VAL_CONTEXT(value));

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -88,7 +88,6 @@ REBTYPE(Port)
 {
     REBVAL *value = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
-    REBCTX *context;
 
     switch (action) {
 

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1453,19 +1453,16 @@ REBNATIVE(make_callback)
     if (RIN_CLOSURE(r) == NULL)
         fail (Error(RE_MISC)); // couldn't allocate closure
 
-    ffi_status status;
+    ffi_status status = ffi_prep_closure_loc(
+        RIN_CLOSURE(r),
+        SER_HEAD(ffi_cif, r->cif),
+        callback_dispatcher,
+        r,
+        RIN_DISPATCHER(r)
+    );
 
-    if (
-        FFI_OK != ffi_prep_closure_loc(
-            RIN_CLOSURE(r),
-            SER_HEAD(ffi_cif, r->cif),
-            callback_dispatcher,
-            r,
-            RIN_DISPATCHER(r)
-        )
-    ){
+    if (status != FFI_OK) 
         fail (Error(RE_MISC)); // couldn't prep closure
-    }
 
     SET_RIN_FLAG(r, ROUTINE_FLAG_CALLBACK);
 

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -486,7 +486,6 @@ static void Sort_String(
     REBCNT skip = 1;
     REBCNT size = 1;
     REBCNT thunk = 0;
-    int (*sfunc)(const void *v1, const void *v2);
 
     // Determine length of sort:
     len = Partial(string, 0, part);

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -567,8 +567,6 @@ REBTYPE(Vector)
 {
     REBVAL *value = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
-    REBINT type;
-    REBINT size;
     REBSER *ser;
 
     // Common operations for any series type (length, head, etc.)

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -147,14 +147,30 @@ void TO_Word(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 //  REBTYPE: C
 //
+// The future plan for WORD! types is that they will be unified somewhat with
+// strings...but that bound words will have read-only data.  Under such a
+// plan, string-converting words would not be necessary for basic textual
+// operations.
+//
 REBTYPE(Word)
 {
     REBVAL *val = D_ARG(1);
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
-    REBINT diff;
-    REBSTR *sym;
 
     switch (action) {
+    case SYM_LENGTH: {
+        const REBYTE *bp = STR_HEAD(VAL_WORD_SPELLING(val));
+        REBCNT len = 0;
+        while (TRUE) {
+            REBUNI ch;
+            if (!(bp = Back_Scan_UTF8_Char(&ch, bp, &len)))
+                fail(Error(RE_BAD_UTF8));
+            if (ch == 0)
+                break;
+        }
+        SET_INTEGER(D_OUT, len);
+        return R_OUT; }
+
     default:
         assert(ANY_WORD(val));
         fail (Error_Illegal_Action(VAL_TYPE(val), action));

--- a/src/core/u-gif.c
+++ b/src/core/u-gif.c
@@ -310,7 +310,6 @@ void Decode_GIF_Image(REBCDI *codi)
         Decode_LZW(dp, &cp, colormap, w, h, interlaced);
 
         if(transparency_index >= 0) {
-            int ADD_alpha_key_detection;
             REBYTE *p=colormap+3*transparency_index;
             ///Chroma_Key_Alpha(Temp_Value, (REBCNT)(p[2]|(p[1]<<8)|(p[0]<<16)), BLIT_MODE_COLOR);
         }

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -692,12 +692,19 @@ typedef u16 REBUNI;
     #define ATTRIBUTE_NO_RETURN __attribute__ ((noreturn))
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
     #define ATTRIBUTE_NO_RETURN _Noreturn
+#elif defined(_MSC_VER)
+    #define ATTRIBUTE_NO_RETURN __declspec(noreturn)
 #else
     #define ATTRIBUTE_NO_RETURN
 #endif
 
 #if __has_builtin(__builtin_unreachable) || GCC_VERSION_AT_LEAST(4, 5)
     #define DEAD_END __builtin_unreachable()
+#elif defined(_MSC_VER)
+    __declspec(noreturn) static inline void msvc_unreachable() {
+        while (TRUE) { }
+    }
+    #define DEAD_END msvc_unreachable()
 #else
     #define DEAD_END
 #endif

--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -84,11 +84,6 @@ Special internal defines used by RT, not Host-Kit developers:
 
 //* Common *************************************************************
 
-// !!! Threading support is largely unimplemented, but this switch was
-// to enable threads.
-#define THREADED
-#define THREAD
-
 
 #ifdef REB_EXE
     // standalone exe from RT
@@ -134,13 +129,6 @@ Special internal defines used by RT, not Host-Kit developers:
     #define HAS_ASYNC_DNS           // supports it
 
     #define NO_TTY_ATTRIBUTES       // used in read-line.c
-
-    #ifdef THREADED
-        #ifndef __MINGW32__
-            #undef THREAD
-            #define THREAD __declspec(thread)
-        #endif
-    #endif
 
     // Used when we build REBOL as a DLL:
     #define API_EXPORT __declspec(dllexport)

--- a/src/include/reb-gob.h
+++ b/src/include/reb-gob.h
@@ -169,14 +169,19 @@ typedef struct gob_window {             // Maps gob to window
 
 #define CLEAR_GOB_STATE(g) ((g)->state = 0)
 
-#define SET_GOB_FLAG(g,f)       SET_FLAG((g)->header.bits, f)
-#define GET_GOB_FLAG(g,f)       GET_FLAG((g)->header.bits, f)
-#define CLR_GOB_FLAG(g,f)       CLR_FLAG((g)->header.bits, f)
-#define CLR_GOB_FLAGS(g,f,h)    CLR_FLAGS((g)->header.bits, f, h)
-#define SET_GOB_STATE(g,f)      SET_FLAG((g)->header.bits, f)
-#define GET_GOB_STATE(g,f)      GET_FLAG((g)->header.bits, f)
-#define CLR_GOB_STATE(g,f)      CLR_FLAG((g)->header.bits, f)
-#define CLR_GOB_STATES(g,f,h)   CLR_FLAGS((g)->header.bits, f, h)
+#define SET_GOB_FLAG(g,f) \
+    cast(void, (g)->header.bits |= (cast(REBUPT, 1) << (f)))
+
+#define GET_GOB_FLAG(g,f) \
+    LOGICAL((g)->header.bits & (cast(REBUPT, 1) << (f)))
+
+#define CLR_GOB_FLAG(g,f) \
+    cast(void, (g)->header.bits &= ~(cast(REBUPT, 1) << (f)))
+
+
+#define SET_GOB_STATE(g,f)      SET_FLAG((g)->state, f)
+#define GET_GOB_STATE(g,f)      GET_FLAG((g)->state, f)
+#define CLR_GOB_STATE(g,f)      CLR_FLAG((g)->state, f)
 
 #define GOB_ALPHA(g)        ((g)->alpha)
 #define GOB_TYPE(g)         ((g)->ctype)

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -244,22 +244,21 @@ inline static void FREE_CONTEXT(REBCTX *c) {
 //
 
 #ifdef NDEBUG
-    #define ANY_CONTEXT_FLAG_X 0
+    #define ANY_CONTEXT_FLAG(n) \
+        (1 << (TYPE_SPECIFIC_BIT + (n)))
 #else
-    #define ANY_CONTEXT_FLAG_X \
-        TYPE_SHIFT_LEFT_FOR_HEADER(REB_OBJECT) // interpreted as ANY-CONTEXT!
+    #define ANY_CONTEXT_FLAG(n) \
+        ((1 << (TYPE_SPECIFIC_BIT + (n))) \
+            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_OBJECT)) // means ANY-CONTEXT!
 #endif
 
-enum {
-    // `ANY_CONTEXT_FLAG_OWNS_PAIRED` is particular to the idea of a "Paired"
-    // REBSER, which is actually just two REBVALs.  For purposes of the API,
-    // it is possible for one of those values to be used to manage the
-    // lifetime of the pair.  One technique is to tie the value's lifetime
-    // to that of a particular FRAME!
-    //
-    ANY_CONTEXT_FLAG_OWNS_PAIRED
-        = (1 << (TYPE_SPECIFIC_BIT + 0)) | ANY_CONTEXT_FLAG_X
-};
+// `ANY_CONTEXT_FLAG_OWNS_PAIRED` is particular to the idea of a "Paired"
+// REBSER, which is actually just two REBVALs.  For purposes of the API,
+// it is possible for one of those values to be used to manage the
+// lifetime of the pair.  One technique is to tie the value's lifetime
+// to that of a particular FRAME!
+//
+#define ANY_CONTEXT_FLAG_OWNS_PAIRED ANY_CONTEXT_FLAG(0)
 
 
 inline static REBCTX *VAL_CONTEXT(const RELVAL *v) {

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -636,10 +636,8 @@ inline static void Drop_Function_Args_For_Frame_Core(
 
 finished:
 
-#if !defined(NDEBUG)
-    f->args_head = cast(REBVAL*, 0xDECAFBAD);
-    f->varlist = cast(REBARR*, 0xDECAFBAD);
-#endif
+    TRASH_POINTER_IF_DEBUG(f->args_head);
+    TRASH_POINTER_IF_DEBUG(f->varlist);
 
     return; // needed for release build so `finished:` labels a statement
 }

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -102,39 +102,40 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
 //=////////////////////////////////////////////////////////////////////////=//
 
 #ifdef NDEBUG
-    #define FUNC_FLAG_X 0
+    #define FUNC_FLAG(n) \
+        (1 << (TYPE_SPECIFIC_BIT + (n)))
 #else
-    #define FUNC_FLAG_X \
-        TYPE_SHIFT_LEFT_FOR_HEADER(REB_FUNCTION)
+    #define FUNC_FLAG(n) \
+        ((1 << (TYPE_SPECIFIC_BIT + (n))) \
+            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_FUNCTION))
 #endif
 
-enum {
-    // RETURN will always be in the last paramlist slot (if present)
-    //
-    FUNC_FLAG_RETURN = (1 << (TYPE_SPECIFIC_BIT + 0)) | FUNC_FLAG_X,
+// RETURN will always be in the last paramlist slot (if present)
+//
+#define FUNC_FLAG_RETURN FUNC_FLAG(0)
 
-    // LEAVE will always be in the last paramlist slot (if present)
-    //
-    FUNC_FLAG_LEAVE = (1 << (TYPE_SPECIFIC_BIT + 1)) | FUNC_FLAG_X,
+// LEAVE will always be in the last paramlist slot (if present)
+//
+#define FUNC_FLAG_LEAVE FUNC_FLAG(1)
 
-    // A function may act as a barrier on its left (so that it cannot act
-    // as an input argument to another function).
-    //
-    // Given the "greedy" nature of infix, a function with arguments cannot
-    // be stopped from infix consumption on its right--because the arguments
-    // would consume them.  Only a function with no arguments is able to
-    // trigger an error when used as a left argument.  This is the ability
-    // given to lookback 0 arity functions, known as "punctuators".
-    //
-    FUNC_FLAG_PUNCTUATES = (1 << (TYPE_SPECIFIC_BIT + 2)) | FUNC_FLAG_X,
+// A function may act as a barrier on its left (so that it cannot act
+// as an input argument to another function).
+//
+// Given the "greedy" nature of infix, a function with arguments cannot
+// be stopped from infix consumption on its right--because the arguments
+// would consume them.  Only a function with no arguments is able to
+// trigger an error when used as a left argument.  This is the ability
+// given to lookback 0 arity functions, known as "punctuators".
+//
+#define FUNC_FLAG_PUNCTUATES FUNC_FLAG(2)
 
-    // A "brancher" is a single arity function that is capable of taking a
-    // LOGIC! value.  Currently testing for this requires a bit of processing
-    // so it is done when the function is made, and then this flag is checked.
-    // It's set even if the function might not take logic or need more
-    // parameters, so that it can be called and cause an error if needed.
-    //
-    FUNC_FLAG_MAYBE_BRANCHER = (1 << (TYPE_SPECIFIC_BIT + 3)) | FUNC_FLAG_X,
+// A "brancher" is a single arity function that is capable of taking a
+// LOGIC! value.  Currently testing for this requires a bit of processing
+// so it is done when the function is made, and then this flag is checked.
+// It's set even if the function might not take logic or need more
+// parameters, so that it can be called and cause an error if needed.
+//
+#define FUNC_FLAG_MAYBE_BRANCHER FUNC_FLAG(3)
 
 #if !defined(NDEBUG)
     //
@@ -144,16 +145,14 @@ enum {
     // function implementation after digging through the layers...because
     // proxies must have new (cloned) paramlists but use the original bodies.
     //
-    FUNC_FLAG_PROXY_DEBUG = (1 << (TYPE_SPECIFIC_BIT + 3)) | FUNC_FLAG_X,
+    #define FUNC_FLAG_PROXY_DEBUG FUNC_FLAG(4)
 
     // BLANK! ("none!") for unused refinements instead of FALSE
     // Also, BLANK! for args of unused refinements instead of not set
     //
-    FUNC_FLAG_LEGACY_DEBUG = (1 << (TYPE_SPECIFIC_BIT + 4)) | FUNC_FLAG_X,
+    #define FUNC_FLAG_LEGACY_DEBUG FUNC_FLAG(5)
 #endif
 
-    FUNC_FLAG_NO_COMMA // needed for proper comma termination of this list
-};
 
 inline static REBFUN *VAL_FUNC(const RELVAL *v) {
     assert(IS_FUNCTION(v));

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -906,12 +906,7 @@ inline static RELVAL *REL(REBVAL *v) {
     return cast(RELVAL*, v); // cast w/input restricted to REBVAL
 }
 
-#ifdef NDEBUG
-    #define SPECIFIED NULL
-#else
-    #define SPECIFIED \
-        cast(REBCTX*, 0xF10F10F1) // helps catch uninitialized locations
-#endif
+#define SPECIFIED NULL
 
 
 // This can be used to turn a RELVAL into a REBVAL.  If the RELVAL is

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -254,7 +254,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 
     inline static void SET_VAL_FLAG(RELVAL *v, REBUPT f) {
         CHECK_VALUE_FLAG_EVIL_MACRO_DEBUG;
-        assert(f && f == (f & -f)); // checks that only one bit is set
+        assert(f && (f & (f - 1)) == 0); // checks that only one bit is set
         v->header.bits |= f;
     }
 
@@ -270,7 +270,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 
     inline static void CLEAR_VAL_FLAG(RELVAL *v, REBUPT f) {
         CHECK_VALUE_FLAG_EVIL_MACRO_DEBUG;
-        assert(f && f == (f & -f)); // checks that only one bit is set
+        assert(f && (f & (f - 1)) == 0); // checks that only one bit is set
         v->header.bits &= ~f;
     }
 #endif

--- a/src/include/sys-varargs.h
+++ b/src/include/sys-varargs.h
@@ -46,19 +46,20 @@
 //
 
 #ifdef NDEBUG
-    #define VARARGS_FLAG_X 0
+    #define VARARGS_FLAG(n) \
+        (cast(REBUPT, 1) << (TYPE_SPECIFIC_BIT + (n))) 
 #else
-    #define VARARGS_FLAG_X \
-        TYPE_SHIFT_LEFT_FOR_HEADER(REB_VARARGS)
+    #define VARARGS_FLAG(n) \
+        ((cast(REBUPT, 1) << (TYPE_SPECIFIC_BIT + (n))) \
+            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_VARARGS))
 #endif
 
-enum {
-    // Was made with a call to MAKE VARARGS! with data from an ANY-ARRAY!
-    // If that is the case, it does not use the varargs payload at all,
-    // rather it uses the Reb_Any_Series payload.
-    //
-    VARARGS_FLAG_NO_FRAME = (1 << (TYPE_SPECIFIC_BIT + 0)) | VARARGS_FLAG_X
-};
+// Was made with a call to MAKE VARARGS! with data from an ANY-ARRAY!
+// If that is the case, it does not use the varargs payload at all,
+// rather it uses the Reb_Any_Series payload.
+//
+#define VARARGS_FLAG_NO_FRAME VARARGS_FLAG(0)
+
 
 inline static const REBVAL *VAL_VARARGS_PARAM(const RELVAL *v)
     { return v->payload.varargs.param; }

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -42,30 +42,34 @@
 //
 
 #ifdef NDEBUG
-    #define WORD_FLAG_X 0
+    #define WORD_FLAG(n) \
+        (1 << (TYPE_SPECIFIC_BIT + (n)))
 #else
-    #define WORD_FLAG_X \
-        TYPE_SHIFT_LEFT_FOR_HEADER(REB_WORD) // interpreted as ANY-WORD!
+    #define WORD_FLAG(n) \
+        ((1 << (TYPE_SPECIFIC_BIT + (n))) \
+            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_WORD)) // interpreted as ANY-WORD!
 #endif
 
-enum {
-    // `WORD_FLAG_BOUND` answers whether a word is bound, but it may be
-    // relatively bound if `VALUE_FLAG_RELATIVE` is set.  In that case, it
-    // does not have a context pointer but rather a function pointer, that
-    // must be combined with more information to get the FRAME! where the
-    // word should actually be looked up.
-    //
-    // If VALUE_FLAG_RELATIVE is set, then WORD_FLAG_BOUND must also be set.
-    //
-    WORD_FLAG_BOUND = (1 << (TYPE_SPECIFIC_BIT + 0)) | WORD_FLAG_X,
+// `WORD_FLAG_BOUND` answers whether a word is bound, but it may be
+// relatively bound if `VALUE_FLAG_RELATIVE` is set.  In that case, it
+// does not have a context pointer but rather a function pointer, that
+// must be combined with more information to get the FRAME! where the
+// word should actually be looked up.
+//
+// If VALUE_FLAG_RELATIVE is set, then WORD_FLAG_BOUND must also be set.
+//
+#define WORD_FLAG_BOUND WORD_FLAG(0)
 
-    // A special kind of word is used during argument fulfillment to hold
-    // a refinement's word on the data stack, augmented with its param
-    // and argument location.  This helps fulfill "out-of-order" refinement
-    // usages more quickly without having to do two full arglist walks.
-    //
-    WORD_FLAG_PICKUP = (1 << (TYPE_SPECIFIC_BIT + 1)) | WORD_FLAG_X
-};
+// A special kind of word is used during argument fulfillment to hold
+// a refinement's word on the data stack, augmented with its param
+// and argument location.  This helps fulfill "out-of-order" refinement
+// usages more quickly without having to do two full arglist walks.
+//
+// !!! Currently this is being done with a VARARGS! though this may not be
+// the best idea, and pickup words may be brought back.
+//
+#define WORD_FLAG_PICKUP WORD_FLAG(1)
+
 
 #define IS_WORD_BOUND(v) \
     GET_VAL_FLAG((v), WORD_FLAG_BOUND)

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -80,6 +80,8 @@
     // when Rebol redefines it.  (Rebol defines IS_XXX for all datatypes.)
     //
     #undef IS_ERROR
+    #undef max
+    #undef min
 #endif
 
 
@@ -152,10 +154,6 @@ const REBYTE breakpoint_str[] =
 const REBYTE interrupted_str[] =
     "** Execution Interrupted (see BACKTRACE, DEBUG, and RESUME)\n\n";
 
-#ifdef TO_WINDOWS
-HINSTANCE App_Instance = 0;
-#endif
-
 #ifndef REB_CORE
 extern void Init_Windows(void);
 extern void OS_Init_Graphics(void);
@@ -165,8 +163,14 @@ extern void OS_Destroy_Graphics(void);
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef TO_WINDOWS
+    HINSTANCE App_Instance = 0;
+#endif
+
     extern void Init_Core_Ext();
     extern void Shutdown_Core_Ext(void);
+
 #ifdef __cplusplus
 }
 #endif
@@ -320,7 +324,7 @@ int Do_String(
 
         Val_Init_Error(out, error);
         *last = *out;
-        return -ERR_NUM(error);
+        return -cast(REBINT, ERR_NUM(error));
     }
 
     REBARR *code = Scan_UTF8_Managed(text, LEN_BYTES(text));
@@ -444,7 +448,6 @@ int Do_String(
 
 
 REBOOL Host_Start_Exiting(int *exit_status, int argc, REBCHR **argv) {
-    REBYTE vers[8];
     REBINT startup_rc;
     REBYTE *embedded_script = NULL;
     REBI64 embedded_size = 0;
@@ -1033,7 +1036,6 @@ int main(int argc, char **argv_ansi)
 {
     int exit_status;
 
-    REBINT startup_rc;
     REBCHR **argv;
 
     //

--- a/src/os/linux/host-event.c
+++ b/src/os/linux/host-event.c
@@ -825,7 +825,8 @@ void Dispatch_Event(XEvent *ev)
                 if (hw != NULL) {
                     OS_FREE(hw);
                 }
-                CLR_GOB_STATES(gob, GOBS_OPEN, GOBS_ACTIVE);
+                CLR_GOB_STATE(gob, GOBS_OPEN);
+                CLR_GOB_STATE(gob, GOBS_ACTIVE);
                 Free_Window(gob);
             }
             break;

--- a/src/os/windows/dev-event.c
+++ b/src/os/windows/dev-event.c
@@ -53,7 +53,13 @@ extern void Done_Device(REBUPT handle, int error);
 HWND Event_Handle = 0;          // Used for async DNS
 static int Timer_Id = 0;        // The timer we are using
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern HINSTANCE App_Instance;  // From Main module.
+#ifdef __cplusplus
+}
+#endif
 
 
 //


### PR DESCRIPTION
This makes some changes to the build process, so that the MSVC 2015
build works and can be done without warnings.

Two warnings (which are actually the same warning, for assignment vs.
initialization) had to be disabled, because they were pervasively used.
They pertain to assigning value with more bits (e.g. 64-bit) to one
with less (e.g. 32-bit), which could mean a possible loss of data.
Most of these cases can be remedied if series indices are changed to
be 64-bit on 64-bit builds, which is a good idea and should be done.