### PR TITLE
Build patches on HaikuOS for gcc 2.95

### DIFF
--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -873,16 +873,16 @@ REBCTX *Construct_Context(
         opt_parent // parent
     );
 
-    const RELVAL *value = head ? head : END_CELL;
+    if (head == NULL)
+        return context;
 
-    if (head) Bind_Values_Shallow(head, context);
+    Bind_Values_Shallow(head, context);
 
+    const RELVAL *value = head;
     for (; NOT_END(value); value += 2) {
         //
         // !!! Objects are a rewrite in progress; error messages need to
         // be improved.
-
-        REBVAL *var;
 
         if (!IS_SET_WORD(value))
             fail (Error(RE_INVALID_TYPE, Type_Of(value)));
@@ -892,8 +892,7 @@ REBCTX *Construct_Context(
 
         assert(!IS_SET_WORD(value + 1)); // TBD: support set words!
 
-        var = GET_MUTABLE_VAR_MAY_FAIL(value, specifier);
-
+        REBVAL *var = GET_MUTABLE_VAR_MAY_FAIL(value, specifier);
         COPY_VALUE(var, value + 1, specifier);
     }
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -985,7 +985,7 @@ REBCTX *Make_Error_Core(REBCNT code, va_list *vaptr)
         //
         const RELVAL *temp =
             IS_STRING(message)
-                ? END_CELL
+                ? cast(const RELVAL*, END_CELL) // needed by gcc/g++ 2.95 (bug)
                 : VAL_ARRAY_HEAD(message);
     #endif
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -213,13 +213,16 @@ REBNATIVE(maybe)
 
     REB_R r;
     if (IS_BLOCK(test)) {
-        RELVAL *item;
+        const RELVAL *item;
         for (item = VAL_ARRAY_AT(test); NOT_END(item); ++item) {
             r = Do_Test_For_Maybe(
                 D_OUT,
                 value,
                 IS_WORD(item)
-                    ? GET_OPT_VAR_MAY_FAIL(item, VAL_SPECIFIER(test))
+                    ? cast(
+                        const RELVAL*,
+                        GET_OPT_VAR_MAY_FAIL(item, VAL_SPECIFIER(test))
+                    ) // cast needed for gcc/g++ 2.95 (bug)
                     : item
             );
 

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -28,6 +28,13 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 
+// lodepng uses the C++ iostream fail, but in the standard namespace, which
+// interferes with Ren-C's definition of the fail() macro.  It has to be
+// included before %sys-core.h.  See REBNATIVE(to_png) below for the only
+// usage of lodepng (added by Saphirion, due to bugs in the existing PNG code)
+//
+#include "png/lodepng.h"
+
 #include "sys-core.h"
 
 #define CLEAR_IMAGE(p, x, y) memset(p, 0, x * y * sizeof(u32))
@@ -1376,8 +1383,6 @@ REBINT PD_Image(REBPVS *pvs)
 // found a problem with that in terms of saving (saving only?) which they
 // added in lodepng for.  This is unfortunate as lodepng repeats deflate
 // code already available in Zlib.
-
-#include "png/lodepng.h"
 
 //
 //  to-png: native [

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -828,7 +828,9 @@ REBNATIVE(construct)
             target, // type
             NULL, // body
             // scan for toplevel set-words
-            IS_BLANK(body) ? END_CELL : VAL_ARRAY_AT(body),
+            IS_BLANK(body)
+                ? cast(const RELVAL*, END_CELL) // needed by gcc/g++ 2.95 (bug)
+                : VAL_ARRAY_AT(body),
             parent
         );
         Val_Init_Object(D_OUT, context);

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -88,9 +88,19 @@
     #include <stdio.h>
 
     // This header file brings in the ability to trigger a programmatic
-    // breakpoint in C code, by calling `debug_break();`
+    // breakpoint in C code, by calling `debug_break();`  It is not supported
+    // by HaikuOS R1, so instead kick into an infinite loop which can be
+    // broken and stepped out of in the debugger.
     //
-    #include "debugbreak.h"
+    #if defined(TO_HAIKU)
+        inline static int debug_break() {
+            int x = 0;
+            while (1) { ++x; }
+            x = 0; // set next statement in debugger to here
+        }
+    #else
+        #include "debugbreak.h"
+    #endif
 #endif
 
 // Special OS-specific definitions:


### PR DESCRIPTION
This allows building on HaikuOS with the distributed GCC 2.95 that
comes with the R1 alpha build, but must be built in C++ mode.

That version of GCC (over 15 years old) does not include options for
a C build to have declarations directly after statements.  That ability
was in C++ since its inception, and was formally added to C in the C99
standard.

There were a few errors resulting from compiler bugs regarding the
type coercion of ?: ternary operators.  Since there were so few and
accomodation so minor, casts were added to get the build working.

On the virtual machine tested, the compiler hit a problem when the
debug build was used.  So -DNDEBUG was also necessary.

The motivation for this is primarily to examine the dependencies of
the build, to see if it can still be built on older and more basic
platforms, using older compilers.