### PR TITLE
No literal blocks in condition of IF/UNLESS/EITHER/CASE

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -111,6 +111,7 @@ Syntax: [
 Script: [
     code: 300
     type: "script error"
+
     no-value:           [:arg1 {has no value}]
     need-value:         [:arg1 {needs a value}]
     not-bound:          [:arg1 {word is not bound to a context}]
@@ -182,7 +183,6 @@ Script: [
 
     past-end:           {out of range or past end}
     missing-arg:        {missing a required argument or refinement}
-    out-of-range:       [{value out of range:} :arg1]
     too-short:          {content too short (or just whitespace)}
     too-long:           {content too long}
     invalid-chars:      {contains invalid characters}
@@ -192,17 +192,12 @@ Script: [
     verify-failed:      [{verification failed for:} :arg1]
 
     invalid-part:       [{invalid /part count:} :arg1]
-    type-limit:         [:arg1 {overflow/underflow}]
-    size-limit:         [{maximum limit reached:} :arg1]
 
     no-return:          {block did not return a value}
     block-lines:        {expected block of lines}
     no-catch:           [{Missing CATCH for THROW of} :arg1]
     no-catch-named:     [{Missing CATCH for THROW of} :arg1 {with /NAME:} :arg2]
 
-    locked-word:        [{variable} :arg1 {locked by PROTECT - cannot modify}]
-    locked:             {value or series locked - cannot modify}
-    hidden:             {not allowed - would expose or modify hidden values}
     bad-bad:            [:arg1 {error:} :arg2]
 
     bad-make-arg:       [{cannot MAKE/TO} :arg1 {from:} :arg2]
@@ -242,19 +237,31 @@ Script: [
     varargs-take-last:  {VARARGS! does not support TAKE-ing only /LAST item}
 
     map-key-unlocked:   [{array key must be locked to add to MAP!} :arg1]
+
+    block-conditional:  [{Literal block used as conditional} :arg1]
+    block-switch:       [{Literal block used as switch value} :arg1]
 ]
 
 Math: [
     code: 400
     type: "math error"
+
     zero-divide:        {attempt to divide by zero}
     overflow:           {math or number overflow}
     positive:           {positive number required}
+
+    type-limit:         [:arg1 {overflow/underflow}]
+    size-limit:         [{maximum limit reached:} :arg1]
+    out-of-range:       [{value out of range:} :arg1]
 ]
 
 Access: [
     code: 500
     type: "access error"
+
+    locked-word:        [{variable} :arg1 {locked by PROTECT - cannot modify}]
+    locked:             {value or series locked - cannot modify}
+    hidden:             {not allowed - would expose or modify hidden values}
 
     cannot-open:        [{cannot open:} :arg1 {reason:} :arg2]
     not-open:           [{port is not open:} :arg1]

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -715,6 +715,21 @@ inline static void SET_FALSE_COMMON(RELVAL *v) {
 #define IS_CONDITIONAL_TRUE(v) \
     NOT(IS_CONDITIONAL_FALSE(v)) // macro gets file + line # in debug build
 
+// Although a BLOCK! value is true, some constructs are safer by not allowing
+// literal blocks.  e.g. `if [x] [print "this is not safe"`.  The evaluated
+// bit can let these instances be distinguished.  Note that making *all*
+// evaluations safe would be limiting, e.g. `foo: any [false-thing []]`.
+//
+inline static REBOOL IS_CONDITIONAL_TRUE_SAFE(const REBVAL *v) {
+    if (IS_BLOCK(v)) {
+        if (GET_VAL_FLAG(v, VALUE_FLAG_EVALUATED))
+            return TRUE;
+
+        fail (Error(RE_BLOCK_CONDITIONAL, v));
+    }
+    return IS_CONDITIONAL_TRUE(v);
+}
+
 inline static REBOOL VAL_LOGIC(const RELVAL *v) {
     assert(IS_LOGIC(v));
     return NOT(GET_VAL_FLAG((v), VALUE_FLAG_FALSE));

--- a/tests/control/if.test.reb
+++ b/tests/control/if.test.reb
@@ -26,8 +26,9 @@
 [if #{00} [true]]
 ; bitset
 [if make bitset! "" [true]]
-; block
-[if [] [true]]
+; literal blocks illegal as condition in Ren-C, but evaluation products ok
+[error? trap [if [] [true]]]
+[if ([]) [true]]
 ; datatype
 [if blank! [true]]
 ; typeset

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -2,13 +2,27 @@
 [error? try [1 / 0]]
 [not error? 1]
 [error! = type-of try [1 / 0]]
+
 ; error evaluation
 [error? do head insert copy [] try [1 / 0]]
+
 ; error that does not exist in the SCRIPT category--all of whose ids are
 ; reserved by the system and must be formed from mezzanine/user code in
 ; accordance with the structure the system would form.  Hence, illegal.
+;
 [try/except [make error! [type: 'script id: 'nonexistent-id]] [true]]
+
+; triggered errors should not be assignable
+;
+[a: 1 error? try [a: 1 / 0] :a =? 1]
+[a: 1 error? try [set 'a 1 / 0] :a =? 1]
+[a: 1 error? try [set/opt 'a 1 / 0] :a =? 1]
+
+; bug#2190
+[127 = catch/quit [attempt [catch/quit [1 / 0]] quit/with 127]]
+
 ; error types that should be predefined
+
 [error? make error! [type: 'syntax id: 'invalid]]
 [error? make error! [type: 'syntax id: 'missing]]
 [error? make error! [type: 'syntax id: 'no-header]]
@@ -17,6 +31,7 @@
 [error? make error! [type: 'syntax id: 'malconstruct]]
 [error? make error! [type: 'syntax id: 'bad-char]]
 [error? make error! [type: 'syntax id: 'needs]]
+
 [error? make error! [type: 'script id: 'no-value]]
 [error? make error! [type: 'script id: 'need-value]]
 [error? make error! [type: 'script id: 'not-bound]]
@@ -45,7 +60,6 @@
 [error? make error! [type: 'script id: 'dup-vars]]
 [error? make error! [type: 'script id: 'past-end]]
 [error? make error! [type: 'script id: 'missing-arg]]
-[error? make error! [type: 'script id: 'out-of-range]]
 [error? make error! [type: 'script id: 'too-short]]
 [error? make error! [type: 'script id: 'too-long]]
 [error? make error! [type: 'script id: 'invalid-chars]]
@@ -53,16 +67,10 @@
 [error? make error! [type: 'script id: 'verify-failed]]
 [error? make error! [type: 'script id: 'verify-void]]
 [error? make error! [type: 'script id: 'invalid-part]]
-[error? make error! [type: 'script id: 'type-limit]]
-[error? make error! [type: 'script id: 'size-limit]]
 [error? make error! [type: 'script id: 'no-return]]
 [error? make error! [type: 'script id: 'block-lines]]
-[error? make error! [type: 'script id: 'locked-word]]
-[error? make error! [type: 'script id: 'locked]]
-[error? make error! [type: 'script id: 'hidden]]
 [error? make error! [type: 'script id: 'bad-bad]]
 [error? make error! [type: 'script id: 'bad-make-arg]]
-[error? make error! [type: 'internal id: 'bad-utf8]]
 [error? make error! [type: 'script id: 'wrong-denom]]
 [error? make error! [type: 'script id: 'bad-compression]]
 [error? make error! [type: 'script id: 'dialect]]
@@ -72,9 +80,17 @@
 [error? make error! [type: 'script id: 'parse-variable]]
 [error? make error! [type: 'script id: 'parse-command]]
 [error? make error! [type: 'script id: 'parse-series]]
+
 [error? make error! [type: 'math id: 'zero-divide]]
 [error? make error! [type: 'math id: 'overflow]]
 [error? make error! [type: 'math id: 'positive]]
+[error? make error! [type: 'math id: 'type-limit]]
+[error? make error! [type: 'math id: 'size-limit]]
+[error? make error! [type: 'math id: 'out-of-range]]
+
+[error? make error! [type: 'access id: 'locked-word]]
+[error? make error! [type: 'access id: 'locked]]
+[error? make error! [type: 'access id: 'hidden]]
 [error? make error! [type: 'access id: 'cannot-open]]
 [error? make error! [type: 'access id: 'not-open]]
 [error? make error! [type: 'access id: 'already-open]]
@@ -93,7 +109,6 @@
 [error? make error! [type: 'access id: 'write-error]]
 [error? make error! [type: 'access id: 'read-error]]
 [error? make error! [type: 'access id: 'read-only]]
-[error? make error! [type: 'internal id: 'no-buffer]]
 [error? make error! [type: 'access id: 'timeout]]
 [error? make error! [type: 'access id: 'no-create]]
 [error? make error! [type: 'access id: 'no-delete]]
@@ -109,7 +124,10 @@
 [error? make error! [type: 'access id: 'bad-extension]]
 [error? make error! [type: 'access id: 'extension-init]]
 [error? make error! [type: 'access id: 'call-fail]]
+
 [error? make error! [type: 'user id: 'message]]
+
+[error? make error! [type: 'internal id: 'no-buffer]]
 [error? make error! [type: 'internal id: 'bad-path]]
 [error? make error! [type: 'internal id: 'not-here]]
 [error? make error! [type: 'internal id: 'no-memory]]
@@ -119,9 +137,4 @@
 [error? make error! [type: 'internal id: 'limit-hit]]
 [error? make error! [type: 'internal id: 'bad-sys-func]]
 [error? make error! [type: 'internal id: 'not-done]]
-; triggered errors should not be assignable
-[a: 1 error? try [a: 1 / 0] :a =? 1]
-[a: 1 error? try [set 'a 1 / 0] :a =? 1]
-[a: 1 error? try [set/opt 'a 1 / 0] :a =? 1]
-; bug#2190
-[127 = catch/quit [attempt [catch/quit [1 / 0]] quit/with 127]]
+[error? make error! [type: 'internal id: 'bad-utf8]]


### PR DESCRIPTION
A very common mistake for new users is to place a BLOCK! around a
conditional expression.  Since blocks are always TRUE, this leads to
confusion and bugs.

(It's an especially easy mistake to make when converting a WHILE into
an IF.)

Mechanically, functions in Ren-C are able to distinguish when a value
received as an argument was the product of an evaluation vs. literal
at the callsite.  So it can tell the difference between:

    x: [something]
    if x [print "legal case, evaluated"]

    if [something] [print "illegal case, literal"]

This distinction is used to generate an error.  Bypassing the check
can be done with a GROUP!:

    if ([something]) [print "now the block is an evaluation product"]

This extends the check to CASE, which is likely to help catch casual
errors where a body block is accidentally serving as a condition.

Also included is a check on SWITCH to not accept literal blocks as
their argument, as this is likely not what was intended (and perhaps
just a monkey-see monkey-do repeat of a block if seen on WHILE, etc.)

Reorders some errors just to avoid hitting the script error limit;
more generalized workaround pending from @ShixinZeng.