### PR TITLE
LOOP-WHILE, LOOP-UNTIL, and UNTIL-2

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -922,7 +922,7 @@ reevaluate:;
                     // didn't trigger revocation, or refine wouldn't be logic.
                     //
                     if (f->refine + 1 != f->arg)
-                        fail(Error_Bad_Refine_Revoke(f));
+                        fail (Error_Bad_Refine_Revoke(f));
 
                     SET_FALSE(f->refine); // can't re-enable...
                     f->refine = ARG_TO_REVOKED_REFINEMENT;
@@ -1175,7 +1175,7 @@ reevaluate:;
         REBVAL *typeset = FUNC_PARAM(f->func, FUNC_NUM_PARAMS(f->func));
         assert(VAL_PARAM_SYM(typeset) == SYM_RETURN);
         if (!TYPE_CHECK(typeset, VAL_TYPE(f->out)))
-            fail(Error_Bad_Return_Type(f->label, VAL_TYPE(f->out)));
+            fail (Error_Bad_Return_Type(f->label, VAL_TYPE(f->out)));
     }
 #endif
 

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -342,7 +342,7 @@ REBNATIVE(backtrace)
         // See notes on handling of breakpoint below for why 0 is accepted.
         //
         if (IS_INTEGER(level) && VAL_INT32(level) < 0)
-            fail(Error_Invalid_Arg(level));
+            fail (Error_Invalid_Arg(level));
     }
 
     REBCNT max_rows; // The "frames" from /LIMIT, plus one (for ellipsis)

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -313,7 +313,7 @@ void RXI_To_Value(REBVAL *val, const RXIARG *arg, REBRXT type)
         break;
 
     default:
-        fail(Error(RE_BAD_CMD_ARGS));
+        fail (Error(RE_BAD_CMD_ARGS));
     }
 
     return;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -494,7 +494,7 @@ REBNATIVE(switch)
     // block in source, as that is likely a mistake.
     //
     if (IS_BLOCK(value) && !GET_VAL_FLAG(value, VALUE_FLAG_EVALUATED))
-        fail(Error(RE_BLOCK_SWITCH, value));
+        fail (Error(RE_BLOCK_SWITCH, value));
 
     // Frame's extra D_CELL is free since the function has > 1 arg.  Reuse it
     // as a temporary GC-safe location for holding evaluations.  This

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -320,7 +320,7 @@ REBNATIVE(apply)
     //
     if (NOT_END(first_def)) {
         if (!IS_SET_WORD(first_def) && !IS_BAR(first_def)) {
-            fail(Error(RE_APPLY_HAS_CHANGED));
+            fail (Error(RE_APPLY_HAS_CHANGED));
         }
     }
 #endif
@@ -335,7 +335,7 @@ REBNATIVE(apply)
         name = Canon(SYM___ANONYMOUS__); // Do_Core requires non-NULL symbol
 
     if (!IS_FUNCTION(D_OUT))
-        fail(Error(RE_APPLY_NON_FUNCTION, ARG(value))); // for SPECIALIZE too
+        fail (Error(RE_APPLY_NON_FUNCTION, ARG(value))); // for SPECIALIZE too
 
     f->gotten = D_OUT;
     f->out = D_OUT;

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -96,7 +96,7 @@ REBNATIVE(trap)
                 return R_OUT;
             }
 
