### PR TITLE
Auto-generate of PARAM() and REFINE() defs for natives/actions

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -199,6 +199,7 @@ pick: action [
 
 find: action [
     {Searches for a value; for series returns where found, else blank.}
+    return: [any-series! blank! logic!]
     series [any-series! any-context! map! gob! bitset! typeset! blank!]
     value [<opt> any-value!]
     /part {Limits the search to a given length or position}
@@ -226,6 +227,9 @@ select: action [
     size [integer!]
     /last {Backwards from end of series}
     /reverse {Backwards from the current position}
+    /tail ;-- for frame compatibility with FIND
+    /match ;-- for frame compatibility with FIND
+
 ]
 
 ;;;;!!! MATCH

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1483,7 +1483,7 @@ RL_API REBI64 RL_Val_Time(const REBVAL *v) {
 //  RL_Val_Date: C
 //
 RL_API REBINT RL_Val_Date(const REBVAL *v) {
-    return VAL_ALL_BITS(v)[2]; // !!! This is what RXIARGs did.
+    return VAL_DATE(v).bits; // !!! Is this right?
 }
 
 //

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -420,8 +420,7 @@ REBNATIVE(action)
 // so when you write FOO: ACTION [...], the FOO: gets quoted to be the verb.
 // The SET/LOOKBACK is done by the bootstrap, after the natives are loaded.
 {
-    PARAM(1, verb);
-    PARAM(2, spec);
+    INCLUDE_PARAMS_OF_ACTION;
 
     REBVAL *spec = ARG(spec);
 

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -597,7 +597,7 @@ void Register_Scheme(REBSTR *name, REBPAF fun)
 //
 REBNATIVE(set_scheme)
 {
-    PARAM(1, scheme);
+    INCLUDE_PARAMS_OF_SET_SCHEME;
 
     REBVAL *name = Obj_Value(ARG(scheme), STD_SCHEME_NAME);
     if (!IS_WORD(name))

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -343,7 +343,7 @@ REBNATIVE(breakpoint)
 //
 REBNATIVE(pause)
 {
-    PARAM(1, code);
+    INCLUDE_PARAMS_OF_PAUSE;
 
     if (Do_Breakpoint_Throws(
         D_OUT,
@@ -389,12 +389,7 @@ REBNATIVE(resume)
 // each host doesn't have to rewrite interpretation in the hook--they only
 // need to recognize a RESUME throw and pass the argument back.
 {
-    REFINE(1, with);
-    PARAM(2, value);
-    REFINE(3, do);
-    PARAM(4, code);
-    REFINE(5, at);
-    PARAM(6, level);
+    INCLUDE_PARAMS_OF_RESUME;
 
     REBARR *instruction;
 

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -270,11 +270,11 @@ void Dump_Stack(REBFRM *f, REBCNT level)
 //
 REBNATIVE(dump)
 {
+    INCLUDE_PARAMS_OF_DUMP;
+
 #ifdef NDEBUG
     fail (Error(RE_DEBUG_ONLY));
 #else
-    PARAM(1, value);
-
     REBVAL *value = ARG(value);
 
     Dump_Stack(frame_, 0);

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -196,7 +196,7 @@ REBNATIVE(where_of)
 // !!! This routine should probably be used to get the information for the
 // where of an error, which should likely be out-of-band.
 {
-    PARAM(1, level);
+    INCLUDE_PARAMS_OF_WHERE_OF;
 
     REBFRM *frame = Frame_For_Stack_Level(NULL, ARG(level), TRUE);
     if (frame == NULL)
@@ -217,7 +217,7 @@ REBNATIVE(where_of)
 //
 REBNATIVE(label_of)
 {
-    PARAM(1, level);
+    INCLUDE_PARAMS_OF_LABEL_OF;
 
     REBFRM *frame = Frame_For_Stack_Level(NULL, ARG(level), TRUE);
 
@@ -246,7 +246,7 @@ REBNATIVE(label_of)
 //
 REBNATIVE(function_of)
 {
-    PARAM(1, level);
+    INCLUDE_PARAMS_OF_FUNCTION_OF;
 
     REBVAL *level = ARG(level);
 
@@ -282,7 +282,7 @@ REBNATIVE(function_of)
 //
 REBNATIVE(backtrace_index)
 {
-    PARAM(1, level);
+    INCLUDE_PARAMS_OF_BACKTRACE_INDEX;
 
     REBCNT number;
 
@@ -316,11 +316,7 @@ REBNATIVE(backtrace_index)
 //
 REBNATIVE(backtrace)
 {
-    PARAM(1, level);
-    REFINE(2, limit);
-    PARAM(3, frames);
-    REFINE(4, brief);
-    REFINE(5, only);
+    INCLUDE_PARAMS_OF_BACKTRACE;
 
     Check_Security(Canon(SYM_DEBUG), POL_READ, 0);
 
@@ -446,7 +442,7 @@ REBNATIVE(backtrace)
                 DS_PUSH_TRASH;
                 Val_Init_Word(DS_TOP, REB_WORD, Canon(SYM_PLUS));
 
-                if (!REF(brief)) {
+                if (NOT(REF(brief))) {
                     //
                     // In the non-/ONLY backtrace, the pairing of the ellipsis
                     // with a plus is used in order to keep the "record size"
@@ -704,7 +700,7 @@ REBOOL Is_Context_Running_Or_Pending(REBCTX *frame_ctx)
 //
 REBNATIVE(running_q)
 {
-    PARAM(1, frame);
+    INCLUDE_PARAMS_OF_RUNNING_Q;
 
     REBCTX *frame_ctx = VAL_CONTEXT(ARG(frame));
     if (GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK))
@@ -733,7 +729,7 @@ REBNATIVE(running_q)
 //
 REBNATIVE(pending_q)
 {
-    PARAM(1, frame);
+    INCLUDE_PARAMS_OF_PENDING_Q;
 
     REBCTX *frame_ctx = VAL_CONTEXT(ARG(frame));
     if (GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK))

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -225,9 +225,7 @@ void Trace_Error(const REBVAL *value)
 //
 REBNATIVE(trace)
 {
-    PARAM(1, mode);
-    REFINE(2, back);
-    REFINE(3, function);
+    INCLUDE_PARAMS_OF_TRACE;
 
     REBVAL *mode = ARG(mode);
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -87,9 +87,7 @@ REBNATIVE(load_extension)
 // quit() - cleanup anything needed
 // call() - dispatch a native
 {
-    PARAM(1, name);
-    REFINE(2, dispatch);
-    PARAM(3, function);
+    INCLUDE_PARAMS_OF_LOAD_EXTENSION;
 
     REBVAL *val = ARG(name);
 
@@ -99,7 +97,7 @@ REBNATIVE(load_extension)
 
     //Check_Security(SYM_EXTENSION, POL_EXEC, val);
 
-    if (!REF(dispatch)) { // use the DLL file
+    if (NOT(REF(dispatch))) { // use the DLL file
 
         if (!IS_FILE(val)) fail (Error_Invalid_Arg(val));
 
@@ -161,7 +159,7 @@ REBNATIVE(load_extension)
         cast(void*, cast(REBUPT, ext->index)) // data
     );
 
-    if (!REF(dispatch))
+    if (NOT(REF(dispatch)))
         *CTX_VAR(context, STD_EXTENSION_LIB_FILE) = *ARG(name);
 
     Val_Init_Binary(CTX_VAR(context, STD_EXTENSION_LIB_BOOT), src);
@@ -251,7 +249,7 @@ bad_func_def:
 //
 REBNATIVE(make_command)
 {
-    PARAM(1, def);
+    INCLUDE_PARAMS_OF_MAKE_COMMAND;
 
     REBVAL *def = ARG(def);
 

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -41,7 +41,7 @@ REBCNT Modify_Array(
     REBARR *dst_arr,        // target
     REBCNT dst_idx,         // position
     const REBVAL *src_val,  // source
-    REBCNT flags,           // AN_ONLY, AN_PART
+    REBCNT flags,           // AM_ONLY, AM_PART
     REBINT dst_len,         // length to remove
     REBINT dups             // dup count
 ) {
@@ -63,9 +63,9 @@ REBCNT Modify_Array(
     if (action == SYM_APPEND || dst_idx > tail) dst_idx = tail;
 
     // Check /PART, compute LEN:
-    if (!GET_FLAG(flags, AN_ONLY) && ANY_ARRAY(src_val)) {
+    if (NOT(flags & AM_ONLY) && ANY_ARRAY(src_val)) {
         // Adjust length of insertion if changing /PART:
-        if (action != SYM_CHANGE && GET_FLAG(flags, AN_PART))
+        if (action != SYM_CHANGE && (flags & AM_PART))
             ilen = dst_len;
         else
             ilen = VAL_LEN_AT(src_val);
@@ -99,7 +99,7 @@ REBCNT Modify_Array(
     else {
         if (size > dst_len)
             Expand_Series(ARR_SERIES(dst_arr), dst_idx, size-dst_len);
-        else if (size < dst_len && GET_FLAG(flags, AN_PART))
+        else if (size < dst_len && (flags & AM_PART))
             Remove_Series(ARR_SERIES(dst_arr), dst_idx, dst_len-size);
         else if (size + dst_idx > tail) {
             EXPAND_SERIES_TAIL(ARR_SERIES(dst_arr), size - (tail - dst_idx));
@@ -144,7 +144,7 @@ REBCNT Modify_String(
     REBSER *dst_ser,        // target
     REBCNT dst_idx,         // position
     const REBVAL *src_val,  // source
-    REBFLGS flags,          // AN_PART
+    REBFLGS flags,          // AM_PART, AM_BINARY_SERIES
     REBINT dst_len,         // length to remove
     REBINT dups             // dup count
 ) {
@@ -157,7 +157,7 @@ REBCNT Modify_String(
     REBINT limit;
 
     // For INSERT/PART and APPEND/PART
-    if (action != SYM_CHANGE && GET_FLAG(flags, AN_PART))
+    if (action != SYM_CHANGE && (flags & AM_PART))
         limit = dst_len; // should be non-negative
     else
         limit = -1;
@@ -166,7 +166,7 @@ REBCNT Modify_String(
     if (action == SYM_APPEND || dst_idx > tail) dst_idx = tail;
 
     // If the src_val is not a string, then we need to create a string:
-    if (GET_FLAG(flags, AN_SERIES)) { // used to indicate a BINARY series
+    if (flags & AM_BINARY_SERIES) {
         if (IS_INTEGER(src_val)) {
             src_ser = Make_Series_Codepoint(Int8u(src_val));
             needs_free = TRUE;
@@ -248,7 +248,7 @@ REBCNT Modify_String(
     } else {
         if (size > dst_len)
             Expand_Series(dst_ser, dst_idx, size - dst_len);
-        else if (size < dst_len && GET_FLAG(flags, AN_PART))
+        else if (size < dst_len && (flags & AM_PART))
             Remove_Series(dst_ser, dst_idx, dst_len - size);
         else if (size + dst_idx > tail) {
             EXPAND_SERIES_TAIL(dst_ser, size - (tail - dst_idx));

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -113,14 +113,15 @@ REBOOL Series_Common_Action_Returns(
         *r = R_OUT;
         return TRUE; // handled
 
-    case SYM_REMOVE:
-        // /PART length
+    case SYM_REMOVE: {
+        INCLUDE_PARAMS_OF_REMOVE;
+
         FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
-        len = D_REF(2) ? Partial(value, 0, D_ARG(3)) : 1;
+        len = REF(part) ? Partial(value, 0, ARG(limit)) : 1;
         index = cast(REBINT, VAL_INDEX(value));
         if (index < tail && len != 0)
             Remove_Series(VAL_SERIES(value), VAL_INDEX(value), len);
-        break;
+        break; }
 
     case SYM_ADD:         // Join_Strings(value, arg);
     case SYM_SUBTRACT:    // "test this" - 10

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -248,27 +248,6 @@ REBINT Int8u(const REBVAL *val)
 
 
 //
-//  Find_Refines: C
-// 
-// Scans the stack for function refinements that have been
-// specified in the mask (each as a bit) and are being used.
-//
-REBCNT Find_Refines(REBFRM *frame_, REBCNT mask)
-{
-    REBINT n;
-    REBCNT result = 0;
-
-    REBINT max = D_ARGC;
-
-    for (n = 0; n < max; n++) {
-        if ((mask & (1 << n) && D_REF(n + 1)))
-            result |= 1 << n;
-    }
-    return result;
-}
-
-
-//
 //  Val_Init_Datatype: C
 //
 void Val_Init_Datatype(REBVAL *out, enum Reb_Kind kind)

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1997,18 +1997,19 @@ void Shutdown_Scanner(void)
 //  
 //  {Translates UTF-8 binary source to values. Returns [value binary].}
 //  
-//      source [binary!] "Must be Unicode UTF-8 encoded"
-//      /next {Translate next complete value (blocks as single value)}
-//      /only "Translate only a single value (blocks dissected)"
-//      /error {Do not cause errors - return error object as value in place}
+//      source [binary!]
+//          "Must be Unicode UTF-8 encoded"
+//      /next
+//          {Translate next complete value (blocks as single value)}
+//      /only
+//          "Translate only a single value (blocks dissected)"
+//      /relax
+//          {Do not cause errors - return error object as value in place}
 //  ]
 //
 REBNATIVE(transcode)
 {
-    PARAM(1, source);
-    REFINE(2, next);
-    REFINE(3, only);
-    REFINE(4, relax);
+    INCLUDE_PARAMS_OF_TRANSCODE;
 
     SCAN_STATE scan_state;
 

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -55,8 +55,7 @@ extern const MAKE_FUNC Make_Dispatch[REB_MAX];
 //
 REBNATIVE(make)
 {
-    PARAM(1, type);
-    PARAM(2, def);
+    INCLUDE_PARAMS_OF_MAKE;
 
     REBVAL *type = ARG(type);
     REBVAL *arg = ARG(def);
@@ -159,8 +158,7 @@ REBNATIVE(make)
 //
 REBNATIVE(to)
 {
-    PARAM(1, type);
-    PARAM(2, value);
+    INCLUDE_PARAMS_OF_TO;
 
     REBVAL *type = ARG(type);
     REBVAL *arg = ARG(value);
@@ -1112,7 +1110,7 @@ REBNATIVE(scan_net_header)
 // It's only being converted into a native to avoid introducing bugs by
 // rewriting it as Rebol in the middle of other changes.
 {
-    PARAM(1, header);
+    INCLUDE_PARAMS_OF_SCAN_NET_HEADER;
 
     REBARR *result = Make_Array(10); // Just a guess at size (use STD_BUF?)
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -50,15 +50,12 @@
 #include "sys-core.h"
 
 
-// Shared logic for IF and UNLESS
+// Shared logic for IF and UNLESS (they have the same frame params layout)
 //
 inline static REB_R If_Unless_Core(REBFRM *frame_, REBOOL trigger)
 {
-    PARAM(1, condition);
-    PARAM(2, branch);
-    REFINE(3, only);
-    REFINE(4, q); //  return TRUE if branch taken, else FALSE
-
+    INCLUDE_PARAMS_OF_IF;  // ? is renamed as "q"
+    
     // Test is "safe", e.g. literal blocks aren't allowed, `if [x] [...]`
     //
     if (IS_CONDITIONAL_TRUE_SAFE(ARG(condition)) != trigger) {
@@ -150,10 +147,7 @@ REBNATIVE(unless)
 //
 REBNATIVE(either)
 {
-    PARAM(1, condition);
-    PARAM(2, true_branch);
-    PARAM(3, false_branch);
-    REFINE(4, only);
+    INCLUDE_PARAMS_OF_EITHER;
 
     return Either_Core(
         D_OUT,
@@ -178,7 +172,7 @@ REBNATIVE(either)
 //
 REBNATIVE(all)
 {
-    PARAM(1, block);
+    INCLUDE_PARAMS_OF_ALL;
 
     Reb_Enumerator e;
     PUSH_SAFE_ENUMERATOR(&e, ARG(block)); // DO-ing code could disrupt `block`
@@ -230,7 +224,7 @@ REBNATIVE(all)
 //
 REBNATIVE(any)
 {
-    PARAM(1, block);
+    INCLUDE_PARAMS_OF_ANY;
 
     Reb_Enumerator e;
     PUSH_SAFE_ENUMERATOR(&e, ARG(block)); // DO-ing code could disrupt `block`
@@ -283,7 +277,7 @@ REBNATIVE(none)
 // !!! In order to reduce confusion and accidents in the near term, the
 // %mezz-legacy.r renames this to NONE-OF and makes NONE report an error.
 {
-    PARAM(1, block);
+    INCLUDE_PARAMS_OF_NONE;
 
     Reb_Enumerator e;
     PUSH_SAFE_ENUMERATOR(&e, ARG(block)); // DO-ing code could disrupt `block`
@@ -331,13 +325,13 @@ REBNATIVE(none)
 //
 REBNATIVE(case)
 {
-    PARAM(1, block); // overwritten as scratch space after enumerator init
-    REFINE(2, all);
-    REFINE(3, only);
-    REFINE(4, q);
+    INCLUDE_PARAMS_OF_CASE; // ? is renamed as "q"
 
     Reb_Enumerator e;
     PUSH_SAFE_ENUMERATOR(&e, ARG(block)); // DO-ing cases could disrupt `block`
+
+    // With the block argument pushed in the enumerator, that frame slot is
+    // available for scratch space in the rest of the routine.
 
     while (NOT_END(e.value)) {
         UPDATE_EXPRESSION_START(&e); // informs the error delivery better
@@ -459,7 +453,7 @@ return_thrown:
 //          "Block of cases to check"
 //      /default
 //          "Default case if no others found"
-//      case
+//      default-case
 //          "Block to execute (or value to return)"
 //      /all
 //          "Evaluate all matches (not just first one)"
@@ -471,13 +465,7 @@ return_thrown:
 //
 REBNATIVE(switch)
 {
-    PARAM(1, value);
-    PARAM(2, cases);
-    REFINE(3, default);
-    PARAM(4, default_case);
-    REFINE(5, all);
-    REFINE(6, strict);
-    REFINE(7, q);
+    INCLUDE_PARAMS_OF_SWITCH; // ? is renamed as "q"
 
     Reb_Enumerator e;
     PUSH_SAFE_ENUMERATOR(&e, ARG(cases)); // DO-ing matches may disrupt `cases`
@@ -627,14 +615,7 @@ REBNATIVE(catch)
 // it (you have to CATCH/ANY/QUIT).  Currently the label for quitting is the
 // NATIVE! function value for QUIT.
 {
-    PARAM(1, block);
-    REFINE(2, name);
-    PARAM(3, names);
-    REFINE(4, quit);
-    REFINE(5, any);
-    REFINE(6, with);
-    PARAM(7, handler);
-    REFINE(8, q);
+    INCLUDE_PARAMS_OF_CATCH; // ? is renamed as "q"
 
     // /ANY would override /NAME, so point out the potential confusion
     //
@@ -791,9 +772,7 @@ REBNATIVE(throw)
 //
 // !!! Should parameters be /NAMED and NAME ?
 {
-    PARAM(1, value);
-    REFINE(2, name);
-    PARAM(3, name_value);
+    INCLUDE_PARAMS_OF_THROW;
 
     REBVAL *value = ARG(value);
 

--- a/src/core/n-crypt.c
+++ b/src/core/n-crypt.c
@@ -111,7 +111,7 @@ static void cleanup_rc4_ctx(const REBVAL *val)
 //  "Encrypt/decrypt data (modifies) using RC4 algorithm."
 //
 //      return: [handle!]
-//          "Returns stream cipher context handle.
+//          "Returns stream cipher context handle."
 //      /key
 //          "Provided only for the first time to get stream HANDLE!"
 //      crypt-key [binary!]
@@ -125,11 +125,7 @@ static void cleanup_rc4_ctx(const REBVAL *val)
 //
 REBNATIVE(rc4)
 {
-    REFINE(1, key);
-    PARAM(2, crypt_key);
-    REFINE(3, stream);
-    PARAM(4, ctx);
-    PARAM(5, data);
+    INCLUDE_PARAMS_OF_RC4;
 
     if (IS_HANDLE(ARG(ctx))) {
         REBVAL *data = ARG(data);
@@ -182,12 +178,7 @@ REBNATIVE(rc4)
 //
 REBNATIVE(rsa)
 {
-    PARAM(1, data);
-    PARAM(2, key_object);
-    REFINE(3, decrypt);
-    REFINE(4, private);
-    REFINE(5, padding);
-    PARAM(6, padding_type);
+    INCLUDE_PARAMS_OF_RSA;
 
     REBOOL padding;
     if (REF(padding))
@@ -355,7 +346,7 @@ REBNATIVE(rsa)
 //
 REBNATIVE(dh_generate_key)
 {
-    PARAM(1, obj);
+    INCLUDE_PARAMS_OF_DH_GENERATE_KEY;
 
     DH_CTX dh_ctx;
     memset(&dh_ctx, 0, sizeof(dh_ctx));
@@ -432,8 +423,7 @@ REBNATIVE(dh_generate_key)
 //
 REBNATIVE(dh_compute_key)
 {
-    PARAM(1, obj);
-    PARAM(2, public_key);
+    INCLUDE_PARAMS_OF_DH_COMPUTE_KEY;
 
     DH_CTX dh_ctx;
     memset(&dh_ctx, 0, sizeof(dh_ctx));
@@ -517,13 +507,7 @@ static void cleanup_aes_ctx(const REBVAL *val)
 //
 REBNATIVE(aes)
 {
-    REFINE(1, key);
-    PARAM(2, crypt_key);
-    PARAM(3, iv);
-    REFINE(4, stream);
-    PARAM(5, ctx);
-    PARAM(6, data);
-    REFINE(7, decrypt);
+    INCLUDE_PARAMS_OF_AES;
     
     if (IS_HANDLE(ARG(ctx))) {
         AES_CTX *aes_ctx = cast(AES_CTX*, VAL_HANDLE_DATA(ARG(ctx)));
@@ -722,9 +706,7 @@ REBOOL Cloak(
 //
 REBNATIVE(decloak)
 {
-    PARAM(1, data);
-    PARAM(2, key);
-    REFINE(3, with);
+    INCLUDE_PARAMS_OF_DECLOAK;
      
     if (!Cloak(
         TRUE,
@@ -757,9 +739,7 @@ REBNATIVE(decloak)
 //
 REBNATIVE(encloak)
 {
-    PARAM(1, data);
-    PARAM(2, key);
-    REFINE(3, with);
+    INCLUDE_PARAMS_OF_ENCLOAK;
 
     if (!Cloak(
         FALSE,

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -70,7 +70,9 @@ static REBOOL Check_Char_Range(REBVAL *val, REBINT limit)
 //
 REBNATIVE(ascii_q)
 {
-    return R_FROM_BOOL(Check_Char_Range(D_ARG(1), 0x7f));
+    INCLUDE_PARAMS_OF_ASCII_Q;
+
+    return R_FROM_BOOL(Check_Char_Range(ARG(value), 0x7f));
 }
 
 
@@ -84,7 +86,9 @@ REBNATIVE(ascii_q)
 //
 REBNATIVE(latin1_q)
 {
-    return R_FROM_BOOL(Check_Char_Range(D_ARG(1), 0xff));
+    INCLUDE_PARAMS_OF_LATIN1_Q;
+
+    return R_FROM_BOOL(Check_Char_Range(ARG(value), 0xff));
 }
 
 
@@ -100,7 +104,7 @@ REBNATIVE(latin1_q)
 //
 REBNATIVE(verify)
 {
-    PARAM(1, conditions);
+    INCLUDE_PARAMS_OF_VERIFY;
 
     if (IS_LOGIC(ARG(conditions))) {
         if (VAL_LOGIC(ARG(conditions)))
@@ -197,9 +201,7 @@ inline static REB_R Do_Test_For_Maybe(
 //
 REBNATIVE(maybe)
 {
-    PARAM(1, test);
-    PARAM(2, value);
-    REFINE(3, q);
+    INCLUDE_PARAMS_OF_MAYBE; // ? is renamed as "q"
 
     REBVAL *test = ARG(test);
     REBVAL *value = ARG(value);
@@ -270,8 +272,7 @@ type_matched:
 //
 REBNATIVE(as_pair)
 {
-    PARAM(1, x);
-    PARAM(2, y);
+    INCLUDE_PARAMS_OF_AS_PAIR;
 
     REBVAL *x = ARG(x);
     REBVAL *y = ARG(y);
@@ -307,12 +308,7 @@ REBNATIVE(as_pair)
 //
 REBNATIVE(bind)
 {
-    PARAM(1, value);
-    PARAM(2, target);
-    REFINE(3, copy);
-    REFINE(4, only);
-    REFINE(5, new);
-    REFINE(6, set);
+    INCLUDE_PARAMS_OF_BIND;
 
     REBVAL *value = ARG(value);
     REBVAL *target = ARG(target);
@@ -415,7 +411,7 @@ REBNATIVE(bind)
 //
 REBNATIVE(context_of)
 {
-    PARAM(1, word);
+    INCLUDE_PARAMS_OF_CONTEXT_OF;
 
     if (IS_WORD_UNBOUND(ARG(word))) return R_BLANK;
 
@@ -442,7 +438,7 @@ REBNATIVE(context_of)
 //
 REBNATIVE(any_value_q)
 {
-    PARAM(1, cell);
+    INCLUDE_PARAMS_OF_ANY_VALUE_Q;
 
     if (IS_VOID(ARG(cell)))
         return R_FALSE;
@@ -455,14 +451,15 @@ REBNATIVE(any_value_q)
 //  
 //  "Unbinds words from context."
 //  
-//      word [block! any-word!] "A word or block (modified) (returned)"
-//      /deep "Process nested blocks"
+//      word [block! any-word!]
+//          "A word or block (modified) (returned)"
+//      /deep
+//          "Process nested blocks"
 //  ]
 //
 REBNATIVE(unbind)
 {
-    PARAM(1, word);
-    REFINE(2, deep);
+    INCLUDE_PARAMS_OF_UNBIND;
 
     REBVAL *word = ARG(word);
 
@@ -494,15 +491,11 @@ REBNATIVE(unbind)
 //
 REBNATIVE(collect_words)
 {
-    PARAM(1, block);
-    REFINE(2, deep);
-    REFINE(3, set);
-    REFINE(4, ignore);
-    PARAM(5, hidden);
+    INCLUDE_PARAMS_OF_COLLECT_WORDS;
 
     REBARR *words;
     REBCNT modes;
-    RELVAL *values = VAL_ARRAY_AT(D_ARG(1));
+    RELVAL *values = VAL_ARRAY_AT(ARG(block));
     RELVAL *prior_values;
 
     if (REF(set))
@@ -552,8 +545,7 @@ REBNATIVE(get)
 // !!! Review if handling ANY-CONTEXT! is a good idea, or if that should be
 // an independent reflector like VALUES-OF.
 {
-    PARAM(1, source);
-    REFINE(2, opt);
+    INCLUDE_PARAMS_OF_GET;
 
     REBVAL *source = ARG(source);
 
@@ -617,7 +609,7 @@ REBNATIVE(get)
         *D_OUT = *source;
     }
 
-    if (!REF(opt) && IS_VOID(D_OUT))
+    if (NOT(REF(opt)) && IS_VOID(D_OUT))
         fail (Error_No_Value(source));
 
     return R_OUT;
@@ -635,7 +627,7 @@ REBNATIVE(get)
 //
 REBNATIVE(to_value)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_TO_VALUE;
 
     if (IS_VOID(ARG(value)))
         return R_BLANK;
@@ -657,7 +649,7 @@ REBNATIVE(to_value)
 //
 REBNATIVE(opt)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_OPT;
 
     if (IS_BLANK(ARG(value)))
         return R_VOID;
@@ -681,8 +673,7 @@ REBNATIVE(in)
 // !!! The argument names here are bad... not necessarily a context and not
 // necessarily a word.  `code` or `source` to be bound in a `target`, perhaps?
 {
-    PARAM(1, context);
-    PARAM(2, word);
+    INCLUDE_PARAMS_OF_IN;
 
     REBVAL *val = ARG(context); // object, error, port, block
     REBVAL *word = ARG(word);
@@ -766,12 +757,7 @@ REBNATIVE(in)
 //
 REBNATIVE(resolve)
 {
-    PARAM(1, target);
-    PARAM(2, source);
-    REFINE(3, only);
-    PARAM(4, from);
-    REFINE(5, all);
-    REFINE(6, extend);
+    INCLUDE_PARAMS_OF_RESOLVE;
 
     if (IS_INTEGER(ARG(from))) {
         // check range and sign
@@ -811,11 +797,7 @@ REBNATIVE(resolve)
 //
 REBNATIVE(set)
 {
-    PARAM(1, target);
-    PARAM(2, value);
-    REFINE(3, opt);
-    REFINE(4, pad);
-    REFINE(5, lookback);
+    INCLUDE_PARAMS_OF_SET;
 
     // Pointers independent from the arguments.  If we change them, they can
     // be reset to point at the original argument again.
@@ -826,7 +808,7 @@ REBNATIVE(set)
     REBCTX *value_specifier;
     REBOOL set_with_block;
 
-    if (!REF(opt) && IS_VOID(ARG(value)))
+    if (NOT(REF(opt)) && IS_VOID(ARG(value)))
         fail (Error(RE_NEED_VALUE, ARG(target)));
 
     enum Reb_Kind eval_type = REF(lookback) ? REB_0_LOOKBACK : REB_FUNCTION;
@@ -945,7 +927,7 @@ REBNATIVE(set)
             //
             if (!set_with_block) continue;
 
-            if (!REF(opt) && IS_VOID(value)) {
+            if (NOT(REF(opt)) && IS_VOID(value)) {
                 REBVAL key_name;
                 Val_Init_Word(&key_name, REB_WORD, VAL_KEY_SPELLING(key));
 
@@ -982,7 +964,8 @@ REBNATIVE(set)
                 continue;
 
             if (IS_END(value)) {
-                if (!REF(pad)) break;
+                if (NOT(REF(pad)))
+                    break;
                 SET_BLANK(var);
                 continue;
             }
@@ -1003,7 +986,7 @@ REBNATIVE(set)
     // words and giving an alert on unsets, check for any unsets before
     // setting half the values and interrupting.
     //
-    if (!REF(opt)) {
+    if (NOT(REF(opt))) {
         for (; NOT_END(target) && NOT_END(value); target++) {
             assert(!IS_VOID(value)); // blocks may not contain voids
 
@@ -1079,7 +1062,8 @@ REBNATIVE(set)
         if (set_with_block) {
             value++;
             if (IS_END(value)) {
-                if (!REF(pad)) break;
+                if (NOT(REF(pad)))
+                    break;
                 set_with_block = FALSE;
                 value = BLANK_VALUE;
                 value_specifier = SPECIFIED;
@@ -1103,7 +1087,7 @@ return_value_arg:
 //
 REBNATIVE(type_of)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_TYPE_OF;
 
     enum Reb_Kind kind = VAL_TYPE(ARG(value));
     if (kind == REB_MAX_VOID)
@@ -1127,7 +1111,7 @@ REBNATIVE(type_of)
 //
 REBNATIVE(unset)
 {
-    PARAM(1, target);
+    INCLUDE_PARAMS_OF_UNSET;
 
     REBVAL *target = ARG(target);
 
@@ -1162,7 +1146,9 @@ REBNATIVE(unset)
 //
 REBNATIVE(lookback_q)
 {
-    REBVAL *source = D_ARG(1);
+    INCLUDE_PARAMS_OF_LOOKBACK_Q;
+
+    REBVAL *source = ARG(source);
 
     if (ANY_WORD(source)) {
         enum Reb_Kind eval_type;
@@ -1201,7 +1187,7 @@ REBNATIVE(semiquoted_q)
 // even then it should be restricted to functions that have labeled
 // themselves as absolutely needing to do this for ergonomic reasons.
 {
-    PARAM(1, parameter);
+    INCLUDE_PARAMS_OF_SEMIQUOTED_Q;
 
     // !!! TBD: Enforce this is a function parameter (specific binding branch
     // makes the test different, and easier)
@@ -1224,7 +1210,7 @@ REBNATIVE(semiquoted_q)
 //
 REBNATIVE(semiquote)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_SEMIQUOTE;
 
     *D_OUT = *ARG(value);
 
@@ -1248,8 +1234,7 @@ REBNATIVE(semiquote)
 //
 REBNATIVE(as)
 {
-    PARAM(1, type);
-    PARAM(2, value);
+    INCLUDE_PARAMS_OF_AS;
 
     enum Reb_Kind kind = VAL_TYPE_KIND(ARG(type));
     REBVAL *value = ARG(value);
@@ -1300,8 +1285,7 @@ REBNATIVE(as)
 //
 REBNATIVE(aliases_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_ALIASES_Q;
 
     if (VAL_SERIES(ARG(value1)) == VAL_SERIES(ARG(value2)))
         return R_TRUE;
@@ -1368,7 +1352,7 @@ inline static REBOOL Is_Set_Modifies(REBVAL *location)
 //
 REBNATIVE(set_q)
 {
-    PARAM(1, location);
+    INCLUDE_PARAMS_OF_SET_Q;
 
     return R_FROM_BOOL(Is_Set_Modifies(ARG(location)));
 }
@@ -1386,7 +1370,7 @@ REBNATIVE(set_q)
 //
 REBNATIVE(unset_q)
 {
-    PARAM(1, location);
+    INCLUDE_PARAMS_OF_UNSET_Q;
 
     return R_FROM_BOOL(NOT(Is_Set_Modifies(ARG(location))));
 }
@@ -1404,7 +1388,7 @@ REBNATIVE(unset_q)
 //
 REBNATIVE(true_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_TRUE_Q;
 
     return R_FROM_BOOL(IS_CONDITIONAL_TRUE(ARG(value)));
 }
@@ -1429,7 +1413,7 @@ REBNATIVE(true_q)
 //
 REBNATIVE(false_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_FALSE_Q;
 
     return R_FROM_BOOL(IS_CONDITIONAL_FALSE(ARG(value)));
 }
@@ -1448,7 +1432,7 @@ REBNATIVE(false_q)
 //
 REBNATIVE(quote)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_QUOTE;
 
     *D_OUT = *ARG(value);
 
@@ -1473,7 +1457,7 @@ REBNATIVE(quote)
 //
 REBNATIVE(void_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_VOID_Q;
 
     return R_FROM_BOOL(IS_VOID(ARG(value)));
 }
@@ -1509,7 +1493,7 @@ REBNATIVE(void)
 //
 REBNATIVE(nothing_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_NOTHING_Q;
 
     return R_FROM_BOOL(
         LOGICAL(IS_BLANK(ARG(value)) || IS_VOID(ARG(value)))
@@ -1532,7 +1516,7 @@ REBNATIVE(nothing_q)
 //
 REBNATIVE(something_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_SOMETHING_Q;
 
     return R_FROM_BOOL(
         NOT(IS_BLANK(ARG(value)) || IS_VOID(ARG(value)))

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -53,8 +53,7 @@
 //
 REBNATIVE(eval)
 {
-    PARAM(1, value);
-    REFINE(2, only);
+    INCLUDE_PARAMS_OF_EVAL;
 
     REBFRM *f = frame_; // implicit parameter to every dispatcher/native
 
@@ -111,20 +110,16 @@ REBNATIVE(eval)
 //      /next
 //          {Do next expression only, return it, update block variable}
 //      var [any-word! blank!]
-//          "Variable updated with new block position"
+//          "If not blank, then a variable updated with new block position"
 //  ]
 //
 REBNATIVE(do)
 {
-    PARAM(1, value);
-    REFINE(2, args);
-    PARAM(3, arg);
-    REFINE(4, next);
-    PARAM(5, var); // if BLANK!, DO/NEXT only but no var update
+    INCLUDE_PARAMS_OF_DO;
 
-    REBVAL *value = ARG(value);
+    REBVAL *source = ARG(source);
 
-    switch (VAL_TYPE(value)) {
+    switch (VAL_TYPE(source)) {
     case REB_MAX_VOID:
         // useful for `do if ...` types of scenarios
         return R_VOID;
@@ -138,21 +133,19 @@ REBNATIVE(do)
         if (REF(next)) {
             REBIXO indexor = DO_NEXT_MAY_THROW(
                 D_OUT,
-                VAL_ARRAY(value),
-                VAL_INDEX(value),
-                VAL_SPECIFIER(value)
+                VAL_ARRAY(source),
+                VAL_INDEX(source),
+                VAL_SPECIFIER(source)
             );
 
             if (indexor == THROWN_FLAG) {
+                //
                 // the throw should make the value irrelevant, but if caught
                 // then have it indicate the start of the thrown expression
-
-                // !!! What if the block was mutated, and D_ARG(1) is no
-                // longer actually the expression that started the throw?
-
+                //
                 if (!IS_BLANK(ARG(var))) {
                     *GET_MUTABLE_VAR_MAY_FAIL(ARG(var), SPECIFIED)
-                        = *value;
+                        = *source;
                 }
 
                 return R_OUT_IS_THROWN;
@@ -169,18 +162,18 @@ REBNATIVE(do)
                 // recover the series again...you'd have to save it.
                 //
                 if (indexor == END_FLAG)
-                    VAL_INDEX(value) = VAL_LEN_HEAD(value);
+                    VAL_INDEX(source) = VAL_LEN_HEAD(source);
                 else
-                    VAL_INDEX(value) = cast(REBCNT, indexor);
+                    VAL_INDEX(source) = cast(REBCNT, indexor);
 
                 *GET_MUTABLE_VAR_MAY_FAIL(ARG(var), SPECIFIED)
-                    = *ARG(value);
+                    = *ARG(source);
             }
 
             return R_OUT;
         }
 
-        if (DO_VAL_ARRAY_AT_THROWS(D_OUT, value))
+        if (DO_VAL_ARRAY_AT_THROWS(D_OUT, source))
             return R_OUT_IS_THROWN;
 
         return R_OUT;
@@ -197,7 +190,7 @@ REBNATIVE(do)
             D_OUT,
             TRUE, // error if not all arguments consumed
             Sys_Func(SYS_CTX_DO_P),
-            value,
+            source,
             REF(args) ? TRUE_VALUE : FALSE_VALUE,
             REF(args) ? ARG(arg) : BLANK_VALUE, // can't put void in block
             REF(next) ? TRUE_VALUE : FALSE_VALUE,
@@ -216,14 +209,14 @@ REBNATIVE(do)
         // does.  However DO of an ERROR! would have to raise an error
         // anyway, so it might as well raise the one it is given.
         //
-        fail (VAL_CONTEXT(value));
+        fail (VAL_CONTEXT(source));
 
     case REB_FUNCTION: {
         //
         // Ren-C will only run arity 0 functions from DO, otherwise EVAL
         // must be used.  Look for the first non-local parameter to tell.
         //
-        REBVAL *param = FUNC_PARAMS_HEAD(VAL_FUNC(value));
+        REBVAL *param = FUNC_PARAMS_HEAD(VAL_FUNC(source));
         while (
             NOT_END(param)
             && (VAL_PARAM_CLASS(param) == PARAM_CLASS_LOCAL)
@@ -233,7 +226,7 @@ REBNATIVE(do)
         if (NOT_END(param))
             fail (Error(RE_USE_EVAL_FOR_EVAL));
 
-        if (EVAL_VALUE_THROWS(D_OUT, value))
+        if (EVAL_VALUE_THROWS(D_OUT, source))
             return R_OUT_IS_THROWN;
         return R_OUT;
     }
@@ -256,7 +249,7 @@ REBNATIVE(do)
         // is for" flavor.
         //
         assert(!GET_ARR_FLAG(
-            CTX_VARLIST(VAL_CONTEXT(value)), CONTEXT_FLAG_STACK)
+            CTX_VARLIST(VAL_CONTEXT(source)), CONTEXT_FLAG_STACK)
         );
 
         REBFRM frame;
@@ -266,11 +259,11 @@ REBNATIVE(do)
         // arguments to be filled in.
         //
         f->out = D_OUT;
-        f->gotten = CTX_FRAME_FUNC_VALUE(VAL_CONTEXT(value));
+        f->gotten = CTX_FRAME_FUNC_VALUE(VAL_CONTEXT(source));
         f->func = VAL_FUNC(f->gotten);
-        f->binding = VAL_BINDING(value);
+        f->binding = VAL_BINDING(source);
 
-        f->varlist = CTX_VARLIST(VAL_CONTEXT(value)); // need w/NULL def
+        f->varlist = CTX_VARLIST(VAL_CONTEXT(source)); // need w/NULL def
 
         return Apply_Frame_Core(f, Canon(SYM___ANONYMOUS__), NULL); }
 
@@ -301,8 +294,7 @@ REBNATIVE(do)
 //
 REBNATIVE(apply)
 {
-    PARAM(1, value);
-    PARAM(2, def);
+    INCLUDE_PARAMS_OF_APPLY;
 
     REBVAL *def = ARG(def);
 
@@ -354,8 +346,7 @@ REBNATIVE(apply)
 //
 REBNATIVE(also)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_ALSO;
 
     *D_OUT = *ARG(value1);
     return R_OUT;
@@ -375,7 +366,7 @@ REBNATIVE(also)
 //
 REBNATIVE(comment)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_COMMENT;
 
     // All the work was already done (at the cost of setting up
     // state that would just have to be torn down).

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -54,10 +54,7 @@
 //
 REBNATIVE(trap)
 {
-    PARAM(1, block);
-    REFINE(2, with);
-    PARAM(3, handler);
-    REFINE(4, q);
+    INCLUDE_PARAMS_OF_TRAP; // ? is renamed as "q"
 
     struct Reb_State state;
     REBCTX *error;
@@ -144,9 +141,7 @@ REBNATIVE(trap)
 //
 REBNATIVE(fail)
 {
-    PARAM(1, reason);
-    REFINE(2, where);
-    PARAM(3, location);
+    INCLUDE_PARAMS_OF_FAIL;
 
     REBVAL *reason = ARG(reason);
 
@@ -275,7 +270,9 @@ REBNATIVE(fail)
 //
 REBNATIVE(attempt)
 {
-    REBVAL *block = D_ARG(1);
+    INCLUDE_PARAMS_OF_ATTEMPT;
+
+    REBVAL *block = ARG(block);
 
     struct Reb_State state;
     REBCTX *error;

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -56,8 +56,7 @@ REBNATIVE(func)
 // Native optimized implementation of a "definitional return" function
 // generator.  See comments on Make_Function_May_Fail for full notes.
 {
-    PARAM(1, spec);
-    PARAM(2, body);
+    INCLUDE_PARAMS_OF_FUNC;
 
     REBFUN *fun = Make_Interpreted_Function_May_Fail(
         ARG(spec), ARG(body), MKF_RETURN | MKF_KEYWORDS
@@ -87,8 +86,7 @@ REBNATIVE(proc)
 // Provides convenient interface similar to FUNC that will not accidentally
 // leak values to the caller.
 {
-    PARAM(1, spec);
-    PARAM(2, body);
+    INCLUDE_PARAMS_OF_PROC;
 
     REBFUN *fun = Make_Interpreted_Function_May_Fail(
         ARG(spec), ARG(body), MKF_LEAVE | MKF_KEYWORDS
@@ -185,10 +183,7 @@ REBNATIVE(exit)
 // BACKTRACE number is a bit low-level, and perhaps should be restricted to
 // a debugging mode (though it is a useful tool in "code golf").
 {
-    REFINE(1, with);
-    PARAM(2, value);
-    REFINE(3, from);
-    PARAM(4, level);
+    INCLUDE_PARAMS_OF_EXIT;
 
     if (NOT(REF(from)))
         SET_INTEGER(ARG(level), 1); // default--exit one function stack level
@@ -211,7 +206,7 @@ REBNATIVE(exit)
 //
 REBNATIVE(return)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_RETURN;
 
     REBVAL *value = ARG(value);
     REBFRM *f = frame_; // implicit parameter to REBNATIVE()
@@ -283,8 +278,7 @@ REBNATIVE(leave)
 //
 REBNATIVE(typechecker)
 {
-    PARAM(1, type);
-    REFINE(2, opt);
+    INCLUDE_PARAMS_OF_TYPECHECKER;
 
     REBVAL *type = ARG(type);
 
@@ -356,8 +350,7 @@ REBNATIVE(brancher)
 // a function wanting to pull the trick ELSE is with its left hand side will
 // have to use some kind of quoting.
 {
-    PARAM(1, true_branch);
-    PARAM(2, false_branch);
+    INCLUDE_PARAMS_OF_BRANCHER;
 
     REBARR *paramlist = Make_Array(2);
     ARR_SERIES(paramlist)->link.meta = NULL;
@@ -411,8 +404,7 @@ REBNATIVE(brancher)
 //
 REBNATIVE(specialize)
 {
-    PARAM(1, value);
-    PARAM(2, def);
+    INCLUDE_PARAMS_OF_SPECIALIZE;
 
     REBSTR *opt_name;
 
@@ -447,8 +439,7 @@ REBNATIVE(specialize)
 //
 REBNATIVE(chain)
 {
-    PARAM(1, pipeline);
-    REFINE(2, quote);
+    INCLUDE_PARAMS_OF_CHAIN;
 
     REBVAL *out = D_OUT; // plan ahead for factoring into Chain_Function(out..
 
@@ -541,8 +532,7 @@ REBNATIVE(chain)
 //
 REBNATIVE(adapt)
 {
-    PARAM(1, adaptee);
-    PARAM(2, prelude);
+    INCLUDE_PARAMS_OF_ADAPT;
 
     REBVAL *adaptee = ARG(adaptee);
 
@@ -658,8 +648,7 @@ REBNATIVE(hijack)
 // case of trying to use unaligned refinements happens.
 //
 {
-    PARAM(1, victim);
-    PARAM(2, hijacker);
+    INCLUDE_PARAMS_OF_HIJACK;
 
     REBVAL victim_value;
     REBSTR *opt_victim_name;
@@ -796,7 +785,7 @@ REBNATIVE(hijack)
 //
 REBNATIVE(variadic_q)
 {
-    PARAM(1, func);
+    INCLUDE_PARAMS_OF_VARIADIC_Q;
 
     REBVAL *param = VAL_FUNC_PARAMS_HEAD(ARG(func));
     for (; NOT_END(param); ++param) {
@@ -838,7 +827,7 @@ REBNATIVE(tighten)
 //
 // But also, the parameter types and help notes are kept in sync.
 {
-    PARAM(1, action);
+    INCLUDE_PARAMS_OF_TIGHTEN;
 
     REBFUN *original = VAL_FUNC(ARG(action));
 

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -45,7 +45,7 @@
 //
 REBNATIVE(echo)
 {
-    PARAM(1, target);
+    INCLUDE_PARAMS_OF_ECHO;
 
     REBVAL *val = ARG(target);
 
@@ -91,11 +91,7 @@ REBNATIVE(echo)
 //
 REBNATIVE(form)
 {
-    PARAM(1, value);
-    REFINE(2, delimit);
-    PARAM(3, delimiter);
-    REFINE(4, quote);
-    REFINE(5, new);
+    INCLUDE_PARAMS_OF_FORM;
 
     REBVAL *value = ARG(value);
 
@@ -144,18 +140,19 @@ REBNATIVE(form)
 //  
 //  "Converts a value to a REBOL-readable string."
 //  
-//      value [any-value!] "The value to mold"
-//      /only {For a block value, mold only its contents, no outer []}
-//      /all "Use construction syntax"
-//      /flat "No indentation"
+//      value [any-value!]
+//          "The value to mold"
+//      /only
+//          {For a block value, mold only its contents, no outer []}
+//      /all
+//          "Use construction syntax"
+//      /flat
+//          "No indentation"
 //  ]
 //
 REBNATIVE(mold)
 {
-    PARAM(1, value);
-    REFINE(2, only);
-    REFINE(3, all);
-    REFINE(4, flat);
+    INCLUDE_PARAMS_OF_MOLD;
 
     REB_MOLD mo;
     CLEARS(&mo);
@@ -196,12 +193,7 @@ REBNATIVE(mold)
 //
 REBNATIVE(print)
 {
-    PARAM(1, value);
-    REFINE(2, only);
-    REFINE(3, delimit);
-    PARAM(4, delimiter);
-    REFINE(5, eval);
-    REFINE(6, quote);
+    INCLUDE_PARAMS_OF_PRINT;
 
     REBVAL *value = ARG(value);
 
@@ -267,11 +259,7 @@ REBNATIVE(print)
 //
 REBNATIVE(new_line)
 {
-    PARAM(1, position);
-    PARAM(2, mark);
-    REFINE(3, all);
-    REFINE(4, skip);
-    PARAM(5, size);
+    INCLUDE_PARAMS_OF_NEW_LINE;
 
     RELVAL *value = VAL_ARRAY_AT(ARG(position));
     REBOOL mark = IS_CONDITIONAL_TRUE(ARG(mark));
@@ -311,7 +299,7 @@ REBNATIVE(new_line)
 //
 REBNATIVE(new_line_q)
 {
-    PARAM(1, position);
+    INCLUDE_PARAMS_OF_NEW_LINE_Q;
 
     if (GET_VAL_FLAG(VAL_ARRAY_AT(ARG(position)), VALUE_FLAG_LINE))
         return R_TRUE;
@@ -427,15 +415,15 @@ REBNATIVE(now)
 //  "Waits for a duration, port, or both."
 //  
 //      value [any-number! time! port! block! blank!]
-//      /all "Returns all in a block"
-//      /only {only check for ports given in the block to this function}
+//      /all
+//          "Returns all in a block"
+//      /only
+//          {only check for ports given in the block to this function}
 //  ]
 //
 REBNATIVE(wait)
 {
-    PARAM(1, value);
-    REFINE(2, all);
-    REFINE(3, only);
+    INCLUDE_PARAMS_OF_WAIT;
 
     REBINT timeout = 0; // in milliseconds
     REBARR *ports = NULL;
@@ -501,8 +489,8 @@ REBNATIVE(wait)
     if (ports) Val_Init_Block(D_OUT, ports);
 
     // Process port events [stack-move]:
-    if (!Wait_Ports(ports, timeout, D_REF(3))) {
-        Sieve_Ports(NULL); /* just reset the waked list */
+    if (!Wait_Ports(ports, timeout, REF(only))) {
+        Sieve_Ports(NULL); // just reset the waked list
         return R_BLANK;
     }
     if (!ports) return R_BLANK;
@@ -510,7 +498,7 @@ REBNATIVE(wait)
     // Determine what port(s) waked us:
     Sieve_Ports(ports);
 
-    if (!REF(all)) {
+    if (NOT(REF(all))) {
         val = ARR_HEAD(ports);
         if (IS_PORT(val)) *D_OUT = *KNOWN(val);
         else SET_BLANK(D_OUT);
@@ -534,8 +522,7 @@ REBNATIVE(wake_up)
 // Calls port update for native actors.
 // Calls port awake function.
 {
-    PARAM(1, port);
-    PARAM(2, event);
+    INCLUDE_PARAMS_OF_WAKE_UP;
 
     REBCTX *port = VAL_CONTEXT(ARG(port));
     REBOOL awakened = TRUE; // start by assuming success
@@ -575,13 +562,15 @@ REBNATIVE(wake_up)
 //
 REBNATIVE(to_rebol_file)
 {
-    REBVAL *arg = D_ARG(1);
-    REBSER *ser;
+    INCLUDE_PARAMS_OF_TO_REBOL_FILE;
 
-    ser = Value_To_REBOL_Path(arg, FALSE);
-    if (!ser) fail (Error_Invalid_Arg(arg));
+    REBVAL *arg = ARG(path);
+    
+    REBSER *ser = Value_To_REBOL_Path(arg, FALSE);
+    if (ser == NULL)
+        fail (Error_Invalid_Arg(arg));
+    
     Val_Init_File(D_OUT, ser);
-
     return R_OUT;
 }
 
@@ -592,18 +581,21 @@ REBNATIVE(to_rebol_file)
 //  {Converts a REBOL file path to the local system file path.}
 //  
 //      path [file! string!]
-//      /full {Prepends current dir for full path (for relative paths only)}
+//      /full
+//          {Prepends current dir for full path (for relative paths only)}
 //  ]
 //
 REBNATIVE(to_local_file)
 {
-    REBVAL *arg = D_ARG(1);
-    REBSER *ser;
+    INCLUDE_PARAMS_OF_TO_LOCAL_FILE;
 
-    ser = Value_To_Local_Path(arg, D_REF(2));
-    if (!ser) fail (Error_Invalid_Arg(arg));
+    REBVAL *arg = ARG(path);
+    
+    REBSER *ser = Value_To_Local_Path(arg, REF(full));
+    if (ser == NULL)
+        fail (Error_Invalid_Arg(arg));
+
     Val_Init_String(D_OUT, ser);
-
     return R_OUT;
 }
 
@@ -665,7 +657,7 @@ REBNATIVE(what_dir)
 //
 REBNATIVE(change_dir)
 {
-    PARAM(1, path);
+    INCLUDE_PARAMS_OF_CHANGE_DIR;
 
     REBVAL *arg = ARG(path);
     REBVAL *current_path = Get_System(SYS_OPTIONS, OPTIONS_CURRENT_PATH);
@@ -705,58 +697,70 @@ REBNATIVE(change_dir)
 //  "Open web browser to a URL or local file."
 //
 //      return: [<opt>]
-//      url [url! file! blank!]
+//      location [url! file! blank!]
 //  ]
 //
 REBNATIVE(browse)
 {
-    REBINT r;
-    REBCHR *url = 0;
-    REBVAL *arg = D_ARG(1);
+    INCLUDE_PARAMS_OF_BROWSE;
 
-    Check_Security(Canon(SYM_BROWSE), POL_EXEC, arg);
+    REBVAL *location = ARG(location);
 
-    if (IS_BLANK(arg))
+    Check_Security(Canon(SYM_BROWSE), POL_EXEC, location);
+
+    if (IS_BLANK(location))
         return R_VOID;
 
     // !!! By passing NULL we don't get backing series to protect!
-    url = Val_Str_To_OS_Managed(NULL, arg);
+    //
+    REBCHR *url = Val_Str_To_OS_Managed(NULL, location);
 
-    r = OS_BROWSE(url, 0);
+    REBINT r = OS_BROWSE(url, 0);
 
-    if (r == 0) {
-        return R_VOID;
-    } else {
+    if (r != 0) {
         Make_OS_Error(D_OUT, r);
         fail (Error(RE_CALL_FAIL, D_OUT));
     }
 
     return R_VOID;
+
 }
 
 
 //
 //  call: native [
 //  
-//  "Run another program; return immediately."
+//  "Run another program; return immediately (unless /WAIT)."
 //  
 //      command [string! block! file!] 
-//      {An OS-local command line (quoted as necessary), a block with arguments, or an executable file}
-//      
-//      /wait "Wait for command to terminate before returning"
-//      /console "Runs command with I/O redirected to console"
-//      /shell "Forces command to be run from shell"
-//      /info "Returns process information object"
-//      /input in [string! binary! file! blank!]
+//          {An OS-local command line (quoted as necessary), a block with
+//          arguments, or an executable file}
+//      /wait
+//          "Wait for command to terminate before returning"
+//      /console
+//          "Runs command with I/O redirected to console"
+//      /shell
+//          "Forces command to be run from shell"
+//      /info
+//          "Returns process information object"
+//      /input
 //          "Redirects stdin to in"
-//      /output out [string! binary! file! blank!]
+//      in [string! binary! file! blank!]
+//      /output
 //          "Redirects stdout to out"
-//      /error err [string! binary! file! blank!]
+//      out [string! binary! file! blank!]
+//      /error
 //          "Redirects stderr to err"
+//      err [string! binary! file! blank!]
 //  ]
 //
 REBNATIVE(call)
+//
+// !!! Parameter usage may require WAIT mode even if not explicitly requested. 
+// /WAIT should be default, with /ASYNC (or otherwise) as exception!
 {
+    INCLUDE_PARAMS_OF_CALL;
+
 #define INHERIT_TYPE 0
 #define NONE_TYPE 1
 #define STRING_TYPE 2
@@ -769,7 +773,7 @@ REBNATIVE(call)
 #define FLAG_INFO 8
 
     REBINT r;
-    REBVAL *arg = D_ARG(1);
+    REBVAL *arg = ARG(command);
     REBU64 pid = MAX_U64; // Was REBI64 of -1, but OS_CREATE_PROCESS wants u64
     u32 flags = 0;
 
@@ -820,26 +824,14 @@ REBNATIVE(call)
     REBCNT output_len = 0;
     REBCNT err_len = 0;
 
-    // Parameter usage may require WAIT mode even if not explicitly requested
-    // !!! /WAIT should be default, with /ASYNC (or otherwise) as exception!
-    //
-    REBOOL flag_wait = FALSE;
-    REBOOL flag_console = FALSE;
-    REBOOL flag_shell = FALSE;
-    REBOOL flag_info = FALSE;
-
     int exit_code = 0;
 
     Check_Security(Canon(SYM_CALL), POL_EXEC, arg);
 
-    if (D_REF(2)) flag_wait = TRUE;
-    if (D_REF(3)) flag_console = TRUE;
-    if (D_REF(4)) flag_shell = TRUE;
-    if (D_REF(5)) flag_info = TRUE;
-
     // If input_ser is set, it will be both managed and saved
-    if (D_REF(6)) {
-        REBVAL *param = D_ARG(7);
+    //
+    if (REF(input)) {
+        REBVAL *param = ARG(in);
         input = param;
         if (IS_STRING(param)) {
             input_type = STRING_TYPE;
@@ -873,8 +865,8 @@ REBNATIVE(call)
     // OS_FREE().)  Hence the case for FILE! is handled specially, where the
     // output_ser must be unsaved instead of OS_FREE()d.
     //
-    if (D_REF(8)) {
-        REBVAL *param = D_ARG(9);
+    if (REF(output)) {
+        REBVAL *param = ARG(out);
         output = param;
         if (IS_STRING(param)) {
             output_type = STRING_TYPE;
@@ -900,8 +892,9 @@ REBNATIVE(call)
     (void)input; // suppress unused warning but keep variable
 
     // Error case...same note about FILE! case as with Output case above
-    if (D_REF(10)) {
-        REBVAL *param = D_ARG(11);
+    //
+    if (REF(error)) {
+        REBVAL *param = ARG(err);
         err = param;
         if (IS_STRING(param)) {
             err_type = STRING_TYPE;
@@ -924,20 +917,29 @@ REBNATIVE(call)
             fail (Error_Invalid_Arg(param));
     }
 
-    /* I/O redirection implies /wait */
-    if (input_type == STRING_TYPE
-        || input_type == BINARY_TYPE
-        || output_type == STRING_TYPE
-        || output_type == BINARY_TYPE
-        || err_type == STRING_TYPE
-        || err_type == BINARY_TYPE) {
-        flag_wait = TRUE;
+    if (
+        REF(wait) ||
+        (
+            input_type == STRING_TYPE
+            || input_type == BINARY_TYPE
+            || output_type == STRING_TYPE
+            || output_type == BINARY_TYPE
+            || err_type == STRING_TYPE
+            || err_type == BINARY_TYPE
+        ) // I/O redirection implies /WAIT
+
+    ){
+        flags |= FLAG_WAIT;
     }
 
-    if (flag_wait) flags |= FLAG_WAIT;
-    if (flag_console) flags |= FLAG_CONSOLE;
-    if (flag_shell) flags |= FLAG_SHELL;
-    if (flag_info) flags |= FLAG_INFO;
+    if (REF(console))
+        flags |= FLAG_CONSOLE;
+
+    if (REF(shell))
+        flags |= FLAG_SHELL;
+
+    if (REF(info))
+        flags |= FLAG_INFO;
 
     // Translate the first parameter into an `argc` and a pointer array for
     // `argv[]`.  The pointer array is backed by `argv_series` which must
@@ -1083,11 +1085,11 @@ REBNATIVE(call)
     if (output_ser) DROP_GUARD_SERIES(output_ser);
     if (input_ser) DROP_GUARD_SERIES(input_ser);
 
-    if (flag_info) {
+    if (REF(info)) {
         REBCTX *info = Alloc_Context(2);
 
         SET_INTEGER(Append_Context(info, NULL, Canon(SYM_ID)), pid);
-        if (flag_wait)
+        if (REF(wait))
             SET_INTEGER(
                 Append_Context(info, NULL, Canon(SYM_EXIT_CODE)),
                 exit_code
@@ -1104,7 +1106,8 @@ REBNATIVE(call)
 
     // We may have waited even if they didn't ask us to explicitly, but
     // we only return a process ID if /WAIT was not explicitly used
-    if (flag_wait)
+    //
+    if (REF(wait))
         SET_INTEGER(D_OUT, exit_code);
     else
         SET_INTEGER(D_OUT, pid);
@@ -1253,14 +1256,7 @@ static REBARR *File_List_To_Array(const REBCHR *str)
 //
 REBNATIVE(request_file)
 {
-    REFINE(1, save);
-    REFINE(2, multi);
-    REFINE(3, file);
-    PARAM(4, name);
-    REFINE(5, title);
-    PARAM(5, text);
-    REFINE(6, filter);
-    PARAM(7, list);
+    INCLUDE_PARAMS_OF_REQUEST_FILE;
 
     // !!! This routine used to have an ENABLE_GC and DISABLE_GC
     // reference.  It is not clear what that was protecting, but
@@ -1338,7 +1334,7 @@ REBNATIVE(request_file)
 //
 REBNATIVE(get_env)
 {
-    PARAM(1, var);
+    INCLUDE_PARAMS_OF_GET_ENV;
 
     REBVAL *var = ARG(var);
 
@@ -1379,8 +1375,7 @@ REBNATIVE(get_env)
 //
 REBNATIVE(set_env)
 {
-    PARAM(1, var);
-    PARAM(2, value);
+    INCLUDE_PARAMS_OF_SET_ENV;
 
     REBVAL *var = ARG(var);
     REBVAL *value = ARG(value);
@@ -1434,24 +1429,29 @@ REBNATIVE(list_env)
 //
 //  access-os: native [
 //  
-//  {Access to various operating system functions (getuid, setuid, getpid, kill, etc.)}
+//  {Access various OS functions (getuid, setuid, getpid, kill, etc.)}
 //  
-//      field [word!] "uid, euid, gid, egid, pid"
-//      /set "To set or kill pid (sig 15)"
+//      field [word!]
+//          "uid, euid, gid, egid, pid"
+//      /set
+//          "To set or kill pid (sig 15)"
 //      value [integer! block!] 
-//      {Argument, such as uid, gid, or pid (in which case, it could be a block with the signal no)}
+//          {Argument, such as uid, gid, or pid (in which case, it could be
+//          a block with the signal number)}
 //  ]
 //
 REBNATIVE(access_os)
 {
+    INCLUDE_PARAMS_OF_ACCESS_OS;
+
 #define OS_ENA   -1
 #define OS_EINVAL -2
 #define OS_EPERM -3
 #define OS_ESRCH -4
 
-    REBVAL *field = D_ARG(1);
-    REBOOL set = D_REF(2);
-    REBVAL *val = D_ARG(3);
+    REBVAL *field = ARG(field);
+    REBOOL set = REF(set);
+    REBVAL *val = ARG(value);
 
     switch (VAL_WORD_SYM(field)) {
         case SYM_UID:

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -106,14 +106,15 @@ static void Arc_Trans(REBVAL *out, const REBVAL *value, REBOOL degrees, REBCNT k
 //  
 //  "Returns the trigonometric cosine."
 //  
-//      value [any-number!] "In degrees by default"
-//      /radians "Value is specified in radians"
+//      value [any-number!]
+//          "In degrees by default"
+//      /radians
+//          "Value is specified in radians"
 //  ]
 //
 REBNATIVE(cosine)
 {
-    PARAM(1, value);
-    REFINE(2, radians);
+    INCLUDE_PARAMS_OF_COSINE;
 
     REBDEC dval = cos(Trig_Value(ARG(value), NOT(REF(radians)), COSINE));
     if (fabs(dval) < DBL_EPSILON) dval = 0.0;
@@ -127,14 +128,15 @@ REBNATIVE(cosine)
 //  
 //  "Returns the trigonometric sine."
 //  
-//      value [any-number!] "In degrees by default"
-//      /radians "Value is specified in radians"
+//      value [any-number!]
+//          "In degrees by default"
+//      /radians
+//          "Value is specified in radians"
 //  ]
 //
 REBNATIVE(sine)
 {
-    PARAM(1, value);
-    REFINE(2, radians);
+    INCLUDE_PARAMS_OF_SINE;
 
     REBDEC dval = sin(Trig_Value(ARG(value), NOT(REF(radians)), SINE));
     if (fabs(dval) < DBL_EPSILON) dval = 0.0;
@@ -148,14 +150,15 @@ REBNATIVE(sine)
 //  
 //  "Returns the trigonometric tangent."
 //  
-//      value [any-number!] "In degrees by default"
-//      /radians "Value is specified in radians"
+//      value [any-number!]
+//          "In degrees by default"
+//      /radians
+//          "Value is specified in radians"
 //  ]
 //
 REBNATIVE(tangent)
 {
-    PARAM(1, value);
-    REFINE(2, radians);
+    INCLUDE_PARAMS_OF_TANGENT;
 
     REBDEC dval = Trig_Value(ARG(value), NOT(REF(radians)), TANGENT);
     if (Eq_Decimal(fabs(dval), pi1 / 2.0)) fail (Error(RE_OVERFLOW));
@@ -170,13 +173,13 @@ REBNATIVE(tangent)
 //  {Returns the trigonometric arccosine (in degrees by default).}
 //  
 //      value [any-number!]
-//      /radians "Returns result in radians"
+//      /radians
+//          "Returns result in radians"
 //  ]
 //
 REBNATIVE(arccosine)
 {
-    PARAM(1, value);
-    REFINE(2, radians);
+    INCLUDE_PARAMS_OF_ARCCOSINE;
 
     Arc_Trans(D_OUT, ARG(value), NOT(REF(radians)), COSINE);
     return R_OUT;
@@ -189,13 +192,13 @@ REBNATIVE(arccosine)
 //  {Returns the trigonometric arcsine (in degrees by default).}
 //  
 //      value [any-number!]
-//      /radians "Returns result in radians"
+//      /radians
+//          "Returns result in radians"
 //  ]
 //
 REBNATIVE(arcsine)
 {
-    PARAM(1, value);
-    REFINE(2, radians);
+    INCLUDE_PARAMS_OF_ARCSINE;
 
     Arc_Trans(D_OUT, ARG(value), NOT(REF(radians)), SINE);
     return R_OUT;
@@ -208,13 +211,13 @@ REBNATIVE(arcsine)
 //  {Returns the trigonometric arctangent (in degrees by default).}
 //  
 //      value [any-number!]
-//      /radians "Returns result in radians"
+//      /radians
+//          "Returns result in radians"
 //  ]
 //
 REBNATIVE(arctangent)
 {
-    PARAM(1, value);
-    REFINE(2, radians);
+    INCLUDE_PARAMS_OF_ARCTANGENT;
 
     Arc_Trans(D_OUT, ARG(value), NOT(REF(radians)), TANGENT);
     return R_OUT;
@@ -231,7 +234,9 @@ REBNATIVE(arctangent)
 //
 REBNATIVE(exp)
 {
-    REBDEC  dval = AS_DECIMAL(D_ARG(1));
+    INCLUDE_PARAMS_OF_EXP;
+
+    REBDEC dval = AS_DECIMAL(ARG(power));
     static REBDEC eps = EPS;
 
     dval = pow(eps, dval);
@@ -251,7 +256,9 @@ REBNATIVE(exp)
 //
 REBNATIVE(log_10)
 {
-    REBDEC dval = AS_DECIMAL(D_ARG(1));
+    INCLUDE_PARAMS_OF_LOG_10;
+
+    REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval <= 0) fail (Error(RE_POSITIVE));
     SET_DECIMAL(D_OUT, log10(dval));
     return R_OUT;
@@ -268,7 +275,9 @@ REBNATIVE(log_10)
 //
 REBNATIVE(log_2)
 {
-    REBDEC dval = AS_DECIMAL(D_ARG(1));
+    INCLUDE_PARAMS_OF_LOG_2;
+
+    REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval <= 0) fail (Error(RE_POSITIVE));
     SET_DECIMAL(D_OUT, log(dval) / LOG2);
     return R_OUT;
@@ -285,7 +294,9 @@ REBNATIVE(log_2)
 //
 REBNATIVE(log_e)
 {
-    REBDEC dval = AS_DECIMAL(D_ARG(1));
+    INCLUDE_PARAMS_OF_LOG_E;
+
+    REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval <= 0) fail (Error(RE_POSITIVE));
     SET_DECIMAL(D_OUT, log(dval));
     return R_OUT;
@@ -302,7 +313,9 @@ REBNATIVE(log_e)
 //
 REBNATIVE(square_root)
 {
-    REBDEC dval = AS_DECIMAL(D_ARG(1));
+    INCLUDE_PARAMS_OF_SQUARE_ROOT;
+
+    REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval < 0) fail (Error(RE_POSITIVE));
     SET_DECIMAL(D_OUT, sqrt(dval));
     return R_OUT;
@@ -339,9 +352,7 @@ REBNATIVE(square_root)
 //
 REBNATIVE(shift)
 {
-    PARAM(1, value);
-    PARAM(2, bits);
-    REFINE(3, logical);
+    INCLUDE_PARAMS_OF_SHIFT;
 
     REBI64 b = VAL_INT64(ARG(bits));
     REBVAL *a = ARG(value);
@@ -521,8 +532,7 @@ compare:
 //
 REBNATIVE(equal_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_EQUAL_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), 0))
         return R_TRUE;
@@ -542,8 +552,7 @@ REBNATIVE(equal_q)
 //
 REBNATIVE(not_equal_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_NOT_EQUAL_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), 0))
         return R_FALSE;
@@ -563,8 +572,7 @@ REBNATIVE(not_equal_q)
 //
 REBNATIVE(strict_equal_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_STRICT_EQUAL_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), 1))
         return R_TRUE;
@@ -584,8 +592,7 @@ REBNATIVE(strict_equal_q)
 //
 REBNATIVE(strict_not_equal_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_STRICT_NOT_EQUAL_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), 1))
         return R_FALSE;
@@ -611,8 +618,7 @@ REBNATIVE(same_q)
 // Rather than incur a cost for all comparisons, this handles the issue
 // specially for those types which support it.
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_SAME_Q;
 
     REBVAL *value1 = ARG(value1);
     REBVAL *value2 = ARG(value2);
@@ -720,8 +726,7 @@ REBNATIVE(same_q)
 //
 REBNATIVE(lesser_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_LESSER_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), -1))
         return R_FALSE;
@@ -740,8 +745,7 @@ REBNATIVE(lesser_q)
 //
 REBNATIVE(lesser_or_equal_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_LESSER_OR_EQUAL_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), -2))
         return R_FALSE;
@@ -760,8 +764,7 @@ REBNATIVE(lesser_or_equal_q)
 //
 REBNATIVE(greater_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_GREATER_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), -2))
         return R_TRUE;
@@ -780,8 +783,7 @@ REBNATIVE(greater_q)
 //
 REBNATIVE(greater_or_equal_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_GREATER_OR_EQUAL_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), -1))
         return R_TRUE;
@@ -801,8 +803,7 @@ REBNATIVE(greater_or_equal_q)
 //
 REBNATIVE(maximum)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_MAXIMUM;
 
     const REBVAL *value1 = ARG(value1);
     const REBVAL *value2 = ARG(value2);
@@ -833,8 +834,7 @@ REBNATIVE(maximum)
 //
 REBNATIVE(minimum)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_MINIMUM;
 
     const REBVAL *value1 = ARG(value1);
     const REBVAL *value2 = ARG(value2);
@@ -865,7 +865,7 @@ REBNATIVE(minimum)
 //
 REBNATIVE(negative_q)
 {
-    PARAM(1, number);
+    INCLUDE_PARAMS_OF_NEGATIVE_Q;
 
     REBVAL zero;
     SET_ZEROED(&zero, VAL_TYPE(ARG(number)));
@@ -887,7 +887,7 @@ REBNATIVE(negative_q)
 //
 REBNATIVE(positive_q)
 {
-    PARAM(1, number);
+    INCLUDE_PARAMS_OF_POSITIVE_Q;
 
     REBVAL zero;
     SET_ZEROED(&zero, VAL_TYPE(ARG(number)));
@@ -909,7 +909,7 @@ REBNATIVE(positive_q)
 //
 REBNATIVE(zero_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_ZERO_Q;
 
     enum Reb_Kind type = VAL_TYPE(ARG(value));
 

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -229,10 +229,7 @@ REB_R Pending_Native_Dispatcher(REBFRM *f) {
 //
 REBNATIVE(make_native)
 {
-    PARAM(1, spec);
-    PARAM(2, source);
-    REFINE(3, linkname);
-    PARAM(4, name);
+    INCLUDE_PARAMS_OF_MAKE_NATIVE;
     
 #if !defined(WITH_TCC)
     fail (Error(RE_NOT_TCC_BUILD));
@@ -348,13 +345,11 @@ REBNATIVE(make_native)
 //
 REBNATIVE(compile)
 {
+    INCLUDE_PARAMS_OF_COMPILE;
+
 #if !defined(WITH_TCC)
     fail (Error(RE_NOT_TCC_BUILD));
 #else
-    PARAM(1, natives);
-    REFINE(2, options);
-    PARAM(3, flags);
-
     REBVAL *natives = ARG(natives);
 
     REBOOL debug = FALSE; // !!! not implemented yet

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -100,9 +100,7 @@ REBOOL Reduce_Any_Array_Throws(
 //
 REBNATIVE(reduce)
 {
-    PARAM(1, value);
-    REFINE(2, into);
-    PARAM(3, target);
+    INCLUDE_PARAMS_OF_REDUCE;
 
     REBVAL *value = ARG(value);
 
@@ -129,7 +127,7 @@ REBNATIVE(reduce)
     if (EVAL_VALUE_THROWS(D_OUT, value))
         return R_OUT_IS_THROWN;
 
-    if (!REF(into))
+    if (NOT(REF(into)))
         return R_OUT; // just return the evaluated item if no /INTO target
 
     REBVAL *into = ARG(target);
@@ -303,11 +301,7 @@ REBOOL Compose_Any_Array_Throws(
 //
 REBNATIVE(compose)
 {
-    PARAM(1, value);
-    REFINE(2, deep);
-    REFINE(3, only);
-    REFINE(4, into);
-    PARAM(5, out);
+    INCLUDE_PARAMS_OF_COMPOSE;
 
     // !!! Should 'compose quote (a (1 + 2) b)' give back '(a 3 b)' ?
     // What about 'compose quote a/(1 + 2)/b' ?

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -279,11 +279,7 @@ static REBSER *Make_Set_Operation_Series(
 //
 REBNATIVE(difference)
 {
-    PARAM(1, series1);
-    PARAM(2, series2);
-    REFINE(3, case);
-    REFINE(4, skip);
-    PARAM(5, size);
+    INCLUDE_PARAMS_OF_DIFFERENCE;
 
     REBVAL *val1 = ARG(series1);
     REBVAL *val2 = ARG(series2);
@@ -350,11 +346,7 @@ REBNATIVE(difference)
 //
 REBNATIVE(exclude)
 {
-    PARAM(1, series);
-    PARAM(2, exclusions);
-    REFINE(3, case);
-    REFINE(4, skip);
-    PARAM(5, size);
+    INCLUDE_PARAMS_OF_EXCLUDE;
 
     REBVAL *val1 = ARG(series);
     REBVAL *val2 = ARG(exclusions);
@@ -409,11 +401,7 @@ REBNATIVE(exclude)
 //
 REBNATIVE(intersect)
 {
-    PARAM(1, series1);
-    PARAM(2, series2);
-    REFINE(3, case);
-    REFINE(4, skip);
-    PARAM(5, size);
+    INCLUDE_PARAMS_OF_INTERSECT;
 
     REBVAL *val1 = ARG(series1);
     REBVAL *val2 = ARG(series2);
@@ -467,11 +455,7 @@ REBNATIVE(intersect)
 //
 REBNATIVE(union)
 {
-    PARAM(1, series1);
-    PARAM(2, series2);
-    REFINE(3, case);
-    REFINE(4, skip);
-    PARAM(5, size);
+    INCLUDE_PARAMS_OF_UNION;
 
     REBVAL *val1 = ARG(series1);
     REBVAL *val2 = ARG(series2);
@@ -524,10 +508,7 @@ REBNATIVE(union)
 //
 REBNATIVE(unique)
 {
-    PARAM(1, series);
-    REFINE(2, case);
-    REFINE(3, skip);
-    PARAM(4, size);
+    INCLUDE_PARAMS_OF_UNIQUE;
 
     REBVAL *val = ARG(series);
 

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -82,7 +82,9 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         }
         return R_BLANK;
 
-    case SYM_READ:
+    case SYM_READ: {
+        INCLUDE_PARAMS_OF_READ;
+
         // This device is opened on the READ:
         if (!IS_OPEN(req)) {
             if (OS_DO_DEVICE(req, RDC_OPEN))
@@ -115,23 +117,24 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         }
 
         *D_OUT = *arg;
-        return R_OUT;
+        return R_OUT; }
 
-    case SYM_WRITE:
+    case SYM_WRITE: {
+        INCLUDE_PARAMS_OF_WRITE;
+
         if (!IS_STRING(arg) && !IS_BINARY(arg))
             fail (Error(RE_INVALID_PORT_ARG, arg));
+        
         // This device is opened on the WRITE:
         if (!IS_OPEN(req)) {
             if (OS_DO_DEVICE(req, RDC_OPEN))
                 fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
         }
 
-        refs = Find_Refines(frame_, ALL_WRITE_REFS);
-
         // Handle /part refinement:
         len = VAL_LEN_AT(arg);
-        if (refs & AM_WRITE_PART && VAL_INT32(D_ARG(ARG_WRITE_LIMIT)) < len)
-            len = VAL_INT32(D_ARG(ARG_WRITE_LIMIT));
+        if (REF(part) && VAL_INT32(ARG(limit)) < len)
+            len = VAL_INT32(ARG(limit));
 
         // If bytes, see if we can fit it:
         if (SER_WIDE(VAL_SERIES(arg)) == 1) {
@@ -173,12 +176,13 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         if (result < 0) fail (Error_On_Port(RE_WRITE_ERROR, port, req->error));
         //if (result == DR_DONE) SET_BLANK(CTX_VAR(port, STD_PORT_DATA));
-        break;
+        break; }
 
-    case SYM_OPEN:
+    case SYM_OPEN: {
+        INCLUDE_PARAMS_OF_OPEN;
         if (OS_DO_DEVICE(req, RDC_OPEN))
             fail (Error_On_Port(RE_CANNOT_OPEN, port, req->error));
-        break;
+        break; }
 
     case SYM_CLOSE:
         OS_DO_DEVICE(req, RDC_CLOSE);

--- a/src/core/p-console.c
+++ b/src/core/p-console.c
@@ -59,7 +59,8 @@ static REB_R Console_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     switch (action) {
 
-    case SYM_READ:
+    case SYM_READ: {
+        INCLUDE_PARAMS_OF_READ;
 
         // If not open, open it:
         if (!IS_OPEN(req)) {
@@ -83,45 +84,18 @@ static REB_R Console_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         req->common.data = SER_DATA_RAW(ser);
         req->length = SER_AVAIL(ser);
 
-#ifdef nono
-        // Is the buffer large enough?
-        req->length = SER_AVAIL(ser); // space available
-        if (req->length < OUT_BUF_SIZE/2) Extend_Series(ser, OUT_BUF_SIZE);
-        req->length = SER_AVAIL(ser);
-
-        // Don't make buffer too large:  Bug #174   ?????
-        if (req->length > 1024) req->length = 1024;  //???
-        req->common.data = BIN_TAIL(ser); // write at tail  //???
-        if (SER_LEN(ser) == 0) req->actual = 0;  //???
-#endif
-
         result = OS_DO_DEVICE(req, RDC_READ);
         if (result < 0) fail (Error_On_Port(RE_READ_ERROR, port, req->error));
 
-#ifdef nono
-        // Does not belong here!!
-        // Remove or replace CRs:
-        result = 0;
-        for (n = 0; n < req->actual; n++) {
-            chr = GET_ANY_CHAR(ser, n);
-            if (chr == CR) {
-                chr = LF;
-                // Skip LF if it follows:
-                if ((n+1) < req->actual &&
-                    LF == GET_ANY_CHAR(ser, n+1)) n++;
-            }
-            SET_ANY_CHAR(ser, result, chr);
-            result++;
-        }
-#endif
         // !!! Among many confusions in this file, it said "Another copy???"
         //Val_Init_String(D_OUT, Copy_OS_Str(ser->data, result));
         Val_Init_Binary(D_OUT, Copy_Bytes(req->common.data, req->actual));
-        break;
+        break; }
 
-    case SYM_OPEN:
+    case SYM_OPEN: {
+        INCLUDE_PARAMS_OF_OPEN;
         SET_OPEN(req);
-        break;
+        break; }
 
     case SYM_CLOSE:
         SET_CLOSED(req);

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -59,7 +59,9 @@ static REB_R DNS_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     switch (action) {
 
-    case SYM_READ:
+    case SYM_READ: {
+        INCLUDE_PARAMS_OF_READ;
+
         if (!IS_OPEN(sock)) {
             if (OS_DO_DEVICE(sock, RDC_OPEN))
                 fail (Error_On_Port(RE_CANNOT_OPEN, port, sock->error));
@@ -97,7 +99,7 @@ static REB_R DNS_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
             len = 1;
             goto pick;
         }
-        break;
+        break; }
 
     case SYM_PICK:  // FIRST - return result
         if (!IS_OPEN(sock))
@@ -127,10 +129,11 @@ pick:
             fail (Error_Out_Of_Range(arg));
         break;
 
-    case SYM_OPEN:
+    case SYM_OPEN: {
+        INCLUDE_PARAMS_OF_OPEN;
         if (OS_DO_DEVICE(sock, RDC_OPEN))
             fail (Error_On_Port(RE_CANNOT_OPEN, port, -12));
-        break;
+        break; }
 
     case SYM_CLOSE:
         OS_DO_DEVICE(sock, RDC_CLOSE);

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -199,7 +199,8 @@ act_blk:
         SET_INTEGER(D_OUT, VAL_LEN_HEAD(state));
         break;
 
-    case SYM_OPEN:
+    case SYM_OPEN: {
+        INCLUDE_PARAMS_OF_OPEN;
         if (!req) { //!!!
             req = OS_MAKE_DEVREQ(RDI_EVENT);
             if (req) {
@@ -207,7 +208,7 @@ act_blk:
                 OS_DO_DEVICE(req, RDC_CONNECT);     // stays queued
             }
         }
-        break;
+        break; }
 
     case SYM_CLOSE:
         OS_ABORT_DEVICE(req);

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -163,8 +163,8 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
     // Actions for an open socket:
     switch (action) {
 
-    case SYM_READ:
-        refs = Find_Refines(frame_, ALL_READ_REFS);
+    case SYM_READ: {
+        INCLUDE_PARAMS_OF_READ;
 
         // Setup the read buffer (allocate a buffer if needed):
         arg = CTX_VAR(port, STD_PORT_DATA);
@@ -196,16 +196,16 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         printf("\n");
 #endif
         *D_OUT = *arg;
-        return R_OUT;
+        return R_OUT; }
 
-    case SYM_WRITE:
-        refs = Find_Refines(frame_, ALL_WRITE_REFS);
+    case SYM_WRITE: {
+        INCLUDE_PARAMS_OF_WRITE;
 
         // Determine length. Clip /PART to size of string if needed.
         spec = D_ARG(2);
         len = VAL_LEN_AT(spec);
-        if (refs & AM_WRITE_PART) {
-            REBCNT n = Int32s(D_ARG(ARG_WRITE_LIMIT), 0);
+        if (REF(part)) {
+            REBCNT n = Int32s(ARG(limit), 0);
             if (n <= len) len = n;
         }
 
@@ -218,7 +218,7 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         //Print("(write length %d)", len);
         result = OS_DO_DEVICE(req, RDC_WRITE); // send can happen immediately
         if (result < 0) fail (Error_On_Port(RE_WRITE_ERROR, port, req->error));
-        break;
+        break; }
 
     case SYM_UPDATE:
         // Update the port object after a READ or WRITE operation.

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -275,8 +275,10 @@ static REB_R Signal_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         case SYM_OPEN_Q:
             return R_TRUE;
 
-        case SYM_OPEN:
+        case SYM_OPEN: {
+            INCLUDE_PARAMS_OF_OPEN;
             fail (Error(RE_ALREADY_OPEN, D_ARG(1)));
+        }
 
         default:
             fail (Error_Illegal_Action(REB_PORT, action));

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -107,13 +107,14 @@ act_blk:
         SET_INTEGER(D_OUT, VAL_LEN_HEAD(state));
         break;
 
-    case SYM_OPEN:
+    case SYM_OPEN: {
+        INCLUDE_PARAMS_OF_OPEN;
         if (!req) { //!!!
             req = OS_MAKE_DEVREQ(RDI_EVENT);
             SET_OPEN(req);
             OS_DO_DEVICE(req, RDC_CONNECT);     // stays queued
         }
-        break;
+        break; }
 
     default:
         fail (Error_Illegal_Action(REB_PORT, action));

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -432,19 +432,20 @@ static REBCNT Find_Str_Char_Old(
     REBUNI c2,
     REBCNT flags
 ) {
-    REBUNI c1;
-    REBOOL uncase = NOT(GET_FLAG(flags, ARG_FIND_CASE - 1)); // case insensitive
+    REBOOL uncase = NOT(flags & AM_FIND_CASE); // case insensitive
 
     if (uncase && c2 < UNICODE_CASES) c2 = LO_CASE(c2);
 
     for (; index >= head && index < tail; index += skip) {
+        REBUNI c1 = GET_ANY_CHAR(ser, index);
+        if (uncase && c1 < UNICODE_CASES)
+            c1 = LO_CASE(c1);
 
-        c1 = GET_ANY_CHAR(ser, index);
-        if (uncase && c1 < UNICODE_CASES) c1 = LO_CASE(c1);
+        if (c1 == c2)
+            return index;
 
-        if (c1 == c2) return index;
-
-        if GET_FLAG(flags, ARG_FIND_MATCH-1) break;
+        if (flags & AM_FIND_MATCH)
+            break;
     }
 
     return NOT_FOUND;
@@ -688,23 +689,25 @@ return_index:
 // 
 // Flags are set according to ALL_FIND_REFS
 //
-REBCNT Find_Str_Bitset(REBSER *ser, REBCNT head, REBCNT index, REBCNT tail, REBINT skip, REBSER *bset, REBCNT flags)
-{
-    REBUNI c1;
-    REBOOL uncase = NOT(GET_FLAG(flags, ARG_FIND_CASE - 1)); // case insensitive
+REBCNT Find_Str_Bitset(
+    REBSER *ser,
+    REBCNT head,
+    REBCNT index,
+    REBCNT tail,
+    REBINT skip,
+    REBSER *bset,
+    REBCNT flags
+) {
+    REBOOL uncase = NOT(flags & AM_FIND_CASE); // case insensitive
 
     for (; index >= head && index < tail; index += skip) {
+        REBUNI c1 = GET_ANY_CHAR(ser, index);
 
-        c1 = GET_ANY_CHAR(ser, index);
+        if (Check_Bit(bset, c1, uncase))
+            return index;
 
-        //if (uncase && c1 < UNICODE_CASES) {
-        //  if (Check_Bit(bset, LO_CASE(c1)) || Check_Bit(bset, UP_CASE(c1)))
-        //      return index;
-        //}
-        //else
-        if (Check_Bit(bset, c1, uncase)) return index;
-
-        if (flags & AM_FIND_MATCH) break;
+        if (flags & AM_FIND_MATCH)
+            break;
     }
 
     return NOT_FOUND;

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -38,14 +38,18 @@ static REBOOL find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 
 
 //
-//  replace_with: C
+//  Whitespace_Replace_With: C
 // 
 // Replace whitespace chars that match WITH string.
 // 
 // Resulting string is always smaller than it was to start.
 //
-static void replace_with(REBSER *ser, REBCNT index, REBCNT tail, REBVAL *with)
-{
+void Whitespace_Replace_With(
+    REBSER *ser,
+    REBCNT index,
+    REBCNT tail,
+    const REBVAL *with
+) {
     #define MAX_WITH 32
     REBCNT wlen;
     REBUNI with_chars[MAX_WITH];    // chars to be trimmed
@@ -98,7 +102,7 @@ static void replace_with(REBSER *ser, REBCNT index, REBCNT tail, REBVAL *with)
 
 
 //
-//  trim_auto: C
+//  Trim_String_Auto: C
 // 
 // Skip any blank lines and then determine indent of
 // first line and make the rest align with it.
@@ -106,7 +110,7 @@ static void replace_with(REBSER *ser, REBCNT index, REBCNT tail, REBVAL *with)
 // BUG!!! If the indentation uses TABS, then it could
 // fill past the source pointer!
 //
-static void trim_auto(REBSER *ser, REBCNT index, REBCNT tail)
+void Trim_String_Auto(REBSER *ser, REBCNT index, REBCNT tail)
 {
     REBCNT out = index;
     REBCNT line;
@@ -159,11 +163,11 @@ static void trim_auto(REBSER *ser, REBCNT index, REBCNT tail)
 
 
 //
-//  trim_lines: C
+//  Trim_String_Lines: C
 // 
 // Remove all newlines and extra space.
 //
-static void trim_lines(REBSER *ser, REBCNT index, REBCNT tail)
+void Trim_String_Lines(REBSER *ser, REBCNT index, REBCNT tail)
 {
     REBINT pad = 1; // used to allow a single space
     REBUNI uc;
@@ -195,13 +199,18 @@ static void trim_lines(REBSER *ser, REBCNT index, REBCNT tail)
 
 
 //
-//  trim_head_tail: C
+//  Trim_String_Head_Tail: C
 // 
 // Trim from head and tail of each line, trim any leading or
 // trailing lines as well, leaving one at the end if present
 //
-static void trim_head_tail(REBSER *ser, REBCNT index, REBCNT tail, REBOOL h, REBOOL t)
-{
+void Trim_String_Head_Tail(
+    REBSER *ser,
+    REBCNT index,
+    REBCNT tail,
+    REBOOL h,
+    REBOOL t
+) {
     REBCNT out = index;
     REBOOL append_line_feed = FALSE;
     REBUNI uc;
@@ -267,35 +276,4 @@ static void trim_head_tail(REBSER *ser, REBCNT index, REBCNT tail, REBOOL h, REB
 
     SET_ANY_CHAR(ser, out, 0);
     SET_SERIES_LEN(ser, out);
-}
-
-
-//
-//  Trim_String: C
-//
-void Trim_String(REBSER *ser, REBCNT index, REBCNT len, REBCNT flags, REBVAL *with)
-{
-    REBCNT tail = index + len;
-
-    // /all or /with
-    if (flags & (AM_TRIM_ALL | AM_TRIM_WITH)) {
-        replace_with(ser, index, tail, with);
-    }
-    // /auto option
-    else if (flags & AM_TRIM_AUTO) {
-        trim_auto(ser, index, tail);
-    }
-    // /lines option
-    else if (flags & AM_TRIM_LINES) {
-        trim_lines(ser, index, tail);
-    }
-    else {
-        trim_head_tail(
-            ser,
-            index,
-            tail,
-            LOGICAL(flags & AM_TRIM_HEAD),
-            LOGICAL(flags & AM_TRIM_TAIL)
-        );
-    }
 }

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -569,9 +569,12 @@ REBTYPE(Bitset)
     // Add AND, OR, XOR
 
     case SYM_PICK:
-    case SYM_FIND:
-        if (!Check_Bits(VAL_SERIES(value), arg, D_REF(ARG_FIND_CASE))) return R_BLANK;
+    case SYM_FIND: {
+        INCLUDE_PARAMS_OF_FIND; // is PICK guaranteed to have CASE at same pos
+        if (!Check_Bits(VAL_SERIES(value), arg, REF(case)))
+            return R_BLANK;
         return R_TRUE;
+    }
 
     case SYM_COMPLEMENT:
     case SYM_NEGATE:
@@ -594,12 +597,20 @@ set_bits:
         if (Set_Bits(VAL_SERIES(value), arg, diff)) break;
         fail (Error_Invalid_Arg(arg));
 
-    case SYM_REMOVE:  // #"a" "abc"  remove/part bs "abcd"  yuk: /part ?
-        if (!D_REF(2)) fail (Error(RE_MISSING_ARG)); // /part required
-        if (Set_Bits(VAL_SERIES(value), D_ARG(3), FALSE)) break;
-        fail (Error_Invalid_Arg(D_ARG(3)));
+    case SYM_REMOVE: {
+        INCLUDE_PARAMS_OF_REMOVE;
 
-    case SYM_COPY:
+        if (NOT(REF(part)))
+            fail (Error(RE_MISSING_ARG));
+
+        if (Set_Bits(VAL_SERIES(value), ARG(limit), FALSE))
+            break;
+
+        fail (Error_Invalid_Arg(ARG(limit))); }
+
+    case SYM_COPY: {
+        INCLUDE_PARAMS_OF_COPY;
+
         Val_Init_Series_Index(
             D_OUT,
             REB_BITSET,
@@ -607,7 +618,7 @@ set_bits:
             VAL_INDEX(value)
         );
         INIT_BITS_NOT(VAL_SERIES(D_OUT), BITS_NOT(VAL_SERIES(value)));
-        return R_OUT;
+        return R_OUT; }
 
     case SYM_LENGTH:
         len = VAL_LEN_HEAD(value) * 8;

--- a/src/core/t-blank.c
+++ b/src/core/t-blank.c
@@ -77,10 +77,11 @@ REBTYPE(Unit)
     case SYM_TAKE:
         return R_BLANK;
 
-    case SYM_COPY:
+    case SYM_COPY: {
+        INCLUDE_PARAMS_OF_COPY;
         if (IS_BLANK(val))
             return R_BLANK; // perhaps allow COPY on any type, as well.
-        break;
+        break; }
 
     default:
         break;

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -211,14 +211,16 @@ REBTYPE(Char)
     case SYM_ODD_Q:
         return (chr & 1) ? R_TRUE : R_FALSE;
 
-    case SYM_RANDOM:  //!!! needs further definition ?  random/zero
-        if (D_REF(2)) { // /seed
+    case SYM_RANDOM: {
+        INCLUDE_PARAMS_OF_RANDOM;
+
+        if (REF(seed)) {
             Set_Random(chr);
             return R_VOID;
         }
         if (chr == 0) break;
-        chr = (REBUNI)(1 + ((REBCNT)Random_Int(D_REF(3)) % chr)); // /secure
-        break;
+        chr = cast(REBUNI, 1 + cast(REBCNT, Random_Int(REF(secure)) % chr));
+        break; }
 
     default:
         fail (Error_Illegal_Action(REB_CHAR, action));

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -433,19 +433,30 @@ REBTYPE(Decimal)
                 return R_TRUE;
             return R_FALSE;
 
-        case SYM_ROUND:
-            arg = D_ARG(3);
-            num = Get_Round_Flags(frame_);
-            if (D_REF(2)) { // to
+        case SYM_ROUND: {
+            INCLUDE_PARAMS_OF_ROUND;
+
+            REBFLGS flags = (
+                (REF(to) ? RF_TO : 0)
+                | (REF(even) ? RF_EVEN : 0)
+                | (REF(down) ? RF_DOWN : 0)
+                | (REF(half_down) ? RF_HALF_DOWN : 0)
+                | (REF(floor) ? RF_FLOOR : 0)
+                | (REF(ceiling) ? RF_CEILING : 0)
+                | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
+            );
+
+            arg = ARG(scale);
+            if (REF(to)) {
                 if (IS_MONEY(arg)) {
                     SET_MONEY(D_OUT, Round_Deci(
-                        decimal_to_deci(d1), num, VAL_MONEY_AMOUNT(arg)
+                        decimal_to_deci(d1), flags, VAL_MONEY_AMOUNT(arg)
                     ));
                     return R_OUT;
                 }
                 if (IS_TIME(arg)) fail (Error_Invalid_Arg(arg));
 
-                d1 = Round_Dec(d1, num, Dec64(arg));
+                d1 = Round_Dec(d1, flags, Dec64(arg));
                 if (IS_INTEGER(arg)) {
                     VAL_RESET_HEADER(D_OUT, REB_INTEGER);
                     VAL_INT64(D_OUT) = cast(REBI64, d1);
@@ -454,16 +465,20 @@ REBTYPE(Decimal)
                 if (IS_PERCENT(arg)) type = REB_PERCENT;
             }
             else
-                d1 = Round_Dec(d1, num | 1, type == REB_PERCENT ? 0.01L : 1.0L); // /TO
-            goto setDec;
+                d1 = Round_Dec(
+                    d1, flags | RF_TO, type == REB_PERCENT ? 0.01L : 1.0L
+                );
+            goto setDec; }
 
-        case SYM_RANDOM:
-            if (D_REF(2)) {
+        case SYM_RANDOM: {
+            INCLUDE_PARAMS_OF_RANDOM;
+
+            if (REF(seed)) {
                 Set_Random(*cast(REBI64*, &VAL_DECIMAL(val))); // use IEEE bits
                 return R_VOID;
             }
-            d1 = Random_Dec(d1, D_REF(3));
-            goto setDec;
+            d1 = Random_Dec(d1, REF(secure));
+            goto setDec; }
 
         case SYM_COMPLEMENT:
             SET_INTEGER(D_OUT, ~(REBINT)d1);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -130,14 +130,17 @@ REBTYPE(Function)
     REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
 
     switch (action) {
-    case SYM_COPY:
+    case SYM_COPY: {
+        INCLUDE_PARAMS_OF_COPY;
+
         // !!! The R3-Alpha theory was that functions could modify "their
         // bodies" while running, effectively accruing state that one might
         // want to snapshot.  See notes on Clonify_Function about why this
         // idea may be incorrect.
+        //
         *D_OUT = *value;
         Clonify_Function(D_OUT);
-        return R_OUT;
+        return R_OUT; }
 
     case SYM_REFLECT: {
         REBSYM sym = VAL_WORD_SYM(arg);
@@ -270,7 +273,7 @@ REBNATIVE(func_class_of)
 // is something like a specialization or an adaptation...but that would be
 // purely documentary, and could lie.
 {
-    PARAM(1, func);
+    INCLUDE_PARAMS_OF_FUNC_CLASS_OF;
 
     REBVAL *value = ARG(func);
     REBCNT n;

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -43,8 +43,7 @@
 //
 REBNATIVE(and_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_AND_Q;
 
     if (IS_CONDITIONAL_TRUE(ARG(value1)) && IS_CONDITIONAL_TRUE(ARG(value2)))
         return R_TRUE;
@@ -64,8 +63,7 @@ REBNATIVE(and_q)
 //
 REBNATIVE(nor_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_NOR_Q;
 
     if (IS_CONDITIONAL_FALSE(ARG(value1)) && IS_CONDITIONAL_FALSE(ARG(value2)))
         return R_TRUE;
@@ -85,8 +83,7 @@ REBNATIVE(nor_q)
 //
 REBNATIVE(nand_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_NAND_Q;
 
     return R_FROM_BOOL(LOGICAL(
         IS_CONDITIONAL_TRUE(ARG(value1)) && IS_CONDITIONAL_TRUE(ARG(value2))
@@ -105,7 +102,7 @@ REBNATIVE(nand_q)
 //
 REBNATIVE(not_q)
 {
-    PARAM(1, value);
+    INCLUDE_PARAMS_OF_NOT_Q;
 
     return R_FROM_BOOL(IS_CONDITIONAL_FALSE(ARG(value)));
 }
@@ -122,8 +119,7 @@ REBNATIVE(not_q)
 //
 REBNATIVE(or_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_OR_Q;
 
     return R_FROM_BOOL(LOGICAL(
         IS_CONDITIONAL_TRUE(ARG(value1)) || IS_CONDITIONAL_TRUE(ARG(value2))
@@ -142,8 +138,7 @@ REBNATIVE(or_q)
 //
 REBNATIVE(xor_q)
 {
-    PARAM(1, value1);
-    PARAM(2, value2);
+    INCLUDE_PARAMS_OF_XOR_Q;
 
     // Note: no boolean ^^ in C; normalize to booleans and check unequal
     //
@@ -247,15 +242,17 @@ REBTYPE(Logic)
         val1 = NOT(val1);
         break;
 
-    case SYM_RANDOM:
-        if (D_REF(2)) { // /seed
+    case SYM_RANDOM: {
+        INCLUDE_PARAMS_OF_RANDOM;
+
+        if (REF(seed)) {
             // random/seed false restarts; true randomizes
             Set_Random(val1 ? (REBINT)OS_DELTA_TIME(0, 0) : 1);
             return R_VOID;
         }
-        if (Random_Int(D_REF(3)) & 1) // /secure
+        if (Random_Int(REF(secure)) & 1)
             return R_TRUE;
-        return R_FALSE;
+        return R_FALSE; }
 
     default:
         fail (Error_Illegal_Action(REB_LOGIC, action));

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -596,15 +596,16 @@ REBTYPE(Map)
         return R_OUT;
 
     case SYM_FIND:
-    case SYM_SELECT:
-        args = Find_Refines(frame_, ALL_FIND_REFS);
+    case SYM_SELECT: {
+        INCLUDE_PARAMS_OF_FIND;
+
         n = Find_Map_Entry(
             map,
             arg,
             SPECIFIED,
             NULL,
             SPECIFIED,
-            LOGICAL(args & AM_FIND_CASE)
+            REF(case)
         );
         if (n == 0) {
             return action == SYM_FIND ? R_BLANK : R_VOID;
@@ -614,19 +615,22 @@ REBTYPE(Map)
             return action == SYM_FIND ? R_BLANK : R_VOID;
         }
         if (action == SYM_FIND) *D_OUT = *val;
-        return R_OUT;
+        return R_OUT; }
 
     case SYM_INSERT:
-    case SYM_APPEND:
+    case SYM_APPEND: {
+        INCLUDE_PARAMS_OF_INSERT;
+
         FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
 
-        if (!IS_BLOCK(arg)) fail (Error_Invalid_Arg(val));
+        if (!IS_BLOCK(arg))
+            fail (Error_Invalid_Arg(val));
         *D_OUT = *val;
-        if (D_REF(AN_DUP)) {
-            n = Int32(D_ARG(AN_COUNT));
+        if (REF(dup)) {
+            n = Int32(ARG(count));
             if (n <= 0) break;
         }
-        Partial1(arg, D_ARG(AN_LIMIT), &tail);
+        Partial1(arg, ARG(limit), &tail);
         Append_Map(
             map,
             VAL_ARRAY(arg),
@@ -634,19 +638,21 @@ REBTYPE(Map)
             VAL_SPECIFIER(arg),
             tail
         );
-        return R_OUT;
+        return R_OUT; }
 
-    case SYM_REMOVE:
+    case SYM_REMOVE: {
+        INCLUDE_PARAMS_OF_REMOVE;
+
         FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
 
-        if (!D_REF(4)) { // /MAP
+        if (NOT(REF(map)))
             fail (Error_Illegal_Action(REB_MAP, action));
-        }
+
         *D_OUT = *val;
         Find_Map_Entry(
             map, D_ARG(5), SPECIFIED, VOID_CELL, SPECIFIED, TRUE
         );
-        return R_OUT;
+        return R_OUT; }
 
     case SYM_POKE:  // CHECK all pokes!!! to be sure they check args now !!!
         FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
@@ -661,13 +667,14 @@ REBTYPE(Map)
         SET_INTEGER(D_OUT, Length_Map(map));
         return R_OUT;
 
-    case SYM_COPY:
+    case SYM_COPY: {
+        INCLUDE_PARAMS_OF_COPY;
         //
         // !!! the copying map case should probably not be a MAKE case, but
         // implemented here as copy.
         //
         MAKE_Map(D_OUT, REB_MAP, val); // may fail()
-        return R_OUT;
+        return R_OUT; }
 
     case SYM_CLEAR:
         FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -214,8 +214,17 @@ REBTYPE(Money)
         return R_OUT;
 
     case SYM_ROUND: {
-        REFINE(2, to);
-        PARAM(3, scale);
+        INCLUDE_PARAMS_OF_ROUND;
+
+        REBFLGS flags = (
+            (REF(to) ? RF_TO : 0)
+            | (REF(even) ? RF_EVEN : 0)
+            | (REF(down) ? RF_DOWN : 0)
+            | (REF(half_down) ? RF_HALF_DOWN : 0)
+            | (REF(floor) ? RF_FLOOR : 0)
+            | (REF(ceiling) ? RF_CEILING : 0)
+            | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
+        );
 
         REBVAL *scale = ARG(scale);
 
@@ -235,7 +244,7 @@ REBTYPE(Money)
 
         SET_MONEY(D_OUT, Round_Deci(
             VAL_MONEY_AMOUNT(val),
-            Get_Round_Flags(frame_),
+            flags,
             VAL_MONEY_AMOUNT(&temp)
         ));
 

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -269,8 +269,10 @@ REBTYPE(Pair)
 
     switch (action) {
 
-    case SYM_COPY:
+    case SYM_COPY: {
+        INCLUDE_PARAMS_OF_COPY;
         goto setPair;
+    }
 
     case SYM_ADD:
         Get_Math_Arg_For_Pair(&x2, &y2, D_ARG(2), action);
@@ -315,16 +317,26 @@ REBTYPE(Pair)
         goto setPair;
 
     case SYM_ROUND: {
-        REBDEC d64;
-        REBFLGS flags = Get_Round_Flags(frame_);
-        if (D_REF(2))
-            d64 = Dec64(D_ARG(3));
-        else {
-            d64 = 1.0L;
-            flags |= 1;
+        INCLUDE_PARAMS_OF_ROUND;
+
+        REBFLGS flags = (
+            (REF(to) ? RF_TO : 0)
+            | (REF(even) ? RF_EVEN : 0)
+            | (REF(down) ? RF_DOWN : 0)
+            | (REF(half_down) ? RF_HALF_DOWN : 0)
+            | (REF(floor) ? RF_FLOOR : 0)
+            | (REF(ceiling) ? RF_CEILING : 0)
+            | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
+        );
+
+        if (REF(to)) {
+            x1 = Round_Dec(x1, flags, Dec64(ARG(scale)));
+            y1 = Round_Dec(y1, flags, Dec64(ARG(scale)));
         }
-        x1 = Round_Dec(x1, flags, d64);
-        y1 = Round_Dec(y1, flags, d64);
+        else {
+            x1 = Round_Dec(x1, flags | RF_TO, 1.0L);
+            y1 = Round_Dec(y1, flags | RF_TO, 1.0L);
+        }
         goto setPair; }
 
     case SYM_REVERSE:
@@ -333,11 +345,15 @@ REBTYPE(Pair)
         y1 = x2;
         goto setPair;
 
-    case SYM_RANDOM:
-        if (D_REF(2)) fail (Error(RE_BAD_REFINES)); // seed
-        x1 = cast(REBDEC, Random_Range(cast(REBINT, x1), D_REF(3)));
-        y1 = cast(REBDEC, Random_Range(cast(REBINT, y1), D_REF(3)));
-        goto setPair;
+    case SYM_RANDOM: {
+        INCLUDE_PARAMS_OF_RANDOM;
+
+        if (REF(seed))
+            fail (Error(RE_BAD_REFINES));
+
+        x1 = cast(REBDEC, Random_Range(cast(REBINT, x1), REF(secure)));
+        y1 = cast(REBDEC, Random_Range(cast(REBINT, y1), REF(secure)));
+        goto setPair; }
 
     case SYM_PICK: {
         REBVAL *arg = D_ARG(2);

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1332,11 +1332,7 @@ REBNATIVE(make_routine)
 // !!! Would be nice if this could just take a filename and the lib management
 // was automatic, e.g. no LIBRARY! type.
 {
-    PARAM(1, lib);
-    PARAM(2, name);
-    PARAM(3, ffi_spec);
-    REFINE(4, abi);
-    PARAM(5, abi_type);
+    INCLUDE_PARAMS_OF_MAKE_ROUTINE;
 
     // Make sure library wasn't closed with CLOSE
     //
@@ -1397,10 +1393,7 @@ REBNATIVE(make_routine_raw)
 // !!! Would be nice if this could just take a filename and the lib management
 // was automatic, e.g. no LIBRARY! type.
 {
-    PARAM(1, pointer);
-    PARAM(2, ffi_spec);
-    REFINE(3, abi);
-    PARAM(4, abi_type);
+    INCLUDE_PARAMS_OF_MAKE_ROUTINE_RAW;
 
     // Cannot cast directly to a function pointer from a 64-bit value
     // on 32-bit systems; first cast to (U)nsigned int that holds (P)oin(T)er
@@ -1442,10 +1435,7 @@ REBNATIVE(make_routine_raw)
 //
 REBNATIVE(make_callback)
 {
-    PARAM(1, action);
-    PARAM(2, ffi_spec);
-    REFINE(3, abi);
-    PARAM(4, abi_type); // void if absent
+    INCLUDE_PARAMS_OF_MAKE_CALLBACK;
 
     REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec));
     REBRIN *r = FUNC_ROUTINE(fun);

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1647,22 +1647,25 @@ REBTYPE(Struct)
 //  destroy-struct-storage: native [
 //
 //  {Destroy the external memory associated the struct}
-//      s   [struct!]
-//      /free func [function!] {Specify the function to free the memory}
+//
+//      struct [struct!]
+//      /free
+//          {Specify the function to free the memory}
+//      free-func [function!]
 //  ]
 //
 REBNATIVE(destroy_struct_storage)
 {
-    PARAM(1, val);
-    REFINE(2, free_q);
-    PARAM(3, free_func);
+    INCLUDE_PARAMS_OF_DESTROY_STRUCT_STORAGE;
 
-    if (REF(free_q)) {
+    if (REF(free)) {
         if (IS_FUNCTION_RIN(ARG(free_func)))
             fail (Error(RE_FREE_NEEDS_ROUTINE));
     }
 
-    return Destroy_External_Storage(D_OUT,
-                                    VAL_STRUCT_DATA_BIN(ARG(val)),
-                                    REF(free_q)? ARG(free_func) : NULL);
+    return Destroy_External_Storage(
+        D_OUT,
+        VAL_STRUCT_DATA_BIN(ARG(struct)),
+        REF(free) ? ARG(free_func) : NULL
+    );
 }

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -596,43 +596,57 @@ REBTYPE(Time)
             if (secs < 0) secs = -secs;
             goto setTime;
 
-        case SYM_ROUND:
-            if (D_REF(2)) {
-                arg = D_ARG(3);
+        case SYM_ROUND: {
+            INCLUDE_PARAMS_OF_ROUND;
+
+            REBFLGS flags = (
+                (REF(to) ? RF_TO : 0)
+                | (REF(even) ? RF_EVEN : 0)
+                | (REF(down) ? RF_DOWN : 0)
+                | (REF(half_down) ? RF_HALF_DOWN : 0)
+                | (REF(floor) ? RF_FLOOR : 0)
+                | (REF(ceiling) ? RF_CEILING : 0)
+                | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
+            );
+
+            if (REF(to)) {
+                arg = ARG(scale);
                 if (IS_TIME(arg)) {
-                    secs = Round_Int(secs, Get_Round_Flags(frame_), VAL_TIME(arg));
+                    secs = Round_Int(secs, flags, VAL_TIME(arg));
                 }
                 else if (IS_DECIMAL(arg)) {
                     VAL_DECIMAL(arg) = Round_Dec(
                         cast(REBDEC, secs),
-                        Get_Round_Flags(frame_),
+                        flags,
                         Dec64(arg) * SEC_SEC
                     );
                     VAL_DECIMAL(arg) /= SEC_SEC;
                     VAL_RESET_HEADER(arg, REB_DECIMAL);
-                    *D_OUT = *D_ARG(3);
+                    *D_OUT = *ARG(scale);
                     return R_OUT;
                 }
                 else if (IS_INTEGER(arg)) {
                     VAL_INT64(arg) = Round_Int(secs, 1, Int32(arg) * SEC_SEC) / SEC_SEC;
                     VAL_RESET_HEADER(arg, REB_INTEGER);
-                    *D_OUT = *D_ARG(3);
+                    *D_OUT = *ARG(scale);
                     return R_OUT;
                 }
                 else fail (Error_Invalid_Arg(arg));
             }
             else {
-                secs = Round_Int(secs, Get_Round_Flags(frame_) | 1, SEC_SEC);
+                secs = Round_Int(secs, flags | RF_TO, SEC_SEC);
             }
-            goto fixTime;
+            goto fixTime; }
 
-        case SYM_RANDOM:
-            if (D_REF(2)) {
+        case SYM_RANDOM: {
+            INCLUDE_PARAMS_OF_RANDOM;
+
+            if (REF(seed)) {
                 Set_Random(secs);
                 return R_VOID;
             }
-            secs = Random_Range(secs / SEC_SEC, D_REF(3)) * SEC_SEC;
-            goto fixTime;
+            secs = Random_Range(secs / SEC_SEC, REF(secure)) * SEC_SEC;
+            goto fixTime; }
 
         case SYM_PICK:
             Pick_Time(D_OUT, val, arg);

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -397,23 +397,16 @@ REBTYPE(Tuple)
         goto ret_value;
     }
     if (action == SYM_RANDOM) {
-        if (D_REF(2)) fail (Error(RE_BAD_REFINES)); // seed
-        for (;len > 0; len--, vp++) {
+        INCLUDE_PARAMS_OF_RANDOM;
+        if (REF(seed))
+            fail (Error(RE_BAD_REFINES));
+        for (; len > 0; len--, vp++) {
             if (*vp)
-                *vp = (REBYTE)(Random_Int(D_REF(3)) % (1+*vp));
+                *vp = cast(REBYTE, Random_Int(REF(secure)) % (1 + *vp));
         }
         goto ret_value;
     }
-/*
-    if (action == A_ZEROQ) {
-        for (;len > 0; len--, vp++) {
-            if (*vp != 0)
-                goto is_false;
-        }
-        goto is_true;
-    }
-*/
-    //a = 1; //???
+
     switch (action) {
     case SYM_LENGTH:
         len = MAX(len, 3);
@@ -432,9 +425,11 @@ REBTYPE(Tuple)
         *D_OUT = *D_ARG(3);
         return R_OUT;*/
 
-    case SYM_REVERSE:
-        if (D_REF(2)) {
-            len = Get_Num_From_Arg(D_ARG(3));
+    case SYM_REVERSE: {
+        INCLUDE_PARAMS_OF_REVERSE;
+
+        if (REF(part)) {
+            len = Get_Num_From_Arg(ARG(limit));
             len = MIN(len, VAL_TUPLE_LEN(value));
         }
         if (len > 0) {
@@ -446,7 +441,7 @@ REBTYPE(Tuple)
                 vp[i] = a;
             }
         }
-        goto ret_value;
+        goto ret_value; }
 /*
   poke_it:
         a = Get_Num_From_Arg(arg);

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -382,18 +382,17 @@ REBTYPE(Varargs)
     }
 
     case SYM_TAKE: {
-        REFINE(2, part);
-        PARAM(3, limit);
-        REFINE(4, deep); // !!! doesn't seem to be implemented on ANY-ARRAY!
-        REFINE(5, last);
+        INCLUDE_PARAMS_OF_TAKE;
 
         REBDSP dsp_orig = DSP;
         REBINT limit;
 
-        if (REF(deep)) fail (Error(RE_MISC));
-        if (REF(last)) fail (Error(RE_VARARGS_TAKE_LAST));
+        if (REF(deep))
+            fail (Error(RE_MISC));
+        if (REF(last))
+            fail (Error(RE_VARARGS_TAKE_LAST));
 
-        if (!REF(part)) {
+        if (NOT(REF(part))) {
             indexor = Do_Vararg_Op_May_Throw(D_OUT, value, VARARG_OP_TAKE);
             if (indexor == THROWN_FLAG)
                 return R_OUT_IS_THROWN;

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -621,19 +621,24 @@ REBTYPE(Vector)
         SET_INTEGER(D_OUT, SER_LEN(vect));
         return R_OUT;
 
-    case SYM_COPY:
+    case SYM_COPY: {
+        INCLUDE_PARAMS_OF_COPY;
         ser = Copy_Sequence(vect);
         ser->misc.size = vect->misc.size; // attributes
         Val_Init_Vector(value, ser);
-        break;
+        break; }
 
-    case SYM_RANDOM:
+    case SYM_RANDOM: {
+        INCLUDE_PARAMS_OF_RANDOM;
+
         FAIL_IF_LOCKED_SERIES(vect);
 
-        if (D_REF(2) || D_REF(4)) fail (Error(RE_BAD_REFINES)); // /seed /only
-        Shuffle_Vector(value, D_REF(3));
+        if (REF(seed) || REF(only))
+            fail (Error(RE_BAD_REFINES));
+
+        Shuffle_Vector(value, REF(secure));
         *D_OUT = *D_ARG(1);
-        return R_OUT;
+        return R_OUT; }
 
     default:
         fail (Error_Illegal_Action(VAL_TYPE(value), action));

--- a/src/core/u-dialect.c
+++ b/src/core/u-dialect.c
@@ -578,12 +578,7 @@ REBINT Do_Dialect(REBCTX *dialect, REBARR *block, REBCNT *index, REBARR **out)
 //
 REBNATIVE(delect)
 {
-    PARAM(1, dialect);
-    PARAM(2, input);
-    PARAM(3, output);
-    REFINE(4, in);
-    PARAM(5, where);
-    REFINE(6, all);
+    INCLUDE_PARAMS_OF_DELECT;
 
     REBDIA dia;
     REBINT err;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -2121,7 +2121,7 @@ REBNATIVE(subparse)
 
                 if (flags & (PF_INSERT | PF_CHANGE)) {
                     count = (flags & PF_INSERT) ? 0 : count;
-                    REBCNT mod_flags = (flags & PF_INSERT) ? 0 : (1<<AN_PART);
+                    REBCNT mod_flags = (flags & PF_INSERT) ? 0 : AM_PART;
 
                     if (IS_END(P_RULE))
                         fail (Error_Parse_End());
@@ -2130,7 +2130,7 @@ REBNATIVE(subparse)
                         REBSYM cmd = VAL_CMD(P_RULE);
                         switch (cmd) {
                         case SYM_ONLY:
-                            mod_flags |= (1<<AN_ONLY);
+                            mod_flags |= AM_ONLY;
                             FETCH_NEXT_RULE_MAYBE_END(f);
                             if (IS_END(P_RULE))
                                 fail (Error_Parse_End());
@@ -2173,7 +2173,7 @@ REBNATIVE(subparse)
                         COPY_VALUE(&specified, rule, P_RULE_SPECIFIER);
 
                         if (P_TYPE == REB_BINARY)
-                            mod_flags |= (1 << AN_SERIES); // special flag
+                            mod_flags |= AM_BINARY_SERIES;
 
                         P_POS = Modify_String(
                             (flags & PF_CHANGE) ? SYM_CHANGE : SYM_INSERT,
@@ -2235,9 +2235,7 @@ REBNATIVE(subparse)
 //
 REBNATIVE(parse)
 {
-    PARAM(1, input);
-    PARAM(2, rules);
-    REFINE(3, case);
+    INCLUDE_PARAMS_OF_PARSE;
 
     REBVAL *rules = ARG(rules);
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -446,15 +446,40 @@ enum {
 #define CRLF "\r\n"
 #define TAB_SIZE 4
 
-// Move this:
-enum Insert_Arg_Nums {
-    AN_SERIES = 1,
-    AN_VALUE,
-    AN_PART,
-    AN_LIMIT,
-    AN_ONLY,
-    AN_DUP,
-    AN_COUNT
+// Move these things:
+enum act_modify_mask {
+    AM_BINARY_SERIES = 1 << 0,
+    AM_PART = 1 << 1,
+    AM_ONLY = 1 << 2
+};
+enum act_find_mask {
+    AM_FIND_ONLY = 1 << 0,
+    AM_FIND_CASE = 1 << 1,
+    AM_FIND_LAST = 1 << 2,
+    AM_FIND_REVERSE = 1 << 3,
+    AM_FIND_TAIL = 1 << 4,
+    AM_FIND_MATCH = 1 << 5
+};
+enum act_read_mask {
+    AM_READ_STRING = 1 << 0,
+    AM_READ_LINES = 1 << 1
+};
+enum act_open_mask {
+    AM_OPEN_NEW = 1 << 0,
+    AM_OPEN_READ = 1 << 1,
+    AM_OPEN_WRITE = 1 << 2,
+    AM_OPEN_SEEK = 1 << 3,
+    AM_OPEN_ALLOW = 1 << 4
+};
+// Rounding flags (passed as refinements to ROUND function):
+enum {
+    RF_TO = 1 << 0,
+    RF_EVEN = 1 << 1,
+    RF_DOWN = 1 << 2,
+    RF_HALF_DOWN = 1 << 3,
+    RF_FLOOR = 1 << 4,
+    RF_CEILING = 1 << 5,
+    RF_HALF_CEILING = 1 << 6
 };
 
 enum rebol_signals {
@@ -560,7 +585,15 @@ enum Reb_Vararg_Op {
 #include "tmp-funcs.h"
 
 #include "tmp-strings.h"
-#include "tmp-funcargs.h"
+
+// %tmp-paramlists.h is the file that contains macros for natives and actions
+// that map their argument names to indices in the frame.  This defines the
+// macros like INCLUDE_ARGS_FOR_INSERT which then allow you to naturally
+// write things like REF(part) and ARG(limit), instead of the brittle integer
+// based system used in R3-Alpha such as D_REF(7) and D_ARG(3).
+//
+#include "tmp-paramlists.h"
+
 #include "tmp-boot.h"
 #include "tmp-errnums.h"
 #include "tmp-sysobj.h"

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -214,7 +214,6 @@ inline static REBCNT FRM_EXPR_INDEX(REBFRM *f) {
 #define D_CELL      FRM_CELL(frame_)        // GC-safe cell if > 1 argument
 #define D_ARGC      FRM_NUM_ARGS(frame_)        // count of args+refinements/args
 #define D_ARG(n)    FRM_ARG(frame_, (n))    // pass 1 for first arg
-#define D_REF(n)    IS_CONDITIONAL_TRUE(D_ARG(n))  // REFinement (!REFerence)
 #define D_FUNC      FRM_FUNC(frame_)        // REBVAL* of running function
 #define D_LABEL_SYM FRM_LABEL(frame_)       // symbol or placeholder for call
 #define D_DSP_ORIG  FRM_DSP_ORIG(frame_)    // Original data stack pointer
@@ -281,9 +280,12 @@ inline static void SET_FRAME_VALUE(REBFRM *f, const RELVAL *value) {
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // These accessors are designed to make it convenient for natives written in
-// C to access their arguments and refinements.  They are able to bind to the
-// implicit Reb_Frame* passed to every REBNATIVE() and read the information
-// out cleanly, like this:
+// C to access their arguments and refinements.  (They are what is behind the
+// implementation of the INCLUDE_PARAMS_OF_XXX macros that are used in
+// natives.)
+//
+// They are able to bind to the implicit Reb_Frame* passed to every
+// REBNATIVE() and read the information out cleanly, like this:
 //
 //     PARAM(1, foo);
 //     REFINE(2, bar);
@@ -461,7 +463,7 @@ return_and_check:
 
 
 // Allocate the series of REBVALs inspected by a function when executed (the
-// values behind D_ARG(1), D_REF(2), etc.)
+// values behind ARG(name), REF(name), D_ARG(3),  etc.)
 //
 // This only allocates space for the arguments, it does not initialize.
 // Do_Core initializes as it goes, and updates f->param so the GC knows how

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -157,7 +157,7 @@ load-header: function [
         set/opt [key: rest:] transcode/only data blank
 
         ; get header block
-        set/opt [hdr: rest:] transcode/next/error rest blank
+        set/opt [hdr: rest:] transcode/next/relax rest blank
 
         not block? :hdr [
             ; header block is incomplete

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -220,7 +220,8 @@ const REBYTE N_debug_spec[] =
         " {Stack level to inspect or dialect block, or enter debug mode}"
     "";
 REB_R N_debug(REBFRM *frame_) {
-    PARAM(1, value);
+    PARAM(1, value); // no automatic INCLUDE_PARAMS_OF_XXX for manual native
+
     REBVAL *value = ARG(value);
 
     if (IS_VOID(value)) {


### PR DESCRIPTION
This commit began as an attempt to simplify the %tmp-funcargs.h code
and eliminate Find_Refines().  It evolved into a general solution for
auto-generating the parameter and refinement lists for natives and
actions.  So instead of writing:

    //
    //  foo: native [arg /ref ref-arg]
    //
    REBNATIVE(foo) {
        PARAM(1, arg);
        REFINE(2, ref);
        PARAM(3, ref_arg);
        // blah blah ARG(arg), REF(ref), ARG(ref_arg);

A macro is auto-generated for you with the correct indices and names.

     //
     //  foo: native [arg /ref ref-arg]
     //
     REBNATIVE(foo) {
         INCLUDE_PARAMS_OF_FOO;
         // blah blah ARG(arg), REF(ref), ARG(ref_arg);

The style of macro taking no arguments was chosen to help call it out
as unique and having no runtime behavior (in the release build).  Also
if it were folded into the REBNATIVE(...) macro, then it would have to
include the `{` character in the macro, which is kind of junky and
alien to C like doing `#define BEGIN {`, `#define END }`.  :-/

But more importantly, this means the macros can be used anywhere and
multiple times, meaning that now actions can include their parameter
lists in the several different switch() statements they appear.
Whether that's how actions will be done in the future is not really
the point, but rather that there's a much less brittle connection
between the parameter order and naming than before.

Because this supersedes the Find_Refines() method completely, it meant
the cases where the argument bit flags were used as flags to pass to
routines outside of the native or action had to be adapted.  This
pared down those flags to a minimal temporary set, but leaving it for
future review.

The modifications to the build process and simplifications are gearing
up for a large change to the "life support" of kludgey C code that
currently lets the evaluator actually do things.  So since this touched
a lot of lines, things like commented-out code were just deleted in
the process.

While all D_REF() instances were eliminated, this did not attack the
D_ARG() cases inside of action switch statements--which are fairly
entrenched because they share handling of arguments which do not
have common names in the action dispatchers.  However, all natives
were converted to the new convention.