### PR TITLE
Replace HAS-TYPE? specializations with TYPECHECKER

### DIFF
--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -80,6 +80,7 @@ title
 ;addr already defined
 
 condition ; used by BRANCHER to name the argument of the generated function
+value ; used by TYPECHECKER to name the argument of the generated function
 
 ; !!! See notes on FUNCTION-META and SPECIALIZER-META in %sysobj.r
 description

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1522,6 +1522,32 @@ REB_R Plain_Dispatcher(REBFRM *f)
 
 
 //
+//  Datatype_Checker_Dispatcher: C
+//
+REB_R Datatype_Checker_Dispatcher(REBFRM *f)
+{
+    RELVAL *datatype = FUNC_BODY(f->func);
+    assert(IS_DATATYPE(datatype));
+    if (VAL_TYPE(FRM_ARG(f, 1)) == VAL_TYPE_KIND(datatype))
+        return R_TRUE;
+    return R_FALSE;
+}
+
+
+//
+//  Typeset_Checker_Dispatcher: C
+//
+REB_R Typeset_Checker_Dispatcher(REBFRM *f)
+{
+    RELVAL *typeset = FUNC_BODY(f->func);
+    assert(IS_TYPESET(typeset));
+    if (TYPE_CHECK(typeset, VAL_TYPE(FRM_ARG(f, 1))))
+        return R_TRUE;
+    return R_FALSE;
+}
+
+
+//
 //  Voider_Dispatcher: C
 //
 // Same as the Plain_Dispatcher, except sets the output value to void.
@@ -1990,6 +2016,55 @@ REBNATIVE(chain)
 
     *D_OUT = *FUNC_VALUE(fun);
     assert(VAL_BINDING(D_OUT) == NULL);
+
+    return R_OUT;
+}
+
+
+//
+//  typechecker: native [
+//
+//  {Function generator for an optimized typechecking routine.}
+//
+//      return: [function!]
+//      type [datatype! typeset!]
+//  ]
+//
+REBNATIVE(typechecker)
+{
+    PARAM(1, type);
+    REFINE(2, opt);
+
+    REBVAL *type = ARG(type);
+
+    REBARR *paramlist = Make_Array(2);
+    
+    REBVAL *archetype = Alloc_Tail_Array(paramlist);
+    VAL_RESET_HEADER(archetype, REB_FUNCTION);
+    archetype->payload.function.paramlist = paramlist;
+    archetype->extra.binding = NULL;
+
+    REBVAL *param = Alloc_Tail_Array(paramlist);
+    Val_Init_Typeset(param, ALL_64, Canon(SYM_VALUE));
+    INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
+    
+    MANAGE_ARRAY(paramlist);
+
+    REBFUN *fun = Make_Function(
+        paramlist,
+        IS_DATATYPE(type)
+            ? &Datatype_Checker_Dispatcher
+            : &Typeset_Checker_Dispatcher,
+        NULL // this is fundamental (no distinct underlying function)
+    );
+
+    *FUNC_BODY(fun) = *type;
+
+    // for now, no help...use REDESCRIBE
+
+    ARR_SERIES(paramlist)->link.meta = NULL;
+
+    *D_OUT = *FUNC_VALUE(fun);
 
     return R_OUT;
 }

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1112,37 +1112,6 @@ REBNATIVE(type_of)
 }
 
 
-//
-//  has-type?: native [
-//
-//  {Checks to see if a value has a type or is in a typeset.}
-//
-//      type [datatype! typeset!]
-//      value [<opt> any-value!]
-//  ]
-//
-REBNATIVE(has_type_q)
-{
-    PARAM(1, type);
-    PARAM(2, value);
-
-    REBVAL *value = ARG(value);
-    REBVAL *type = ARG(type);
-
-    if (IS_DATATYPE(type)) {
-        if (VAL_TYPE(value) == VAL_TYPE_KIND(type))
-            return R_TRUE;
-    }
-    else {
-        assert(IS_TYPESET(type));
-        if (TYPE_CHECK(type, VAL_TYPE(value)))
-            return R_TRUE;
-    }
-
-    return R_FALSE;
-}
-
-
 
 //
 //  unset: native [

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -37,17 +37,30 @@ eval proc [
     {Make type testing functions (variadic to quote "top-level" words)}
     :set-word... [set-word! <...>]
     <local>
-        set-word type-name
+        set-word type-name tester meta
 ][
     while [? set-word: take set-word...] [
         type-name: append (head clear find (spelling-of set-word) {?}) "!"
-        set set-word specialize 'has-type? compose [
-            type: (bind (to word! type-name) set-word)
+        tester: typechecker (get bind (to word! type-name) set-word)
+        set set-word :tester
+
+        ; The TYPECHECKER generator doesn't have make meta information by
+        ; default, so it leaves it up to the user code.  Note REDESCRIBE is
+        ; not defined yet, so this just makes the meta object directly.
+        ;
+        meta: copy system/standard/function-meta
+        meta/description: form reduce [
+            {Returns TRUE if the value is a} type-name
         ]
+        meta/return-type: [logic!]
+        set-meta :tester meta 
     ]
 ]
     ; This list consumed by the variadic evaluation, up to the | barrier
-    ; Each makes a specialization, XXX: SPECIALIZE 'HAS-TYPE? [TYPE: XXX!]
+    ; Each makes a specialization, `XXX: TYPECHECKER XXX!`.  A special
+    ; generator is used vs. something like a specialization of a HAS-TYPE?
+    ; function...because the generated dispatcher can be more optimized...
+    ; and type checking is quite common.
     ;
     blank?:
     bar?:

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -368,7 +368,6 @@ redescribe: function [
 
             not notes: any [:meta/parameter-notes] [
                 return () ; specialized or adapted, HELP uses original notes
-                pass
             ]
 
             not frame? notes [


### PR DESCRIPTION
Checking against types or typesets was previously done by way of
specializing an arity-2 HAS-TYPE? function, which took both a data
type and a value to check.  So during bootstrap, a loop would make
a specialization for each type, something like:

     string?: specialize :has-type? [type: string!]

However, there is a small cost to the specializations compared to
having something more like a separate native function to check each
type.

This commit does something almost as good performance-wise as having
a native per type and typeset.  It introduces TYPECHECKER, which is a
function generator that makes a different type of function.  The "body"
is actually the type or typeset to check, and it uses a different
dispatcher for types and typesets...so even that doesn't have to be
branched on.

HAS-TYPE? is replaced by the more generalized MAYBE?, which is richer
since it is a dialect and can run test functions.