-            panic(Error(RE_MISC)); // should not be possible (type-checking)
+            panic (Error(RE_MISC)); // should not be possible (type-checking)
         }
 
         if (REF(q)) return R_TRUE;

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -118,12 +118,12 @@ void Make_Thrown_Exit_Value(
     if (IS_INTEGER(level)) {
         REBCNT count = VAL_INT32(level);
         if (count <= 0)
-            fail(Error(RE_INVALID_EXIT));
+            fail (Error(RE_INVALID_EXIT));
 
         REBFRM *f = frame->prior;
         for (; TRUE; f = f->prior) {
             if (f == NULL)
-                fail(Error(RE_INVALID_EXIT));
+                fail (Error(RE_INVALID_EXIT));
 
             if (NOT(Is_Any_Function_Frame(f))) continue; // only exit functions
 
@@ -217,7 +217,7 @@ REBNATIVE(return)
     REBFRM *f = frame_; // implicit parameter to REBNATIVE()
 
     if (f->binding == NULL) // raw native, not a variant FUNCTION made
-        fail(Error(RE_RETURN_ARCHETYPE));
+        fail (Error(RE_RETURN_ARCHETYPE));
 
     // The frame this RETURN is being called from may well not be the target
     // function of the return (that's why it's a "definitional return").  So
@@ -237,7 +237,7 @@ REBNATIVE(return)
     // wound up catching it.
     //
     if (!TYPE_CHECK(typeset, VAL_TYPE(value)))
-        fail(Error_Bad_Return_Type(
+        fail (Error_Bad_Return_Type(
             f->label, // !!! Should climb stack to get real label?
             VAL_TYPE(value)
         ));
@@ -262,7 +262,7 @@ REBNATIVE(leave)
 // See notes on REBNATIVE(return)
 {
     if (frame_->binding == NULL) // raw native, not a variant PROCEDURE made
-        fail(Error(RE_RETURN_ARCHETYPE));
+        fail (Error(RE_RETURN_ARCHETYPE));
 
     *D_OUT = *NAT_VALUE(exit); // see also Make_Thrown_Exit_Value
     D_OUT->extra.binding = frame_->binding;
@@ -418,7 +418,7 @@ REBNATIVE(specialize)
     Get_If_Word_Or_Path_Arg(&specializee, &opt_name, ARG(value));
 
     if (!IS_FUNCTION(&specializee))
-        fail(Error(RE_APPLY_NON_FUNCTION, ARG(value))); // for APPLY too
+        fail (Error(RE_APPLY_NON_FUNCTION, ARG(value))); // for APPLY too
 
     if (Specialize_Function_Throws(D_OUT, &specializee, opt_name, ARG(def)))
         return R_OUT_IS_THROWN;
@@ -468,7 +468,7 @@ REBNATIVE(chain)
     REBVAL *check = first;
     while (NOT_END(check)) {
         if (!IS_FUNCTION(check))
-            fail(Error_Invalid_Arg(check));
+            fail (Error_Invalid_Arg(check));
         ++check;
     }
 
@@ -543,7 +543,7 @@ REBNATIVE(adapt)
     REBSTR *opt_adaptee_name;
     Get_If_Word_Or_Path_Arg(D_OUT, &opt_adaptee_name, adaptee);
     if (!IS_FUNCTION(D_OUT))
-        fail(Error(RE_APPLY_NON_FUNCTION, adaptee));
+        fail (Error(RE_APPLY_NON_FUNCTION, adaptee));
 
     *adaptee = *D_OUT;
 
@@ -662,7 +662,7 @@ REBNATIVE(hijack)
     );
     REBVAL *victim = &victim_value;
     if (!IS_FUNCTION(victim))
-        fail(Error(RE_MISC));
+        fail (Error(RE_MISC));
 
     REBVAL hijacker_value;
     REBSTR *opt_hijacker_name;
@@ -671,14 +671,14 @@ REBNATIVE(hijack)
     );
     REBVAL *hijacker = &hijacker_value;
     if (!IS_FUNCTION(hijacker) && !IS_BLANK(hijacker))
-        fail(Error(RE_MISC));
+        fail (Error(RE_MISC));
 
     // !!! Should hijacking a function with itself be a no-op?  One could make
     // an argument from semantics that the effect of replacing something with
     // itself is not to change anything, but erroring may give a sanity check.
     //
     if (!IS_BLANK(hijacker) && VAL_FUNC(victim) == VAL_FUNC(hijacker))
-        fail(Error(RE_MISC));
+        fail (Error(RE_MISC));
 
     if (IS_FUNCTION_HIJACKER(victim) && IS_BLANK(VAL_FUNC_BODY(victim))) {
         //
@@ -691,7 +691,7 @@ REBNATIVE(hijack)
         // that no new proxy could be made.
 
         if (IS_BLANK(hijacker))
-            fail(Error(RE_MISC)); // !!! Allow re-blanking a blank?
+            fail (Error(RE_MISC)); // !!! Allow re-blanking a blank?
 
         SET_BLANK(D_OUT);
     }

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -78,7 +78,7 @@ static void tcc_error_report(void *ignored, const char *msg)
     REBSER *ser = Make_Binary(strlen(msg) + 2);
     Append_Series(ser, cb_cast(msg), strlen(msg));
     Val_Init_String(&err, ser);
-    fail(Error(RE_TCC_ERROR_WARN, &err));
+    fail (Error(RE_TCC_ERROR_WARN, &err));
 }
 
 
@@ -350,7 +350,7 @@ REBNATIVE(make_native)
 REBNATIVE(compile)
 {
 #if !defined(WITH_TCC)
-    fail(Error(RE_NOT_TCC_BUILD));
+    fail (Error(RE_NOT_TCC_BUILD));
 #else
     PARAM(1, natives);
     REFINE(2, options);
@@ -361,7 +361,7 @@ REBNATIVE(compile)
     REBOOL debug = FALSE; // !!! not implemented yet
 
     if (VAL_LEN_AT(ARG(natives)) == 0)
-        fail(Error(RE_TCC_EMPTY_SPEC));
+        fail (Error(RE_TCC_EMPTY_SPEC));
 
     RELVAL *spec = NULL;
     RELVAL *inc = NULL;
@@ -375,13 +375,13 @@ REBNATIVE(compile)
 
         for (; NOT_END(val); ++val) {
             if (!IS_WORD(val))
-                fail(Error(RE_TCC_EXPECT_WORD, val));
+                fail (Error(RE_TCC_EXPECT_WORD, val));
 
             switch (VAL_WORD_SYM(val)) {
             case SYM_INCLUDE:
                 ++val;
                 if (!(IS_BLOCK(val) || IS_FILE(val) || ANY_STRING(val)))
-                    fail(Error(RE_TCC_INVALID_INCLUDE, val));
+                    fail (Error(RE_TCC_INVALID_INCLUDE, val));
                 inc = val;
                 break;
 
@@ -392,33 +392,33 @@ REBNATIVE(compile)
             case SYM_OPTIONS:
                 ++val;
                 if (!ANY_STRING(val) || !VAL_BYTE_SIZE(val))
-                    fail(Error(RE_TCC_INVALID_OPTIONS, val));
+                    fail (Error(RE_TCC_INVALID_OPTIONS, val));
                 options = val;
                 break;
 
             case SYM_RUNTIME_PATH:
                 ++val;
                 if (!(IS_FILE(val) || IS_STRING(val)))
-                    fail(Error(RE_TCC_INVALID_LIBRARY_PATH, val));
+                    fail (Error(RE_TCC_INVALID_LIBRARY_PATH, val));
                 rundir = val;
                 break;
 
             case SYM_LIBRARY_PATH:
                 ++val;
                 if (!(IS_BLOCK(val) || IS_FILE(val) || ANY_STRING(val)))
-                    fail(Error(RE_TCC_INVALID_LIBRARY_PATH, val));
+                    fail (Error(RE_TCC_INVALID_LIBRARY_PATH, val));
                 libdir = val;
                 break;
 
             case SYM_LIBRARY:
                 ++val;
                 if (!(IS_BLOCK(val) || IS_FILE(val) || ANY_STRING(val)))
-                    fail(Error(RE_TCC_INVALID_LIBRARY, val));
+                    fail (Error(RE_TCC_INVALID_LIBRARY, val));
                 lib = val;
                 break;
 
             default:
-                fail(Error(RE_TCC_NOT_SUPPORTED_OPT, val));
+                fail (Error(RE_TCC_NOT_SUPPORTED_OPT, val));
             }
         }
     }
@@ -549,7 +549,7 @@ REBNATIVE(compile)
 
     TCCState *state = tcc_new();
     if (!state)
-        fail(Error(RE_TCC_CONSTRUCTION));
+        fail (Error(RE_TCC_CONSTRUCTION));
 
     tcc_set_error_func(state, NULL, tcc_error_report);
 
@@ -587,7 +587,7 @@ REBNATIVE(compile)
     sym = &r3_libtcc1_symbols[0];
     for (; *sym != NULL; sym += 2) {
         if (tcc_add_symbol(state, cast(const char*, *sym), *(sym + 1)) < 0)
-            fail(Error(RE_TCC_RELOCATE));
+            fail (Error(RE_TCC_RELOCATE));
     }
 
     if ((err = add_path(
@@ -603,7 +603,7 @@ REBNATIVE(compile)
         do_set_path(state, rundir, tcc_set_lib_path);
 
     if (tcc_relocate(state, TCC_RELOCATE_AUTO) < 0)
-        fail(Error(RE_TCC_RELOCATE));
+        fail (Error(RE_TCC_RELOCATE));
 
     REBVAL handle;
     Init_Handle_Managed(
@@ -635,7 +635,7 @@ REBNATIVE(compile)
         );
 
         if (!c_func)
-            fail(Error(RE_TCC_SYM_NOT_FOUND, name));
+            fail (Error(RE_TCC_SYM_NOT_FOUND, name));
 
         FUNC_DISPATCHER(VAL_FUNC(var)) = c_func;
         *stored_state = handle;

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -247,7 +247,7 @@ static REB_R Signal_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
             result = OS_DO_DEVICE(req, RDC_READ);
             if (result < 0) {
                 Free_Series(ser);
-                fail(Error_On_Port(RE_READ_ERROR, port, req->error));
+                fail (Error_On_Port(RE_READ_ERROR, port, req->error));
             }
 
             arg = CTX_VAR(port, STD_PORT_DATA);

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -107,5 +107,5 @@ REBINT CT_Handle(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 REBTYPE(Handle)
 {
-    fail(Error_Illegal_Action(REB_HANDLE, action));
+    fail (Error_Illegal_Action(REB_HANDLE, action));
 }

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -608,7 +608,7 @@ REBINT PD_String(REBPVS *pvs)
 REBSER *File_Or_Url_Path_Dispatch(REBPVS *pvs)
 {
     if (pvs->opt_setval)
-        fail(Error_Bad_Path_Set(pvs));
+        fail (Error_Bad_Path_Set(pvs));
 
     REBSER *ser = Copy_Sequence_At_Position(KNOWN(pvs->value));
 

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -474,32 +474,32 @@ static REBOOL assign_scalar_core(
     switch (field->type) {
         case FFI_TYPE_SINT8:
             if (i > 0x7f || i < -128)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(i8*)data = (i8)i;
             break;
         case FFI_TYPE_UINT8:
             if (i > 0xff || i < 0)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(u8*)data = (u8)i;
             break;
         case FFI_TYPE_SINT16:
             if (i > 0x7fff || i < -0x8000)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(i16*)data = (i16)i;
             break;
         case FFI_TYPE_UINT16:
             if (i > 0xffff || i < 0)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(u16*)data = (u16)i;
             break;
         case FFI_TYPE_SINT32:
             if (i > 0x7fffffff || i < -0x80000000LL)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(i32*)data = (i32)i;
             break;
         case FFI_TYPE_UINT32:
             if (i > 0xffffffffU || i < 0)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(u32*)data = (u32)i;
             break;
         case FFI_TYPE_SINT64:
@@ -508,12 +508,12 @@ static REBOOL assign_scalar_core(
             break;
         case FFI_TYPE_UINT64:
             if (i < 0)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *(u64*)data = (u64)i;
             break;
         case FFI_TYPE_POINTER:
             if (sizeof(void*) < 8 && i > 0xffffffff)
-                fail(Error(RE_OVERFLOW));
+                fail (Error(RE_OVERFLOW));
             *cast(void**, data) = cast(void*, cast(REBUPT, i));
             break;
         case FFI_TYPE_FLOAT:

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -137,7 +137,7 @@ REBIXO Do_Vararg_Op_May_Throw(
         pclass = VAL_PARAM_CLASS(param);
 
         if (op == VARARG_OP_FIRST && pclass != PARAM_CLASS_HARD_QUOTE)
-            fail(Error(RE_VARARGS_NO_LOOK)); // lookahead needs hard quote
+            fail (Error(RE_VARARGS_NO_LOOK)); // lookahead needs hard quote
 
         // If the VARARGS! has a call frame, then ensure that the call frame where
         // the VARARGS! originated is still on the stack.
@@ -151,7 +151,7 @@ REBIXO Do_Vararg_Op_May_Throw(
             GET_CTX_FLAG(context, CONTEXT_FLAG_STACK)
             && !GET_CTX_FLAG(context, SERIES_FLAG_ACCESSIBLE)
         ) {
-            fail(Error(RE_VARARGS_NO_STACK));
+            fail (Error(RE_VARARGS_NO_STACK));
         }
 
         f = CTX_FRAME(context);

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -164,7 +164,7 @@ REBTYPE(Word)
         while (TRUE) {
             REBUNI ch;
             if (!(bp = Back_Scan_UTF8_Char(&ch, bp, &len)))
-                fail(Error(RE_BAD_UTF8));
+                fail (Error(RE_BAD_UTF8));
             if (ch == 0)
                 break;
         }

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -105,10 +105,7 @@ REBSER *Compress(
     REBOOL gzip,
     REBOOL raw
 ) {
-    REBCNT buf_size;
-    REBSER *output;
     int ret;
-    z_stream strm;
 
     assert(BYTE_SIZE(input)); // must be BINARY!
 
@@ -116,6 +113,7 @@ REBSER *Compress(
     // if you want it to pick what the library author considers the "worth it"
     // tradeoff of time to generally suggest.
     //
+    z_stream strm;
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
@@ -136,12 +134,12 @@ REBSER *Compress(
 
     // http://stackoverflow.com/a/4938401/211160
     //
-    buf_size = deflateBound(&strm, len);
+    REBCNT buf_size = deflateBound(&strm, len);
 
     strm.avail_in = len;
     strm.next_in = BIN_HEAD(input) + index;
 
-    output = Make_Binary(buf_size);
+    REBSER *output = Make_Binary(buf_size);
     strm.avail_out = buf_size;
     strm.next_out = BIN_HEAD(output);
 
@@ -210,19 +208,15 @@ REBSER *Decompress(
     REBOOL gzip,
     REBOOL raw
 ) {
-    struct Reb_State state;
-    REBCTX *error;
-
-    REBCNT buf_size;
-    REBSER *output;
     int ret;
-    z_stream strm;
 
+    z_stream strm;
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
     strm.total_out = 0;
 
+    REBCNT buf_size;
     if (gzip || !raw) {
         //
         // Both gzip and Rebol's envelope have the size living in the last
@@ -296,6 +290,9 @@ REBSER *Decompress(
     // Since we do the trap anyway, this is the way we handle explicit errors
     // called in the code below also.
     //
+    struct Reb_State state;
+    REBCTX *error;
+
     PUSH_UNHALTABLE_TRAP(&error, &state);
 
 // The first time through the following code 'error' will be NULL, but...
@@ -311,7 +308,7 @@ REBSER *Decompress(
 
     // Since the initialization succeeded, go ahead and make the output buffer
     //
-    output = Make_Binary(buf_size);
+    REBSER *output = Make_Binary(buf_size);
     strm.avail_out = buf_size;
     strm.next_out = BIN_HEAD(output);
 
@@ -331,43 +328,41 @@ REBSER *Decompress(
             break;
         }
 
-        if (ret == Z_OK) {
-            //
-            // Still more data to come.  Use remaining data amount to guess
-            // size to add.
-            //
-            REBCNT old_size = buf_size;
-
-            if (max >= 0 && buf_size >= cast(REBCNT, max)) {
-                REBVAL temp;
-                SET_INTEGER(&temp, max);
-
-                // NOTE: You can hit this on 'make prep' without doing a full
-                // rebuild.  'make clean' and build again, it should go away.
-                //
-                fail (Error(RE_SIZE_LIMIT, &temp));
-            }
-
-            buf_size = buf_size + strm.avail_in * 3;
-            if (max >= 0 && buf_size > cast(REBCNT, max))
-                buf_size = max;
-
-            assert(strm.avail_out == 0); // !!! is this guaranteed?
-            assert(
-                strm.next_out == BIN_HEAD(output) + old_size - strm.avail_out
-            );
-
-            Extend_Series(output, buf_size - old_size);
-
-            // Extending keeps the content but may realloc the pointer, so
-            // put it at the same spot to keep writing to
-            //
-            strm.next_out = BIN_HEAD(output) + old_size - strm.avail_out;
-
-            strm.avail_out += buf_size - old_size;
-        }
-        else
+        if (ret != Z_OK)
             fail (Error_Compression(&strm, ret));
+
+        // Still more data to come.  Use remaining data amount to guess
+        // size to add.
+        //
+        REBCNT old_size = buf_size;
+
+        if (max >= 0 && buf_size >= cast(REBCNT, max)) {
+            REBVAL temp;
+            SET_INTEGER(&temp, max);
+
+            // NOTE: You can hit this on 'make prep' without doing a full
+            // rebuild.  'make clean' and build again, it should go away.
+            //
+            fail (Error(RE_SIZE_LIMIT, &temp));
+        }
+
+        buf_size = buf_size + strm.avail_in * 3;
+        if (max >= 0 && buf_size > cast(REBCNT, max))
+            buf_size = max;
+
+        assert(strm.avail_out == 0); // !!! is this guaranteed?
+        assert(
+            strm.next_out == BIN_HEAD(output) + old_size - strm.avail_out
+        );
+
+        Extend_Series(output, buf_size - old_size);
+
+        // Extending keeps the content but may realloc the pointer, so
+        // put it at the same spot to keep writing to
+        //
+        strm.next_out = BIN_HEAD(output) + old_size - strm.avail_out;
+
+        strm.avail_out += buf_size - old_size;
     }
 
     SET_BIN_END(output, strm.total_out);

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -261,7 +261,7 @@ inline static REBVAL *Sys_Func(REBCNT inum)
     REBVAL *value = CTX_VAR(Sys_Context, inum);
 
     if (!IS_FUNCTION(value))
-        fail(Error(RE_BAD_SYS_FUNC, value));
+        fail (Error(RE_BAD_SYS_FUNC, value));
 
     return value;
 }

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -23,6 +23,14 @@ REBOL [
 ]
 
 
+; !!! The long term goal for Ren-C is that UNTIL and WHILE both be arity-2 and
+; inversions of each other, with LOOP-UNTIL and LOOP-WHILE being arity-1.
+; To avoid rocking the boat in the default distribution, this is changed here.
+;
+until-2: :until
+until: :loop-until
+
+
 ; Words for BLANK! and BAR!, for those who don't like symbols
 
 blank: _

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -474,7 +474,7 @@ check-data: func [port /local headers res data out chunk-size mk1 mk2 trailer st
             ;clear the port data only at the beginning of the request --Richard
             unless port/data [port/data: make binary! length data]
             out: port/data
-            until [
+            loop-until [
                 either parse data [
                     copy chunk-size some hex-digits thru crlfbin mk1: to end
                 ] [


### PR DESCRIPTION
In the once-hotly-debated question of whether it made more sense for
UNTIL to be arity-2 (to match WHILE) and then have arity-1 forms of
both WHILE and UNTIL as "LOOP-UNTIL" and "LOOP-WHILE", it was decided
to keep UNTIL as arity-1 and put the burden of reconfiguring on the
user (and then to make sure that burden was very small).

To make that burden as small as possible, this goes ahead and does the
implementation of all four variants by the "ideal" definition.  Then
during boot it simply says:

    until-2: :until
    until: :loop-until

This can be undone by a user with `until: :until-2`.  The definitions
are used in Rebmu as UT, WH, LU, LW.

Includes some comment editing in %sys-rebval.h, and moves Reb_All to
not be platform dependent (but use platform-dependent REBUPT).