### PR TITLE
/ASTRAL refinement for TO-STRING

### DIFF
--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -210,16 +210,12 @@ static REBCNT find_string(
 }
 
 
-static REBSER *make_string(const REBVAL *arg, REBOOL make)
+static REBSER *MAKE_TO_String_Common(const REBVAL *arg)
 {
     REBSER *ser = 0;
 
-    // MAKE <type> 123
-    if (make && (IS_INTEGER(arg) || IS_DECIMAL(arg))) {
-        ser = Make_Binary(Int32s(arg, 0));
-    }
     // MAKE/TO <type> <binary!>
-    else if (IS_BINARY(arg)) {
+    if (IS_BINARY(arg)) {
         REBYTE *bp = VAL_BIN_AT(arg);
         REBCNT len = VAL_LEN_AT(arg);
         switch (What_UTF(bp, len)) {
@@ -247,12 +243,8 @@ static REBSER *make_string(const REBVAL *arg, REBOOL make)
         ser = (VAL_CHAR(arg) > 0xff) ? Make_Unicode(2) : Make_Binary(2);
         Append_Codepoint_Raw(ser, VAL_CHAR(arg));
     }
-    // MAKE/TO <type> <any-value>
-//  else if (IS_BLANK(arg)) {
-//      ser = Make_Binary(0);
-//  }
     else
-        ser = Copy_Form_Value(arg, 1<<MOPT_TIGHT);
+        ser = Copy_Form_Value(arg, 1 << MOPT_TIGHT);
 
     return ser;
 }
@@ -355,7 +347,18 @@ static REBSER *make_binary(const REBVAL *arg, REBOOL make)
 //  MAKE_String: C
 //
 void MAKE_String(REBVAL *out, enum Reb_Kind kind, const REBVAL *def) {
-    if (IS_BLOCK(def)) {
+    REBSER *ser; // goto would cross initialization
+
+    if (IS_INTEGER(def)) {
+        //
+        // !!! R3-Alpha tolerated decimal, e.g. `make string! 3.14`, which
+        // is semantically nebulous (round up, down?) and generally bad.
+        //
+        ser = Make_Binary(Int32s(def, 0));
+        Val_Init_Series(out, kind, ser);
+        return;
+    }
+    else if (IS_BLOCK(def)) {
         //
         // The construction syntax for making strings or binaries that are
         // preloaded with an offset into the data is #[binary [#{0001} 2]].
@@ -386,10 +389,10 @@ void MAKE_String(REBVAL *out, enum Reb_Kind kind, const REBVAL *def) {
         return;
     }
 
-    REBSER *ser; // goto would cross initialization
-    ser = (kind != REB_BINARY)
-        ? make_string(def, TRUE)
-        : make_binary(def, TRUE);
+    if (kind == REB_BINARY)
+        ser = make_binary(def, TRUE);
+    else
+        ser = MAKE_TO_String_Common(def);
 
     if (!ser)
         goto bad_make;
@@ -407,14 +410,69 @@ bad_make:
 //
 void TO_String(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    REBSER *ser = (kind != REB_BINARY)
-        ? make_string(arg, FALSE)
-        : make_binary(arg, FALSE);
+    REBSER *ser;
+    if (kind == REB_BINARY)
+        ser = make_binary(arg, FALSE);
+    else
+        ser = MAKE_TO_String_Common(arg);
 
     if (!ser)
         fail (Error_Invalid_Arg(arg));
 
     Val_Init_Series(out, kind, ser);
+}
+
+
+//
+//  to-string: native [
+//
+//  {Like TO STRING! but with additional options.}
+//
+//      value [any-value!]
+//          {Value to convert to a string.}
+//      /astral
+//          {Provide special handling for codepoints bigger than 0xFFFF}
+//      handler [function! string! char!]
+//          {If function, receives integer argument of large codepoint value}
+//  ]
+//
+REBNATIVE(to_string)
+{
+    PARAM(1, value);
+    REFINE(2, astral);
+    PARAM(3, handler);
+
+    REBVAL *value = ARG(value);
+
+    if (!REF(astral) || !IS_BINARY(value)) {
+        TO_String(D_OUT, REB_STRING, value); // just act like TO STRING!
+        return R_OUT;
+    }
+
+    // Ordinarily, UTF8 decoding is done into the unicode buffer.  The number
+    // of unicode codepoints is guaranteed to be <= the number of UTF8 bytes,
+    // so the length is used as a conservative bound.  Since we don't know
+    // how many astral codepoints there are, it's not easy to know the size
+    // in advance.  So the series may be expanded multiple times.
+    //
+    REBSER *ser = Make_Unicode(VAL_LEN_AT(value));
+    if (Decode_UTF8_Maybe_Astral_Throws(
+        D_OUT,
+        ser,
+        VAL_BIN_AT(value),
+        VAL_LEN_AT(value),
+        TRUE, // cr/lf => lf conversion is done by TO_String (review)
+        ARG(handler)
+    )){
+        return R_OUT_IS_THROWN;
+    }
+
+    // !!! Note also that since this conversion does not go through the
+    // unicode buffer, so it's not copied out with "slimming" if it turns out
+    // to not contain wide chars.
+
+    Val_Init_String(D_OUT, ser);
+    return R_OUT;
 }
 
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -203,7 +203,6 @@ typedef void (*CLEANUP_FUNC)(const REBVAL*); // for some HANDLE!s GC callback
 typedef void (*MAKE_FUNC)(REBVAL*, enum Reb_Kind, const REBVAL*);
 typedef void (*TO_FUNC)(REBVAL*, enum Reb_Kind, const REBVAL*);
 
-#include "sys-scan.h"
 #include "sys-state.h"
 #include "sys-rebfrm.h" // `REBFRM` definition (also used by value)
 
@@ -712,6 +711,8 @@ struct Struct_Field; //forward declaration to avoid conflict in Prepare_Field_Fo
 
 #include "sys-frame.h"
 #include "sys-bind.h"
+
+#include "sys-scan.h"
 
 #include "reb-struct.h"
 

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -21,8 +21,11 @@ REBOL [
 ; These must be listed explicitly in order for the words to be collected
 ; as legal "globals" for the mezzanine context (otherwise SET would fail)
 
+; Note that TO-INTEGER and TO-STRING are currently their own natives with
+; additional refinements, and thus should not be overwritten here
+
 to-logic: to-decimal: to-percent: to-money: to-char: to-pair:
-to-tuple: to-time: to-date: to-binary: to-string: to-file: to-email: to-url: to-tag:
+to-tuple: to-time: to-date: to-binary: to-file: to-email: to-url: to-tag:
 to-bitset: to-image: to-vector: to-block: to-group:
 to-path: to-set-path: to-get-path: to-lit-path: to-map: to-datatype: to-typeset:
 to-word: to-set-word: to-get-word: to-lit-word: to-refinement: to-issue:


### PR DESCRIPTION
The current implementation limits codepoints in strings to 2 bytes in
size maximum (the "standard" unicode plane).  This means it's not
possible to represent codepoints in the higher planes, which are
humorously referred to as the "astral planes".

Historically these were not very commonly used, and were for more
esoteric historical languages (egyptian linear B).  The growth of
emoji usage has made them more common in Internet communication.

As a stopgap to full support, this makes TO-STRING a native which can
accept a handler.  This handler can substitute other string or
character values for the high codepoints, e.g.:

    >> test-data: #{22646973706C61796E616D65223A224A6F6E20F09F98BA22}
    == #{22646973706C61796E616D65223A224A6F6E20F09F98BA22}

    >> decode-cat: func [x] [
        if x = 128570 [return "[smiling cat with open mouth]"]
    ]

    >> to-string/astral test-data :decode-cat
    == {"displayname":"Jon [smiling cat with open mouth]"}

Literal characters or strings can also be passed as the parameter to
the /astral refinement.