### PR TITLE
Unentangle FFI code from core GC, some GC streamlining

### DIFF
--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -237,7 +237,6 @@ addr
 raw-memory
 raw-size
 extern
-rebval
 
 ;routine
 void

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -237,6 +237,7 @@ addr
 raw-memory
 raw-size
 extern
+rebval
 
 ;routine
 void

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -163,19 +163,6 @@ static void Assert_Basics(void)
     // you'd like to catch IS_END() tests on trash.)
     //
     assert(REB_MAX < 256);
-
-    // Types that are used for memory pooled allocations are required to be
-    // multiples of 8 bytes in size.  This way it's possible to reliably align
-    // 64-bit values using the node's allocation pointer as a baseline that
-    // is known to be 64-bit aligned.  (Rounding internally to the allocator
-    // would be possible, but that would add calculation as well as leading
-    // to wasting space--whereas this way any padding is visible.)
-    //
-    // This check is reinforced in the pool initialization itself.
-    //
-    assert(sizeof(REBI64) == 8);
-    assert(sizeof(REBSER) % 8 == 0);
-    assert(sizeof(REBGOB) % 8 == 0);
 }
 
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -176,7 +176,6 @@ static void Assert_Basics(void)
     assert(sizeof(REBI64) == 8);
     assert(sizeof(REBSER) % 8 == 0);
     assert(sizeof(REBGOB) % 8 == 0);
