### PR TITLE
Introduce "managed handles" with a GC cleanup function

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -357,7 +357,11 @@ RL_API void *RL_Extend(const REBYTE *source, RXICAL call)
     value = Alloc_Tail_Array(array);
     Val_Init_Binary(value, Copy_Bytes(source, -1)); // UTF-8
     value = Alloc_Tail_Array(array);
-    SET_HANDLE_CODE(value, cast(CFUNC*, call));
+    Init_Handle_Simple(
+        value,
+        cast(CFUNC*, call), // code
+        NULL // data
+    );
 
     return Extension_Lib();
 }

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1165,7 +1165,11 @@ void Register_Codec(const REBYTE *name, codo dispatcher)
     REBSTR *sym = Intern_UTF8_Managed(name, LEN_BYTES(name));
 
     value = Append_Context(VAL_CONTEXT(value), 0, sym);
-    SET_HANDLE_CODE(value, cast(CFUNC*, dispatcher));
+    Init_Handle_Simple(
+        value,
+        cast(CFUNC*, dispatcher), // code
+        NULL // data
+    );
 }
 
 

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -736,6 +736,21 @@ void Queue_Mark_Value_Deep(const RELVAL *val)
             break;
 
         case REB_HANDLE:
+            //
+            // See %sys-handle.h for an explanation of the two different types
+            // of HANDLE!; one uses a singular REBSER to participate in GC
+            // and another is just an opaque pointer with no GC hook.
+            //
+            if (val->extra.singular) {
+            #if !defined(NDEBUG)
+                assert(ARR_LEN(val->extra.singular) == 1);
+                RELVAL *h = ARR_HEAD(val->extra.singular);
+                assert(IS_HANDLE(h));
+                assert(h->extra.singular == val->extra.singular);
+            #endif
+
+                Mark_Series_Only(ARR_SERIES(val->extra.singular));
+            }
             break;
 
         case REB_DATATYPE:

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -226,9 +226,10 @@ static void Schema_From_Block_May_Fail(
         // through a struct creation.  There are "raw" structs with no memory,
         // which would avoid the data series (not the REBSTU array, though)
         //
-        SET_HANDLE_DATA(
+        Init_Handle_Simple(
             schema_out,
-            ARR_SERIES(VAL_STRUCT(&temp))->link.schema
+            NULL, // code
+            ARR_SERIES(VAL_STRUCT(&temp))->link.schema // data
         );
 
         // Saying "struct!" is legal would suggest any structure is legal.
@@ -1292,7 +1293,11 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
         &Routine_Dispatcher,
         NULL // no underlying function, this is fundamental
     );
-    SET_HANDLE_DATA(FUNC_BODY(fun), cast(REBRIN*, r));
+    Init_Handle_Simple(
+        FUNC_BODY(fun),
+        NULL, // code
+        cast(REBRIN*, r) // data
+    );
 
     ARR_SERIES(paramlist)->link.meta = NULL;
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -193,6 +193,9 @@ typedef struct rebol_mem_pool REBPOL;
 
 #include "sys-rebval.h" // REBVAL structure definition
 #include "sys-action.h"
+
+typedef void (*CLEANUP_FUNC)(const REBVAL*); // for some HANDLE!s GC callback
+
 #include "sys-rebser.h" // REBSER series definition (embeds REBVAL definition)
 
 typedef void (*MAKE_FUNC)(REBVAL*, enum Reb_Kind, const REBVAL*);
@@ -680,6 +683,8 @@ enum Reb_Vararg_Op {
 #include "sys-string.h"
 
 #include "sys-array.h"
+
+#include "sys-handle.h"
 
 #include "sys-typeset.h"
 #include "sys-context.h"

--- a/src/include/sys-handle.h
+++ b/src/include/sys-handle.h
@@ -1,0 +1,122 @@
+//
+//  File: %sys-handle.h
+//  Summary: "Definitions for GC-able and non-GC-able Handles"
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2016 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// In Rebol terminology, a HANDLE! is a pointer to a function or data that
+// represents an arbitrary external resource.  While such data could also
+// be encoded as a BINARY! "blob" (as it might be in XML), the HANDLE! type
+// is intentionally "opaque" to user code so that it is a black box.
+//
+// In the C language, sizeof(void*) may not be the same size as a function
+// pointer; hence they can't necessarily be cast between each other.  Since
+// there is room for it, each HANDLE! in Ren-C is able to store one of each:
+// a code pointer and data pointer.  Or it may use only one or the other.
+//
+// Additionally, Ren-C added the idea of a garbage collector callback for
+// "Managed" handles.  This is implemented by means of making the handle cost
+// a single REBSER node shared among its instances, which is a "singular"
+// Array containing a canon value of the handle itself.  When there are no
+// references left to the handle and the GC runs, it will run a hook stored
+// in the ->misc field of the singular array.
+//
+// As an added benefit of the Managed form, the code and data pointers in the
+// value itself are not used; instead preferring the data held in the REBARR.
+// This allows one instance of a managed handle to have its code or data
+// pointer changed and be reflected in all instances.  The simple form of
+// handle however is such that each REBVAL copied instance is independent,
+// and changing one won't change the others.
+//
+
+inline static CFUNC *VAL_HANDLE_CODE(const RELVAL *v) {
+    assert(IS_HANDLE(v));
+    if (v->extra.singular)
+        return ARR_HEAD(v->extra.singular)->payload.handle.code;
+    else
+        return v->payload.handle.code;
+}
+
+inline static void *VAL_HANDLE_DATA(const RELVAL *v) {
+    assert(IS_HANDLE(v));
+    if (v->extra.singular)
+        return ARR_HEAD(v->extra.singular)->payload.handle.data;
+    else
+        return v->payload.handle.data;
+}
+
+inline static void SET_HANDLE_CODE(RELVAL *v, CFUNC *code) {
+    assert(IS_HANDLE(v));
+    if (v->extra.singular)
+        ARR_HEAD(v->extra.singular)->payload.handle.code = code;
+    else
+        v->payload.handle.code = code;
+}
+
+inline static void SET_HANDLE_DATA(RELVAL *v, void *data) {
+    assert(IS_HANDLE(v));
+    if (v->extra.singular)
+        ARR_HEAD(v->extra.singular)->payload.handle.data = data;
+    else
+        v->payload.handle.data = data;
+}
+
+inline static void Init_Handle_Simple(
+    RELVAL *out,
+    CFUNC *code,
+    void *data
+){
+    VAL_RESET_HEADER(out, REB_HANDLE);
+    out->extra.singular = NULL;
+    out->payload.handle.code = code;
+    out->payload.handle.data = data;
+}
+
+inline static void Init_Handle_Managed(
+    RELVAL *out,
+    CFUNC *code,
+    void *data,
+    CLEANUP_FUNC cleaner
+){
+    REBARR *singular = Alloc_Singular_Array();
+    ARR_SERIES(singular)->misc.cleaner = cleaner;
+
+    RELVAL *v = ARR_HEAD(singular);
+    VAL_RESET_HEADER(v, REB_HANDLE);
+    v->extra.singular = singular;
+    v->payload.handle.code = code;
+    v->payload.handle.data = data;
+
+    MANAGE_ARRAY(singular);
+
+    // Don't fill the handle properties in the instance if it's the managed
+    // form.  This way, you can set the properties in the canon value and
+    // effectively update all instances...since the bits live in the shared
+    // series component.
+    //
+    SET_TRASH_IF_DEBUG(out);
+    VAL_RESET_HEADER(out, REB_HANDLE);
+    out->extra.singular = singular;
+}

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -437,6 +437,7 @@ struct Reb_Series {
             REBINT high:16;
             REBINT low:16;
         } bind_index; // canon words hold index for binding--demo sharing 2
+        CLEANUP_FUNC cleaner; // some HANDLE!s use this for GC finalization
     } misc;
 
 #if !defined(NDEBUG)

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -519,6 +519,9 @@ struct Reb_Varargs {
     REBVAL *arg;
 };
 
+// Note that the ->extra field of the REBVAL may contain a singular REBARR
+// that is leveraged for its GC-awareness.
+//
 struct Reb_Handle {
     CFUNC *code;
     void *data;
@@ -664,6 +667,14 @@ union Reb_Value_Extra {
     union Reb_Eventee eventee;
 
     unsigned m0:32; // !!! significand, lowest part - see notes on Reb_Money
+
+    // There are two types of HANDLE!, and one version leverages the GC-aware
+    // ability of a REBSER to know when no references to the handle exist and
+    // call a cleanup function.  The GC-aware variant allocates a "singular"
+    // array, which is the exact size of a REBSER and carries the canon data.
+    // If the cheaper kind that's just raw data and no callback, this is NULL.
+    //
+    REBARR *singular;
 
 #if !defined(NDEBUG)
     REBUPT do_count; // used by track payloads

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1071,44 +1071,6 @@ inline static void SET_TUPLE(RELVAL *v, const void *data) {
 }
 
 
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  HANDLE! (`struct Reb_Handle`)
-//
-//=////////////////////////////////////////////////////////////////////////=//
-//
-// Type for holding an arbitrary code or data pointer inside of a Rebol data
-// value.  What kind of function or data is not known to the garbage collector,
-// so it ignores it.
-//
-// !!! Review usages of this type where they occur.
-//
-
-#define VAL_HANDLE_CODE(v) \
-    ((v)->payload.handle.code)
-
-#define VAL_HANDLE_DATA(v) \
-    ((v)->payload.handle.data)
-
-#define VAL_HANDLE_NUMBER(v) \
-    cast(REBUPT, (v)->payload.handle.data)
-
-inline static void SET_HANDLE_CODE(RELVAL *v, CFUNC *code) {
-    VAL_RESET_HEADER(v, REB_HANDLE);
-    VAL_HANDLE_CODE(v) = code;
-}
-
-inline static void SET_HANDLE_DATA(RELVAL *v, void *data) {
-    VAL_RESET_HEADER(v, REB_HANDLE);
-    VAL_HANDLE_DATA(v) = data;
-}
-
-inline static void SET_HANDLE_NUMBER(RELVAL *v, REBUPT number) {
-    VAL_RESET_HEADER(v, REB_HANDLE);
-    VAL_HANDLE_DATA(v) = cast(void*, number);
-}
-
-
 
 //=////////////////////////////////////////////////////////////////////////=//
 //


### PR DESCRIPTION
This creates a new kind of "Managed" HANDLE!, which is distinct from
the traditional "Simple" HANDLE! (that was just an opaque pointer to
some data the system knew how to interpret, but that the user was
not supposed to see).

A managed handle uses a singular array--which is the size of a REBSER
node--in order to engage the garbage collector.  When the handle is
GC'd, it calls a hook function that receives the handle's REBVAL*
to do a finalization.

As an added advantage to managed handles, changing their content will
change all the references to that handle.  This means a pointer can be
moved or reallocated safely, even if several copies of that handle
REBVAL have been made.