### PR TITLE
Specification blocks for natives are now required.

### DIFF
--- a/src/tools/make-natives.r
+++ b/src/tools/make-natives.r
@@ -40,10 +40,17 @@ emit-proto: proc [proto] [
                 'native = proto-parser/data/2/1
             ]
         ]
-        block? proto-parser/data/3
     ] [
 
         line: line-of source.text proto-parser/parse.position
+
+        if not block? proto-parser/data/3 [
+            fail [
+                "Native" (uppercase form to word! proto-parser/data/1)
+                "needs loadable specification block."
+                (mold the-file) (line)
+            ]
+        ]
 
         append case [
             ; could do tests here to create special buffer categories to


### PR DESCRIPTION
Previously the presence of a specification block was used to identify natives. As a result, syntax errors in the specification block would mean that the native was skipped by the parser.

An error will now be raised if a specification block cannot be loaded.