### PR TITLE
Working implementation of stack-frame GC'd pairings

### DIFF
--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -674,6 +674,27 @@ return_maybe_set_number_out:
 
 
 //
+//  Is_Context_Running_Or_Pending: C
+//
+REBOOL Is_Context_Running_Or_Pending(REBCTX *frame_ctx)
+{
+    if (GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK))
+        if (!GET_CTX_FLAG(frame_ctx, SERIES_FLAG_ACCESSIBLE))
+            return FALSE;
+
+    REBFRM *f = CTX_FRAME(frame_ctx);
+
+    if (NOT(Is_Any_Function_Frame(f)))
+        return FALSE;
+
+    if (Is_Function_Frame_Fulfilling(f))
+        return FALSE;
+
+    return TRUE;
+}
+
+
+//
 //  running?: native [
 //
 //  "Returns TRUE if a FRAME! is on the stack and executing (arguments done)."

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -946,7 +946,7 @@ const REBYTE *Scan_Pair(REBVAL *out, const REBYTE *cp, REBCNT len)
         return NULL;
 
     VAL_RESET_HEADER(out, REB_PAIR);
-    out->payload.pair = Make_Pairing(NULL);
+    out->payload.pair = Alloc_Pairing(NULL);
     VAL_RESET_HEADER(out->payload.pair, REB_DECIMAL);
     VAL_RESET_HEADER(PAIRING_KEY(out->payload.pair), REB_DECIMAL);
 

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -976,9 +976,9 @@ REBSER *Make_Series(REBCNT capacity, REBYTE wide, REBCNT flags)
 
 
 //
-//  Make_Pairing: C
+//  Alloc_Pairing: C
 //
-// Make a paired set of values.  The "key" is in the cell *before* the
+// Allocate a paired set of values.  The "key" is in the cell *before* the
 // returned pointer.
 //
 // Because pairings are created in large numbers and left outstanding, they
@@ -989,25 +989,42 @@ REBSER *Make_Series(REBCNT capacity, REBYTE wide, REBCNT flags)
 //
 // However, untracked/unmanaged pairings have a special ability.  It's
 // possible for them to be "owned" by a FRAME!, which sits in the first cell.
+// This provides an alternate mechanism for plain C code to do cleanup besides
+// handlers based on PUSH_TRAP().
 //
-REBVAL *Make_Pairing(REBCTX *opt_owning_frame) {
+REBVAL *Alloc_Pairing(REBCTX *opt_owning_frame) {
     REBSER *s = cast(REBSER*, Make_Node(SER_POOL)); // 2x REBVAL size
 
     REBVAL *key = cast(REBVAL*, s);
-    REBVAL *pairing = key + 1;
+    REBVAL *paired = key + 1;
 
     INIT_CELL_IF_DEBUG(key);
     if (opt_owning_frame) {
         Val_Init_Context(key, REB_FRAME, opt_owning_frame);
-        SET_VAL_FLAG(key, ANY_CONTEXT_FLAG_OWNS_PAIRED);
+        SET_VAL_FLAGS(
+            key, ANY_CONTEXT_FLAG_OWNS_PAIRED | REBSER_REBVAL_FLAG_ROOT
+        );
     }
-    else
-        SET_VOID(key); // won't signal GC, header is not purely 0
+    else {
+        // Client will need to put *something* in the key slot (accessed with
+        // PAIRING_KEY).  Whatever they end up writing should be acceptable
+        // to avoid a GC, since the header is not purely 0...and it works out
+        // that all "ordinary" values will just act as unmanaged metadata.
+        //
+        SET_TRASH_IF_DEBUG(key);
+    }
 
-    INIT_CELL_IF_DEBUG(pairing);
-    SET_BLANK(pairing); // default for AnyValue in Ren-Cpp, so same here
+    INIT_CELL_IF_DEBUG(paired);
+    SET_TRASH_IF_DEBUG(paired);
 
-    return pairing;
+#if !defined(NDEBUG)
+    s->guard = cast(int*, malloc(sizeof(*s->guard)));
+    free(s->guard);
+
+    s->do_count = TG_Do_Count;
+#endif
+
+    return paired;
 }
 
 
@@ -1033,7 +1050,12 @@ void Free_Pairing(REBVAL *paired) {
     REBVAL *key = PAIRING_KEY(paired);
     assert(!GET_VAL_FLAG(key, REBSER_REBVAL_FLAG_MANAGED));
     REBSER *series = cast(REBSER*, key);
+    SET_TRASH_IF_DEBUG(paired);
     Free_Node(SER_POOL, series);
+
+#if !defined(NDEBUG)
+    series->do_count = TG_Do_Count;
+#endif
 }
 
 
@@ -1428,10 +1450,6 @@ void GC_Kill_Series(REBSER *s)
     assert(!IS_FREE_NODE(s));
     assert(NOT(s->header.bits & CELL_MASK)); // use Free_Paired
 
-#if !defined(NDEBUG)
-    PG_Reb_Stats->Series_Freed++;
-#endif
-
     // Special handling for adjusting canons.  (REVIEW: do this by keeping the
     // symbol REBSERs in their own pools, and letting that pool's sweeper
     // do it instead of checking all series for it)
@@ -1506,6 +1524,14 @@ void GC_Kill_Series(REBSER *s)
 
     // GC may no longer be necessary:
     if (GC_Ballast > 0) CLR_SIGNAL(SIG_RECYCLE);
+
+#if !defined(NDEBUG)
+    PG_Reb_Stats->Series_Freed++;
+
+    // Update the do count to be the count on which the series was freed
+    //
+    s->do_count = TG_Do_Count;
+#endif
 }
 
 
