### PR TITLE
FORM non-STRING! (instead of non-ANY-STRING!) in FIND

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -205,9 +205,6 @@ find: action [
     limit [any-number! any-series! pair!]
     /only {Treats a series value as only a single value}
     /case {Characters are case-sensitive}
-    /any  {Enables the * and ? wildcards}
-    /with {Allows custom wildcards}
-    wild [string!] "Specifies alternates for * and ?"
     /skip {Treat the series as records of fixed size}
     size [integer!]
     /last {Backwards from end of series}
@@ -225,9 +222,6 @@ select: action [
     limit [any-number! any-series! pair!]
     /only {Treats a series value as only a single value}
     /case {Characters are case-sensitive}
-    /any  {Enables the * and ? wildcards}
-    /with {Allows custom wildcards}
-    wild [string!] "Specifies alternates for * and ?"
     /skip {Treat the series as records of fixed size}
     size [integer!]
     /last {Backwards from end of series}

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -752,8 +752,16 @@ find:
             }
         }
         else {
-            if (IS_CHAR(arg) || IS_BITSET(arg)) len = 1;
-            else if (!ANY_STRING(arg)) {
+            if (IS_CHAR(arg) || IS_BITSET(arg))
+                len = 1;
+            else if (!IS_STRING(arg)) {
+                //
+                // !! This FORM creates a temporary value that is then handed
+                // over to the GC.  Not only could the temporary value be
+                // unmanaged (and freed), a more efficient matching could
+                // be done e.g. of `FIND "<abc...z>" <abc...z>` without having
+                // to create an entire series just to include the delimiters.
+                // 
                 REBSER *copy = Copy_Form_Value(arg, 0);
                 Val_Init_String(arg, copy);
             }

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -194,7 +194,7 @@ make-arg-enums: func [word] [
     refs: copy []
     ; Gather arg words:
     for-each w first def [
-        if any-word? w [
+        if all [any-word? w | not set-word? w] [
             append args uw: uppercase replace/all form to word! w #"-" #"_"
             if refinement? w [append refs uw  w: to word! w]
         ]


### PR DESCRIPTION
Rebol issue 1160 pointed out a problem with using a TAG! to search
over a string:

https://github.com/rebol/rebol-issues/issues/1160

This change uses FORM on the argument, so `find "<abc>" <abc>` will
account for the tag delimiters.

Searching has some strange ramifications for other types, given that
you can't really get a good result out of `find <abc> "<"`.  For
lack of a better rule, though, this goes ahead and FORMs.

Also gets rid of the unimplemented wildcard features in FIND and
SELECT, which are more suited to a PARSE or GLOB dialect.