### PR TITLE
User native enhancements, separate MAKE-NATIVE and COMPILE steps

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -244,7 +244,6 @@ Script: [
     tcc-invalid-library-path: [{Library path expects a block or a path:} :arg1]
     tcc-invalid-runtime-path: [{Runtime library path expects a block or a path:} :arg1]
     tcc-empty-spec:    	{Spec for natives must not be empty}
-    tcc-invalid-spec-length: [{Spec length for natives must be an even number:} :arg1]
     tcc-empty-source:    {Source for natives must not be empty}
     tcc-construction:    {TCC failed to create a TCC context}
     tcc-set-options:     {TCC failed to set TCC options}

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -168,7 +168,7 @@ REBYTE *Temp_Byte_Chars_May_Fail(
 // instead of managing a created result they could be responsible
 // for freeing it if so.
 //
-REBSER *Temp_Bin_Str_Managed(const REBVAL *val, REBCNT *index, REBCNT *length)
+REBSER *Temp_Bin_Str_Managed(const RELVAL *val, REBCNT *index, REBCNT *length)
 {
     REBCNT len = (length && *length) ? *length : VAL_LEN_AT(val);
     REBSER *series;

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -1223,7 +1223,7 @@ REBSER *Make_UTF8_Binary(
 // series must be either freed or handed to the GC.
 //
 REBSER *Make_UTF8_From_Any_String(
-    const REBVAL *value,
+    const RELVAL *value,
     REBCNT len,
     REBFLGS opts
 ) {

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -133,6 +133,14 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
 // 
 #define FUNC_FLAG_DEFERS_LOOKBACK_ARG FUNC_FLAG(3)
 
+// The COMPILE-NATIVES command wants to operate on user natives, and be able
+// to recompile unchanged natives as part of a unit even after they were
+// initially compiled.  But since that replaces their dispatcher with an
+// arbitrary function, they can't be recognized to know they have the specific
+// body structure of a user native.  So this flag is used.
+//
+#define FUNC_FLAG_USER_NATIVE FUNC_FLAG(4)
+
 #if !defined(NDEBUG)
     //
     // This flag is set on the canon function value when a proxy for a
@@ -141,12 +149,12 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
     // function implementation after digging through the layers...because
     // proxies must have new (cloned) paramlists but use the original bodies.
     //
-    #define FUNC_FLAG_PROXY_DEBUG FUNC_FLAG(4)
+    #define FUNC_FLAG_PROXY_DEBUG FUNC_FLAG(5)
 
     // BLANK! ("none!") for unused refinements instead of FALSE
     // Also, BLANK! for args of unused refinements instead of not set
     //
-    #define FUNC_FLAG_LEGACY_DEBUG FUNC_FLAG(5)
+    #define FUNC_FLAG_LEGACY_DEBUG FUNC_FLAG(6)
 #endif
 
 

--- a/tests/misc/fib.r
+++ b/tests/misc/fib.r
@@ -2,30 +2,32 @@ REBOL [
     Title: {Initial test for user natives by @ShixinZeng}
 ]
 
-c-fib: first make-native/opt [
-    "N_c_fib" [
-        "nth Fibonacci Number"
-        n [integer!]
-    ]
-] {
-    REBNATIVE(c_fib) {
-        PARAM(1, n);
+c-fib: make-native [
+   "nth Fibonacci Number"
+   n [integer!]
+]{
+    int n = VAL_INT64(ARG(n));
 
-        int i = VAL_INT64(ARG(n));
-        int i0 = 0, i1 = 1;
-        //MARK_CELL_WRITABLE_IF_CPP_DEBUG(D_OUT);
-        if (i < 0) SET_INTEGER(D_OUT, -1);
-        if (i <= 1) SET_INTEGER(D_OUT, i);
-        while (-- i > 0) {
-            int t = i1;
-            i1 = i1 + i0;
-            i0 = t;
-        }
-        SET_INTEGER(D_OUT, i1);
-        D_OUT->header.bits |= 1 << (GENERAL_VALUE_BIT + 5);
-        return R_OUT;
+    if (n < zero) { SET_INTEGER(D_OUT, -1); return R_OUT; }
+    if (n <= one) { SET_INTEGER(D_OUT, n); return R_OUT; }
+
+    int i0 = zero;
+    int i1 = one;
+    while (n > one) {
+        int t = i1;
+        i1 = i1 + i0;
+        i0 = t;
+        --n;
     }
-} compose [
+    SET_INTEGER(D_OUT, i1);
+    return R_OUT;
+}
+
+compile/options [
+    "const int zero = 0;"
+    "const int one = 1;"
+    c-fib
+] compose [
     runtime-path (join first split-path system/options/boot %tcc)
 ]
 
@@ -45,7 +47,7 @@ fib: func [
     i1
 ]
 
-print ["fib 30:" c-fib 30]
+print ["c-fib 30:" c-fib 30]
 print ["fib 30:" fib 30]
 
 n-loop: 10000


### PR DESCRIPTION
This commit is @HostileFork's first set of suggestions for the user
native interface.

* The step of creating a native generates a function without compiling
  it yet.  Then a separate COMPILE command is used to group together
  some number of user natives and other source string fragments.

* If COMPILE is not explicitly called on a native before that native
  is called, then a default COMPILE containing just that native's
  code will attempt to run.

* The PARAM() and REFINE() macros are generated automatically in the
  body of the function, so the user does not have to type those in.

* A linker name for the user native is automatically generated if one
  is not provided explicitly.

See the changes to %tests/misc/fib.r for some of the impact.