### PR TITLE
Reverse the sense of the EVALUATED value bit to UNEVALUATED

### DIFF
--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1164,8 +1164,8 @@ REBCTX *Error(REBCNT num, ... /* REBVAL *arg1, REBVAL *arg2, ... */)
 //  Error_Lookback_Quote_Too_Late: C
 //
 // You can't have infix operators as `(1 + 2) infix-op 3 4 5` which quote
-// their left-hand sides, because they have been evaluated.  However, the
-// VALUE_FLAG_EVALUATED permits the determination of inerts that would have
+// their left-hand sides, because they have been evaluated.  However,
+// VALUE_FLAG_UNEVALUATED permits the determination of inerts that would have
 // been okay to quote, e.g. `<a tag> infix-op 3 4 5`.
 //
 REBCTX *Error_Lookback_Quote_Too_Late(REBFRM *f) {

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -1037,7 +1037,7 @@ REBOOL Form_Value_Throws(
             if (IS_VOID(out) || IS_BLANK(out))
                 continue; // no output, don't disrupt pending delimiter
 
-            literal = NOT(GET_VAL_FLAG(out, VALUE_FLAG_EVALUATED));
+            literal = GET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);
 
             item = out;
             // The DO_NEXT already refetched...
@@ -1045,7 +1045,7 @@ REBOOL Form_Value_Throws(
         else {
             assert(!IS_VOID(item)); // should not be possible, no literal voids
 
-            // do not use VALUE_FLAG_EVALUATED, because since this isn't the
+            // don't clear VALUE_FLAG_UNEVALUATED, because since this isn't the
             // direct product of an evaluation it might get the evaluated flag
             // from a COMPOSE or whatever made the block.
             //

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -481,7 +481,7 @@ REBNATIVE(switch)
     // For safety, notice if someone wrote `switch [x] [...]` with a literal
     // block in source, as that is likely a mistake.
     //
-    if (IS_BLOCK(value) && !GET_VAL_FLAG(value, VALUE_FLAG_EVALUATED))
+    if (IS_BLOCK(value) && GET_VAL_FLAG(value, VALUE_FLAG_UNEVALUATED))
         fail (Error(RE_BLOCK_SWITCH, value));
 
     // Frame's extra D_CELL is free since the function has > 1 arg.  Reuse it

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1196,7 +1196,7 @@ REBNATIVE(semiquoted_q)
     const REBVAL *var = Get_Var_Core( // may fail
         &eval_type, ARG(parameter), SPECIFIED, GETVAR_READ_ONLY
     );
-    return GET_VAL_FLAG(var, VALUE_FLAG_EVALUATED) ? R_FALSE : R_TRUE;
+    return GET_VAL_FLAG(var, VALUE_FLAG_UNEVALUATED) ? R_TRUE : R_FALSE;
 }
 
 
@@ -1214,12 +1214,11 @@ REBNATIVE(semiquote)
 
     *D_OUT = *ARG(value);
 
-    // We cannot clear the VALUE_FLAG_EVALUATED bit here and make it stick,
-    // because the bit would just get added back on by Do_Core when the
-    // function finished.  So instead Do_Core recognizes this native
-    // specificially and clears the bit there.
+    // We cannot set the VALUE_FLAG_UNEVALUATED bit here and make it stick,
+    // because the bit would just get cleared off by Do_Core when the
+    // function finished.  So ask the evaluator to set the bit for us.
 
-    return R_OUT;
+    return R_OUT_UNEVALUATED;
 }
 
 
@@ -1427,7 +1426,7 @@ REBNATIVE(false_q)
 //      return: [any-value!]
 //      :value [any-value!]
 //  ][
-//      :value
+//      :value ;-- actually also sets unevaluated bit, how could a user do so?
 //  ]
 //
 REBNATIVE(quote)
@@ -1436,12 +1435,11 @@ REBNATIVE(quote)
 
     *D_OUT = *ARG(value);
 
-    // We cannot clear the VALUE_FLAG_EVALUATED bit here and make it stick,
-    // because the bit would just get added back on by Do_Core when the
-    // function finished.  So instead Do_Core recognizes this native
-    // specificially and clears the bit there.
+    // We cannot set the VALUE_FLAG_UNEVALUATED bit here and make it stick,
+    // because the bit would just get cleared off by Do_Core when the
+    // function finished.  Ask evaluator to add the bit for us.
 
-    return R_OUT;
+    return R_OUT_UNEVALUATED;
 }
 
 

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -207,7 +207,7 @@ REBNATIVE(print)
     //
     if (
         IS_BLOCK(value)
-        && GET_VAL_FLAG(value, VALUE_FLAG_EVALUATED)
+        && NOT(GET_VAL_FLAG(value, VALUE_FLAG_UNEVALUATED))
         && NOT(REF(eval))
     ){
         fail (Error(RE_PRINT_NEEDS_EVAL));

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -75,7 +75,7 @@ REBIXO Do_Vararg_Op_May_Throw(
     enum Reb_Param_Class pclass;
 
     const RELVAL *param; // for type checking
-    REBVAL *arg; // for updating VALUE_FLAG_EVALUATED
+    REBVAL *arg; // for updating VALUE_FLAG_UNEVALUATED
 
     REBVAL *shared;
 
@@ -232,10 +232,10 @@ REBIXO Do_Vararg_Op_May_Throw(
             return THROWN_FLAG;
 
         if (arg) {
-            if (GET_VAL_FLAG(out, VALUE_FLAG_EVALUATED))
-                SET_VAL_FLAG(arg, VALUE_FLAG_EVALUATED);
+            if (GET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED))
+                SET_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
             else
-                CLEAR_VAL_FLAG(arg, VALUE_FLAG_EVALUATED);
+                CLEAR_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
         }
         break;
 
@@ -244,7 +244,7 @@ REBIXO Do_Vararg_Op_May_Throw(
 
         QUOTE_NEXT_REFETCH(out, f);
         if (arg)
-            CLEAR_VAL_FLAG(arg, VALUE_FLAG_EVALUATED);
+            SET_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
         break;
 
     case PARAM_CLASS_SOFT_QUOTE:
@@ -259,10 +259,10 @@ REBIXO Do_Vararg_Op_May_Throw(
                 return THROWN_FLAG;
 
             if (arg) {
-                if (GET_VAL_FLAG(out, VALUE_FLAG_EVALUATED))
-                    SET_VAL_FLAG(arg, VALUE_FLAG_EVALUATED);
+                if (GET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED))
+                    SET_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
                 else
-                    CLEAR_VAL_FLAG(arg, VALUE_FLAG_EVALUATED);
+                    CLEAR_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
             }
             FETCH_NEXT_ONLY_MAYBE_END(f);
         }
@@ -272,7 +272,7 @@ REBIXO Do_Vararg_Op_May_Throw(
             QUOTE_NEXT_REFETCH(out, f);
 
             if (arg)
-                CLEAR_VAL_FLAG(arg, VALUE_FLAG_EVALUATED);
+                SET_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
         }
         break;
 

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -59,6 +59,17 @@ enum Reb_Result {
     //
     R_OUT,
 
+    // By default, all return results will not have the VALUE_FLAG_UNEVALUATED
+    // bit when they come back from a function.  To override that, this asks
+    // the dispatch to clear the bit instead.  It should be noted that since
+    // there is no meaningful way to carry the bit when copying values around
+    // internally, this is only a useful bit to read on things that were
+    // known to go directly through an evaluation step...e.g. arguments to
+    // functions on their initial fulfillment.  So this is returned by the
+    // QUOTE native (for instance).
+    //
+    R_OUT_UNEVALUATED,
+
     // See comments on OPT_VALUE_THROWN about the migration of "thrownness"
     // from being a property signaled to the evaluator.
     //

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -275,7 +275,7 @@ inline static void Lookback_For_Set_Word_Or_Set_Path(REBVAL *out, REBFRM *f)
     enum Reb_Kind kind = VAL_TYPE(DS_TOP);
     if (kind == REB_SET_WORD) {
         *out = *DS_TOP;
-        CLEAR_VAL_FLAG(out, VALUE_FLAG_EVALUATED);
+        SET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);
         VAL_SET_TYPE_BITS(DS_TOP, REB_GET_WORD); // See Do_Core/ET_SET_WORD
     }
     else if (kind == REB_SET_PATH) {
@@ -293,7 +293,7 @@ inline static void Lookback_For_Set_Word_Or_Set_Path(REBVAL *out, REBFRM *f)
                 fail (Error(RE_INFIX_PATH_GROUP, temp));
 
         *out = *DS_TOP;
-        CLEAR_VAL_FLAG(out, VALUE_FLAG_EVALUATED);
+        SET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);
         VAL_SET_TYPE_BITS(DS_TOP, REB_GET_PATH); // See Do_Core/ET_SET_PATH
     }
     else {
@@ -359,7 +359,7 @@ inline static void Do_Pending_Sets_May_Invalidate_Gotten(
             //
             f->gotten = NULL;
 
-            // leave VALUE_FLAG_EVALUATED as is
+            // leave VALUE_FLAG_UNEVALUATED as is
             break; }
 
         case REB_GET_PATH: {
@@ -379,7 +379,7 @@ inline static void Do_Pending_Sets_May_Invalidate_Gotten(
                 fail (Error_No_Catch_For_Throw(out));
             }
 
-            // leave VALUE_FLAG_EVALUATED as is
+            // leave VALUE_FLAG_UNEVALUATED as is
 
             // We did not pass in a symbol, so not a call... hence we cannot
             // process refinements.  Should not get any back.
@@ -608,7 +608,7 @@ inline static void DO_NEXT_REFETCH_MAY_THROW(
     //
     if (IS_KIND_INERT(child->eval_type)) {
         COPY_VALUE(out, parent->value, parent->specifier);
-        CLEAR_VAL_FLAG(out, VALUE_FLAG_EVALUATED);
+        SET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);
     }
     else {
         switch (child->eval_type) {
@@ -641,7 +641,7 @@ inline static void DO_NEXT_REFETCH_MAY_THROW(
                 fail (Error_No_Value_Core(parent->value, parent->specifier));
 
             *out = *child->gotten;
-            SET_VAL_FLAG(out, VALUE_FLAG_EVALUATED);
+            CLEAR_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);
 
         #if !defined(NDEBUG)
             if (LEGACY(OPTIONS_LIT_WORD_DECAY) && IS_LIT_WORD(out))
@@ -657,7 +657,7 @@ inline static void DO_NEXT_REFETCH_MAY_THROW(
                 parent->specifier,
                 GETVAR_READ_ONLY
             );
-            SET_VAL_FLAG(out, VALUE_FLAG_EVALUATED);
+            CLEAR_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);
             }
             break;
 
@@ -750,7 +750,7 @@ no_optimization:
 inline static void QUOTE_NEXT_REFETCH(REBVAL *dest, REBFRM *f) {
     TRACE_FETCH_DEBUG("QUOTE_NEXT_REFETCH", f, FALSE);
     COPY_VALUE(dest, f->value, f->specifier);
-    CLEAR_VAL_FLAG(dest, VALUE_FLAG_EVALUATED);
+    SET_VAL_FLAG(dest, VALUE_FLAG_UNEVALUATED);
     f->gotten = NULL;
     FETCH_NEXT_ONLY_MAYBE_END(f);
     TRACE_FETCH_DEBUG("QUOTE_NEXT_REFETCH", (f), TRUE);

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -266,14 +266,17 @@ enum {
     //
     VALUE_FLAG_RELATIVE = 1 << (GENERAL_VALUE_BIT + 3),
 
-    // `VALUE_FLAG_EVALUATED` is a somewhat dodgy-yet-important concept.
+    // `VALUE_FLAG_UNEVALUATED` is a somewhat dodgy-yet-important concept.
     // This is that some functions wish to be sensitive to whether or not
     // their argument came as a literal in source or as a product of an
     // evaluation.  While all values carry the bit, it is only guaranteed
     // to be meaningful on arguments in function frames...though it is
-    // valid on any result at the moment of taking it from Do_Core().
+    // valid on any result at the moment of taking it from Do_Core().  It
+    // is in the negative sense because the act of requesting it is
+    // uncommon, e.g. from the QUOTE operator, so an arbitrary SET_BLANK()
+    // or other assignment should default to being "evaluative".
     //
-    VALUE_FLAG_EVALUATED = 1 << (GENERAL_VALUE_BIT + 4),
+    VALUE_FLAG_UNEVALUATED = 1 << (GENERAL_VALUE_BIT + 4),
 
     // v-- BEGIN TYPE SPECIFIC BITS HERE
 };
@@ -523,7 +526,7 @@ struct Reb_Varargs {
     // Similar to the param, the arg is only good for the lifetime of the
     // FRAME!...but even less so, because VARARGS! can (currently) be
     // overwritten with another value in the function frame at any point.
-    // Despite this, we proxy the VALUE_FLAG_EVALUATED from the last TAKE
+    // Despite this, we proxy the VALUE_FLAG_UNEVALUATED from the last TAKE
     // onto the argument to reflect its *argument* status.
     //
     REBVAL *arg;

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -722,10 +722,10 @@ inline static void SET_FALSE_COMMON(RELVAL *v) {
 //
 inline static REBOOL IS_CONDITIONAL_TRUE_SAFE(const REBVAL *v) {
     if (IS_BLOCK(v)) {
-        if (GET_VAL_FLAG(v, VALUE_FLAG_EVALUATED))
-            return TRUE;
-
-        fail (Error(RE_BLOCK_CONDITIONAL, v));
+        if (GET_VAL_FLAG(v, VALUE_FLAG_UNEVALUATED))
+            fail (Error(RE_BLOCK_CONDITIONAL, v));
+            
+        return TRUE;
     }
     return IS_CONDITIONAL_TRUE(v);
 }


### PR DESCRIPTION
Noticing a pattern in problems, Ren-C added the feature that it would
be possible for a function FOO with an evaluated argument to tell the
difference between being called as `FOO [y]` vs. `FOO SECOND [[x] [y]]`
or `BLK: [y] | FOO BLK`.  The reason this distinction was important
was to give errors like:

    >> if [x] [print "oops"]
    ** Script error: Literal block used as conditional [x]
    ** Where: if
    ** Near: if [x] [print "oops"] ??

...while still allowing `var: [x] | if var [print "ok"]`.

The initial experiment to add this feature added a bit to REBVALs
called VALUE_FLAG_EVALUATED.  Every function evaluation or variable
fetch would set this bit, while literal values or QUOTE would clear
it off.  It was a property of the functions QUOTE and SEMIQUOTE,
which had to be tested for explicitly on each evaluation.

(Note: This opens a bit of a can of worms, since the QUOTE native
is no longer purely compatible with a user function that implements
QUOTE by just returning a GET-WORD!-styled argument.  That could
be addressed by allowing user functions to mark their return values
as literal, either with a RETURN/LITERAL or just saying that a function
will always return what is effectively a literal or not.)

In any case, the feature was added before the R_XXX function overhaul,
which makes good use of the ability of functions to do one level of
optimized switch statement after dispatch.  Hence there's no need
for each and every evaluator step to examine the function pointer and
do two comparisons against QUOTE and SEMIQUOTE to decide what to do
about the bit...instead, those natives can just return a different
value as R_OUT_UNEVALUATED.

In addition to that optimization, this changes it so that the default
for all the initialization operations is to make evaluated values.
So the flag in the positive sense is VALUE_FLAG_UNEVALUATED instead of
VALUE_FLAG_EVALUATED.  Technically speaking this doesn't matter that
much since the optimizer would fold together operations like
`SET_BLANK(val); SET_VAL_FLAG(val, VALUE_FLAG_EVALUATED);` into a
single assignment of the header bits, but given that the unevaluated
bit is the "special" case there are fewer mentions by reversing the
sense of the bit.