### PR TITLE
Make Date host API fill a date REBVAL, not arbitrary struct

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1609,6 +1609,41 @@ RL_API float RL_Val_Pair_Y_Float(const REBVAL *v) {
     return VAL_PAIR_Y(v);
 }
 
+//
+//  RL_Init_Date: C
+//
+// There was a data structure called a REBOL_DAT in R3-Alpha which was defined
+// in %reb-defs.h, and it appeared in the host callbacks to be used in
+// `os_get_time()` and `os_file_time()`.  This allowed the host to pass back
+// date information without actually knowing how to construct a date REBVAL.
+//
+// Today "host code" (which may all become "port code") is expected to either
+// be able to speak in terms of Rebol values through linkage to the internal
+// API or the more minimal RL_Api.  Either way, it should be able to make
+// REBVALs corresponding to dates...even if that means making a string of
+// the date to load and then RL_Do_String() to produce the value.
+//
+// This routine is a quick replacement for the format of the struct, as a
+// temporary measure while it is considered whether things like os_get_time()
+// will have access to the full internal API or not.
+//
+RL_API void RL_Init_Date(
+    REBVAL *out,
+    int year,
+    int month,
+    int day,
+    int time,
+    int nano,
+    int zone
+) {
+    VAL_RESET_HEADER(out, REB_DATE);
+    VAL_YEAR(out)  = year;
+    VAL_MONTH(out) = month;
+    VAL_DAY(out) = day;
+    VAL_ZONE(out) = zone / ZONE_MINS;
+    VAL_TIME(out) = TIME_SEC(time) + nano;
+}
+
 
 #include "reb-lib-lib.h"
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1382,18 +1382,6 @@ void Init_Task(void)
 
 
 //
-//  Init_Year: C
-//
-void Init_Year(void)
-{
-    REBOL_DAT dat;
-
-    OS_GET_TIME(&dat);
-    Current_Year = dat.year;
-}
-
-
-//
 //  Init_Core: C
 // 
 // Initialize the interpreter core.
@@ -1597,7 +1585,6 @@ void Init_Core(REBARGS *rargs)
         panic (Error(RE_MISC));
     }
 
-    Init_Year();
     Init_Crypto();
 
     // Initialize mezzanine functions:

