### PR TITLE
Update evaluator to properly handle postfix, make ? postfix

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1190,17 +1190,13 @@ static void Init_Codecs(void)
 
 static void Set_Option_String(REBCHR *str, REBCNT field)
 {
-    if (str) {
-        REBVAL *val = Get_System(SYS_OPTIONS, field);
-        Val_Init_String(val, Copy_OS_Str(str, OS_STRLEN(str)));
-    }
+    REBVAL *val = Get_System(SYS_OPTIONS, field);
+    Val_Init_String(val, Copy_OS_Str(str, OS_STRLEN(str)));
 }
 
 
 static REBSTR *Set_Option_Word(REBCHR *str, REBCNT field)
 {
-    if (!str) return NULL;
-
     REBYTE buf[40]; // option words always short ASCII strings
 
     REBCNT len = OS_STRLEN(str); // WC correct

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -216,7 +216,7 @@ REB_R Pending_Native_Dispatcher(REBFRM *f) {
 //  {Create a "user native" function compiled from C source}
 //
 //      return: [function!]
-//          "Function value, will be compiled on demand or by COMPILE-NATIVE"
+//          "Function value, will be compiled on demand or by COMPILE"
 //      spec [block!]
 //          "The spec of the native"
 //      source [string!]
@@ -244,7 +244,7 @@ REBNATIVE(make_native)
     
     REBFUN *fun = Make_Function(
         Make_Paramlist_Managed_May_Fail(ARG(spec), MKF_NONE),
-        &Pending_Native_Dispatcher, // will be replaced e.g. by COMPILE-NATIVE
+        &Pending_Native_Dispatcher, // will be replaced e.g. by COMPILE
         NULL // no underlying function, this is fundamental
     );
 
@@ -253,7 +253,7 @@ REBNATIVE(make_native)
     if (GET_SER_FLAG(VAL_SERIES(source), SERIES_FLAG_LOCKED))
         Append_Value(info, source); // no need to copy it...
     else {
-        // have to copy it (might change before compile-natives is called)
+        // have to copy it (might change before COMPILE is called)
         //
         Val_Init_String(
             Alloc_Tail_Array(info),

--- a/src/include/reb-ext.h
+++ b/src/include/reb-ext.h
@@ -154,7 +154,7 @@ typedef int (*RXICAL)(int cmd, RXIFRM *args, REBCEC *ctx);
 #define RXA_MODULE(f,n) (RXA_ARG(f,n).context)
 #define RXA_IMAGE(f,n)  (RXA_ARG(f,n).iwh.image)
 #define RXA_IMAGE_BITS(f,n) \
-	cast(REBYTE *, RL_SERIES((RXA_ARG(f,n).iwh.image), RXI_SER_DATA))
+    cast(REBYTE *, RL_SERIES((RXA_ARG(f,n).iwh.image), RXI_SER_DATA))
 #define RXA_IMAGE_WIDTH(f,n)  (RXA_ARG(f,n).iwh.width)
 #define RXA_IMAGE_HEIGHT(f,n) (RXA_ARG(f,n).iwh.height)
 #define RXA_COLOR_TUPLE(f,n) \

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -39,7 +39,7 @@ eval proc [
     <local>
         set-word type-name tester meta
 ][
-    while [? set-word: take set-word...] [
+    while [any-value? set-word: take set-word...] [
         type-name: append (head clear find (spelling-of set-word) {?}) "!"
         tester: typechecker (get bind (to word! type-name) set-word)
         set set-word :tester

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -184,6 +184,22 @@ xor+: enfix func [arg1 [any-value!] arg2 [<defer> any-value!]] [
 ]
 
 
+; Postfix operator for asking the most existential question of Rebol...is it
+; a Rebol value at all?  (non-void)
+;
+; !!! Originally in Rebol2 and R3-Alpha, ? was a synonym for HELP, which seems
+; wasteful for the language as a whole when it's easy enough to type HELP.
+; Postfix was not initially considered, because there was no ability of
+; enfixed operators to force the left hand side of expressions to be as
+; maximal as possible.  Hence `while [take blk ?] [...]` would ask if blk was
+; void, not `take blk`.  So it was tried as a prefix operator, which wound
+; up looking somewhat junky.
+
+?: enfix function [arg [<defer> <opt> any-value!]] [
+    any-value? :arg
+]
+
+
 ; ELSE is an experiment to try and allow IF condition [branch1] ELSE [branch2]
 ; For efficiency it uses references to the branches and does not copy them
 ; into the body or protect them from mutation.  It is supported by the


### PR DESCRIPTION
While postfix operators were possible in theory, none existed...so there
was a bug in the handling of them if they were the last value in a
series.  This does a light reorganization of the evaluator to correct
that issue and get rid of some redundant code.

Given the ability to defer the left hand argument in postfix, then the
concept becomes much more interesting--because it means a complete
expression can be gathered before it is applied.  This uses deferment
as a trial for ? to be a postfix test for ANY-VALUE?:

    >> blk: [1 2 3 4]

    >> while [x: take blk ?] [print x]
    1
    2
    3
    4

This replaces the previous experiment of ? as a prefix synonym for
ANY-VALUE?.

(Also, updates some comments.)