### PR TITLE
ANY-TYPE! synonym for ANY-VALUE! except in r3-legacy FUNC

### DIFF
--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -830,8 +830,14 @@ static void Mold_Typeset(const REBVAL *value, REB_MOLD *mold, REBOOL molded)
     }
 #endif
 
-    // Convert bits to types (we can make this more efficient !!)
-    for (n = 0; n < REB_MAX; n++) {
+    // Convert bits to types.  Note that although REB_0 is used as an
+    // implementation detail for the special typesets in function paramlists
+    // or context keys to indicate <opt>-style optionality, the "absence of
+    // a type" is not generally legal to encode in ordinary typesets.
+    //
+    assert(!TYPE_CHECK(value, REB_0) || VAL_KEY_SPELLING(value) != NULL);
+
+    for (n = REB_0 + 1; n < REB_MAX; n++) {
         if (TYPE_CHECK(value, cast(enum Reb_Kind, n))) {
             Emit(mold, "+DN ", SYM_DATATYPE_X, Canon(cast(REBSYM, n)));
         }


### PR DESCRIPTION
While there is no UNSET! (or VOID!) type in Ren-C, an implementation
detail of functions and contexts uses a 0 Reb_Type value to signal the
absence of a value...hence this bit is used to carry the `<opt>`
optionality status of a parameter.  (This is an optimization, and is
becoming more obviously so in light of design for user-defined types.)

However, this trick was exploited to implement the ANY-TYPE! typeset
for r3-legacy.  This made a user facing typeset that contained a
"non type", which was causing an assertion to fire when the ANY-TYPE!
typeset from r3-legacy was shown (since there was no symbol).

This changes the trick so that the ANY-TYPE! typeset is just a synonym
for ANY-VALUE!.  The ability to allow for optional arguments to
functions is done with a different compatibility hack--the r3-legacy
FUNC and FUNCTION constructs explicitly look for `[any-type!]`, and
turn it into `[<opt> any-value!]`.