### PR TITLE
Allow FOR-EACH to enumerate all the FUNCTION!s

### DIFF
--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -837,6 +837,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
     //
     DS_DROP_TO(dsp_orig);
 
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     return paramlist;
 }
 
@@ -1405,6 +1406,7 @@ REBOOL Specialize_Function_Throws(
     }
 
     REBARR *paramlist = Pop_Stack_Values(dsp_orig);
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     RELVAL *rootparam = ARR_HEAD(paramlist);
@@ -1491,6 +1493,7 @@ void Clonify_Function(REBVAL *value)
         FUNC_PARAMLIST(original_fun),
         SPECIFIED
     );
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
 
@@ -1900,9 +1903,10 @@ REBNATIVE(brancher)
     REBVAL *param = SINK(ARR_AT(paramlist, 1));
     Val_Init_Typeset(param, FLAGIT_64(REB_LOGIC), Canon(SYM_CONDITION));
     INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
-
-    MANAGE_ARRAY(paramlist);
     TERM_ARRAY_LEN(paramlist, 2);
+
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    MANAGE_ARRAY(paramlist);
 
     REBFUN *func = Make_Function(
         paramlist,
@@ -2061,6 +2065,7 @@ REBNATIVE(chain)
         VAL_FUNC_PARAMLIST(ARR_HEAD(chainees)), SPECIFIED
     );
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *specializer;
@@ -2117,7 +2122,7 @@ REBNATIVE(typechecker)
     REBVAL *type = ARG(type);
 
     REBARR *paramlist = Make_Array(2);
-    
+
     REBVAL *archetype = Alloc_Tail_Array(paramlist);
     VAL_RESET_HEADER(archetype, REB_FUNCTION);
     archetype->payload.function.paramlist = paramlist;
@@ -2126,7 +2131,8 @@ REBNATIVE(typechecker)
     REBVAL *param = Alloc_Tail_Array(paramlist);
     Val_Init_Typeset(param, ALL_64, Canon(SYM_VALUE));
     INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
-    
+
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *fun = Make_Function(
@@ -2205,6 +2211,7 @@ REBNATIVE(adapt)
         VAL_FUNC_PARAMLIST(adaptee), SPECIFIED
     );
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *fun = Make_Function(
@@ -2338,6 +2345,7 @@ REBNATIVE(hijack)
         ARR_HEAD(proxy_paramlist)->payload.function.paramlist
             = proxy_paramlist;
         ARR_SERIES(proxy_paramlist)->link.meta = VAL_FUNC_META(victim);
+        SET_ARR_FLAG(proxy_paramlist, ARRAY_FLAG_PARAMLIST);
 
         // If the proxy had a body, then that body will be bound relative
         // to the original paramlist that's getting hijacked.  So when the

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -238,7 +238,7 @@ static REBSER *Make_Set_Operation_Series(
                         SER_LEN(mo.series), // tail
                         skip, // skip
                         cased ? AM_FIND_CASE : 0 // flags
-	    )
+        )
                 ) {
                     Append_String(mo.series, ser, i, skip);
                 }

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -46,6 +46,10 @@ struct Reb_Func {
 #endif
 
 inline static REBARR *FUNC_PARAMLIST(REBFUN *f) {
+#if !defined(NDEBUG)
+    if (!GET_ARR_FLAG(&f->paramlist, ARRAY_FLAG_PARAMLIST))
+        Panic_Array(&f->paramlist);
+#endif
     return &f->paramlist;
 }
 

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -152,6 +152,13 @@ enum {
     //
     STRING_FLAG_CANON = 1 << 4,
 
+    // `ARRAY_FLAG_PARAMLIST` uses the same bit as STRING_FLAG_CANON, so the
+    // meaning depends on whether the SERIES_FLAG_ARRAY or SERIES_FLAG_STRING
+    // bit is set.  This indicates the array is the parameter list of a
+    // FUNCTION! (the first element will be a canon value of the function)
+    //
+    ARRAY_FLAG_PARAMLIST = 1 << 4,
+
     // `SERIES_FLAG_ARRAY` indicates that this is a series of REBVAL values,
     // and suitable for using as the payload of an ANY-ARRAY! value.  When a
     // series carries this bit, that means that if it is also SER_MANAGED


### PR DESCRIPTION
This permits you to use `for-each f function! [...]` to get an instance
of each function value that was in existence at the start of the
FOR-EACH.  If in the body any functions are created, they will not
be included in the enumeration.

This means that the routine has to snapshot all the values at the
start of the routine, and protect them from GC during it.  So it is
not a particularly efficient operation.  However, it is intended
primarily for instrumentation purposes (getting tables of functions to
print out for statistics).

To faciliate this, a REBSER identifying a function's paramlist is now
identified by an ARRAY_FLAG_PARAMLIST bit.  This also addresses an
outstanding issue with using functions as a garbage collection root--
as previously, it wasn't possible to tell if a REBSER was a paramlist
or not.