### PR TITLE
Replace <defer> with new semantics as <tight>

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -35,7 +35,7 @@ opt-tag         ; FUNC+PROC use as alternative to _ to mark optional void? args
 end-tag         ; FUNC+PROC use as alternative to | to mark endable args
 local-tag       ; marks the beginning of a list of "pure locals"
 durable-tag     ; !!! In progress - argument word lookup survives call ending
-defer-tag       ; Argument suppresses evaluator lookahead or lookback
+tight-tag       ; Argument completes shortest legal expression (not longest)
 
 ;; !!! See notes on FUNCTION-META in %sysobj.r
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -557,7 +557,7 @@ static void Init_Function_Tags(void)
     Init_Function_Tag("end", ROOT_END_TAG);
     Init_Function_Tag("local", ROOT_LOCAL_TAG);
     Init_Function_Tag("durable", ROOT_DURABLE_TAG);
-    Init_Function_Tag("defer", ROOT_DEFER_TAG);
+    Init_Function_Tag("tight", ROOT_TIGHT_TAG);
 }
 
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -938,7 +938,7 @@ REBFUN *Make_Function(
             //
             SET_VAL_FLAG(rootparam, FUNC_FLAG_MAYBE_BRANCHER);
 
-            if (GET_VAL_FLAG(param, TYPESET_FLAG_DEFER))
+            if (!GET_VAL_FLAG(param, TYPESET_FLAG_TIGHT))
                 SET_VAL_FLAG(rootparam, FUNC_FLAG_DEFERS_LOOKBACK_ARG);
 
             goto done_caching; }

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -328,8 +328,8 @@ REBNATIVE(typechecker)
 //  {Create a function that selects between two values based on a LOGIC!}
 //
 //      return: [function!]
-//      true-branch [any-value!]
-//      false-branch [any-value!]
+//      :true-branch [block!]
+//      :false-branch [block!]
 //  ][
 //      specialize 'either [
 //          true-branch: true-branch
@@ -349,6 +349,12 @@ REBNATIVE(brancher)
 // to not create series...but a special kind of REBVAL which would morph
 // into a function on demand.  IF and UNLESS could recognize this special
 // value type and treat it like a branch.
+//
+// !!! Currently it is limited to hard quoted BLOCK!s based on the
+// limitations of left-handed enfixed functions w.r.t. quoting.  This is
+// based on the assumption that in the long run, <tight> will not exist; and
+// a function wanting to pull the trick ELSE is with its left hand side will
+// have to use some kind of quoting.
 {
     PARAM(1, true_branch);
     PARAM(2, false_branch);

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -190,13 +190,13 @@ REBOOL Update_Typeset_Bits_Core(
         }
         else if (
             keywords && IS_TAG(item) && (
-                0 == Compare_String_Vals(item, ROOT_DEFER_TAG, TRUE)
+                0 == Compare_String_Vals(item, ROOT_TIGHT_TAG, TRUE)
             )
         ) {
             // Makes enfixed first arguments "lazy" and other arguments will
             // use the DO_FLAG_NO_LOOKAHEAD.
             // 
-            SET_VAL_FLAG(typeset, TYPESET_FLAG_DEFER);
+            SET_VAL_FLAG(typeset, TYPESET_FLAG_TIGHT);
         }
         else if (
             IS_BAR(item) || (keywords && IS_TAG(item) && (

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -721,7 +721,7 @@ left-bar: func [
     {Expression barrier that evaluates to left side but executes right.}
     return: [<opt> any-value!]
         {Evaluative result of `left`.}
-    left [<defer> <opt> <end> any-value!]
+    left [<opt> <end> any-value!]
         {A single complete expression on the left.}
     right [<opt> any-value! <...>]
         {Any number of expressions on the right.}
@@ -734,7 +734,7 @@ right-bar: func [
     {Expression barrier that evaluates to first expression on right.}
     return: [<opt> any-value!]
         {Evaluative result of first of the right expressions.}
-    left [<defer> <opt> <end> any-value!]
+    left [<opt> <end> any-value!]
         {A single complete expression on the left.}
     right [<opt> any-value! <...>]
         {Any number of expressions on the right.}
@@ -746,7 +746,7 @@ right-bar: func [
 once-bar: func [
     {Expression barrier that's willing to only run one expression after it}
     return: [<opt> any-value!]
-    left [<defer> <opt> <end> any-value!]
+    left [<opt> <end> any-value!]
     right [<opt> any-value! <...>]
     :lookahead [any-value! <...>]
     look:


### PR DESCRIPTION
R3-Alpha achieved an apparent "left-to-right" via lookahead suppression.
So when evaluating:

    1 + 2 * 3

Lookahead would be enabled by default, 1 would evaluate to itself
and see an OP! in that lookahead.  During evaluation of the remaining
`[2 * 3]`, lookahead would be disabled.  (This would happen during the
right-hand side evaluation of any OP!.)  Hence it would see the 2,
which would evaluate to itself, and the addition would run--thus
finishing the first infix operation.  Lookahead would be re-enabled, so
it would see the `*`, lookahead would be disabled while evaluating the
3...and so on.

(In this case there's nothing further to see, so the expression is 9.)

This form of limiting argument evaluation was seen as a poor default
behavior for Ren-C.  So enfixing operators would not have this property
and would gather their arguments without lookahead suppression--just as
a prefix operation would.  So at one time, `1 + 2 * 3` would behave
just like `add 1 2 * 3`, which would behave the same as
`add 1 multiply 2 3`.  So it would evaluate to 7.

While more uniform, this was not backward-compatible.  So the `<defer>`
annotation was introduced, which could be marked on any parameter in
order to say that parameter should not do infix lookahead during its
evaluation.  Compatibility versions of the operators used this.

Because it was emerging as necessary for certain operators, the idea of
being able to control the "eagerness" of evaluation on the left hand
side of an enfixed operation was also considered.  Hence a meaning
for the <defer> annotation on that slot was given, to be "non-eager"
and complete as much of the left hand side as possible.  So if the
left-hand side of SOME-INFIX was deferred, while the right was not,
it would be interpreted as:

    1 + 2 foo 3 + 4 => (1 + 2) foo (3 + 4)

This commit switches the behavior so this bias for complete expressions
on the left hand side is the default...as is the bias for complete
expression on the right hand side.  Interestingly, this gives rise
to a legacy-compatible left-to-right interpretation of infix...but
for a different reason.

So in `1 + 2 * 3`, the `+` reads from `[2 * 3]` with the lookahead
fully enabled.  But when the `*` is hit, its default is to ask that
the left-hand side be as complete as possible.  This pushes evaluation
back to the 1 + 2, which completes, and then runs the multiplication
to get 9.

Now the request for shortest-possible-expression uses the `<tight>`
annotation on both left and right args.