### PR TITLE
JOIN => JOIN-OF, reserve JOIN, act like R3-Alpha REPEND

### DIFF
--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -23,14 +23,6 @@ REBOL [
 ]
 
 
-; !!! The long term goal for Ren-C is that UNTIL and WHILE both be arity-2 and
-; inversions of each other, with LOOP-UNTIL and LOOP-WHILE being arity-1.
-; To avoid rocking the boat in the default distribution, this is changed here.
-;
-until-2: :until
-until: :loop-until
-
-
 ; Words for BLANK! and BAR!, for those who don't like symbols
 
 blank: _

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -877,7 +877,7 @@ module: func [
     ; Collect 'export keyword exports, removing the keywords
     if find body 'export [
         unless block? select spec 'exports [
-            repend spec ['exports make block! 10]
+            join spec ['exports make block! 10]
         ]
 
         ; Note: 'export overrides 'hidden, silently for now

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -733,7 +733,7 @@ left-bar: func [
     right [<opt> any-value! <...>]
         {Any number of expressions on the right.}
 ][
-    while [not tail? right] [take right]
+    loop-until [void? take right]
     :left
 ]
 
@@ -746,7 +746,7 @@ right-bar: func [
     right [<opt> any-value! <...>]
         {Any number of expressions on the right.}
 ][
-    also take right (while [not tail? right] [take right])
+    also take right (loop-until [void? take right])
 ]
 
 

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -120,7 +120,7 @@ assert-debug: function [
     ][
         ; Otherwise it's a block!
         active: true
-        while [not tail? conditions] [
+        until [tail? conditions] [
             if option: maybe [issue! tag!] :conditions/1 [
                 unless any-value? (active: select live-asserts-map option) [
                     ;

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -174,7 +174,7 @@ list-dir: procedure [
             change info second split-path info/1
             printf [indent 16 -8 #" " 24 #" " 6] info
             if all [r | dir? file] [
-                list-dir/l/r/i :file join indent "    "
+                list-dir/l/r/i :file join-of indent "    "
             ]
         ]
     ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -286,7 +286,7 @@ help: procedure [
             tmp: http://www.rebol.com/r3/docs/datatypes/
             remove back tail item ; the !
         ]
-        browse join tmp [item ".html"]
+        browse join-of tmp [item ".html"]
     ]
 
     ; If arg is a string or datatype! word, search the system:
@@ -322,7 +322,7 @@ help: procedure [
     type-name: func [value] [
         value: mold type-of :value
         clear back tail value
-        join either find "aeiou" first value ["an "]["a "] value
+        join-of either find "aeiou" first value ["an "]["a "] value
     ]
 
     ; Print literal values:
@@ -722,7 +722,7 @@ why?: procedure [
 
         say-browser
         err: lowercase ajoin [err/type #"-" err/id]
-        browse join http://www.rebol.com/r3/docs/errors/ [err ".html"]
+        browse join-of http://www.rebol.com/r3/docs/errors/ [err ".html"]
     ][
         print "No information is available."
     ]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -433,7 +433,7 @@ r3-alpha-apply: function [
     params: words-of :action
     using-args: true
 
-    while [not tail? block] [
+    until [tail? block] [
         arg: either only [
             also block/1 (block: next block)
         ][
@@ -809,7 +809,7 @@ set 'r3-legacy* func [<local> if-flags] [
             either function? :source [
                 code: reduce [:source]
                 params: words-of :source
-                while [not tail? params] [
+                for-next params [
                     append code switch type-of params/1 [
                         :word! [take normals]
                         :lit-word! [take softs]
@@ -818,7 +818,6 @@ set 'r3-legacy* func [<local> if-flags] [
                         :refinement! [break]
                         (fail ["bad param type" params/1])
                     ]
-                    params: next params
                 ]
                 lib/do code
             ][
@@ -941,7 +940,7 @@ set 'r3-legacy* func [<local> if-flags] [
             ;
             use :vars [
                 position: data
-                while [not tail? position] compose [
+                until [tail? position] compose [
                     (collect [
                         every item vars [
                             case [

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -98,7 +98,7 @@ save: function [
                     remove find select header-data 'options 'compress
                 ]
                 not block? select header-data 'options [
-                    repend header-data ['options copy [compress]]
+                    join header-data ['options copy [compress]]
                 ]
                 not find header-data/options 'compress [
                     append header-data/options 'compress

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -96,7 +96,7 @@ secure: function [
         blk: make block! 4
         n: 1
         for-each act [read write execute] [
-            repend blk [pick acts 1 + pol/:n act]
+            join blk [pick acts 1 + pol/:n act]
             ++ n
         ]
         blk
@@ -139,13 +139,13 @@ secure: function [
         for-each [target pol] pol-obj [
             case [
                 ; file 0.0.0 (policies)
-                tuple? pol [repend out [target word-policy pol]]
+                tuple? pol [join out [target word-policy pol]]
                 ; file [allow read quit write]
                 block? pol [
                     for-each [item pol] pol [
                         if binary? item [item: to-string item] ; utf-8 decode
                         if string? item [item: to-rebol-file item]
-                        repend out [item word-policy pol]
+                        join out [item word-policy pol]
                     ]
                 ]
             ]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -43,15 +43,21 @@ extend: func [
     :val
 ]
 
-rejoin: func [
+rejoin: function [
     "Reduces and joins a block of values."
     block [block!] "Values to reduce and join"
     ;/with "separator"
+    <local> position
 ][
-    if empty? block: reduce block [return block]
-    append either any-series? first block [copy first block][
-        form first block
-    ] next block
+    either void? base: do/next block 'position [
+        blank
+    ][
+        either any-series? :base [
+            join-of base position
+        ][
+            join form base position
+        ]
+    ]
 ]
 
 remold: func [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -260,7 +260,7 @@ reword: function [
             vals: make map! length values  ; Make a new map internally
             not only block? values  ; Should we evaluate value expressions?
         ] [
-            while [not tail? values] [
+            until [tail? values] [
                 w: first+ values  ; Keywords are not evaluated
                 v: do/next values 'values
                 if any [set-word? :w lit-word? :w] [w: to word! :w]

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -203,11 +203,11 @@ make-http-request: func [
         " HTTP/1.0" CRLF
     ]
     for-each [word string] headers [
-        repend result [mold word #" " string CRLF]
+        join result [mold word #" " string CRLF]
     ]
     if content [
         content: to binary! content
-        repend result ["Content-Length: " length content CRLF]
+        join result ["Content-Length: " length content CRLF]
     ]
     append result CRLF
     result: to binary! result

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -55,7 +55,7 @@ sync-op: func [port body /local state] [
     ;NOTE: We'll wait in a WHILE loop so the timeout cannot occur during 'reading-data state.
     ;The timeout should be triggered only when the response from other side exceeds the timeout value.
     ;--Richard
-    while [not find [ready close] state/state][
+    until [find [ready close] state/state][
         unless port? wait [state/connection port/spec/timeout] [
             fail make-http-error "Timeout"
         ]

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -22,7 +22,7 @@ emit: func [
     ctx [object!]
     code [block! binary!]
 ] [
-    repend ctx/msg code
+    join ctx/msg code
 ]
 
 to-bin: func [

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -96,7 +96,7 @@ do*: function [
     ; If a file is being mentioned as a DO location and the "current path"
     ; is a URL!, then adjust the value to be a URL! based from that path.
     if all [url? original-path  file? value] [
-         value: join original-path value
+         value: join-of original-path value
     ]
 
     ; Load the data, first so it will error before change-dir
@@ -184,7 +184,7 @@ export: func [
     "Low level export of values (e.g. functions) to lib."
     words [block!] "Block of words (already defined in local context)"
 ][
-    for-each word words [repend lib [word get word]]
+    for-each word words [join lib [word get word]]
 ]
 
 assert-utf8: function [

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -177,7 +177,7 @@ load-header: function [
         ]
 
         find hdr/options 'content [
-            repend hdr ['content data] ; as of start of header
+            join hdr ['content data] ; as of start of header
         ]
 
         13 = rest/1 [rest: next rest] ; skip CR
@@ -578,7 +578,7 @@ do-needs: function [
             set name [word! | file! | url!]
             set vers opt tuple!
             set hash opt binary!
-            (repend mods [name vers hash])
+            (join mods [name vers hash])
         ]
     ][
         cause-error 'script 'invalid-arg here
@@ -756,7 +756,7 @@ load-module: function [
                     set mod [word! | module! | file! | url! | string! | binary!]
                     set ver opt tuple!
                     set sum opt binary! ; ambiguous
-                    (repend data [mod ver sum if name [to word! name]])
+                    (join data [mod ver sum if name [to word! name]])
                 ]
             ][
                 cause-error 'script 'invalid-arg tmp

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -225,7 +225,7 @@ init-schemes: func [
             ; Process all events (even if no awake ports).
             n-event: 0
             event-list: sport/state
-            while [not empty? event-list][
+            until [empty? event-list][
                 if n-event > 8 [break] ; Do only 8 events at a time (to prevent polling lockout).
                 event: first event-list
                 port: event/port

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -26,10 +26,10 @@ make-port*: func [
     case [
         file? spec  [
             name: pick [dir file] dir? spec
-            spec: join [ref:] spec
+            spec: join-of [ref:] spec
         ]
         url? spec [
-            spec: repend decode-url spec [to set-word! 'ref spec]
+            spec: join decode-url spec [to set-word! 'ref spec]
             name: select spec to set-word! 'scheme
         ]
         block? spec [

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -44,10 +44,25 @@ finish-init-core: procedure [
     ;
     init-schemes
 
-    ; Make the user's global context
+    ; Make the user's global context.  Remove functions whose names are being
+    ; retaken for new functionality--to be kept this way during a deprecation
+    ; period.
     ;
     tmp: make object! 320
-    append tmp reduce ['system :system]
+    append tmp reduce [
+        'system :system
+        
+        'adjoin (get 'join)
+        'join (func [dummy1 dummy2] [
+            fail/where [
+                {JOIN is reserved in Ren-C for future use}
+                {(It will act like R3's REPEND, which has a slight difference}
+                {from APPEND of a REDUCE'd value: it only reduces blocks).}
+                {Use ADJOIN for the future JOIN, JOIN-OF for non-mutating.}
+                {If in <r3-legacy> mode, old JOIN meaning is available.}
+            ] 'dummy1
+        ])
+    ]
     system/contexts/user: tmp
 
     ; Remove the reference through which this function we are running is

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -62,6 +62,17 @@ finish-init-core: procedure [
                 {If in <r3-legacy> mode, old JOIN meaning is available.}
             ] 'dummy1
         ])
+
+        'while-not (get 'until)
+        'until (func [dummy] [
+            fail/where [
+                {UNTIL is reserved in Ren-C for future use}
+                {(It will be arity-2 and act like WHILE [NOT ...] [...])}
+                {Use LOOP-UNTIL for the single arity form, and see also}
+                {LOOP-WHILE for the arity-1 form of WHILE.}
+                {If in <r3-legacy> mode, old UNTIL meaning is available.}
+            ] 'dummy
+        ])
     ]
     system/contexts/user: tmp
 

--- a/src/os/generic/iso3166.r
+++ b/src/os/generic/iso3166.r
@@ -34,7 +34,7 @@ binary-to-chex: func [
     print ["bin: " mold bin]
     ret: copy ""
     for-each c bin [
-        append ret join "\x" skip to-hex to integer! to char! c 6
+        append ret join-of "\x" skip to-hex to integer! to char! c 6
     ]
     ret
 ]
@@ -53,7 +53,7 @@ capitalize: func [
                 append ret "U.S."
             ]
             'else [
-                append ret join uppercase first w reduce [lowercase next w " "]
+                append ret join-of uppercase first w reduce [lowercase next w " "]
             ]
         ]
     ]

--- a/src/os/generic/iso639.r
+++ b/src/os/generic/iso639.r
@@ -33,7 +33,7 @@ binary-to-chex: func [
     print ["bin:" mold bin]
     ret: copy ""
     for-each c bin [
-        append ret join "\x" skip to-hex to integer! to char! c 6
+        join ret ["\x" skip (to-hex to integer! to char! c) 6]
     ]
     ret
 ]

--- a/src/tools/common-emitter.r
+++ b/src/tools/common-emitter.r
@@ -25,7 +25,7 @@ REBOL [
 buf-emit: make string! 100000
 
 
-emit: proc [data] [repend buf-emit data]
+emit: proc [data] [adjoin buf-emit data]
 
 
 unemit: proc [

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -342,12 +342,11 @@ proto-parser: context [
     ] c.lexical/grammar
 ]
 
-rewrite-if-directives: func [
-    {Bottom up rewrite of conditional directives to remove unnecessary sections.}
+rewrite-if-directives: function [
+    {Bottom up rewrite conditional directives to remove unnecessary sections.}
     position
-    /local rewritten
 ][
-    until [
+    loop-until [
         parse position [
             (rewritten: false)
             some [

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -282,14 +282,13 @@ find-record-unique: function [
 ]
 
 
-parse-args: func [
+parse-args: function [
     args ;args in form of "NAME=VALUE"
-    /local a name value ret
 ][
     ret: make block! 4
     args: any [args copy []]
     unless block? args [args: split args [some " "]]
-    foreach a args [
+    for-each a args [
         if to logic! idx: find a #"=" [
             name: to word! copy/part a (index-of idx) - 1
             value: copy next idx

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -366,7 +366,7 @@ for-each-record type boot-types [
             "LOGICAL(VAL_TYPE(v)==REB_" (uppercase to-c-name type/name) ")"
         ]
 
-        append new-types to-word join type/name "!"
+        append new-types to-word join-of type/name "!"
     ]
 
     n: n + 1
@@ -871,7 +871,7 @@ mezz-files: load %../mezz/boot-files.r ; base lib, sys, mezz
 for-each section [boot-base boot-sys boot-mezz] [
     set section make block! 200
     for-each file first mezz-files [
-        append get section load join %../mezz/ file
+        append get section load join-of %../mezz/ file
     ]
 
     ;-- Expectation is that section does not return result; GROUP! makes unset
@@ -882,7 +882,7 @@ for-each section [boot-base boot-sys boot-mezz] [
 
 boot-protocols: make block! 20
 for-each file first mezz-files [
-    m: load/all join %../mezz/ file ; not REBOL word
+    m: load/all join-of %../mezz/ file ; not REBOL word
     append/only append/only boot-protocols m/2 skip m 2
 ]
 

--- a/src/tools/make-embedded-header.r
+++ b/src/tools/make-embedded-header.r
@@ -35,7 +35,7 @@ append out rejoin [
     {#include "sys-core.h"^/}
     "extern const REBYTE core_header_source[];^/"
     "const REBYTE core_header_source[] = {^/"
-    binary-to-c join inp #{00}
+    binary-to-c join-of inp #{00}
     "};^/"
 ]
 

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -127,7 +127,7 @@ process: func [file] [
 
 rlib: form-header/gen "REBOL Interface Library" %reb-lib.h %make-headers.r
 append rlib newline
-emit-rlib: func [d] [append repend rlib d newline]
+emit-rlib: func [d] [append adjoin rlib d newline]
 
 
 ;-------------------------------------------------------------------------
@@ -136,7 +136,7 @@ proto-count: 0
 
 fsymbol-file: %tmp-symbols.c
 fsymbol-buffer: make string! 20000
-emit-fsymb: func [x] [append repend fsymbol-buffer x newline]
+emit-fsymb: func [x] [append adjoin fsymbol-buffer x newline]
 
 emit-header "Function Prototypes" %funcs.h
 
@@ -204,7 +204,7 @@ file-base: has load %../tools/file-base.r
 parse file-base/core [
     any [
         to '+ mark: (
-            poke mark 2 join output-dir/core [%/ mark/2]
+            poke mark 2 join-of output-dir/core [%/ mark/2]
             remove mark ;remove '+
         )
     ]

--- a/src/tools/make-host-ext.r
+++ b/src/tools/make-host-ext.r
@@ -52,7 +52,7 @@ collect-files: func [
 ;-- Emit Functions -----------------------------------------------------------
 
 out: make string! 10000
-emit: func [d] [repend out d]
+emit: func [d] [adjoin out d]
 
 emit-cmt: func [text] [
     emit [
@@ -138,8 +138,4 @@ emit-file: func [
     emit ["#endif" newline]
 
     write rejoin [output-dir/include %/ file %.h] out
-
-;   clear out
-;   emit form-header/gen join title " - Module Initialization" second split-path file %make-host-ext.r
-;   write rejoin [%../os/ file %.c] out
 ]

--- a/src/tools/make-host-init.r
+++ b/src/tools/make-host-init.r
@@ -39,7 +39,7 @@ make-dir dir
 ;** Utility Functions **************************************************
 
 out: make string! 100000
-emit: func [data] [repend out data]
+emit: func [data] [adjoin out data]
 
 emit-head: func [title file] [
     clear out

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -306,7 +306,7 @@ make-dir outdir
 make-dir outdir/objs
 
 output: make string! 10000
-emit: func [d] [repend output d]
+emit: func [d] [adjoin output d]
 
 ;******************************************************************************
 ;** Functions
@@ -341,7 +341,7 @@ macro++: procedure ['name obj [object!]] [
         all [
             obj/:n
             flag? (n)
-            repend out [space obj/:n]
+            adjoin out [space obj/:n]
         ]
     ]
     macro+ (name) out

--- a/src/tools/make-natives.r
+++ b/src/tools/make-natives.r
@@ -68,9 +68,14 @@ emit-proto: proc [proto] [
     ]
 ]
 
-process: func [file] [
+process: func [
+    file
+    ; <with> the-file ;-- note external variable (can't do this in R3-Alpha)
+][
+    the-file: file
     if verbose [probe [file]]
-    source.text: read join core-folder the-file: file
+
+    source.text: read join-of core-folder file
     if r3 [source.text: deline to-string source.text]
     proto-parser/emit-proto: :emit-proto
     proto-parser/process source.text

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -79,7 +79,7 @@ count: func [s c /local n] [
     output-buffer: copy "(a"
     n: 1
     while [s: find/tail s c][
-        repend output-buffer [#"," #"a" + n]
+        adjoin output-buffer [#"," #"a" + n]
         n: n + 1
     ]
     append output-buffer ")"

--- a/src/tools/make-reb-lib.r
+++ b/src/tools/make-reb-lib.r
@@ -54,11 +54,11 @@ mlib-buffer: make string! 1000
 dlib-buffer: make string! 1000
 xsum-buffer: make string! 1000
 
-emit: func [d] [append repend xlib-buffer d newline]
-emit-rlib: func [d] [append repend rlib-buffer d newline]
-emit-dlib: func [d] [append repend dlib-buffer d newline]
+emit: func [d] [append adjoin xlib-buffer d newline]
+emit-rlib: func [d] [append adjoin rlib-buffer d newline]
+emit-dlib: func [d] [append adjoin dlib-buffer d newline]
 emit-mlib: proc [d /nol] [
-    repend mlib-buffer d
+    adjoin mlib-buffer d
     if not nol [append mlib-buffer newline]
 ]
 
@@ -67,7 +67,7 @@ count: func [s c /local n] [
     out: copy "(a"
     n: 1
     while [s: find/tail s c][
-        repend out [#"," #"a" + n]
+        adjoin out [#"," #"a" + n]
         n: n + 1
     ]
     append out ")"

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -362,6 +362,16 @@ join: does [
 adjoin: get 'repend
 
 
+; It's not possible to write loop wrappers that work correctly with RETURN,
+; and so a good forward-compatible version of UNTIL as WHILE-NOT isn't really
+; feasible.  So just don't use it.
+;
+loop-until: get 'until
+until: does [
+    fail "UNTIL in Ren-C will be arity 2 (WHILE-NOT), can't mimic in R3-Alpha"
+]
+
+
 ; Note: any-context! and any-context? supplied at top of file
 
 ; *all* typesets now ANY-XXX to help distinguish them from concrete types

--- a/tests/atronix/varargs.r
+++ b/tests/atronix/varargs.r
@@ -35,7 +35,7 @@ sprintf: make routine! [
 i: 1000
 j: 0.0
 printf reduce [
-    join "i: %d, %f" newline
+    join-of "i: %d, %f" newline
     i [int32]
     j [float]
 ]

--- a/tests/bench.r3
+++ b/tests/bench.r3
@@ -148,7 +148,7 @@ merge: func [
 a la b lb /local c
 ] [
 c: copy/part a la
-until [
+loop-until [
 either (compare first b first c) [
 change/only a first b
 b: next b

--- a/tests/control/until.test.reb
+++ b/tests/control/until.test.reb
@@ -1,35 +1,35 @@
 ; functions/control/until.r
 [
     num: 0
-    until [num: num + 1 num > 9]
+    loop-until [num: num + 1 num > 9]
     num = 10
 ]
 ; Test body-block return values
-[1 = until [1]]
+[1 = loop-until [1]]
 ; Test break and break/return
-[void? until [break true]]
-[1 = until [break/return 1 true]]
+[void? loop-until [break true]]
+[1 = loop-until [break/return 1 true]]
 ; Test continue
 [
     success: true
     cycle?: true
-    until [if cycle? [cycle?: false continue success: false] true]
+    loop-until [if cycle? [cycle?: false continue success: false] true]
     success
 ]
 ; Test that return stops the loop
 [
-    f1: does [until [return 1]]
+    f1: does [loop-until [return 1]]
     1 = f1
 ]
 ; Test that errors do not stop the loop
-[1 = until [try [1 / 0] 1]]
+[1 = loop-until [try [1 / 0] 1]]
 ; Recursion check
 [
     num1: 0
     num3: 0
-    until [
+    loop-until [
         num2: 0
-        until [
+        loop-until [
             num3: num3 + 1
             1 < (num2: num2 + 1)
         ]

--- a/tests/file/open.test.reb
+++ b/tests/file/open.test.reb
@@ -1,3 +1,10 @@
 ; functions/file/open.r
 ; bug#1422: "Rebol crashes when opening the 128th port"
-[error? try [repeat n 200 [try [close open open join tcp://localhost: n]]] true]
+[
+    error? try [
+        repeat n 200 [
+            try [close open open join-of tcp://localhost: n]
+        ]
+    ]
+    true
+]

--- a/tests/lib/text-lines.reb
+++ b/tests/lib/text-lines.reb
@@ -24,9 +24,9 @@ decode-lines: function [
         fail [{decode-lines expects each line to begin with} (mold line-prefix) { and finish with a newline.}]
     ]
     insert text newline
-    replace/all text join newline line-prefix newline
+    replace/all text join-of newline line-prefix newline
     if not empty? indent [
-        replace/all text join newline indent newline
+        replace/all text join-of newline indent newline
     ]
     remove text
     remove back tail text

--- a/tests/misc/fib.r
+++ b/tests/misc/fib.r
@@ -28,7 +28,7 @@ compile/options [
     "const int one = 1;"
     c-fib
 ] compose [
-    runtime-path (join first split-path system/options/boot %tcc)
+    runtime-path (join-of (first split-path system/options/boot) %tcc)
 ]
 
 fib: func [

--- a/tests/misc/shttpd.r
+++ b/tests/misc/shttpd.r
@@ -56,7 +56,7 @@ awake-client: function [event] [
     port: event/port
     switch event/type [
         read [
-            either find port/data to-binary join crlf crlf [
+            either find port/data to-binary join-of crlf crlf [
                 res: handle-request port/locals/config port/data
                 start-response port res
             ] [
@@ -77,7 +77,7 @@ awake-server: func [event /local client] [
 ]
 
 serve: func [web-port web-root /local listen-port] [
-    listen-port: open join tcp://: web-port
+    listen-port: open join-of tcp://: web-port
     listen-port/locals: has compose/deep [
         config: [root: (web-root)]
     ]

--- a/tests/misc/unzip.reb
+++ b/tests/misc/unzip.reb
@@ -203,7 +203,7 @@ ctx-zip: context [
             return value
         ]
         value: decode-url value
-        join %"" [
+        join-of %"" [
             value/host "/"
             any [value/path ""]
             any [value/target ""]
@@ -308,7 +308,7 @@ ctx-zip: context [
     ][
         errors: 0
         info: unless all [quiet not verbose][
-            func [value][prin join "" value]
+            func [value][prin join-of "" value]
         ]
         if any-file? where [where: dirize where]
         if all [any-file? where not exists? where][

--- a/tests/misc/varargs-old.r
+++ b/tests/misc/varargs-old.r
@@ -35,7 +35,7 @@ sprintf: make routine! [
 i: 1000
 j: 0.0
 printf reduce [
-    join "i: %d, %f" newline
+    join-of "i: %d, %f" newline
     i [int32]
     j [float]
 ]
@@ -65,7 +65,7 @@ h: make struct! [
 ]
 len: sprintf reduce [
     addr-of h
-    join "hello %s" newline
+    join-of "hello %s" newline
     "world" [pointer]
 ]
 prin ["h:" copy/part to string! values-of h len]

--- a/tests/misc/varargs.r
+++ b/tests/misc/varargs.r
@@ -36,7 +36,7 @@ i: 1000
 j: make struct! [x [double]]
 j/x: 12.34
 (printf
-    join "1. i: %d, %f" newline
+    join-of "1. i: %d, %f" newline
     i [int64]
     j [struct! [x [double]]]
 )
@@ -64,7 +64,7 @@ h: make struct! [
 ]
 len: (sprintf
     addr-of h
-    join "hello %s" newline
+    join-of "hello %s" newline
     "world" [pointer]
 )
 

--- a/tests/series/emptyq.test.reb
+++ b/tests/series/emptyq.test.reb
@@ -7,4 +7,4 @@
 ]
 [empty? blank]
 ; bug#190
-[x: copy "xx^/" loop 20 [enline x: join x x] true]
+[x: copy "xx^/" loop 20 [enline x: join-of x x] true]

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -261,8 +261,8 @@ rebsource: context [
 
             files: make block! []
             for-each path fixed-source-paths [
-                for-each file read join src-folder path [
-                    append files join path file
+                for-each file read join-of src-folder path [
+                    append files join-of path file
                 ]
             ]
 


### PR DESCRIPTION
The classic definition of REDUCE doesn't necessarily REDUCE in
R3-Alpha:

    >> x: 10
    >> reduce 'x
    == x

This was remedied in Ren-C and in Red.  The resulting consequence
was that REPEND also began reducing things, as its definition was
REPEND SERIES VALUE => REPEND SERIES REDUCE VALUE.  However, this
may or may not be as useful for REPEND's common case.

In fact, there is another word in Rebol space that one could
think of as being more appropriate as being a variant of what REPEND
is doing--namely JOIN.  Historically, JOIN is just a non-modifying
version of REPEND.  Its name does not have the baggage of sensibly
needing to mean "apPEND buffer REduce x"...it can take artistic
license and do whatever it's most useful for a JOIN to do.

Yet in the Rebol world, basic terms (APPEND, INSERT, REMOVE, UPPERCASE)
are modifying by default.  Ren-C is trying to bring in a vocabulary for
immutable variations of these, which could be optimized via a
refinement (e.g. `APPEND/COPY X Y` can be made more efficient than
`APPEND COPY X Y`, because APPEND can know the length of the final
result ahead of time from the sum of the lengths of X and Y, and do
one allocation for that size, vs COPY doing one allocation at X size
and then APPEND needing to expand that.)

So it makes sense to give the mutable operation to the undecorated
name, JOIN.  And for the immutable version (a.k.a.) JOIN/COPY, this
can be abbreviated to JOIN-OF.  (Abbreviation has the advantage that
it can be done as `join-of: adapt 'join [series: copy series]`,
even before the refinement is implemented.)

And it looks better, also making a better impression on new users than
REPEND does:

    buffer: copy ""
    emit: func [x] [join buffer x]

This goes ahead and refactors REPEND, JOIN, and JOIN-OF...as well as
reframing REJOIN to be in terms of JOIN.  It also makes REJOIN []
return BLANK!, as opposed to a BLOCK!, since it has no basis for
knowing what content type to return.

In order to let JOIN-OF have time to settle, a synonym for the new
JOIN is established as ADJOIN and JOIN gives an error message.