### PR TITLE
Efficient TIGHTEN generator for making OP!-like stubs

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -129,6 +129,7 @@ Script: [
     apply-has-changed:  {APPLY takes frame def block (or see r3-alpha-apply)}
     apply-non-function: [:arg1 {needs to be a function for APPLY/SPECIALIZE}]
 
+    invalid-tighten:    {TIGHTEN does not support SPECIALIZE/ADAPT/CHAIN}
     print-needs-eval:   {PRINT needs /EVAL to process non-literal blocks}
 
     hijack-blank:       {Hijacked function was captured but no body given yet}

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -806,3 +806,106 @@ REBNATIVE(variadic_q)
 
     return R_FALSE;
 }
+
+
+//
+//  tighten: native [
+//
+//  {Returns alias of a function whose args are gathered <tight>ly}
+//
+//      return: [function!]
+//      action [function!]
+//  ]
+//
+REBNATIVE(tighten)
+//
+// !!! The <tight> annotation was introduced while trying to define a bridge
+// for compatibility with R3-Alpha's OP!.  That code made use of "lookahead
+// suppression" on the right hand side of infix operators, in order to give
+// a left-to-right evaluation ordering in pure infix expressions.  After some
+// experimentation, Ren-C came up with a more uniform rule across both
+// "enfixed" expressions (of arbitrary arity) and ordinary prefix expressions,
+// which still gave a left-to-right effect for binary infix ops.
+//
+// Hence <tight> is likely to be phased out; but it exists for compatibility.
+// This routine exists to avoid the overhead of a user-function stub where
+// all the parameters are <tight>, e.g. the behavior of R3-Alpha's OP!s.
+// So `+: enfix tighten :add` is a faster equivalent of:
+//
+//     +: enfix func [arg1 [<tight> any-value!] arg2 [<tight> any-value!] [
+//         add :arg1 :arg2
+//     ]
+//
+// But also, the parameter types and help notes are kept in sync.
+{
+    PARAM(1, action);
+
+    REBFUN *original = VAL_FUNC(ARG(action));
+
+    // !!! With specializations and chaining, functions can be a stack of
+    // entities which must have consistent defintions and point to each other.
+    // The identity comes from the top-most function, while the functionality
+    // often comes from the lowest one...and the pointers must be consistent.
+    // This means that tweaking function copies gets somewhat involved.  :-/
+    //
+    // For now this only supports tightening native or interpreted functions,
+    // to avoid walking the function chain and adjusting each level.  The
+    // option is still currently available to manually create a new user
+    // function that explicitly calls chained/specialized/adapted functions
+    // but has <tight> parameters...it will just not be as fast.
+    //
+    REBFUN *specializer;
+    REBFUN *underlying = Underlying_Function(&specializer, ARG(action));
+    if (underlying != original)
+        fail (Error(RE_INVALID_TIGHTEN));
+
+    // Copy the paramlist, which serves as the function's unique identity (the
+    // body can be reused as-is)
+    //
+    REBARR *paramlist = Copy_Array_Shallow(
+        FUNC_PARAMLIST(original),
+        SPECIFIED // no relative values in parameter lists
+    );
+    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST); // flags not auto-copied
+
+    // Now set the tight flag on all the parameters.
+    //
+    RELVAL *param = ARR_AT(paramlist, 1); // first parameter (0 is FUNCTION!)
+    for (; NOT_END(param); ++param)
+        SET_VAL_FLAG(param, TYPESET_FLAG_TIGHT);
+
+    // !!! This does not make a unique copy of the meta information context.
+    // Hence updates to the title/parameter-descriptions/etc. of the tightened
+    // function will affect the original, and vice-versa.  Because this is
+    // a legacy support issue that's probably a feature and not a bug, but
+    // other function-copying abstractions should do it.
+    //    
+    ARR_SERIES(paramlist)->link.meta = FUNC_META(original);
+
+    // Update the underlying function (we should know it was equal to the
+    // original function from the test at the start)
+    //
+    ARR_SERIES(paramlist)->misc.underlying = AS_FUNC(paramlist);
+
+    assert(IS_FUNCTION(ARR_AT(paramlist, 0))); // canon value, must update
+    ARR_AT(paramlist, 0)->payload.function.paramlist = paramlist;
+    MANAGE_ARRAY(paramlist);
+
+    // The function should not indicate any longer that it defers lookback
+    // arguments (this flag is calculated from <tight> annotations in
+    // Make_Function())
+    //
+    CLEAR_VAL_FLAG(ARR_AT(paramlist, 0), FUNC_FLAG_DEFERS_LOOKBACK_ARG);
+
+    *D_OUT = *KNOWN(ARR_AT(paramlist, 0)); // canon value we just updated
+
+    // Currently esoteric case if someone chose to tighten a definitional
+    // return, so `return 1 + 2` would return 1 instead of 3.  Would need to
+    // preserve the binding of the incoming value, which is never present in
+    // the canon value of the function.
+    //
+    assert(D_OUT->extra.binding == NULL);
+    D_OUT->extra.binding = ARG(action)->extra.binding;
+
+    return R_OUT;
+}

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -355,9 +355,8 @@ redescribe: function [
 
     ; For efficiency, objects are only created on demand by hitting the
     ; required point in the PARSE.  Hence `redescribe [] :foo` will not tamper
-    ; with the meta information at all, while `reescribe [{stuff}] :foo` will
-    ; only manipulate the description.not created unless they are needed by
-    ; hitting the required point in the PARSE of the spec.
+    ; with the meta information at all, while `redescribe [{stuff}] :foo` will
+    ; only manipulate the description.
 
     on-demand-meta: does [
         case/all [

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -81,155 +81,38 @@ right-flag: bind (pick make block! "|>" 1) context-of 'lambda
 ; feature is theorized to be unnecessary.
 ;
 
-+: enfix func [arg1 [<tight> any-value!] arg2 [<tight> any-value!]] [
-    add :arg1 :arg2
-]
++: enfix tighten :add
+-: enfix tighten :subtract
+*: enfix tighten :multiply
+**: enfix tighten :power
 
--: enfix func [arg1 [<tight> any-value!] arg2 [<tight> any-value!]] [
-    subtract :arg1 :arg2
-]
+set/lookback dv tighten :divide
+set/lookback dvdv tighten :remainder
 
-*: enfix func [arg1 [<tight> any-value!] arg2 [<tight> any-value!]] [
-    multiply :arg1 :arg2
-]
+=: enfix tighten :equal?
+=?: enfix tighten :same?
 
-**: enfix func [arg1 [<tight> any-value!] arg2 [<tight> any-value!]] [
-    power :arg1 :arg2
-]
+==: enfix tighten :strict-equal?
+!=: enfix tighten :not-equal?
+!==: enfix tighten :strict-not-equal?
 
-set/lookback dv func [arg1 [<tight> any-value!] arg2 [<tight> any-value!]] [
-    divide :arg1 :arg2
-]
+set/lookback should-be-empty-tag tighten :not-equal?
 
-set/lookback dvdv func [arg1 [<tight> any-value!] arg2 [<tight> any-value!]] [
-    remainder :arg1 :arg2
-]
+set/lookback lt tighten :lesser?
+set/lookback lteq tighten :lesser-or-equal?
 
-=: enfix func [
-    arg1 [<tight> <opt> any-value!]
-    arg2 [<tight> <opt> any-value!]
-][
-    equal? :arg1 :arg2
-]
+set/lookback gt tighten :greater?
+set/lookback gteq tighten :greater-or-equal?
 
-=?: enfix func [
-    arg1 [<tight> <opt> any-value!]
-    arg2 [<tight> <opt> any-value!]
-][
-    same? :arg1 :arg2
-]
+and: enfix tighten :and?
+or: enfix tighten :or?
+xor: enfix tighten :xor?
+nor: enfix tighten :nor?
 
-==: enfix func [
-    arg1 [<tight> <opt> any-value!]
-    arg2 [<tight> <opt> any-value!]
-][
-    strict-equal? :arg1 :arg2
-]
-
-!=: enfix func [
-    arg1 [<tight> <opt> any-value!]
-    arg2 [<tight> <opt> any-value!]
-][
-    not-equal? :arg1 :arg2
-]
-
-!==: enfix func [
-    arg1 [<tight> <opt> any-value!]
-    arg2 [<tight> <opt> any-value!]
-][
-    strict-not-equal? :arg1 :arg2
-]
-
-set/lookback should-be-empty-tag func [
-    arg1 [<tight> <opt> any-value!]
-    arg2 [<tight> <opt> any-value!]
-][
-    not-equal? :arg1 :arg2
-]
-
-set/lookback lt func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    lesser? :arg1 :arg2
-]
-
-set/lookback lteq func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    lesser-or-equal? :arg1 :arg2
-]
-
-set/lookback gt func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    greater? :arg1 :arg2
-]
-
-set/lookback gteq func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    greater-or-equal? :arg1 :arg2
-]
-
-and: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    and? :arg1 :arg2
-]
-
-or: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    or? :arg1 :arg2
-]
-
-xor: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    xor? :arg1 :arg2
-]
-
-nor: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    nor? :arg1 :arg2
-]
-
-nand: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    nand? :arg1 :arg2
-]
-
-and*: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    and~ :arg1 :arg2
-]
-
-or+: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    or~ :arg1 :arg2
-]
-
-xor+: enfix func [
-    arg1 [<tight> any-value!]
-    arg2 [<tight> any-value!]
-][
-    xor~ :arg1 :arg2
-]
+nand: enfix tighten :nand?
+and*: enfix tighten :and~
+or+: enfix tighten :or~
+xor+: enfix tighten :xor~
 
 
 ; Postfix operator for asking the most existential question of Rebol...is it


### PR DESCRIPTION
This makes `+: enfix tighten :add` a faster version of:

    +: enfix func [arg1 [<tight> any-value!] arg2 [<tight> any-value!] [
        add :arg1 :arg2
    ]

It avoids the overhead of the user code stub, via direct reuse of the
function's implementation (just with an updated parameter list).  Also
the parameter types and help notes will match the original.

Currently this cannot be used on specialized, adapted, or chained
functions.  However, the <tight> feature is likely to be phased out in
Ren-C, so this is not likely to be a priority.

(The <tight> annotation was introduced while trying to define a bridge
for compatibility with R3-Alpha's OP!.  That code made use of
"lookahead suppression" on the right hand side of infix operators, in
order to give a left-to-right evaluation ordering in pure infix
expressions.  After some experimentation, Ren-C came up with a more
uniform rule across both "enfixed" expressions (of arbitrary arity) and
ordinary prefix expressions, which still gave a left-to-right effect
for binary infix ops.  This form of dispatch is likely to be the only
form supported in the future.)