### PR TITLE
Add <with> to FUNC, eliminate <no-return> and <no-leave>

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -29,8 +29,7 @@ space-char      ; a value that is a space CHAR!
 ;; Tags used in the native-optimized versions of user-function-generators
 ;; FUNC and PROC
 
-no-return-tag   ; func w/o definitional return, ignores non-definitional ones
-no-leave-tag    ; func w/o definitional leave, ignores non-definitional ones
+with-tag        ; <with> for no locals gather (disables RETURN/LEAVE in FUNC)
 ellipsis-tag    ; FUNC+PROC use as alternative to [[]] to mark varargs
 opt-tag         ; FUNC+PROC use as alternative to _ to mark optional void? args
 end-tag         ; FUNC+PROC use as alternative to | to mark endable args

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -521,11 +521,7 @@ static void Add_Lib_Keys_R3Alpha_Cant_Make(void)
 
 
 //
-//  Init_Function_Tags: C
-//
-// FUNC and PROC search for these tags, like <opt> and <local>.  They are
-// natives and run during bootstrap, so these string comparisons are
-// needed.
+// Init_Function_Tag: C
 //
 // !!! It didn't seem there was a "compare UTF8 byte array to arbitrary
 // decoded REB_TAG which may or may not be REBUNI" routine, but there was
@@ -533,35 +529,35 @@ static void Add_Lib_Keys_R3Alpha_Cant_Make(void)
 // quick, but a better solution should be reviewed in terms of an overall
 // string and UTF8 rethinking.
 //
