### PR TITLE
Optimization for empty user function bodies

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -281,9 +281,11 @@ RL_API int RL_Start(REBYTE *bin, REBINT len, REBYTE *script, REBINT script_len, 
     if (IS_VOID(&result))
         error_num = 0; // no error
     else {
-        assert(FALSE); // should not happen (raise an error instead)
         Debug_Fmt("** finish-rl-start returned non-NONE!:");
         Debug_Fmt("%r", &result);
+
+        assert(FALSE); // should not happen (raise an error instead)
+
         error_num = RE_MISC;
     }
 

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -89,7 +89,7 @@ static void Bind_Values_Inner_Loop(
         }
         else if (
             IS_FUNCTION(value)
-            && IS_FUNCTION_PLAIN(value)
+            && IS_FUNCTION_INTERPRETED(value)
             && (flags & BIND_FUNC)
         ) {
             // !!! Likely-to-be deprecated functionality--rebinding inside the
@@ -342,7 +342,7 @@ void Rebind_Values_Deep(
                 );
             }
         }
-        else if (IS_FUNCTION(value) && IS_FUNCTION_PLAIN(value)) {
+        else if (IS_FUNCTION(value) && IS_FUNCTION_INTERPRETED(value)) {
             //
             // !!! Extremely questionable feature--walking into function
             // bodies and changing them.  This R3-Alpha concept was largely

--- a/src/core/e-func-symbols.c
+++ b/src/core/e-func-symbols.c
@@ -90,12 +90,12 @@ const void *rebol_symbols [] = {
     SYM_FUNC(Make_Function), // c-function.c
     SYM_FUNC(Make_Expired_Frame_Ctx_Managed), // c-function.c
     SYM_FUNC(Get_Maybe_Fake_Func_Body), // c-function.c
-    SYM_FUNC(Make_Plain_Function_May_Fail), // c-function.c
+    SYM_FUNC(Make_Interpreted_Function_May_Fail), // c-function.c
     SYM_FUNC(Make_Frame_For_Function), // c-function.c
     SYM_FUNC(Specialize_Function_Throws), // c-function.c
     SYM_FUNC(Clonify_Function), // c-function.c
     SYM_FUNC(Action_Dispatcher), // c-function.c
-    SYM_FUNC(Plain_Dispatcher), // c-function.c
+    SYM_FUNC(Unchecked_Dispatcher), // c-function.c
     SYM_FUNC(Voider_Dispatcher), // c-function.c
     SYM_FUNC(Returner_Dispatcher), // c-function.c
     SYM_FUNC(Specializer_Dispatcher), // c-function.c

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -319,7 +319,7 @@ REBFUN *Underlying_Function_Debug(
     // what was originally a body made for another function.  In that case,
     // the frame needs to be "for that", so it is the underlying function.
 
-    if (IS_FUNCTION_PLAIN(value)) {
+    if (IS_FUNCTION_INTERPRETED(value)) {
         RELVAL *body = VAL_FUNC_BODY(value);
         assert(IS_RELATIVE(body));
         return VAL_RELATIVE(body);
@@ -409,7 +409,7 @@ REBCTX *Context_For_Frame_May_Reify_Core(REBFRM *f) {
     // possible in the debugger anyway.)  For now, protect unless it's a
     // user function.
     //
-    if (NOT(IS_FUNCTION_PLAIN(FUNC_VALUE(f->func))))
+    if (NOT(IS_FUNCTION_INTERPRETED(FUNC_VALUE(f->func))))
         SET_ARR_FLAG(CTX_VARLIST(context), SERIES_FLAG_LOCKED);
 
     return context;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1206,7 +1206,7 @@ void Make_Thrown_Exit_Value(
 
         #if !defined(NDEBUG)
             if (LEGACY(OPTIONS_DONT_EXIT_NATIVES))
-                if (NOT(IS_FUNCTION_PLAIN(FUNC_VALUE(f->func))))
+                if (NOT(IS_FUNCTION_INTERPRETED(FUNC_VALUE(f->func))))
                     continue; // R3-Alpha would exit the first user function
         #endif
 

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -538,7 +538,7 @@ REBNATIVE(compile)
                 VAL_INDEX(var),
                 VAL_LEN_AT(var)
             );
-            Append_Unencoded(mo.series, "\n"); 
+            Append_Unencoded(mo.series, "\n");
         }
         else {
             assert(FALSE);

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -876,7 +876,7 @@ static void Mold_Function(const REBVAL *value, REB_MOLD *mold)
     Mold_Array_At(mold, words_list, 0, 0);
     Free_Array(words_list);
 
-    if (IS_FUNCTION_PLAIN(value)) {
+    if (IS_FUNCTION_INTERPRETED(value)) {
         //
         // MOLD is an example of user-facing code that needs to be complicit
         // in the "lie" about the effective bodies of the functions made

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -101,7 +101,9 @@ void MAKE_Function(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     // code (though round-tripping it via text is not possible in
     // general in any case due to loss of bindings.)
     //
-    REBFUN *fun = Make_Plain_Function_May_Fail(&spec, &body, MKF_ANY_VALUE);
+    REBFUN *fun = Make_Interpreted_Function_May_Fail(
+        &spec, &body, MKF_ANY_VALUE
+    );
 
     *out = *FUNC_VALUE(fun);
 }
@@ -170,7 +172,7 @@ REBTYPE(Function)
             if (IS_FUNCTION_HIJACKER(value))
                 fail (Error(RE_MISC)); // body corrupt, need to recurse
 
-            if (IS_FUNCTION_PLAIN(value)) {
+            if (IS_FUNCTION_INTERPRETED(value)) {
                 //
                 // BODY-OF is an example of user-facing code that needs to be
                 // complicit in the "lie" about the effective bodies of the
@@ -273,7 +275,7 @@ REBNATIVE(func_class_of)
     REBVAL *value = ARG(func);
     REBCNT n;
 
-    if (IS_FUNCTION_PLAIN(value))
+    if (IS_FUNCTION_INTERPRETED(value))
         n = 2;
     else if (IS_FUNCTION_ACTION(value))
         n = 3;

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -184,7 +184,7 @@ inline static REBNAT VAL_FUNC_DISPATCHER(const RELVAL *v)
 inline static REBCTX *VAL_FUNC_META(const RELVAL *v)
     { return ARR_SERIES(v->payload.function.paramlist)->link.meta; }
 
-inline static REBOOL IS_FUNCTION_PLAIN(const RELVAL *v) {
+inline static REBOOL IS_FUNCTION_INTERPRETED(const RELVAL *v) {
     //
     // !!! Review cases where this is supposed to matter, because they are
     // probably all bad.  With the death of function categories, code should
@@ -192,7 +192,8 @@ inline static REBOOL IS_FUNCTION_PLAIN(const RELVAL *v) {
     // the dispatchers they run on...with only the dispatch itself caring.
     //
     return LOGICAL(
-        VAL_FUNC_DISPATCHER(v) == &Plain_Dispatcher
+        VAL_FUNC_DISPATCHER(v) == &Noop_Dispatcher
+        || VAL_FUNC_DISPATCHER(v) == &Unchecked_Dispatcher
         || VAL_FUNC_DISPATCHER(v) == &Voider_Dispatcher
         || VAL_FUNC_DISPATCHER(v) == &Returner_Dispatcher
     );


### PR DESCRIPTION
If you write something like `foo: func [...] []`, this substitutes the
ordinary dispatcher with one that is an absolute no-op and returns
void.  This means there's no invocation equivalent to `DO []`, and
there is also no overhead for frame reification.

While this may seem like an uncommon case to optimize for, it actually
does have an application, exemplified by the default definition for
ASSERT...which is an empty body.  It's only when you are in "debug mode"
(currently the default) that ASSERT gets HIJACKed with an actual
implementation.

So in addition to helping optimize the rare case where a body ends up
being a no-op due to a COMPOSE or other random reason, this makes it
possible to create low-overhead stubs for instrumentation...which can
be hijacked with implementations when needed.

Also removes the `_May_Fail` designation from Make_Function, since it now
takes an already built paramlist.  Transitions the fail-on-non-block code to
debug build only assertions.