### PR TITLE
Add MAYBE? variant for MAYBE, improve void handling

### DIFF
--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -453,9 +453,7 @@ inline static void COPY_VALUE(
     assert(!IS_END(src));
     assert(!IS_TRASH_DEBUG(src));
 
-#ifdef __cplusplus
-    Assert_Cell_Writable(dest, __FILE__, __LINE__);
-#endif
+    ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(dest, __FILE__, __LINE__);
 
     if (IS_RELATIVE(src)) {
     #if !defined(NDEBUG)

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -341,7 +341,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
         | NOT_END_MASK | CELL_MASK)
 
 #ifdef NDEBUG
-    #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v) \
+    #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v,file,line) \
         NOOP
 
     #define MARK_CELL_WRITABLE_IF_CPP_DEBUG(v) \

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -427,7 +427,7 @@ redescribe: function [
             ;
             opt [[set note: string!] (
                 on-demand-meta
-                either (set-word? param) and (param = quote return:) [
+                either all [set-word? param | equal? param quote return:] [
                     meta/return-note: either equal? note {} [
                         _
                     ][
@@ -534,6 +534,14 @@ all?: redescribe [
     {Shortcut AND, ignores voids. Unlike plain ALL, forces result to LOGIC!}
 ](
     chain [:all :true?]
+)
+
+maybe?: redescribe [
+    {Check value using tests (match types, TRUE? or FALSE?, filter function)}
+    ; return: [logic!] ;-- blocks for type changes not supported yet
+    ;    {TRUE if match, FALSE if no match (use MAYBE to pass through value)}
+](
+    specialize 'maybe [?: true]
 )
 
 find?: redescribe [


### PR DESCRIPTION
In order to line up with the usual type checking routines like
integer? (which is void-tolerant to fail the test), MAYBE would allow
voids... even though they have no type.  This pushes it further so
that even `maybe :void? ()` will work.  It passes through the void.

Also includes a ? version to hand back logic, in case knowing whether
the test passed generically (even for FALSE, BLANK, and voids) is more
important than passing through the value.