+static void Init_Function_Tag(const char *name, REBVAL *slot)
+{
+    Val_Init_Tag(
+        slot,
+        Append_UTF8_May_Fail(NULL, cb_cast(name), strlen(name))
+    );
+    SET_SER_FLAG(VAL_SERIES(slot), SERIES_FLAG_FIXED_SIZE);
+    SET_SER_FLAG(VAL_SERIES(slot), SERIES_FLAG_LOCKED);
+}
+
+
+//
+//  Init_Function_Tags: C
+//
+// FUNC and PROC search for these tags, like <opt> and <local>.  They are
+// natives and run during bootstrap, so these string comparisons are
+// needed.  This routine does not use a table directly, because the slots
+// it initializes are not constants...and older TCCs don't support local
+// struct arrays of that form.
+//
 static void Init_Function_Tags(void)
 {
-    struct {
-        const char *name;
-        REBVAL *slot;
-    } tags[] = {
-        "no-return", ROOT_NO_RETURN_TAG,
-        "no-leave", ROOT_NO_LEAVE_TAG,
-        "...", ROOT_ELLIPSIS_TAG,
-        "opt", ROOT_OPT_TAG,
-        "end", ROOT_END_TAG,
-        "local", ROOT_LOCAL_TAG,
-        "durable", ROOT_DURABLE_TAG,
-        "defer", ROOT_DEFER_TAG,
-        NULL, NULL
-    };
-
-    REBINT i = 0;
-    while (tags[i].name) {
-        Val_Init_Tag(
-            tags[i].slot,
-            Append_UTF8_May_Fail(
-                NULL, cb_cast(tags[i].name), strlen(tags[i].name)
-            )
-        );
-        SET_SER_FLAG(VAL_SERIES(tags[i].slot), SERIES_FLAG_FIXED_SIZE);
-        SET_SER_FLAG(VAL_SERIES(tags[i].slot), SERIES_FLAG_LOCKED);
-        ++i;
-    }
+    Init_Function_Tag("with", ROOT_WITH_TAG);
+    Init_Function_Tag("...", ROOT_ELLIPSIS_TAG);
+    Init_Function_Tag("opt", ROOT_OPT_TAG);
+    Init_Function_Tag("end", ROOT_END_TAG);
+    Init_Function_Tag("local", ROOT_LOCAL_TAG);
+    Init_Function_Tag("durable", ROOT_DURABLE_TAG);
+    Init_Function_Tag("defer", ROOT_DEFER_TAG);
 }
 
 

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -778,7 +778,7 @@ void Rebind_Context_Deep(
 //
 // This routine will *always* make a context with a SELF.  This lacks the
 // nuance that is expected of the generators, which will have an equivalent
-// to <no-return>.
+// to `<with> return` or `<with> leave` to suppress it.
 //
 REBCTX *Make_Selfish_Context_Detect(
     enum Reb_Kind kind,

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -706,8 +706,8 @@ REBNATIVE(construct)
 // represents a "spec".
 //
 // !!! This assumes you want a SELF defined.  The entire concept of SELF
-// needs heavy review, but at minimum this needs a <no-self> override to
-// match the <no-return> for functions.
+// needs heavy review, but at minimum this needs an override to match the
+// `<with> return` or `<with> local` for functions.
 //
 // !!! This mutates the bindings of the body block passed in, should it
 // be making a copy instead (at least by default, perhaps with performance

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -315,7 +315,7 @@ enum {
     MKF_NONE        = 0,        // no special handling (e.g. MAKE FUNCTION!)
     MKF_RETURN      = 1 << 0,   // has definitional RETURN
     MKF_LEAVE       = 1 << 1,   // has definitional LEAVE
-    MKF_KEYWORDS    = 1 << 2,   // respond to tags like <opt>, <no-return>
+    MKF_KEYWORDS    = 1 << 2,   // respond to tags like <opt>, <with>, <local>
     MKF_ANY_VALUE   = 1 << 3,   // args and return are [<opt> any-value!]
     MKF_FAKE_RETURN = 1 << 4    // has RETURN but not actually in frame
 };

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -190,7 +190,11 @@ make-action: func [
         )
         any [set other: [word! | path!] (bind new-body get other)]
     |
-        <with> any [set other: [word! | path!] (append exclusions other)]
+        <with> any [
+            set other: [word! | path!] (append exclusions other)
+        |
+            string! ;-- skip over as commentary
+        ]
     |
         <static> (
             unless statics [
@@ -773,14 +777,14 @@ use: func [
     ; body may have RETURN words with bindings in them already that we do
     ; not want to disturb with the definitional bindings in the new code.
     ; So that means either using MAKE FUNCTION! (which wouldn't disrupt
-    ; RETURN bindings) or using the more friendly FUNC with <no-return>
+    ; RETURN bindings) or using the more friendly FUNC and `<with> return`
     ; (they do the same thing, just FUNC is arity-2)
     ;
     ; <durable> is used so that the data for the locals will still be
     ; available if any of the words leak out and are accessed after the
     ; execution is finished.
     ;
-    eval func compose [<durable> <no-return> /local (vars)] body
+    eval func compose [<durable> <local> (vars) <with> return] body
 ]
 
 ; Shorthand helper for CONSTRUCT (similar to DOES for FUNCTION).

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -448,7 +448,7 @@ collect-with: func [
         ; that word.  FUNC does binding and variable creation so let it
         ; do the work.
         ;
-        eval func reduce [<no-return> name [function!]] body :keeper
+        eval func compose [(name) [function!] <with> return] body :keeper
     ][
         ; A lit-word `name` indicates that the word for the keeper already
         ; exists.  Set the variable and DO the body bound as-is.


### PR DESCRIPTION
Ren-C replaced FUNCTION's /EXTERN refinement with the idea of having
`<with>` in function specs, paralleling how locals are specified.  This
adds `<with>` to FUNC, even though there is no "locals gathering" which
would affect it in the way FUNCTION needs externs.

This allows for easier transitions between FUNC and FUNCTION modes of
coding.  The `<with>` lets you put strings after the words which are
ignored, which can help serve commentary purposes on what external
variables are for.  (The strings are thrown out and not stored anywhere
accessible to HELP, merely source comments.)

    k: 10
    foo: func [
        x [integer!]
        <with> k "number of variants"
    ][
        k: x ;-- <with> was commentary, no mechanical difference
    ]

But most interestingly, it gets rid of the awkward <no-return> and
<no-leave> refinements for telling FUNC and PROC you don't want a
definitional RETURN or LEAVE.  Simply saying `<with> return` or
`<with> leave` is enough to indicate you're bringing in those words
from the outside context, and the function should not define local
meanings for them.