--- a/src/core/e-func-symbols.c
+++ b/src/core/e-func-symbols.c
@@ -12,7 +12,6 @@ const void *rebol_symbols [] = {
     SYM_FUNC(Codec_UTF16BE), // b-init.c
     SYM_FUNC(Register_Codec), // b-init.c
     SYM_FUNC(Init_Task), // b-init.c
-    SYM_FUNC(Init_Year), // b-init.c
     SYM_FUNC(Init_Core), // b-init.c
     SYM_FUNC(Shutdown_Core), // b-init.c
     SYM_FUNC(Bind_Values_Core), // c-bind.c
@@ -479,7 +478,6 @@ const void *rebol_symbols [] = {
     SYM_FUNC(MAKE_Datatype), // t-datatype.c
     SYM_FUNC(TO_Datatype), // t-datatype.c
     SYM_FUNC(Set_Date_UTC), // t-date.c
-    SYM_FUNC(Set_Date), // t-date.c
     SYM_FUNC(CT_Date), // t-date.c
     SYM_FUNC(Emit_Date), // t-date.c
     SYM_FUNC(Julian_Date), // t-date.c
@@ -768,7 +766,6 @@ const void *rebol_symbols [] = {
     SYM_DATA(PG_Pool_Map),
 
     SYM_DATA(PG_Boot_Time),
-    SYM_DATA(Current_Year),
     SYM_DATA(Reb_Opts),
 
 #ifndef NDEBUG

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -510,44 +510,6 @@ const REBYTE *Scan_Money(const REBYTE *cp, REBCNT len, REBVAL *value)
     if (end != cp + len) return 0;
 
     return end;
-
-#ifdef ndef
-    REBYTE *bp = cp;
-    REBYTE buf[MAX_NUM_LEN+8];
-    REBYTE *ep = buf;
-    REBCNT n = 0;
-    REBOOL dig = FALSE;
-
-    if (*cp == '+') cp++;
-    else if (*cp == '-') *ep++ = *cp++;
-
-    if (*cp != '$') {
-        for (; Upper_Case[*cp] >= 'A' && Upper_Case[*cp] <= 'Z' && n < 3; cp++, n++) {
-            VAL_MONEY_DENOM(value)[n] = Upper_Case[*cp];
-        }
-        if (*cp != '$' || n > 3) return 0;
-        VAL_MONEY_DENOM(value)[n] = 0;
-    } else VAL_MONEY_DENOM(value)[0] = 0;
-    cp++;
-
-    while (ep < buf+MAX_NUM_LEN && (IS_LEX_NUMBER(*cp) || *cp == '\''))
-        if (*cp != '\'') *ep++ = *cp++, dig=1;
-        else cp++;
-    if (*cp == ',' || *cp == '.') cp++;
-    *ep++ = '.';
-    while (ep < buf+MAX_NUM_LEN && (IS_LEX_NUMBER(*cp) || *cp == '\''))
-        if (*cp != '\'') *ep++ = *cp++, dig=1;
-        else cp++;
-    if (!dig) return 0;
-    if (ep >= buf+MAX_NUM_LEN) return 0;
-    *ep = 0;
-
-    if ((REBCNT)(cp-bp) != len) return 0;
-    VAL_RESET_HEADER(value, REB_MONEY);
-    VAL_MONEY_AMOUNT(value) = atof((char*)(&buf[0]));
-    if (fabs(VAL_MONEY_AMOUNT(value)) == HUGE_VAL) fail (Error(RE_OVERFLOW));
-    return cp;
-#endif
 }
 
 
@@ -558,31 +520,34 @@ const REBYTE *Scan_Money(const REBYTE *cp, REBCNT len, REBVAL *value)
 //
 const REBYTE *Scan_Date(const REBYTE *cp, REBCNT len, REBVAL *value)
 {
-    const REBYTE *ep;
     const REBYTE *end = cp + len;
-    REBINT num;
-    REBINT day;
-    REBINT month;
-    REBINT year;
-    REBINT tz = 0;
-    REBYTE sep;
-    REBCNT size;
 
     // Skip spaces:
     for (; *cp == ' ' && cp != end; cp++);
 
     // Skip day name, comma, and spaces:
+    const REBYTE *ep;
     for (ep = cp; *ep != ',' && ep != end; ep++);
     if (ep != end) {
         cp = ep + 1;
         while (*cp == ' ' && cp != end) cp++;
     }
-    if (cp == end) return 0;
+    if (cp == end)
+        return NULL;
+
+    REBINT num;
 
     // Day or 4-digit year:
     ep = Grab_Int(cp, &num);
-    if (num < 0) return 0;
-    size = (REBCNT)(ep - cp);
+    if (num < 0)
+        return NULL;
+
+    REBINT day;
+    REBINT month;
+    REBINT year;
+    REBINT tz = 0;
+
+    REBCNT size = cast(REBCNT, ep - cp);
     if (size >= 4) {
         // year is set in this branch (we know because day is 0)
         // Ex: 2009/04/20/19:00:00+0:00
@@ -599,69 +564,111 @@ const REBYTE *Scan_Date(const REBYTE *cp, REBCNT len, REBVAL *value)
         // how it connects with year being set or not.  Suppress warning.
         year = MIN_I32; // !!! Garbage, should not be read.
     }
-    else return NULL;
+    else
+        return NULL;
 
     cp = ep;
 
     // Determine field separator:
-    if (*cp != '/' && *cp != '-' && *cp != '.' && *cp != ' ') return 0;
-    sep = *cp++;
+    if (*cp != '/' && *cp != '-' && *cp != '.' && *cp != ' ')
+        return NULL;
+
+    REBYTE sep = *cp++;
 
     // Month as number or name:
     ep = Grab_Int(cp, &num);
-    if (num < 0) return 0;
-    size = (REBCNT)(ep - cp);
-    if (size > 0) month = num;  // got a number
-    else {      // must be a word
-        for (ep = cp; IS_LEX_WORD(*ep); ep++); // scan word
-        size = (REBCNT)(ep - cp);
-        if (size < 3) return 0;
+    if (num < 0)
+        return NULL;
+
+    size = cast(REBCNT, ep - cp);
+
+    if (size > 0)
+        month = num; // got a number
+    else { // must be a word
+        for (ep = cp; IS_LEX_WORD(*ep); ep++)
+            NOOP; // scan word
+
+        size = cast(REBCNT, ep - cp);
+        if (size < 3)
+            return NULL;
+
         for (num = 0; num < 12; num++) {
-            if (!Compare_Bytes(cb_cast(Month_Names[num]), cp, size, TRUE)) break;
+            if (!Compare_Bytes(cb_cast(Month_Names[num]), cp, size, TRUE))
+                break;
         }
         month = num + 1;
     }
-    if (month < 1 || month > 12) return 0;
+
+    if (month < 1 || month > 12)
+        return NULL;
+
     cp = ep;
-    if (*cp++ != sep) return 0;
+    if (*cp++ != sep)
+        return NULL;
 
     // Year or day (if year was first):
     ep = Grab_Int(cp, &num);
-    if (*cp == '-' || num < 0) return 0;
-    size = (REBCNT)(ep - cp);
-    if (!size) return 0;
+    if (*cp == '-' || num < 0)
+        return NULL;
+
+    size = cast(REBCNT, ep - cp);
+    if (size == 0)
+        return NULL;
 
     if (day == 0) {
         // year already set, but day hasn't been
         day = num;
     }
     else {
-        // day has been set, but year hasn't been
-
-        // Allow shorthand form (e.g. /96) ranging +49,-51 years
-        //      (so in year 2050 a 0 -> 2000 not 2100)
-        if (size >= 3) year = num;
+        // day has been set, but year hasn't been.
+        if (size >= 3)
+            year = num;
         else {
-            year = (Current_Year / 100) * 100 + num;
-            if (year - Current_Year > 50) year -=100;
-            else if (year - Current_Year < -50) year += 100;
+            // !!! Originally this allowed shorthands, so that 96 = 1996, etc.
+            //
+            //     if (num >= 70)
+            //         year = 1900 + num;
+            //     else
+            //         year = 2000 + num;
+            //
+            // It was trickier than that, because it actually used the current
+            // year (from the clock) to guess what the short year meant.  That
+            // made it so the scanner would scan the same source code
+            // differently based on the clock, which is bad.  By allowing
+            // short dates to be turned into their short year equivalents, the
+            // user code can parse such dates and fix them up after the fact
+            // according to their requirements, `if date/year < 100 [...]`
+            // 
+            year = num;
         }
     }
-    if (year > MAX_YEAR || day < 1 || day > Month_Max_Days[month-1]) return 0;
+
+    if (year > MAX_YEAR || day < 1 || day > Month_Max_Days[month-1])
+        return NULL;
+
     // Check February for leap year or century:
     if (month == 2 && day == 29) {
-        if (((year % 4) != 0) ||        // not leap year
+        if (
+            ((year % 4) != 0) ||        // not leap year
             ((year % 100) == 0 &&       // century?
-            (year % 400) != 0)) return 0; // not leap century
+            (year % 400) != 0)
+        ){
+            return NULL; // not leap century
+        }
     }
 
     cp = ep;
     VAL_TIME(value) = NO_TIME;
-    if (cp >= end) goto end_date;
+    
+    if (cp >= end)
+        goto end_date;
 
     if (*cp == '/' || *cp == ' ') {
         sep = *cp++;
-        if (cp >= end) goto end_date;
+        
+        if (cp >= end)
+            goto end_date;
+
         cp = Scan_Time(cp, 0, value);
         if (
             !cp
@@ -677,28 +684,46 @@ const REBYTE *Scan_Date(const REBYTE *cp, REBCNT len, REBVAL *value)
 
     // Time zone can be 12:30 or 1230 (optional hour indicator)
     if (*cp == '-' || *cp == '+') {
-        if (cp >= end) goto end_date;
-        ep = Grab_Int(cp+1, &num);
-        if (ep-cp == 0) return 0;
+        if (cp >= end)
+            goto end_date;
+
+        ep = Grab_Int(cp + 1, &num);
+        if (ep - cp == 0)
+            return NULL;
+
         if (*ep != ':') {
-            int h, m;
-            if (num < -1500 || num > 1500) return 0;
-            h = (num / 100);
-            m = (num - (h * 100));
+            if (num < -1500 || num > 1500)
+                return NULL;
+
+            int h = (num / 100);
+            int m = (num - (h * 100));
+
             tz = (h * 60 + m) / ZONE_MINS;
-        } else {
-            if (num < -15 || num > 15) return 0;
-            tz = num * (60/ZONE_MINS);
+        }
+        else {
+            if (num < -15 || num > 15)
+                return NULL;
+
+            tz = num * (60 / ZONE_MINS);
+
             if (*ep == ':') {
-                ep = Grab_Int(ep+1, &num);
-                if (num % ZONE_MINS != 0) return 0;
+                ep = Grab_Int(ep + 1, &num);
+                if (num % ZONE_MINS != 0)
+                    return NULL;
+
                 tz += num / ZONE_MINS;
             }
         }
-        if (ep != end) return 0;
-        if (*cp == '-') tz = -tz;
+
+        if (ep != end)
+            return NULL;
+
+        if (*cp == '-')
+            tz = -tz;
+
         cp = ep;
     }
+
 end_date:
     Set_Date_UTC(value, year, month, day, VAL_TIME(value), tz);
     return cp;

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -92,20 +92,6 @@ static void Cleanup_File(REBREQ *file)
 
 
 //
-//  Set_File_Date: C
-// 
-// Set a value with the UTC date of a file.
-//
-static void Set_File_Date(REBREQ *file, REBVAL *val)
-{
-    REBOL_DAT dat;
-
-    OS_FILE_TIME(file, &dat);
-    Set_Date(val, &dat);
-}
-
-
-//
 //  Ret_Query_File: C
 // 
 // Query file and set RET value to resulting STD_FILE_INFO object.
@@ -113,13 +99,11 @@ static void Set_File_Date(REBREQ *file, REBVAL *val)
 void Ret_Query_File(REBCTX *port, REBREQ *file, REBVAL *ret)
 {
     REBVAL *info = In_Object(port, STD_PORT_SCHEME, STD_SCHEME_INFO, 0);
-    REBCTX *context;
-    REBSER *ser;
 
     if (!info || !IS_OBJECT(info))
         fail (Error_On_Port(RE_INVALID_SPEC, port, -10));
 
-    context = Copy_Context_Shallow(VAL_CONTEXT(info));
+    REBCTX *context = Copy_Context_Shallow(VAL_CONTEXT(info));
 
     Val_Init_Object(ret, context);
     Val_Init_Word(
@@ -130,9 +114,9 @@ void Ret_Query_File(REBCTX *port, REBREQ *file, REBVAL *ret)
     SET_INTEGER(
         CTX_VAR(context, STD_FILE_INFO_SIZE), file->special.file.size
     );
-    Set_File_Date(file, CTX_VAR(context, STD_FILE_INFO_DATE));
+    OS_FILE_TIME(CTX_VAR(context, STD_FILE_INFO_DATE), file);
 
-    ser = To_REBOL_Path(
+    REBSER *ser = To_REBOL_Path(
         file->special.file.path, 0, (OS_WIDE ? PATH_OPT_UNI_SRC : 0)
     );
 

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -53,23 +53,6 @@ void Set_Date_UTC(REBVAL *val, REBINT y, REBINT m, REBINT d, REBI64 t, REBINT z)
 
 
 //
-//  Set_Date: C
-// 
-// Convert OS date struct to REBOL value struct.
-// NOTE: Input zone is in minutes.
-//
-void Set_Date(REBVAL *val, REBOL_DAT *dat)
-{
-    VAL_YEAR(val)  = dat->year;
-    VAL_MONTH(val) = dat->month;
-    VAL_DAY(val)   = dat->day;
-    VAL_ZONE(val)  = dat->zone / ZONE_MINS;
-    VAL_TIME(val)  = TIME_SEC(dat->time) + dat->nano;
-    VAL_RESET_HEADER(val, REB_DATE);
-}
-
-
-//
 //  CT_Date: C
 //
 REBINT CT_Date(const RELVAL *a, const RELVAL *b, REBINT mode)

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -141,30 +141,38 @@ REBINT Cmp_Pair(const RELVAL *t1, const RELVAL *t2)
 //
 void Min_Max_Pair(REBVAL *out, const REBVAL *a, const REBVAL *b, REBOOL maxed)
 {
-    REBXYF aa;
+    // !!! This used to use REBXYF (a structure containing "X" and "Y" as
+    // floats).  It's not clear why floats would be preferred here, and
+    // also not clear what the types should be if they were mixed (INTEGER!
+    // vs. DECIMAL! for the X or Y).  REBXYF is now a structure only used
+    // in GOB! so it is taken out of mention here.
+
+    float ax;
+    float ay;
     if (IS_PAIR(a)) {
-        aa.x = VAL_PAIR_X(a);
-        aa.y = VAL_PAIR_Y(a);
+        ax = VAL_PAIR_X(a);
+        ay = VAL_PAIR_Y(a);
     }
     else if (IS_INTEGER(a))
-        aa.x = aa.y = cast(REBDEC, VAL_INT64(a));
+        ax = ay = cast(REBDEC, VAL_INT64(a));
     else
         fail (Error_Invalid_Arg(a));
 
-    REBXYF bb;
+    float bx;
+    float by;
     if (IS_PAIR(b)) {
-        bb.x = VAL_PAIR_X(b);
-        bb.y = VAL_PAIR_Y(b);
+        bx = VAL_PAIR_X(b);
+        by = VAL_PAIR_Y(b);
     }
     else if (IS_INTEGER(b))
-        bb.x = bb.y = cast(REBDEC, VAL_INT64(b));
+        bx = by = cast(REBDEC, VAL_INT64(b));
     else
         fail (Error_Invalid_Arg(b));
 
     if (maxed)
-        SET_PAIR(out, MAX(aa.x, bb.x), MAX(aa.y, bb.y));
+        SET_PAIR(out, MAX(ax, bx), MAX(ay, by));
     else
-        SET_PAIR(out, MIN(aa.x, bb.x), MIN(aa.y, bb.y));
+        SET_PAIR(out, MIN(ax, bx), MIN(ay, by));
 }
 
 

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -26,8 +26,16 @@
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// This file is used by internal and external C code. It
-// should not depend on many other header files prior to it.
+// This file is used by internal and external C code.  It should not depend
+// on any other include files before it.
+//
+// If REB_DEF is defined, it expects full definitions of the structures behind
+// REBVAL and REBSER.  If not, then it treats them opaquely.  The reason this
+// is done in a single file with an #ifdef as opposed to just doing the
+// opaque definitions in %reb-ext.h (and not including %reb-defs.h there) is
+// because of %a-lib.c - which wants to use the non-opaque definitions to
+// implement the API while still having the various enums in %reb-ext.h
+// available to the compiler.
 //
 
 #ifndef REB_DEFS_H  // due to sequences within the lib build itself
@@ -159,8 +167,6 @@
 #endif
 
 
-#pragma pack(4)
-
 struct Reb_Header {
     REBUPT bits;
 };
@@ -204,37 +210,5 @@ inline static void Init_Header_Aliased(struct Reb_Header *alias, REBUPT bits)
 {
     alias->bits = bits; // write from generic pointer to `struct Reb_Header`
 }
-
-
-// X/Y coordinate pair as floats:
-struct Reb_Pair {
-    float x;
-    float y;
-};
-
-// !!! Use this instead of struct Reb_Pair when all integer pairs are gone?
-// (Apparently PAIR went through an int-to-float transition at some point)
-/* typedef struct Reb_Pair REBPAR; */
-
-// !!! Temporary name for Reb_Pair "X and Y as floats"
-typedef struct Reb_Pair REBXYF;
-
-// X/Y coordinate pair as integers:
-typedef struct rebol_xy_int {
-    int x;
-    int y;
-} REBXYI;
-
-// Standard date and time:
-typedef struct rebol_dat {
-    int year;
-    int month;
-    int day;
-    int time;
-    int nano;
-    int zone;
-} REBOL_DAT;  // not same as REBDAT
-
-#pragma pack()
 
 #endif

--- a/src/include/reb-gob.h
+++ b/src/include/reb-gob.h
@@ -98,6 +98,16 @@ enum GOB_DTYPES {       // Userdata types
 
 #pragma pack(4)
 
+// These packed values for Rebol pairs are "X and Y coordinates" as "F"loat.
+// (For PAIR! in Ren-C, actual pairing series are used, which
+// can hold two values at full REBVAL precision (either integer or decimal)
+
+typedef struct {
+    float x;
+    float y;
+} REBXYF;
+
+
 typedef struct rebol_gob REBGOB;
 
 struct rebol_gob {

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -80,7 +80,6 @@ PVAR REBUNI *Lower_Cases;
 PVAR REBYTE *PG_Pool_Map;   // Memory pool size map (created on boot)
 
 PVAR REBI64 PG_Boot_Time;   // Counter when boot started
-PVAR REBINT Current_Year;
 PVAR REB_OPTS *Reb_Opts;
 
 #ifndef NDEBUG

--- a/src/os/windows/host-lib.c
+++ b/src/os/windows/host-lib.c
@@ -71,14 +71,17 @@ static void *Task_Ready;
 // Convert local format of system time into standard date
 // and time structure.
 //
-void Convert_Date(SYSTEMTIME *stime, REBOL_DAT *dat, long zone)
+void Convert_Date(REBVAL *out, long zone, const SYSTEMTIME *stime)
 {
-    dat->year  = stime->wYear;
-    dat->month = stime->wMonth;
-    dat->day   = stime->wDay;
-    dat->time  = stime->wHour * 3600 + stime->wMinute * 60 + stime->wSecond;
-    dat->nano  = 1000000 * stime->wMilliseconds;
-    dat->zone  = zone;
+    RL_Init_Date(
+        out,
+        stime->wYear, // year
+        stime->wMonth, // month
+        stime->wDay, // day
+        stime->wHour * 3600 + stime->wMinute * 60 + stime->wSecond, // "time"
+        1000000 * stime->wMilliseconds, // nano
+        zone
+    );
 }
 
 //
@@ -476,7 +479,7 @@ REBCHR *OS_List_Env(void)
 // 
 // Get the current system date/time in UTC plus zone offset (mins).
 //
-void OS_Get_Time(REBOL_DAT *dat)
+void OS_Get_Time(REBVAL *out)
 {
     SYSTEMTIME stime;
     TIME_ZONE_INFORMATION tzone;
@@ -486,7 +489,7 @@ void OS_Get_Time(REBOL_DAT *dat)
     if (TIME_ZONE_ID_DAYLIGHT == GetTimeZoneInformation(&tzone))
         tzone.Bias += tzone.DaylightBias;
 
-    Convert_Date(&stime, dat, -tzone.Bias);
+    Convert_Date(out, -tzone.Bias, &stime);
 }
 
 
@@ -554,7 +557,7 @@ REBOOL OS_Set_Current_Dir(REBCHR *path)
 // Convert file.time to REBOL date/time format.
 // Time zone is UTC.
 //
-void OS_File_Time(REBREQ *file, REBOL_DAT *dat)
+void OS_File_Time(REBVAL *out, REBREQ *file)
 {
     SYSTEMTIME stime;
     TIME_ZONE_INFORMATION tzone;
@@ -563,7 +566,7 @@ void OS_File_Time(REBREQ *file, REBOL_DAT *dat)
         tzone.Bias += tzone.DaylightBias;
 
     FileTimeToSystemTime(cast(FILETIME *, &file->special.file.time), &stime);
-    Convert_Date(&stime, dat, -tzone.Bias);
+    Convert_Date(out, -tzone.Bias, &stime);
 }
 
 

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -179,16 +179,7 @@ newline
 {#define HOST_LIB_SIZE} space proto-count newline
 
 {
-
-// Function signature typically used to provide the callback for
-// starting a thread, e.g. with beginthread()
-
 // !!! SEE **WARNING** BEFORE EDITING
-#ifdef WIN32
-    typedef void (__cdecl THREADFUNC)(void *);
-#else
-    typedef void (THREADFUNC)(void *);
-#endif
 
 #ifdef __cplusplus
 extern "C" ^{


### PR DESCRIPTION
There were two aspects to the "host kit".  One was a library for
calling Rebol services from C...the so-called Reb-Lib-Api, or "RL_API".
The obvious service was RL_Do_String(), which would LOAD and DO a
C string of UTF-8 text.

The other aspect was services provided by the host.  This covered
things such as getting the system time, starting processes, generating
UUIDs, etc.  Any time a platform-specific service was needed, a new
function would be added into the table that a host needed to provide.

(Note: One of the most generalized hooks was the provision of code
for creating requests for "rebol devices", and then polling or
dispatching to these devices.  This was similarly ad-hoc.)

Because Rebol was closed source, it was assumed that the code providing
the OS services did not have access to Rebol's "internal API".  This
meant that if data were to be exchanged between the interpreter and
the host, the Rebol side would have to formulate its query parameters
using something other than Rebol data.  And the result would be
handed back in the form of something other than Rebol data.  Then the
Rebol side would have to put it together into a Rebol value.

An example of this runaround was shown by the existence of a structure
called REBOL_DAT.  This was *not* how date data was encoded internally
to Rebol, rather it was a go-between C structure for passing the
various month/date/time/nanoseconds/timezone fields between the OS
get-time service (for NOW or reading times off files).

As a first step toward simplification, this commit switches to use an
actual REBVAL date to exchange this information.  A small RL_Api
routine to make a date is added; but the internal API could provide
this functionality, as could more generalized DO-based RL_Apis.