### PR TITLE
Tweak voids in REMOVE-EACH/"UNTIL", use data stack in MAP-EACH

### DIFF
--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1667,18 +1667,14 @@ REBCNT Recycle(void)
 //
 //  Guard_Series_Core: C
 //
+// Does not ensure the series being guarded is managed, since it can be
+// interesting to guard the managed *contents* of an unmanaged array.  The
+// calling wrappers ensure managedness or not.
+//
 void Guard_Series_Core(REBSER *series)
 {
-    // It would seem there isn't any reason to save a series from being
-    // garbage collected if it is already invisible to the garbage
-    // collector.  But some kind of "saving" feature which added a
-    // non-managed series in as if it were part of the root set would
-    // be useful.  That would be for cases where you are building a
-    // series up from constituent values but might want to abort and
-    // manually free it.  For the moment, we don't have that feature.
-    ASSERT_SERIES_MANAGED(series);
-
-    if (SER_FULL(GC_Series_Guard)) Extend_Series(GC_Series_Guard, 8);
+    if (SER_FULL(GC_Series_Guard))
+        Extend_Series(GC_Series_Guard, 8);
 
     *SER_AT(
         REBSER*,

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -143,12 +143,6 @@ inline static void TERM_SERIES(REBSER *s) {
 #define FAIL_IF_LOCKED_ARRAY(a) \
     FAIL_IF_LOCKED_SERIES(ARR_SERIES(a))
 
-#define PUSH_GUARD_ARRAY(a) \
-    PUSH_GUARD_SERIES(ARR_SERIES(a))
-
-#define DROP_GUARD_ARRAY(a) \
-    DROP_GUARD_SERIES(ARR_SERIES(a))
-
 #define IS_ARRAY_MANAGED(array) \
     IS_SERIES_MANAGED(ARR_SERIES(array))
 
@@ -157,6 +151,30 @@ inline static void TERM_SERIES(REBSER *s) {
 
 #define ENSURE_ARRAY_MANAGED(array) \
     ENSURE_SERIES_MANAGED(ARR_SERIES(array))
+
+#define PUSH_GUARD_ARRAY(a) \
+    PUSH_GUARD_SERIES(ARR_SERIES(a))
+
+#define DROP_GUARD_ARRAY(a) \
+    DROP_GUARD_SERIES(ARR_SERIES(a))
+
+inline static void PUSH_GUARD_ARRAY_CONTENTS(REBARR *a) {
+    assert(!IS_ARRAY_MANAGED(a)); // if managed, just use PUSH_GUARD_ARRAY
+    Guard_Series_Core(ARR_SERIES(a));
+}
+
+inline static void DROP_GUARD_ARRAY_CONTENTS(REBARR *a) {
+#if !defined(NDEBUG)
+    //
+    // Make sure no unmanaged values were put in the array, because they
+    // would have caused errors if the GC had seen them!
+    //
+    RELVAL *test = ARR_HEAD(a);
+    for (; NOT_END(test); ++test)
+        ASSERT_VALUE_MANAGED(test);
+#endif
+    DROP_GUARD_SERIES(ARR_SERIES(a));
+}
 
 
 // Make a series that is the right size to store REBVALs (and

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -406,8 +406,10 @@ static inline void UNMARK_REBSER(REBSER *rebser) {
 // guarding, the last value guarded must be the first one you DROP_GUARD on.
 //
 
-#define PUSH_GUARD_SERIES(s) \
-    Guard_Series_Core(s)
+inline static void PUSH_GUARD_SERIES(REBSER *s) {
+    ASSERT_SERIES_MANAGED(s); // see PUSH_GUARD_ARRAY_CONTENTS if you need it
+    Guard_Series_Core(s);
+}
 
 inline static void DROP_GUARD_SERIES(REBSER *s) {
     assert(GET_SER_FLAG(GC_Series_Guard, SERIES_FLAG_HAS_DYNAMIC));


### PR DESCRIPTION
In Ren-C, CONTINUE has a /WITH refinement.  The meaning of calling
CONTINUE/WITH a value is to do exactly the same thing as if the loop
body had finished normally and evaluated to that value:

    >> map-each x [1 2 3] [if x = 2 [continue/with 666] x + 100]
    == [101 666 103]

(Note: BREAK also has a /WITH refinement--instead of /RETURN--with a
similar semantic of acting like the body returned the value...it just
also stops the loop after that.)

The next rule is that a CONTINUE *without* a /WITH refinement acts
exactly like if the loop body had no result.  Hence if one desires
the following:

    >> foo: [1 2 3]
    >> remove-each x foo [either x = 2 [true] [continue]]
    >> probe foo
    [1 3]

...that implies that if the loop body of REMOVE-EACH evaluates to no
value, it is "opting out" of the removal.  Hence it will act the same
as a FALSE or BLANK! value would.

    >> foo: [1 2 3]
    >> remove-each x foo [print "hi"]
    hi
    hi
    hi
    >> probe foo
    [1 2 3]

This fixes what was an safety asserting case (logic testing on a void)
by resolving it to be consistent with this invariant.  It also goes
ahead and updates the behavior for LOOP-WHILE and LOOP-UNTIL (aka
"UNTIL") to similarly allow voids to opt out, to give the same
consistency with CONTINUE.  Hence LOOP-UNTIL [print "hi"] is an
infinite loop, as LOOP-UNTIL [false] was, and LOOP-WHILE [print "hi"]
is an infinite loop, as LOOP-WHILE [true] is.

(Note: The somewhat unusual impliciation is that CONTINUE/WITH TRUE
will break a LOOP-UNTIL, and CONTINUE/WITH FALSE will break a
LOOP-WHILE, but it makes sense as their body and condition are the
same thing.)

In addition to resolving this issue, the commit relaxes the requirement
that you cannot guard a series from garbage collection unless it is
managed by the garbage collector.  The way it is relaxed is that if
the series is an array--and unmanaged--then there is a special form
of guarding of its *contents*.  This was initially used to enhance the
handling of MAP-EACH's temporary buffer, before realizing that MAP-EACH
really should be using the data stack.  The data stack already offers
the necessary protection, as well as helping to generate an array of
the right size.  This is why REDUCE and other routines use it.