-    assert(sizeof(REBRIN) % 8 == 0);
 }
 
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -78,7 +78,7 @@ void Assert_State_Balanced_Debug(
     const char *file,
     int line
 ) {
-    REBSER *panic = NULL;
+    REBSER *smoking_gun = NULL;
 
     if (s->dsp != DSP) {
         Debug_Fmt(
@@ -99,7 +99,7 @@ void Assert_State_Balanced_Debug(
             "PUSH_GUARD_SERIES()x%d without DROP_GUARD_SERIES",
             SER_LEN(GC_Series_Guard) - s->series_guard_len
         );
-        panic = *SER_AT(
+        smoking_gun = *SER_AT(
             REBSER*,
             GC_Series_Guard,
             SER_LEN(GC_Series_Guard) - 1
@@ -144,7 +144,7 @@ void Assert_State_Balanced_Debug(
             "Make_Series()x%d without Free_Series or MANAGE_SERIES",
             SER_LEN(GC_Manuals) - s->manuals_len
         );
-        panic = *(SER_AT(
+        smoking_gun = *(SER_AT(
             REBSER*,
             GC_Manuals,
             SER_LEN(GC_Manuals) - 1
@@ -161,8 +161,8 @@ void Assert_State_Balanced_Debug(
 
 problem_found:
     Debug_Fmt("in File: %s Line: %d", file, line);
-    if (panic)
-        Panic_Series(panic);
+    if (smoking_gun != NULL)
+        Panic_Series(smoking_gun);
     assert(FALSE);
     DEAD_END;
 }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -468,6 +468,12 @@ void Val_Init_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *context) {
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(context));
 
     *out = *CTX_VALUE(context);
+
+    // Currently only FRAME! uses the ->binding field.  Following the pattern
+    // of function, we assume the archetype form of a frame has no binding,
+    // and it's only REBVAL instances besides the canon that become bound.
+    //
+    assert(VAL_BINDING(out) == NULL);
 }
 
 

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -244,7 +244,6 @@ const REBPOOLSPEC Mem_Pool_Spec[MAX_POOLS] =
 
     DEF_POOL(sizeof(REBSER), 4096), // Series headers
     DEF_POOL(sizeof(REBGOB), 128),  // Gobs
-    DEF_POOL(sizeof(REBRIN), 128), // external routines
     DEF_POOL(sizeof(REBI64), 1), // Just used for tracking main memory
 };
 

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1739,23 +1739,6 @@ REBOOL Is_Value_Managed(const RELVAL *value)
 
 
 //
-//  Free_Gob: C
-//
-// Free a gob, returning its memory for reuse.
-//
-void Free_Gob(REBGOB *gob)
-{
-    Free_Node(GOB_POOL, gob);
-
-    if (REB_I32_ADD_OF(GC_Ballast, Mem_Pools[GOB_POOL].wide, &GC_Ballast)) {
-        GC_Ballast = MAX_I32;
-    }
-
-    if (GC_Ballast > 0) CLR_SIGNAL(SIG_RECYCLE);
-}
-
-
-//
 //  Series_In_Pool: C
 //
 // Confirm that the series value is in the series pool.

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -484,8 +484,8 @@ void Assert_Series_Core(REBSER *series)
 //
 //  Panic_Series_Debug: C
 //
-// This could be done in the PANIC_SERIES macro, but having it
-// as an actual function gives you a place to set breakpoints.
+// This could be done in the PANIC_SERIES macro, but having it as an actual
+// function gives you a place to set breakpoints.
 //
 ATTRIBUTE_NO_RETURN void Panic_Series_Debug(
     REBSER *series,

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -402,6 +402,7 @@ REBCTX *Context_For_Frame_May_Reify_Core(REBFRM *f) {
     VAL_RESET_HEADER(CTX_VALUE(context), REB_FRAME);
     CTX_VALUE(context)->payload.any_context.varlist = CTX_VARLIST(context);
     INIT_CONTEXT_FRAME(context, f);
+    CTX_VALUE(context)->extra.binding = f->binding;
 
     // A reification of a frame for native code should not allow changing
     // the values out from under it, because that could cause it to crash

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1434,15 +1434,15 @@ void Mold_Value(REB_MOLD *mold, const RELVAL *value, REBOOL molded)
         Mold_Event(const_KNOWN(value), mold);
         break;
 
-    case REB_STRUCT:
-    {
-        REBARR *array;
+    case REB_STRUCT: {
         Pre_Mold(value, mold);
-        array = Struct_To_Array(VAL_STRUCT(value));
+
+        REBARR *array = Struct_To_Array(VAL_STRUCT(value));
         Mold_Array_At(mold, array, 0, 0);
+        Free_Array(array);
+
         End_Mold(mold);
-    }
-        break;
+        break; }
 
     case REB_LIBRARY: {
         Pre_Mold(value, mold);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -147,19 +147,11 @@ REBTYPE(Function)
 
         switch (sym) {
         case SYM_ADDR:
-            if (
-                IS_FUNCTION_RIN(value)
-                && GET_RIN_FLAG(VAL_FUNC_ROUTINE(value), ROUTINE_FLAG_CALLBACK)
-            ) {
-                SET_INTEGER(
-                    D_OUT, cast(REBUPT, RIN_DISPATCHER(VAL_FUNC_ROUTINE(value)))
-                );
-                return R_OUT;
-            }
-            if (
-                IS_FUNCTION_RIN(value)
-                && !GET_RIN_FLAG(VAL_FUNC_ROUTINE(value), ROUTINE_FLAG_CALLBACK)
-            ) {
+            if (IS_FUNCTION_RIN(value)) {
+                //
+                // The CFUNC is fabricated by the FFI if it's a callback, or
+                // just the wrapped DLL function if it's an ordinary routine
+                //
                 SET_INTEGER(
                     D_OUT, cast(REBUPT, RIN_CFUNC(VAL_FUNC_ROUTINE(value)))
                 );
@@ -285,7 +277,7 @@ REBNATIVE(func_class_of)
     else if (IS_FUNCTION_COMMAND(value))
         n = 4;
     else if (IS_FUNCTION_RIN(value)) {
-        if (!GET_RIN_FLAG(VAL_FUNC_ROUTINE(value), ROUTINE_FLAG_CALLBACK))
+        if (NOT(RIN_IS_CALLBACK(VAL_FUNC_ROUTINE(value))))
             n = 5;
         else
             n = 6;

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -827,8 +827,11 @@ REB_R Routine_Dispatcher(REBFRM *f)
 
     REBCNT i = 0;
 
-    // First gather the fixed parameters from the frame (known to be
-    // of correct types--they were checked by Do_Core() before this point.)
+    // First gather the fixed parameters from the frame.  They are known to
+    // be of correct general types (they were checked by Do_Core for the call)
+    // but a STRUCT! might not be compatible with the type of STRUCT! in
+    // the parameter specification.  They might also be out of range, e.g.
+    // a too-large or negative INTEGER! passed to a uint8.  Could fail() here.
     //
     for (; i < num_fixed; ++i) {
         REBUPT offset = arg_to_ffi(
@@ -844,12 +847,11 @@ REB_R Routine_Dispatcher(REBFRM *f)
     // If an FFI routine takes a fixed number of arguments, then its Call
     // InterFace (CIF) can be created just once.  This will be in the RIN_CIF.
     // However a variadic routine requires a CIF that matches the number
-    // and types of arguments for that specific call.  This CIF variable will
-    // be set to the RIN_CIF if it exists already--or to a dynamically
-    // allocated CIF for the varargs case (which will need to be freed).
+    // and types of arguments for that specific call.
     //
     // Note that because these pointers need to be freed by HANDLE! cleanup,
-    // they need to know the size.
+    // they need to remember the size.  OS_ALLOC() is used, at least until
+    // HANDLE! is changed to support sizes.
     //
     ffi_cif *cif; // pre-made if not variadic, built for this call otherwise
     ffi_type **args_fftypes; // ffi_type*[] if num_variable > 0

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -571,11 +571,13 @@ static REBUPT arg_to_ffi(
             break;}
 
         case REB_FUNCTION:{
-            if (!GET_RIN_FLAG(VAL_FUNC_ROUTINE(arg), ROUTINE_FLAG_CALLBACK))
-                fail (Error(RE_ONLY_CALLBACK_PTR));
+            if (!IS_FUNCTION_RIN(arg))
+                fail (Error(RE_ONLY_CALLBACK_PTR)); // actually routines too
 
-            void* dispatcher = RIN_DISPATCHER(VAL_FUNC_ROUTINE(arg));
-            memcpy(dest, &dispatcher, sizeof(dispatcher));
+            CFUNC* cfunc = RIN_CFUNC(VAL_FUNC_ROUTINE(arg));
+            if (sizeof(cfunc) != sizeof(void*)) // not necessarily true
+                fail (Error(RE_MISC));
+            memcpy(dest, &cfunc, sizeof(void*));
             break;}
 
         default:
@@ -742,7 +744,7 @@ REB_R Routine_Dispatcher(REBFRM *f)
     REBCNT num_variable;
     REBDSP dsp_orig = DSP; // variadic args pushed to stack, so save base ptr
 
-    if (NOT(GET_RIN_FLAG(rin, ROUTINE_FLAG_VARIADIC)))
+    if (NOT(RIN_IS_VARIADIC(rin)))
         num_variable = 0;
     else {
         // The function specification should have one extra parameter for
@@ -843,13 +845,14 @@ REB_R Routine_Dispatcher(REBFRM *f)
     // of correct types--they were checked by Do_Core() before this point.)
     //
     for (; i < num_fixed; ++i) {
-        *SER_AT(void*, arg_offsets, i) = cast(void*, arg_to_ffi(
+        REBCNT offset = arg_to_ffi(
             store, // ffi-converted arg appended here
             NULL, // dest pointer must be NULL if store is non-NULL
             FRM_ARG(f, i + 1), // 1-based
             RIN_ARG_SCHEMA(rin, i), // 0-based
             FUNC_PARAM(FRM_FUNC(f), i + 1) // 1-based
-        ));
+        );
+        *SER_AT(void*, arg_offsets, i) = cast(void*, offset); // convert later
     }
 
     // If an FFI routine takes a fixed number of arguments, then its Call
@@ -859,28 +862,26 @@ REB_R Routine_Dispatcher(REBFRM *f)
     // be set to the RIN_CIF if it exists already--or to a dynamically
     // allocated CIF for the varargs case (which will need to be freed).
     //
-    REBSER *cif; // one ffi_cif element (in a REBSER for GC on fail())
-    REBSER *args_fftypes; // list of ffi_type* if num_variable > 0
+    // Note that because these pointers need to be freed by HANDLE! cleanup,
+    // they need to know the size.
+    //
+    ffi_cif *cif; // pre-made if not variadic, built for this call otherwise
+    ffi_type **args_fftypes; // ffi_type*[] if num_variable > 0
 
     if (num_variable == 0) {
-        cif = rin->cif;
+        cif = RIN_CIF(rin);
     }
     else {
-        assert(rin->cif == NULL);
+        assert(IS_BLANK(RIN_AT(rin, 5)));
 
         // CIF creation requires a C array of argument descriptions that is
         // contiguous across both the fixed and variadic parts.  Start by
         // filling in the ffi_type*s for all the fixed args.
         //
-        args_fftypes = Make_Series(
-            num_fixed + num_variable,
-            sizeof(ffi_type*),
-            MKS_NONE
-        );
+        args_fftypes = OS_ALLOC_N(ffi_type*, num_fixed + num_variable);
 
         for (i = 0; i < num_fixed; ++i)
-            *SER_AT(ffi_type*, args_fftypes, i)
-                = SCHEMA_FFTYPE(RIN_ARG_SCHEMA(rin, i));
+            args_fftypes[i] = SCHEMA_FFTYPE(RIN_ARG_SCHEMA(rin, i));
 
         REBDSP dsp;
         for (dsp = dsp_orig + 1; i < num_args; dsp += 2, ++i) {
@@ -899,7 +900,7 @@ REB_R Routine_Dispatcher(REBFRM *f)
                 DS_AT(dsp + 1) // will error if this is not a block
             );
 
-            *SER_AT(ffi_type*, args_fftypes, i) = SCHEMA_FFTYPE(&schema);
+            args_fftypes[i] = SCHEMA_FFTYPE(&schema);
 
             INIT_TYPESET_NAME(&param, Canon(SYM_ELLIPSIS));
 
@@ -914,21 +915,24 @@ REB_R Routine_Dispatcher(REBFRM *f)
 
         DS_DROP_TO(dsp_orig); // done w/args (converted to bytes in `store`)
 
-        cif = Make_Series(1, sizeof(ffi_cif), MKS_NONE);
+        cif = OS_ALLOC(ffi_cif);
 
         ffi_status status = ffi_prep_cif_var( // "_var"-iadic prep_cif version
-            SER_HEAD(ffi_cif, cif),
+            cif,
             RIN_ABI(rin),
             num_fixed, // just fixed
             num_args, // fixed plus variable
             IS_BLANK(RIN_RET_SCHEMA(rin))
                 ? &ffi_type_void
                 : SCHEMA_FFTYPE(RIN_RET_SCHEMA(rin)), // return FFI type
-            SER_HEAD(ffi_type*, args_fftypes) // arguments FFI types
+            args_fftypes // arguments FFI types
         );
 
-        if (status != FFI_OK)
+        if (status != FFI_OK) {
+            OS_FREE(cif);
+            OS_FREE(args_fftypes);
             fail (Error(RE_MISC)); // Couldn't prep CIF_VAR
+        }
     }
 
     // Now that all the additions to store have been made, we want to change
@@ -955,7 +959,7 @@ REB_R Routine_Dispatcher(REBFRM *f)
         SET_UNREADABLE_BLANK(&Callback_Error); // !!! is it already?
 
         ffi_call(
-            SER_HEAD(ffi_cif, cif),
+            cif,
             RIN_CFUNC(rin),
             ret_offset, // actually a real pointer now (no longer an offset)
             (num_args == 0)
@@ -978,8 +982,8 @@ REB_R Routine_Dispatcher(REBFRM *f)
     Free_Series(store);
 
     if (num_variable != 0) {
-        Free_Series(cif);
-        Free_Series(args_fftypes);
+        OS_FREE(cif);
+        OS_FREE(args_fftypes);
     }
 
     // Note: cannot "throw" a Rebol value across an FFI boundary.
@@ -989,18 +993,36 @@ REB_R Routine_Dispatcher(REBFRM *f)
 }
 
 
+// The GC-able HANDLE! used by callbacks contains a ffi_closure pointer that
+// needs to be freed when the handle references go away (really only one
+// reference is likely--in the FUNC_BODY of the callback, but still this is
+// how the GC gets hooked in Ren-C)
 //
-//  Free_Routine: C
-//
-void Free_Routine(REBRIN *rin)
-{
-    CLEAR_RIN_FLAG(rin, ROUTINE_FLAG_MARK);
-    if (GET_RIN_FLAG(rin, ROUTINE_FLAG_CALLBACK))
-        ffi_closure_free(RIN_CLOSURE(rin));
+static void cleanup_ffi_closure(const REBVAL *v) {
+    assert(IS_HANDLE(v));
+    assert(v->payload.handle.code != NULL); // the cfunc thunk within closure
+    assert(v->payload.handle.data != NULL);
 
-    // cif and ffargs are GC-managed, will free themselves
+    ffi_closure_free(cast(ffi_closure*, v->payload.handle.data));
+}
 
-    Free_Node(RIN_POOL, rin);
+// Because HANDLE! has enough bits to store the pointer to a REBSER node for
+// a singular array, and the data, and then another void* size element left
+// over, the decision was to allow a handle to store more than one pointer...
+// one code and one data.  But that doesn't leave any info for a size, and
+// allocations from Rebol's memory manager do not encode the size in that
+// allocation.  It may be wiser in the long run to make the second value a
+// size, especially given that those wanting two HANDLE!s in one slot can
+// do so using a pairing series now, relatively efficiently.  (One of the
+// original motives was that Ren-Cpp needed to store a function pointer and
+// a data pointer in a function body.)
+// 
+static void cleanup_os_alloc(const REBVAL *v) {
+    assert(IS_HANDLE(v));
+    assert(v->payload.handle.code == NULL);
+    assert(v->payload.handle.data != NULL);
+
+    OS_FREE(v->payload.handle.data); // OS_FREE or free() knows the size
 }
 
 
@@ -1024,7 +1046,7 @@ static void callback_dispatcher(
         return;
 
     REBRIN *rin = cast(REBRIN*, user_data);
-    assert(!GET_RIN_FLAG(rin, ROUTINE_FLAG_VARIADIC));
+    assert(!RIN_IS_VARIADIC(rin));
     assert(cif->nargs == RIN_NUM_FIXED_ARGS(rin));
 
     // We do not want to longjmp() out of the callback if there is an error.
@@ -1107,15 +1129,15 @@ static void callback_dispatcher(
 //     return: [type] "note"
 // ]
 //
-REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
+static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
     assert(IS_BLOCK(ffi_spec));
 
-    REBRIN *r = cast(REBRIN*, Make_Node(RIN_POOL));
-    assert(r->header.bits == 0);
-    SET_RIN_FLAG(r, ROUTINE_FLAG_USED); // so pooled node knows it's in use
-    r->abi = FFI_DEFAULT_ABI;
+    REBRIN *r = Make_Array(8);
 
-    INIT_CELL_IF_DEBUG(RIN_RET_SCHEMA(r));
+    SET_UNREADABLE_BLANK(RIN_AT(r, 0)); // caller updates to be cfunc handle
+    SET_INTEGER(RIN_AT(r, 1), abi);
+    SET_UNREADABLE_BLANK(RIN_AT(r, 2)); // caller updates to LIBRARY/FUNCTION
+
     SET_BLANK(RIN_RET_SCHEMA(r)); // blank means returns void (the default)
 
     const REBCNT capacity_guess = 8; // !!! Magic number...why 8? (can grow)
@@ -1138,11 +1160,12 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
     //
     // !!! Should the spec analysis be allowed to do evaluation? (it does)
     //
-    r->args_schemas = Make_Array(capacity_guess);
-    MANAGE_ARRAY(r->args_schemas);
-    PUSH_GUARD_ARRAY(r->args_schemas);
+    REBARR *args_schemas = Make_Array(capacity_guess);
+    MANAGE_ARRAY(args_schemas);
+    PUSH_GUARD_ARRAY(args_schemas);
 
     REBCNT num_fixed = 0; // number of fixed (non-variadic) arguments
+    REBOOL is_variadic = FALSE; // default to not being variadic
 
     RELVAL *item = VAL_ARRAY_AT(ffi_spec);
     for (; NOT_END(item); ++item) {
@@ -1155,10 +1178,10 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
             REBSTR *name = VAL_WORD_SPELLING(item);
 
             if (SAME_STR(name, Canon(SYM_ELLIPSIS))) { // variadic
-                if (GET_RIN_FLAG(r, ROUTINE_FLAG_VARIADIC))
+                if (is_variadic)
                     fail (Error_Invalid_Arg(KNOWN(item))); // duplicate "..."
 
-                SET_RIN_FLAG(r, ROUTINE_FLAG_VARIADIC);
+                is_variadic = TRUE;
 
                 REBVAL *param = Alloc_Tail_Array(paramlist);
 
@@ -1176,7 +1199,7 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
                 INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
             }
             else { // ordinary argument
-                if (GET_RIN_FLAG(r, ROUTINE_FLAG_VARIADIC))
+                if (is_variadic)
                     fail (Error_Invalid_Arg(KNOWN(item))); // variadic is final
 
                 REBVAL *param = Alloc_Tail_Array(paramlist);
@@ -1187,7 +1210,7 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
                 COPY_VALUE(&block, item, VAL_SPECIFIER(ffi_spec));
 
                 Schema_From_Block_May_Fail(
-                    Alloc_Tail_Array(r->args_schemas), // schema (out)
+                    Alloc_Tail_Array(args_schemas), // schema (out)
                     param, // param (out)
                     &block // block (in)
                 );
@@ -1227,58 +1250,62 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
         }
     }
 
-    TERM_ARRAY_LEN(r->args_schemas, num_fixed);
-    ASSERT_ARRAY(r->args_schemas);
+    SET_LOGIC(RIN_AT(r, 7), is_variadic);
 
-    if (GET_RIN_FLAG(r, ROUTINE_FLAG_VARIADIC)) {
+    TERM_ARRAY_LEN(r, 8);
+    ASSERT_ARRAY(args_schemas);
+    Val_Init_Block(RIN_AT(r, 4), args_schemas);
+
+    if (RIN_IS_VARIADIC(r)) {
         //
         // Each individual call needs to use `ffi_prep_cif_var` to make the
         // proper variadic CIF for that call.
         //
-        r->cif = NULL;
-        r->args_fftypes = NULL;
+        SET_BLANK(RIN_AT(r, 5));
+        SET_BLANK(RIN_AT(r, 6));
     }
     else {
         // The same CIF can be used for every call of the routine if it is
-        // not variadic.  The fftypes array pointer used must stay alive
-        // for the entire the lifetime of the CIF, apparently :-/
+        // not variadic.  The CIF must stay alive for the entire the lifetime
+        // of the args_fftypes, apparently.
         //
-        r->cif = Make_Series(1, sizeof(ffi_cif), MKS_NONE);
+        ffi_cif *cif = OS_ALLOC(ffi_cif);
 
+        ffi_type **args_fftypes;
         if (num_fixed == 0)
-            r->args_fftypes = NULL; // 0 size series illegal (others wasteful)
+            args_fftypes = NULL;
         else
-            r->args_fftypes = Make_Series(
-                num_fixed, sizeof(ffi_type*), MKS_NONE
-            );
+            args_fftypes = OS_ALLOC_N(ffi_type*, num_fixed);
 
         REBCNT i;
         for (i = 0; i < num_fixed; ++i)
-            *SER_AT(ffi_type*, r->args_fftypes, i)
-                = SCHEMA_FFTYPE(RIN_ARG_SCHEMA(r, i));
+            args_fftypes[i] = SCHEMA_FFTYPE(RIN_ARG_SCHEMA(r, i));
 
         if (
             FFI_OK != ffi_prep_cif(
-                SER_HEAD(ffi_cif, r->cif),
-                RIN_ABI(r),
+                cif,
+                abi,
                 num_fixed,
                 IS_BLANK(RIN_RET_SCHEMA(r))
                     ? &ffi_type_void
                     : SCHEMA_FFTYPE(RIN_RET_SCHEMA(r)),
-                (r->args_fftypes == NULL)
-                    ? NULL
-                    : SER_HEAD(ffi_type*, r->args_fftypes)
+                args_fftypes // NULL if 0 fixed args
             )
         ){
             fail (Error(RE_MISC)); // !!! Couldn't prep cif...
         }
 
-        MANAGE_SERIES(r->cif);
-        if (r->args_fftypes)
-            MANAGE_SERIES(r->args_fftypes); // must have same lifetime as cif
+        Init_Handle_Managed(RIN_AT(r, 5), NULL, cif, &cleanup_os_alloc);
+
+        if (args_fftypes == NULL)
+            SET_BLANK(RIN_AT(r, 6));
+        else
+            Init_Handle_Managed(
+                RIN_AT(r, 6), NULL, args_fftypes, &cleanup_os_alloc
+            ); // lifetime must match cif lifetime
     }
 
-    DROP_GUARD_ARRAY(r->args_schemas);
+    DROP_GUARD_ARRAY(args_schemas);
 
     // Now fill in the canon value of the paramlist so it is an actual "REBFUN"
     //
@@ -1286,9 +1313,7 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
     rootparam->payload.function.paramlist = paramlist;
     rootparam->extra.binding = NULL;
 
-    // The "body" value of a routine is a handle which points to the routine
-    // info.  This is available to the Routine_Dispatcher when the function
-    // gets called.
+    // The "body" value of a routine is the routine info array.
     //
     SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
@@ -1297,11 +1322,7 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec) {
         &Routine_Dispatcher,
         NULL // no underlying function, this is fundamental
     );
-    Init_Handle_Simple(
-        FUNC_BODY(fun),
-        NULL, // code
-        cast(REBRIN*, r) // data
-    );
+    Val_Init_Block(FUNC_BODY(fun), r);
 
     ARR_SERIES(paramlist)->link.meta = NULL;
 
@@ -1334,6 +1355,12 @@ REBNATIVE(make_routine)
 {
     INCLUDE_PARAMS_OF_MAKE_ROUTINE;
 
+    ffi_abi abi;
+    if (REF(abi))
+        abi = Abi_From_Word(ARG(abi_type));
+    else
+        abi = FFI_DEFAULT_ABI;
+
     // Make sure library wasn't closed with CLOSE
     //
     REBLIB *lib = VAL_LIBRARY(ARG(lib));
@@ -1358,14 +1385,11 @@ REBNATIVE(make_routine)
 
     // Process the parameter types into a function, then fill it in
 
-    REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec));
+    REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec), abi);
     REBRIN *r = FUNC_ROUTINE(fun);
 
-    if (REF(abi))
-        r->abi = Abi_From_Word(ARG(abi_type));
-
-    r->code.routine.cfunc = cfunc;
-    r->code.routine.lib = lib;
+    Init_Handle_Simple(RIN_AT(r, 0), cfunc, NULL);
+    *RIN_AT(r, 2) = *ARG(lib);
 
     *D_OUT = *FUNC_VALUE(fun);
     return R_OUT;
@@ -1395,6 +1419,12 @@ REBNATIVE(make_routine_raw)
 {
     INCLUDE_PARAMS_OF_MAKE_ROUTINE_RAW;
 
+    ffi_abi abi;
+    if (REF(abi))
+        abi = Abi_From_Word(ARG(abi_type));
+    else
+        abi = FFI_DEFAULT_ABI;
+
     // Cannot cast directly to a function pointer from a 64-bit value
     // on 32-bit systems; first cast to (U)nsigned int that holds (P)oin(T)er
     //
@@ -1403,14 +1433,12 @@ REBNATIVE(make_routine_raw)
     if (cfunc == NULL)
         fail (Error_Invalid_Arg(ARG(pointer)));
 
-    REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec));
+    REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec), abi);
     REBRIN *r = FUNC_ROUTINE(fun);
 
-    if (REF(abi))
-        r->abi = Abi_From_Word(ARG(abi_type));
-
-    r->code.routine.cfunc = cfunc;
-    r->code.routine.lib = NULL;
+    Init_Handle_Simple(RIN_AT(r, 0), cfunc, NULL);
+    SET_INTEGER(RIN_AT(r, 1), abi);
+    SET_BLANK(RIN_AT(r, 2)); // no LIBRARY! in this case.
 
     *D_OUT = *FUNC_VALUE(fun);
     return R_OUT;
@@ -1437,33 +1465,42 @@ REBNATIVE(make_callback)
 {
     INCLUDE_PARAMS_OF_MAKE_CALLBACK;
 
-    REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec));
+    ffi_abi abi;
+    if (REF(abi))
+        abi = Abi_From_Word(ARG(abi_type));
+    else
+        abi = FFI_DEFAULT_ABI;
+
+    REBFUN *fun = Alloc_Ffi_Function_For_Spec(ARG(ffi_spec), abi);
     REBRIN *r = FUNC_ROUTINE(fun);
 
-    if (REF(abi))
-        r->abi = Abi_From_Word(ARG(abi_type));
-
-    RIN_CALLBACK_FUNC(r) = VAL_FUNC(ARG(action));
-
-    r->code.callback.closure = cast(ffi_closure*, ffi_closure_alloc(
-        sizeof(ffi_closure), &RIN_DISPATCHER(r)
+    void *thunk; // actually CFUNC (FFI uses void*, may not be same size!)
+    ffi_closure *closure = cast(ffi_closure*, ffi_closure_alloc(
+        sizeof(ffi_closure), &thunk
     ));
 
-    if (RIN_CLOSURE(r) == NULL)
+    if (closure == NULL)
         fail (Error(RE_MISC)); // couldn't allocate closure
 
     ffi_status status = ffi_prep_closure_loc(
-        RIN_CLOSURE(r),
-        SER_HEAD(ffi_cif, r->cif),
-        callback_dispatcher,
-        r,
-        RIN_DISPATCHER(r)
+        closure,
+        RIN_CIF(r),
+        callback_dispatcher, // when thunk is called it calls this function...
+        r, // ...and this piece of data is passed to callback_dispatcher
+        thunk
     );
 
     if (status != FFI_OK)
         fail (Error(RE_MISC)); // couldn't prep closure
 
-    SET_RIN_FLAG(r, ROUTINE_FLAG_CALLBACK);
+    Init_Handle_Managed(
+        RIN_AT(r, 0),
+        cast(CFUNC*, thunk),
+        closure,
+        &cleanup_ffi_closure
+    );
+    SET_INTEGER(RIN_AT(r, 1), abi);
+    *RIN_AT(r, 2) = *ARG(action);
 
     *D_OUT = *FUNC_VALUE(fun);
     return R_OUT;

--- a/src/include/mem-pools.h
+++ b/src/include/mem-pools.h
@@ -43,11 +43,8 @@
 **
 ***********************************************************************/
 {
-    struct  rebol_mem_segment *next;
-    REBCNT  size;
-#if defined(__LP64__) || defined (__LLP64__)
-//  REBCNT  padding; /* make if 16 byte long, such that the next element is pointer aligned */
-#endif
+    struct rebol_mem_segment *next;
+    REBUPT size;
 } REBSEG;
 
 
@@ -97,7 +94,6 @@
     MEM_BIG_POOLS   = MEM_MID_POOLS   +  4, // larger pools
     SER_POOL     = MEM_BIG_POOLS,
     GOB_POOL,
-    RIN_POOL, /* routine info */
     SYSTEM_POOL,
     MAX_POOLS
 };

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -666,12 +666,19 @@ typedef u16 REBUNI;
         inline static void TRASH_POINTER_IF_DEBUG(T* &p) {
             p = reinterpret_cast<T*>(static_cast<REBUPT>(0xDECAFBAD));
         }
-    #elif defined(__LP64__) || defined(__LLP64__)
-        #define TRASH_POINTER_IF_DEBUG(p) \
-            (p) = cast(void*, 0xDECAFBADLL)
+
+        template<class T>
+        inline static REBOOL IS_POINTER_TRASH_DEBUG(T* p) {
+            return LOGICAL(
+                p == reinterpret_cast<T*>(static_cast<REBUPT>(0xDECAFBAD))
+            );
+        }
     #else
         #define TRASH_POINTER_IF_DEBUG(p) \
-            (p) = cast(void*, 0xDECAFBAD)
+            ((p) = cast(void*, cast(REBUPT, 0xDECAFBAD)))
+
+        #define IS_POINTER_TRASH_DEBUG(p) \
+            LOGICAL((p) == cast(void*, cast(REBUPT, 0xDECAFBAD)))
     #endif
 #endif
 

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -35,6 +35,24 @@
 
 
 //
+// STATIC ASSERT
+//
+// Some conditions can be checked at compile-time, instead of deferred to a
+// runtime assert.  This macro triggers an error message at compile time.
+// `static_assert` is an arity-2 keyword in C++11 (which was expanded in
+// C++17 to have an arity-1 form).  This uses the name `static_assert_c` to
+// implement a poor-man's version of the arity-1 form in C, that only works
+// inside of function bodies.
+//
+// !!! This was the one being used, but review if it's the best choice:
+//
+// http://stackoverflow.com/questions/3385515/static-assert-in-c
+//
+#define static_assert_c(e) \
+    do {(void)sizeof(char[1 - 2*!(e)]);} while(0)
+
+
+//
 // CASTING MACROS
 //
 // The following code and explanation is from "Casts for the Masses (in C)":

--- a/src/include/reb-gob.h
+++ b/src/include/reb-gob.h
@@ -233,8 +233,4 @@ typedef struct gob_window {             // Maps gob to window
 #define IS_GOB_STRING(g) (GOB_CONTENT(g) && GOB_TYPE(g) == GOBT_STRING)
 #define IS_GOB_TEXT(g)   (GOB_CONTENT(g) && GOB_TYPE(g) == GOBT_TEXT)
 
-#define IS_GOB_MARK(g)  GET_GOB_FLAG((g), GOBF_MARK)
-#define MARK_GOB(g)     SET_GOB_FLAG((g), GOBF_MARK)
-#define UNMARK_GOB(g)   CLR_GOB_FLAG((g), GOBF_MARK)
-
 extern REBGOB *Gob_Root; // Top level GOB (the screen)

--- a/src/include/reb-struct.h
+++ b/src/include/reb-struct.h
@@ -164,62 +164,126 @@ inline static void *VAL_LIBRARY_FD(const RELVAL *v) {
 #endif // HAVE_LIBFFI_AVAILABLE
 
 
+// Returns an ffi_type* (which contains a ->type field, that holds the
+// FFI_TYPE_XXX enum).
+//
+// !!! In the original Atronix implementation this was done with a table
+// indexed by FFI_TYPE_XXX constants.  But since those constants do not have
+// guaranteed values or ordering, there was a parallel separate enum to use
+// for indexing (STRUCT_TYPE_XXX).  Getting rid of the STRUCT_TYPE_XXX and
+// just using a switch statement should effectively act as a table anyway
+// if the SYM_XXX numbers are in sequence.  :-/
+//
+inline static ffi_type *Get_FFType_For_Sym(REBSYM sym) {
+    switch (sym) {
+    case SYM_UINT8:
+        return &ffi_type_uint8;
+
+    case SYM_INT8:
+        return &ffi_type_sint8;
+
+    case SYM_UINT16:
+        return &ffi_type_uint16;
+
+    case SYM_INT16:
+        return &ffi_type_sint16;
+
+    case SYM_UINT32:
+        return &ffi_type_uint32;
+
+    case SYM_INT32:
+        return &ffi_type_sint32;
+
+    case SYM_UINT64:
+        return &ffi_type_uint64;
+
+    case SYM_INT64:
+        return &ffi_type_sint64;
+
+    case SYM_FLOAT:
+        return &ffi_type_float;
+
+    case SYM_DOUBLE:
+        return &ffi_type_double;
+
+    case SYM_POINTER:
+        return &ffi_type_pointer;
+
+    case SYM_REBVAL:
+        return &ffi_type_pointer;
+
+    // !!! SYM_INTEGER, SYM_DECIMAL, SYM_STRUCT was "-1" in original table
+
+    default:
+        return NULL;
+    }
+}
+
+
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// What used to be a specialized C structure for representing a FFI field
-// has been changed to an ordinary Rebol array.  This makes it so it does not
-// require modifications to the garbage collector.
+// FIELD (FLD) describing an FFI struct element
 //
-// [0] - A WORD! name for the field (or BLANK! if anonymous ?)  What should
-//       probably happen here is that structs should use a keylist for this;
-//       though that would mean anonymous fields would not be legal.
+//=////////////////////////////////////////////////////////////////////////=//
 //
-// [1] - WORD! type or a BLOCK! of fields if this is a struct.  The symbols
-//       generally map to FFI_TYPE_XXX constant (e.g. UINT8) but may also
-//       be a special extension, such as REBVAL.
+// A field is used by the FFI code to describe an element inside the layout
+// of a C `struct`, so that Rebol data can be proxied to and from C.  It
+// contains field type descriptions, dimensionality, and name of the field.
+// It is implemented as a small BLOCK!, which should eventually be coupled
+// with a keylist so it can be an easy-to-read OBJECT!
 //
-// [2] - An INTEGER! of the array dimensionality, or BLANK! if not an array
-//
-// [3] - HANDLE! to the ffi_type* representing this entire field.  This will
-//       appear other places, so it uses the shared form of HANDLE! which
-//       will GC the memory pointed to when the last reference goes away.
-//
-//       !!! This is a cache, in a sense that it is fully produced from
-//       the rest of the information.  It was sometimes set to NULL in the
-//       previous implementation and then calculated and cached, so the
-//       BLANK! state is used for that.  Is this state really necessary, or
-//       can it be guaranteed there's always a handle here?
-//
-// [4] - An INTEGER! of the offset this field is relative to the beginning
-//       of its entire containing structure.  Will be BLANK! if the structure
-//       is actually the root structure itself.
-//
-//       !!! Comment said "size is limited by struct->offset, so only 16-bit"
-//
-// [5] - An INTEGER! size of an individual field element ("wide"), in bytes.
-//
-// !!! Previously, there was a bit tracking whether the field represented a
-// REBVAL or not.  The actual FFI type was an array of FFI_TYPE_POINTER of
-// length 4, hence carrying the literal bit pattern of a value, in a place
-// that would be needed to be protected from GC.  Ren-C will not do this,
-// instead if a value is to be passed around it should be done by pointer
-// and protected from GC by something else.  (RL_API routines will be using
-// REBVAL* pointers into series nodes that have GC protection for the length
-// of their function call...and internal api clients do explicit handling.)
-// 
 
 typedef REBARR REBFLD;
 
-#define FLD_AT(a, n) ARR_AT((a), (n)) // help locate indexed accesses
+enum {
+    // A WORD! name for the field (or BLANK! if anonymous ?)  What should
+    // probably happen here is that structs should use a keylist for this;
+    // though that would mean anonymous fields would not be legal.
+    //
+    IDX_FIELD_NAME = 0,
+
+    // WORD! type symbol or a BLOCK! of fields if this is a struct.  Symbols
+    // generally map to FFI_TYPE_XXX constant (e.g. UINT8) but may also
+    // be a special extension, such as REBVAL.
+    //
+    IDX_FIELD_TYPE = 1,
+
+    // An INTEGER! of the array dimensionality, or BLANK! if not an array.
+    //
+    IDX_FIELD_DIMENSION = 2,
+
+    // HANDLE! to the ffi_type* representing this entire field.  If it's a
+    // premade ffi_type then it's a simple HANDLE! with no GC participation.
+    // If it's a struct then it will use the shared form of HANDLE!, which
+    // will GC the memory pointed to when the last reference goes away.
+    //
+    IDX_FIELD_FFTYPE = 3,
+
+    // An INTEGER! of the offset this field is relative to the beginning
+    // of its entire containing structure.  Will be BLANK! if the structure
+    // is actually the root structure itself.
+    //
+    // !!! Comment said "size is limited by struct->offset, so only 16-bit"?
+    //
+    IDX_FIELD_OFFSET = 4,
+
+    // An INTEGER! size of an individual field element ("wide"), in bytes.
+    //
+    IDX_FIELD_WIDE = 5,
+
+    IDX_FIELD_MAX
+};
+
+#define FLD_AT(a, n) SER_AT(REBVAL, ARR_SERIES(a), (n)) // locate index access
 
 inline static REBSTR *FLD_NAME(REBFLD *f) {
-    if (IS_BLANK(FLD_AT(f, 0)))
+    if (IS_BLANK(FLD_AT(f, IDX_FIELD_NAME)))
         return NULL;
-    return VAL_WORD_SPELLING(FLD_AT(f, 0));
+    return VAL_WORD_SPELLING(FLD_AT(f, IDX_FIELD_NAME));
 }
 
 inline static REBOOL FLD_IS_STRUCT(REBFLD *f)
-    { return IS_BLOCK(FLD_AT(f, 1)); }
+    { return IS_BLOCK(FLD_AT(f, IDX_FIELD_TYPE)); }
 
 inline static unsigned short FLD_TYPE_SYM(REBFLD *f) {
     if (FLD_IS_STRUCT(f)) {
@@ -231,40 +295,54 @@ inline static unsigned short FLD_TYPE_SYM(REBFLD *f) {
         return SYM_STRUCT_X;
     }
 
-    assert(IS_WORD(FLD_AT(f, 1)));
-    return VAL_WORD_SYM(FLD_AT(f, 1));
+    assert(IS_WORD(FLD_AT(f, IDX_FIELD_TYPE)));
+    return VAL_WORD_SYM(FLD_AT(f, IDX_FIELD_TYPE));
 }
 
 inline static REBARR *FLD_FIELDLIST(REBFLD *f) {
     assert(FLD_IS_STRUCT(f));
-    return VAL_ARRAY(FLD_AT(f, 1));
+    return VAL_ARRAY(FLD_AT(f, IDX_FIELD_TYPE));
 }
 
 inline static REBOOL FLD_IS_ARRAY(REBFLD *f) {
-    if (IS_BLANK(FLD_AT(f, 2)))
+    if (IS_BLANK(FLD_AT(f, IDX_FIELD_DIMENSION)))
         return FALSE;
-    assert(IS_INTEGER(FLD_AT(f, 2)));
+    assert(IS_INTEGER(FLD_AT(f, IDX_FIELD_DIMENSION)));
     return TRUE;
 }
 
 inline static REBCNT FLD_DIMENSION(REBFLD *f) {
     assert(FLD_IS_ARRAY(f));
-    return VAL_INT32(FLD_AT(f, 2));
+    return VAL_INT32(FLD_AT(f, IDX_FIELD_DIMENSION));
 }
 
 inline static ffi_type *FLD_FFTYPE(REBFLD *f)
-    { return cast(ffi_type*, VAL_HANDLE_DATA(FLD_AT(f, 3))); }
+    { return cast(ffi_type*, VAL_HANDLE_DATA(FLD_AT(f, IDX_FIELD_FFTYPE))); }
 
 inline static REBCNT FLD_OFFSET(REBFLD *f)
-    { return VAL_INT32(FLD_AT(f, 4)); }
+    { return VAL_INT32(FLD_AT(f, IDX_FIELD_OFFSET)); }
 
 inline static REBCNT FLD_WIDE(REBFLD *f)
-    { return VAL_INT32(FLD_AT(f, 5)); }
+    { return VAL_INT32(FLD_AT(f, IDX_FIELD_WIDE)); }
 
 inline static REBCNT FLD_LEN_BYTES_TOTAL(REBFLD *f) {
     if (FLD_IS_ARRAY(f))
         return FLD_WIDE(f) * FLD_DIMENSION(f);
     return FLD_WIDE(f);
+}
+
+inline static ffi_type* SCHEMA_FFTYPE(const RELVAL *schema) {
+    if (IS_BLOCK(schema)) {
+        REBFLD *field = VAL_ARRAY(schema);
+        return FLD_FFTYPE(field);
+    }
+
+    // Avoid creating a "VOID" type in order to not give the illusion of
+    // void parameters being legal.  The NONE! return type is handled
+    // exclusively by the return value, to prevent potential mixups.
+    //
+    assert(IS_WORD(schema));
+    return Get_FFType_For_Sym(VAL_WORD_SYM(schema));
 }
 
 
@@ -277,14 +355,8 @@ inline static REBCNT FLD_LEN_BYTES_TOTAL(REBFLD *f) {
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// Struct is used by the FFI code to describe the layout of a C `struct`,
-// so that Rebol data can be proxied to a C function call.
-//
-// !!! Atronix added the struct type to get coverage in the FFI, and it is
-// possible to make and extract structure data even if one is not calling
-// a routine at all.  This might not be necessary, in that the struct
-// description could be an ordinary OBJECT! which is used in FFI specs
-// and tells how to map data into a Rebol object used as a target.
+// Struct is a value type that is the the combination of a "schema" (field or
+// list of fields) along with a blob of binary data described by that schema.
 //
 
 inline static REBVAL *STU_VALUE(REBSTU *stu) {
@@ -351,62 +423,6 @@ inline static REBOOL VAL_STRUCT_INACCESSIBLE(const RELVAL *v) {
     STU_FFTYPE(VAL_STRUCT(v))
 
 
-// Returns an ffi_type* (which contains a ->type field, that holds the
-// FFI_TYPE_XXX enum).
-//
-// !!! In the original Atronix implementation this was done with a table
-// indexed by FFI_TYPE_XXX constants.  But since those constants do not have
-// guaranteed values or ordering, there was a parallel separate enum to use
-// for indexing (STRUCT_TYPE_XXX).  Getting rid of the STRUCT_TYPE_XXX and
-// just using a switch statement should effectively act as a table anyway
-// if the SYM_XXX numbers are in sequence.  :-/
-//
-inline static ffi_type *Get_FFType_For_Sym(REBSYM sym) {
-    switch (sym) {
-    case SYM_UINT8:
-        return &ffi_type_uint8;
-
-    case SYM_INT8:
-        return &ffi_type_sint8;
-
-    case SYM_UINT16:
-        return &ffi_type_uint16;
-
-    case SYM_INT16:
-        return &ffi_type_sint16;
-
-    case SYM_UINT32:
-        return &ffi_type_uint32;
-
-    case SYM_INT32:
-        return &ffi_type_sint32;
-
-    case SYM_UINT64:
-        return &ffi_type_uint64;
-
-    case SYM_INT64:
-        return &ffi_type_sint64;
-
-    case SYM_FLOAT:
-        return &ffi_type_float;
-
-    case SYM_DOUBLE:
-        return &ffi_type_double;
-
-    case SYM_POINTER:
-        return &ffi_type_pointer;
-
-    case SYM_REBVAL:
-        return &ffi_type_pointer;
-
-    // !!! SYM_INTEGER, SYM_DECIMAL, SYM_STRUCT was "-1" in original table
-
-    default:
-        return NULL;
-    }
-}
-
-
 //=////////////////////////////////////////////////////////////////////////=//
 //
 //  ROUTINE SUPPORT
@@ -432,106 +448,121 @@ inline static ffi_type *Get_FFType_For_Sym(REBSYM sym) {
 // could be done with PARSE, as opposed to harder-to-edit-and-maintain
 // internal API C code.
 //
-// The layout of the array of the REBRIN* BLOCK! is as follows:
-//
-// [0] - The HANDLE! of a CFUNC*, obeying the interface of the C-format call.
-//       If it's a routine, then it's the pointer to a pre-existing function
-//       in the DLL that the routine intends to wrap.  If a callback, then
-//       it's a fabricated function pointer returned by ffi_closure_alloc,
-//       which presents the "thunk"...a C function that other C functions can
-//       call which will then delegate to Rebol to call the wrapped FUNCTION!.
-//
-//       Additionally, callbacks poke a data pointer into the HANDLE! with
-//       ffi_closure*.  (The closure allocation routine gives back a void* and
-//       not an ffi_closure* for some reason.  Perhaps because it takes a
-//       size that might be bigger than the size of a closure?)
-//
-// [1] - An INTEGER! indicating which ABI is used by the CFUNC (enum ffi_abi)
 
-// [2] - The LIBRARY! the CFUNC* lives in if a routine, or the FUNCTION! to
-//       be called if this is a callback.
-//
-// [3] - The "schema" of the return type.  This is either an INTEGER! (which
-//       is the FFI_TYPE constant of the return) or a BINARY! containing
-//       the bit pattern of a `Struct_Field` (it's held in a series to allow
-//       it to be referenced multiple places and participate in GC, though
-//       the ultimate goal is to just use OBJECT! here.)
-//
-// [4] - An ARRAY! of the argument schemas; each also INTEGER! or BINARY!,
-//       following the same pattern as the return value.
-//
-// [5] - A HANDLE! containing one ffi_cif*, or BLANK! if variadic.  The Call
-//       InterFace (CIF) for a C function with fixed arguments can be created
-//       once and then used many times.  For a variadic routine, it must be
-//       created on each call to match the number and types of arguments.
-//
-// [6] - A HANDLE! which is actually an array of ffi_type*, so a C array of
-//       pointers.  They refer into the CIF so the CIF must live as long
-//       as these references are to be used.  BLANK! if variadic.
-//
-// [7] - A LOGIC! of whether this routine is variadic.  Since variadic-ness is
-//       something that gets exposed in the FUNCTION! interface itself, this
-//       may become redundant as an internal property of the implementation.
-//
+enum {
+    // The HANDLE! of a CFUNC*, obeying the interface of the C-format call.
+    // If it's a routine, then it's the pointer to a pre-existing function
+    // in the DLL that the routine intends to wrap.  If a callback, then
+    // it's a fabricated function pointer returned by ffi_closure_alloc,
+    // which presents the "thunk"...a C function that other C functions can
+    // call which will then delegate to Rebol to call the wrapped FUNCTION!.
+    //
+    // Additionally, callbacks poke a data pointer into the HANDLE! with
+    // ffi_closure*.  (The closure allocation routine gives back a void* and
+    // not an ffi_closure* for some reason.  Perhaps because it takes a
+    // size that might be bigger than the size of a closure?)
+    //
+    IDX_ROUTINE_CFUNC = 0,
 
-#define RIN_AT(a, n) ARR_AT((a), (n)) // help locate indexed accesses
+    // An INTEGER! indicating which ABI is used by the CFUNC (enum ffi_abi)
+    //
+    // !!! It would be better to change this to use a WORD!, especially if
+    // the routine descriptions will ever become user visible objects.
+    //
+    IDX_ROUTINE_ABI = 1,
+
+    // The LIBRARY! the CFUNC* lives in if a routine, or the FUNCTION! to
+    // be called if this is a callback.
+    //
+    IDX_ROUTINE_ORIGIN = 2,
+
+    // The "schema" of the return type.  This is either a WORD! (which
+    // is a symbol corresponding to the FFI_TYPE constant of the return) or
+    // a BLOCK! representing a field (this REBFLD will hopefully become
+    // OBJECT! at some point).  If it is BLANK! then there is no return type.
+    //
+    IDX_ROUTINE_RET_SCHEMA = 3,
+
+    // An ARRAY! of the argument schemas; each also WORD! or ARRAY!, following
+    // the same pattern as the return value...but not allowed to be blank
+    // (no such thing as a void argument)
+    //
+    IDX_ROUTINE_ARG_SCHEMAS = 4,
+
+    // A HANDLE! containing one ffi_cif*, or BLANK! if variadic.  The Call
+    // InterFace (CIF) for a C function with fixed arguments can be created
+    // once and then used many times.  For a variadic routine, it must be
+    // created on each call to match the number and types of arguments.
+    //
+    IDX_ROUTINE_CIF = 5,
+
+    // A HANDLE! which is actually an array of ffi_type*, so a C array of
+    // pointers.  This array was passed into the CIF at its creation time,
+    // and it holds references to them as long as you use that CIF...so this
+    // array must survive as long as the CIF does.  BLANK! if variadic.
+    //
+    IDX_ROUTINE_ARG_FFTYPES = 6,
+
+    // A LOGIC! of whether this routine is variadic.  Since variadic-ness is
+    // something that gets exposed in the FUNCTION! interface itself, this
+    // may become redundant as an internal property of the implementation.
+    //
+    IDX_ROUTINE_IS_VARIADIC = 7,
+
+    IDX_ROUTINE_MAX
+};
+
+#define RIN_AT(a, n) SER_AT(REBVAL, ARR_SERIES(a), (n)) // locate index access
 
 inline static CFUNC *RIN_CFUNC(REBRIN *r)
-    { return VAL_HANDLE_CODE(RIN_AT(r, 0)); }
+    { return VAL_HANDLE_CODE(RIN_AT(r, IDX_ROUTINE_CFUNC)); }
 
 inline static ffi_abi RIN_ABI(REBRIN *r)
-    { return cast(ffi_abi, VAL_INT32(RIN_AT(r, 1))); }
+    { return cast(ffi_abi, VAL_INT32(RIN_AT(r, IDX_ROUTINE_ABI))); }
 
 inline static REBOOL RIN_IS_CALLBACK(REBRIN *r) {
-    if (IS_FUNCTION(RIN_AT(r, 2)))
+    if (IS_FUNCTION(RIN_AT(r, IDX_ROUTINE_ORIGIN)))
         return TRUE;
-    assert(IS_LIBRARY(RIN_AT(r, 2)) || IS_BLANK(RIN_AT(r, 2)));
+    assert(
+        IS_LIBRARY(RIN_AT(r, IDX_ROUTINE_ORIGIN))
+        || IS_BLANK(RIN_AT(r, IDX_ROUTINE_ORIGIN))
+    );
     return FALSE;
 }
 
 inline static ffi_closure* RIN_CLOSURE(REBRIN *r) {
     assert(RIN_IS_CALLBACK(r)); // only callbacks have ffi_closure
-    return cast(ffi_closure*, VAL_HANDLE_DATA(RIN_AT(r, 0)));
+    return cast(ffi_closure*, VAL_HANDLE_DATA(RIN_AT(r, IDX_ROUTINE_CFUNC)));
 }
 
 inline static REBLIB *RIN_LIB(REBRIN *r) {
     assert(NOT(RIN_IS_CALLBACK(r)));
-    return VAL_LIBRARY(RIN_AT(r, 2));
+    return VAL_LIBRARY(RIN_AT(r, IDX_ROUTINE_ORIGIN));
 }
 
 inline static REBFUN *RIN_CALLBACK_FUNC(REBRIN *r) {
     assert(RIN_IS_CALLBACK(r));
-    return VAL_FUNC(RIN_AT(r, 2));
+    return VAL_FUNC(RIN_AT(r, IDX_ROUTINE_ORIGIN));
 }
 
 inline static REBVAL *RIN_RET_SCHEMA(REBRIN *r)
-    { return KNOWN(RIN_AT(r, 3)); }
+    { return KNOWN(RIN_AT(r, IDX_ROUTINE_RET_SCHEMA)); }
 
 inline static REBCNT RIN_NUM_FIXED_ARGS(REBRIN *r)
-    { return VAL_LEN_HEAD(RIN_AT(r, 4)); }
+    { return VAL_LEN_HEAD(RIN_AT(r, IDX_ROUTINE_ARG_SCHEMAS)); }
 
-inline static REBVAL *RIN_ARG_SCHEMA(REBRIN *r, REBCNT n) // 0-based arg index
-    { return KNOWN(VAL_ARRAY_AT_HEAD(RIN_AT(r, 4), (n))); }
+inline static REBVAL *RIN_ARG_SCHEMA(REBRIN *r, REBCNT n) { // 0-based index
+    return KNOWN(VAL_ARRAY_AT_HEAD(RIN_AT(r, IDX_ROUTINE_ARG_SCHEMAS), n));
+}
 
 inline static ffi_cif *RIN_CIF(REBRIN *r)
-    { return cast(ffi_cif*, VAL_HANDLE_DATA(RIN_AT(r, 5))); }
+    { return cast(ffi_cif*, VAL_HANDLE_DATA(RIN_AT(r, IDX_ROUTINE_CIF))); }
 
-inline static ffi_type** RIN_ARG_TYPES(REBRIN *r)
-    { return cast(ffi_type**, VAL_HANDLE_DATA(RIN_AT(r, 6))); }
+inline static ffi_type** RIN_ARG_FFTYPES(REBRIN *r) {
+    return cast(ffi_type**,
+        VAL_HANDLE_DATA(RIN_AT(r, IDX_ROUTINE_ARG_FFTYPES))
+    );
+}
 
 inline static REBOOL RIN_IS_VARIADIC(REBRIN *r)
-    { return VAL_LOGIC(RIN_AT(r, 7)); }
-
-inline static ffi_type* SCHEMA_FFTYPE(const RELVAL *schema) {
-    if (IS_BLOCK(schema)) {
-        REBFLD *field = VAL_ARRAY(schema);
-        return FLD_FFTYPE(field);
-    }
-
-    // Avoid creating a "VOID" type in order to not give the illusion of
-    // void parameters being legal.  The NONE! return type is handled
-    // exclusively by the return value, to prevent potential mixups.
-    //
-    assert(IS_WORD(schema));
-    return Get_FFType_For_Sym(VAL_WORD_SYM(schema));
-}
+    { return VAL_LOGIC(RIN_AT(r, IDX_ROUTINE_IS_VARIADIC)); }

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -223,4 +223,7 @@ typedef REB_R (*REBPAF)(REBFRM *frame_, REBCTX *p, REBSYM a);
 // COMMAND! function
 typedef REB_R (*CMD_FUNC)(REBCNT n, REBSER *args);
 
-typedef struct Reb_Routine_Info REBRIN;
+// "Routine INfo" was once a specialized C structure, now an ordinary Rebol
+// REBARR pointer.
+//
+typedef REBARR REBRIN;

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -94,7 +94,7 @@ inline static REBVAL *FUNC_PARAMS_HEAD(REBFUN *f) {
 }
 
 inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
-    return cast(REBRIN*, FUNC_BODY(f)->payload.handle.data);
+    return VAL_ARRAY(FUNC_BODY(f));
 }
 
 
@@ -233,7 +233,7 @@ inline static REBOOL IS_FUNCTION_HIJACKER(const RELVAL *v)
     { return LOGICAL(VAL_FUNC_DISPATCHER(v) == &Hijacker_Dispatcher); }
 
 inline static REBRIN *VAL_FUNC_ROUTINE(const RELVAL *v) {
-    return cast(REBRIN*, VAL_FUNC_BODY(v)->payload.handle.data);
+    return VAL_ARRAY(VAL_FUNC_BODY(v));
 }
 
 

--- a/src/include/sys-handle.h
+++ b/src/include/sys-handle.h
@@ -119,4 +119,8 @@ inline static void Init_Handle_Managed(
     SET_TRASH_IF_DEBUG(out);
     VAL_RESET_HEADER(out, REB_HANDLE);
     out->extra.singular = singular;
+#if !defined(NDEBUG)
+    TRASH_POINTER_IF_DEBUG(out->payload.handle.code);
+    TRASH_POINTER_IF_DEBUG(out->payload.handle.data);
+#endif
 }

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -403,7 +403,7 @@ struct Reb_Series {
     union {
         REBSER *hashlist; // MAP datatype uses this
         REBARR *keylist; // used by CONTEXT
-        REBSER *schema; // STRUCT uses this (parallels object's keylist)
+        REBARR *schema; // for STRUCT (a REBFLD, parallels object's keylist)
         REBCTX *meta; // paramlists and keylists can store a "meta" object
         REBSTR *synonym; // circularly linked list of othEr-CaSed string forms
     } link;

--- a/tests/misc/qsort_r.r
+++ b/tests/misc/qsort_r.r
@@ -1,0 +1,80 @@
+REBOL [
+    Title: {Demo tunneling of REBVAL* through routine to callback in FFI}
+    Description: {
+        There are two versions of quicksort in the C library.  Plain `qsort`
+        is written in such a way that if your comparator needs any information
+        besides the two items to compare, it has to get that from global
+        variables.  `qsort_r` takes an additional void pointer parameter
+        which it passes through to the comparator, which could hold some
+        state information and thus eliminate the requirement to use global
+        variables for any parameterization of the comparator.
+
+        This demonstrates the use of the FFI argument type of REBVAL.
+        While the purpose of the FFI is to talk to libraries that likely
+        are not linked to any Rebol APIs (and hence would not be able to
+        make use of a REBVAL), this shows the use of it to "tunnel" a
+        Rebol value through to a written-in-Rebol comparator callback.
+    }
+]
+
+recycle/torture
+
+
+f: func [
+    a [integer!] "pointer to an integer"
+    b [integer!] "pointer to an integer"
+    arg [any-value!] "some tunneled argument"
+][
+    print mold arg
+
+    i: make struct! compose/deep [
+        [raw-memory: (a)]
+        i [int32]
+    ]
+    j: make struct! compose/deep [
+        [raw-memory: (b)]
+        i [int32]
+    ]
+    case [
+        i/i = j/i [0]
+        i/i < j/i [-1]
+        i/i > j/i [1]
+     ]
+]
+
+cb: make callback! [
+    [
+        a [pointer]
+        b [pointer]
+        arg [rebval]
+        return: [int64]
+    ]
+    :f
+]
+
+libc: make library! %libc.so.6
+
+x64?: 40 = fifth system/version
+size_t: either x64? ['int64]['int32]
+
+; This tests the compatibility shim for MAKE that lets MAKE ROUTINE! work,
+; though that is deprecated (use MAKE-ROUTINE or MAKE-ROUTINE-RAW)
+;
+qsort_r: make routine! compose/deep [
+    [
+        base [pointer]
+        nmemb [(size_t)]
+        size [(size_t)]
+        comp [pointer]
+        arg [rebval]
+    ]
+    (libc) "qsort_r"
+]
+
+array: make vector! [integer! 32 5 [10 8 2 9 5]]
+print ["array:" mold array]
+probe (reflect :cb 'addr)
+qsort_r array 5 4 :cb <A Tunneled Tag>
+print ["array:" mold array] ; [2 5 8 9 10]
+
+close libc


### PR DESCRIPTION
The FFI implementation originally used dedicated C structures, which
were allocated from a specialized memory pool.  This required some
fairly invasive changes to the GC in order to put these structures
into the graph of "live" references for the system.  Because these
specialized structures had their own GC code, it was also not as
complete as the system's ordinary code...meaning deeply nested
structures could overflow the stack.

Rather than keep expanding or bulletproofing that approach, this moves
in the other direction to get rid of the specialized code.  The "REBRIN"
and "struct Reb_Field" have been turned into ordinary BLOCK!s, which
are candidates for further becoming ordinary OBJECT!s (with keylists).

This change allows all the FFI-oriented code to be removed from
%m-gc.c...simplifying the garbage collector, and meaning that non-FFI
builds aren't paying for code in the core related to that.  It also focuses
the core on enhancing generalized features that provide benefit across
the board, without the risk of brittle specialized code for the FFI structures.

*(A similar process is to be pursued for GOB!, codecs, devices, and events,
to the extent it is possible to do so.)*

Also included is a thorough going-over of the mark-and-sweep garbage
collector code, with an eye toward catching edge cases and simplification.
Several changes likely improve the performance some amount, by
avoiding redundant markings or checks.  However, the big push was
to reduce the total amount of code and improve the quality of the
comments and function names.

One vetting that this does is to completely eliminate C stack recursion
in the GC.  Deeply nested structures in R3-Alpha could overflow the
C call stack with Mark_Array calling Mark_Array calling Mark_Array...
but that was solved with a queue in Ren-C.  However, that wasn't the
only possible problem, just the most likely.

With additions like objects having meta objects, if you call
Queue_Mark_Context of CTX_META(context) from inside Queue_Mark_Context
you could theoretically get the same problem.  The same goes for
marking underlying functions while marking a function.  While neither
of these are too likely to make chains too long for the C stack, it
is possible--and the discipline of organizing the code to stop this
kind of problem helps for any similar patterns which *would* be
likely.