@@ -1573,10 +1599,6 @@ void Free_Series(REBSER *s)
         Debug_Fmt("Trying to Free_Series() on a series managed by GC.");
         Panic_Series(s);
     }
-
-    // Update the do count to be the count on which the series was freed
-    //
-    s->do_count = TG_Do_Count;
 #endif
 
     Drop_Manual_Series(s);

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -497,11 +497,16 @@ ATTRIBUTE_NO_RETURN void Panic_Series_Debug(
     // during mold and other times.
     //
     printf("\n\n*** Panic_Series() in %s at line %d\n", file, line);
-    if (IS_FREE_NODE(series))
-        printf("Likely freed ");
+    if (IS_SERIES_MANAGED(series))
+        printf("managed");
     else
-        printf("Likely created ");
-    printf("during evaluator tick: %d\n", cast(REBCNT, series->do_count));
+        printf("unmanaged");
+    printf(" series was likely ");
+    if (IS_FREE_NODE(series))
+        printf("freed");
+    else
+        printf("created");
+    printf(" during evaluator tick: %d\n", cast(REBCNT, series->do_count));
     fflush(stdout);
 
     if (*series->guard == 1020) // should make valgrind or asan alert

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -384,7 +384,7 @@ REBNATIVE(brancher)
 
     RELVAL *body = FUNC_BODY(func);
 
-    REBVAL *branches = Make_Pairing(NULL);
+    REBVAL *branches = Alloc_Pairing(NULL);
     *PAIRING_KEY(branches) = *ARG(true_branch);
     *branches = *ARG(false_branch);
     Manage_Pairing(branches);

--- a/src/include/sys-pair.h
+++ b/src/include/sys-pair.h
@@ -65,7 +65,7 @@ inline static REBVAL *PAIRING_KEY(REBVAL *pairing) {
 
 inline static void SET_PAIR(RELVAL *v, float x, float y) {
     VAL_RESET_HEADER(v, REB_PAIR);
-    v->payload.pair = Make_Pairing(NULL);
+    v->payload.pair = Alloc_Pairing(NULL);
     SET_DECIMAL(PAIRING_KEY((v)->payload.pair), x);
     SET_DECIMAL((v)->payload.pair, y);
     Manage_Pairing((v)->payload.pair);


### PR DESCRIPTION
When it was made possible for "singular" Rebol Arrays to hold a value
inside the REBSER node itself (and still act as terminated), this
made it more feasible to use these singular arrays as a way of
generically getting GC behavior for small REBVAL-sized items.  This
was used in places like function bodies, or to make a form of HANDLE!
that could participate in GC.

Another place where lifetime management for individual REBVAL-sized
things would be helpful is the external C API (or "RL_API").  Before it
spoke in terms of proxy REBVALs called "RXIARG"s which had no design
for their lifetime.  If the REBVALs used in the API lived inside of
something like a singular REBSER, they could participate in GC, and
have their lifetime attached to something like the lifetime of the
function frame that requested them.

Although a singular array could be used for this purpose, the singular
array has a property that's not really needed...which is to have
termination via an END marker.  The REBVAL is isolated and does not
have to appear as a BLOCK! of values.  This raised the possibility of
coming up with another layout for the bits inside the REBSER...which
could actually lay two entire REBVALs inside of a REBSER node.

This new structure (known as a "pairing") meant the API exposed values
could also have a "meta value".  This value could be anything from an
INTEGER! reference count, to a HANDLE!, to a FRAME! of the function
which--when it is done running--should indicate the garbage collection
of the value and its pointer.  But also, it gave a reusable "exactly
two values long" form of series that could be used with very little
overhead--and which would be unlikely to fragment memory, because the
size was the commonly-used size of a REBSER.

This commit goes ahead and makes the FRAME!-based GC of these values
work (it was just pseudocode before).