### PR TITLE
Add sets-suppress-lookahead flag for R3-Legacy

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -158,6 +158,7 @@ options: construct [] [  ; Options supplied to REBOL during startup
     get-will-get-anything: false
     no-reduce-nested-print: false
     arg1-arg2-arg3-error: false
+    sets-unsuppress-lookahead: false
 
     ; These option will only apply if the function which is currently executing
     ; was created after legacy mode was enabled, and if refinements-blank is

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -685,6 +685,7 @@ set 'r3-legacy* func [<local> if-flags] [
         paren-instead-of-group: true
         get-will-get-anything: true
         no-reduce-nested-print: true
+        sets-unsuppress-lookahead: true
     ]
 
     append system/contexts/user compose [


### PR DESCRIPTION
In R3-Alpha, `10 = 5 + 5` would be an error due to lookahead
suppression from `=`... so it gets interpreted as `(10 = 5) + 5`.
However, `10 = x: 5 + 5` would not be an error, as the SET-WORD!
caused a recursion in the evaluator which was morally equivalent
to as if a single-arity prefix function were being called.

For efficiency in Ren-C, SET-WORD!s do not bear the overhead of state
of a recursion--which is reserved for cases requiring "FRAME!s".  Hence
the introduction of SET-WORD!s or SET-PATH!s into expressions merely
"sample" the value at that point--in a ghostly fashion--without
affecting the flow of the expressions.

This is likely good, because it means that although PROBE may change
the evaluation flow, a SET-WORD! will not.  That makes them a good
tool for sampling the value at any point in an expression, and gives
a clear logic for their effects...(none at all).

If it were desired to see a SET-WORD! to override the lookahead
suppression, that would need to be done explicitly...adding a slight
cost to each assignment.  This adds a legacy control flag to show
the exact positions where this behavior can be changed.