### PR TITLE
Initial Implementation of Immutable Source

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -280,8 +280,12 @@ Access: [
     code: 5000
     type: "access error"
 
-    locked-word:        [{variable} :arg1 {locked by PROTECT - cannot modify}]
-    locked:             {value or series locked - cannot modify}
+    protected-word:     [{variable} :arg1 {locked by PROTECT (see UNPROTECT)}]
+    
+    series-protected:   {series read-only due to PROTECT (see UNPROTECT)}
+    series-frozen:      {series is source or permanently locked, can't modify}
+    series-running:     {series temporarily read-only for running (DO, PARSE)}
+
     hidden:             {not allowed - would expose or modify hidden values}
 
     cannot-open:        [{cannot open:} :arg1 {reason:} :arg2]

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -146,7 +146,6 @@ options: construct [] [  ; Options supplied to REBOL during startup
 
     lit-word-decay: false
     exit-functions-only: false
-    mutable-function-bodies: false
     broken-case-semantics: false
     refinements-blank: false
     forever-64-bit-ints: false
@@ -159,6 +158,7 @@ options: construct [] [  ; Options supplied to REBOL during startup
     no-reduce-nested-print: false
     arg1-arg2-arg3-error: false
     sets-unsuppress-lookahead: false
+    unlocked-source: false
 
     ; These option will only apply if the function which is currently executing
     ; was created after legacy mode was enabled, and if refinements-blank is

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -550,6 +550,17 @@ RL_API int RL_Do_String(
         Resolve_Context(user, Lib_Context, &vali, FALSE, FALSE);
     }
 
+    // The new policy for source code in Ren-C is that it loads read only.
+    // This didn't go through the LOAD Rebol function (should it?  it never
+    // did before.  :-/)  For now, stick with simple binding but lock it.
+    //
+#if defined(NDEBUG)
+    Deep_Freeze_Array(code);
+#else
+    if (!LEGACY(OPTIONS_UNLOCKED_SOURCE))
+        Deep_Freeze_Array(code);
+#endif
+
     REBVAL result;
     if (Do_At_Throws(&result, code, 0, SPECIFIED)) { // implicitly guarded
         if (
@@ -1262,7 +1273,7 @@ RL_API int RL_Set_Field(REBSER *obj, REBSTR *word_id, REBVAL val, int type)
     REBCNT index = Find_Canon_In_Context(context, STR_CANON(word_id), FALSE);
     if (index == 0) return 0;
 
-    if (GET_VAL_FLAG(CTX_KEY(context, index), TYPESET_FLAG_LOCKED))
+    if (GET_VAL_FLAG(CTX_KEY(context, index), TYPESET_FLAG_PROTECTED))
         return 0;
 
     *CTX_VAR(context, index) = val;

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -347,7 +347,7 @@ static void Init_Datatypes(void)
         // which appears to copy this subset out from the Lib_Context.)
         //
         assert(value == Get_Type(cast(enum Reb_Kind, n)));
-        SET_VAL_FLAG(CTX_KEY(Lib_Context, 1), TYPESET_FLAG_LOCKED);
+        SET_VAL_FLAG(CTX_KEY(Lib_Context, 1), TYPESET_FLAG_PROTECTED);
     }
 }
 
@@ -508,8 +508,7 @@ static void Init_Function_Tag(const char *name, REBVAL *slot)
         slot,
         Append_UTF8_May_Fail(NULL, cb_cast(name), strlen(name))
     );
-    SET_SER_FLAG(VAL_SERIES(slot), SERIES_FLAG_FIXED_SIZE);
-    SET_SER_FLAG(VAL_SERIES(slot), SERIES_FLAG_LOCKED);
+    Freeze_Sequence(VAL_SERIES(slot));
 }
 
 
@@ -794,14 +793,12 @@ static void Init_Root_Context(void)
     // The EMPTY_BLOCK provides EMPTY_ARRAY.  It is locked for protection.
     //
     Val_Init_Block(ROOT_EMPTY_BLOCK, Make_Array(0));
-    SET_SER_FLAG(VAL_SERIES(ROOT_EMPTY_BLOCK), SERIES_FLAG_LOCKED);
-    SET_SER_FLAG(VAL_SERIES(ROOT_EMPTY_BLOCK), SERIES_FLAG_FIXED_SIZE);
+    Deep_Freeze_Array(VAL_ARRAY(ROOT_EMPTY_BLOCK));
 
     REBSER *empty_series = Make_Binary(1);
     *BIN_AT(empty_series, 0) = '\0';
     Val_Init_String(ROOT_EMPTY_STRING, empty_series);
-    SET_SER_FLAG(VAL_SERIES(ROOT_EMPTY_STRING), SERIES_FLAG_LOCKED);
-    SET_SER_FLAG(VAL_SERIES(ROOT_EMPTY_STRING), SERIES_FLAG_FIXED_SIZE);
+    Freeze_Sequence(VAL_SERIES(ROOT_EMPTY_STRING));
 
     // Used by REBNATIVE(print)
     //

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -1074,7 +1074,7 @@ void Resolve_Context(
     REBOOL all,
     REBOOL expand
 ) {
-    FAIL_IF_LOCKED_CONTEXT(target);
+    FAIL_IF_READ_ONLY_CONTEXT(target);
 
     REBVAL *key;
     REBVAL *var;
@@ -1157,7 +1157,7 @@ void Resolve_Context(
         if (m != 0) {
             // "the remove succeeded, so it's marked as set now" (old comment)
             if (
-                !GET_VAL_FLAG(key, TYPESET_FLAG_LOCKED)
+                !GET_VAL_FLAG(key, TYPESET_FLAG_PROTECTED)
                 && (all || IS_VOID(var))
             ) {
                 if (m < 0) SET_VOID(var); // no value in source context

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1394,7 +1394,7 @@ REBCTX *Error_Protected_Key(REBVAL *key)
     REBVAL key_name;
     Val_Init_Word(&key_name, REB_WORD, VAL_KEY_SPELLING(key));
 
-    return Error(RE_LOCKED_WORD, &key_name, END_CELL);
+    return Error(RE_PROTECTED_WORD, &key_name, END_CELL);
 }
 
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1234,11 +1234,6 @@ REBFUN *Make_Interpreted_Function_May_Fail(
     }
 #endif
 
-#if !defined(NDEBUG)
-    if (LEGACY(OPTIONS_MUTABLE_FUNCTION_BODIES))
-        return fun; // don't run protection code below
-#endif
-
     // All the series inside of a function body are "relatively bound".  This
     // means that there's only one copy of the body, but the series handle
     // is "viewed" differently based on which call it represents.  Though
@@ -1246,16 +1241,12 @@ REBFUN *Make_Interpreted_Function_May_Fail(
     // it...hence the series must be read only to keep modifying a view
     // that seems to have one identity but then affecting another.
     //
-    // !!! This protection needs to be system level, as the user is able to
-    // unprotect conventional protection via UNPROTECT.
-    //
-    Protect_Series(
-        ARR_SERIES(VAL_ARRAY(body)),
-        0, // start protection at index 0
-        FLAGIT(PROT_DEEP) | FLAGIT(PROT_SET)
-    );
-    assert(GET_ARR_FLAG(VAL_ARRAY(body), SERIES_FLAG_LOCKED));
-    Uncolor_Array(VAL_ARRAY(body));
+#if defined(NDEBUG)
+    Deep_Freeze_Array(VAL_ARRAY(body));
+#else
+    if (!LEGACY(OPTIONS_UNLOCKED_SOURCE))
+        Deep_Freeze_Array(VAL_ARRAY(body));
+#endif
 
     return fun;
 }

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -116,7 +116,7 @@ REBOOL Series_Common_Action_Returns(
     case SYM_REMOVE: {
         INCLUDE_PARAMS_OF_REMOVE;
 
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
         len = REF(part) ? Partial(value, 0, ARG(limit)) : 1;
         index = cast(REBINT, VAL_INDEX(value));
         if (index < tail && len != 0)

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -386,7 +386,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         break; }
 
     case REB_HANDLE: { // See %sys-handle.h
-        REBARR *singular = v->extra.singular; 
+        REBARR *singular = v->extra.singular;
         if (singular == NULL) {
             //
             // This HANDLE! was created with Init_Handle_Simple.  There is
@@ -610,7 +610,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         //
         // Not an actual ANY-VALUE! "value", just a void cell.  Instead of
         // this "Opt"ional routine, use Queue_Mark_Value_Deep() on slots
-        // that should not be void. 
+        // that should not be void.
         //
         break;
 
@@ -986,7 +986,7 @@ static void Mark_Guarded_Series(void)
 static void Mark_Guarded_Values(void)
 {
     REBVAL **vp = SER_HEAD(REBVAL*, GC_Value_Guard);
-    REBCNT n = SER_LEN(GC_Value_Guard); 
+    REBCNT n = SER_LEN(GC_Value_Guard);
     for (; n > 0; --n, ++vp) {
         if (NOT_END(*vp))
             Queue_Mark_Opt_Value_Deep(*vp);

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -539,14 +539,13 @@ void Free_Node(REBCNT pool_id, void *pv)
 //
 //  Series_Data_Alloc: C
 //
-// Allocates element array for an already allocated REBSER header
-// structure.  Resets the bias and tail to zero, and sets the new
-// width.  Flags like SERIES_FLAG_LOCKED are left as they were, and other
-// fields in the series structure are untouched.
+// Allocates element array for an already allocated REBSER node structure.
+// Resets the bias and tail to zero, and sets the new width.  Flags like
+// SERIES_FLAG_FIXED_SIZE are left as they were, and other fields in the
+// series structure are untouched.
 //
-// This routine can thus be used for an initial construction
-// or an operation like expansion.  Currently not exported
-// from this file.
+// This routine can thus be used for an initial construction or an operation
+// like expansion.  Currently not exported from this file.
 //
 static REBOOL Series_Data_Alloc(
     REBSER *s,
@@ -613,7 +612,7 @@ static REBOOL Series_Data_Alloc(
         Mem_Pools[SYSTEM_POOL].free++;
     }
 
-    // Keep tflags like SERIES_FLAG_LOCKED, but use new width and bias to 0
+    // Keep flags like SERIES_FLAG_FIXED_SIZE, but use new width and bias to 0
     //
     SER_SET_WIDE(s, wide);
 

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -348,7 +348,7 @@ void Reset_Array(REBARR *a)
 //
 void Clear_Series(REBSER *s)
 {
-    assert(!GET_SER_FLAG(s, SERIES_FLAG_LOCKED));
+    assert(!Is_Series_Read_Only(s));
 
     if (GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)) {
         Unbias_Series(s, FALSE);

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -245,7 +245,7 @@ void Pop_Stack_Values_Into(REBVAL *into, REBDSP dsp_start) {
     REBVAL *values = KNOWN(ARR_AT(DS_Array, dsp_start + 1));
 
     assert(ANY_ARRAY(into));
-    FAIL_IF_LOCKED_ARRAY(VAL_ARRAY(into));
+    FAIL_IF_READ_ONLY_ARRAY(VAL_ARRAY(into));
 
     VAL_INDEX(into) = Insert_Series(
         ARR_SERIES(VAL_ARRAY(into)),
@@ -407,11 +407,12 @@ REBCTX *Context_For_Frame_May_Reify_Core(REBFRM *f) {
     // A reification of a frame for native code should not allow changing
     // the values out from under it, because that could cause it to crash
     // the interpreter.  (Generally speaking, modification should only be
-    // possible in the debugger anyway.)  For now, protect unless it's a
-    // user function.
+    // possible in the debugger anyway.)  For now, mark the array as
+    // running...which should not stop FRM_ARG from working in the native
+    // itself, but should stop modifications from user code.
     //
     if (NOT(IS_FUNCTION_INTERPRETED(FUNC_VALUE(f->func))))
-        SET_ARR_FLAG(CTX_VARLIST(context), SERIES_FLAG_LOCKED);
+        ARR_SERIES(CTX_VARLIST(context))->header.bits |= REBSER_FLAG_RUNNING;
 
     return context;
 }

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -917,10 +917,10 @@ REBNATIVE(set)
             if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
                 continue;
 
-            // Locked words cannot be modified, so a SET should error instead
-            // of going ahead and changing them
+            // Protected words cannot be modified, so a SET should error
+            // instead of going ahead and changing them
             //
-            if (GET_VAL_FLAG(key, TYPESET_FLAG_LOCKED))
+            if (GET_VAL_FLAG(key, TYPESET_FLAG_PROTECTED))
                 fail (Error_Protected_Key(key));
 
             // If we're setting to a single value and not a block, then

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -174,7 +174,7 @@ REBNATIVE(fail)
         // we accept (reserving room for future dialect expansion)
         //
         for (; NOT_END(item); item++) {
-            if (IS_STRING(item) || IS_SCALAR(item))
+            if (IS_STRING(item) || ANY_SCALAR(item))
                 continue;
 
             // Leave the group in and let the reduce take care of it

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -1421,7 +1421,7 @@ REBNATIVE(list_env)
 {
     REBARR *array = String_List_To_Array(OS_LIST_ENV());
     REBMAP *map = Mutate_Array_Into_Map(array);
-    Val_Init_Map(D_OUT, map);
+    Init_Map(D_OUT, map);
 
     return R_OUT;
 }

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -247,7 +247,7 @@ REBNATIVE(make_native)
 
     REBARR *info = Make_Array(3); // [source name tcc_state]
 
-    if (GET_SER_FLAG(VAL_SERIES(source), SERIES_FLAG_LOCKED))
+    if (Is_Series_Frozen(VAL_SERIES(source)))
         Append_Value(info, source); // no need to copy it...
     else {
         // have to copy it (might change before COMPILE is called)
@@ -265,7 +265,7 @@ REBNATIVE(make_native)
     if (REF(linkname)) {
         REBVAL *name = ARG(name);
 
-        if (GET_SER_FLAG(VAL_SERIES(name), SERIES_FLAG_LOCKED))
+        if (Is_Series_Frozen(VAL_SERIES(name)))
             Append_Value(info, name);
         else {
             Val_Init_String(

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -132,7 +132,7 @@ REBNATIVE(reduce)
 
     REBVAL *into = ARG(target);
     assert(ANY_ARRAY(into));
-    FAIL_IF_LOCKED_ARRAY(VAL_ARRAY(into));
+    FAIL_IF_READ_ONLY_ARRAY(VAL_ARRAY(into));
 
     // Insert the single item into the target array at its current position,
     // and return the position after the insertion (the /INTO convention)

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -398,13 +398,13 @@ REBSER *Make_Hash_Sequence(REBCNT len)
 
 
 //
-//  Val_Init_Map: C
+//  Init_Map: C
 //
 // A map has an additional hash element hidden in the ->extra
 // field of the REBSER which needs to be given to memory
 // management as well.
 //
-void Val_Init_Map(REBVAL *out, REBMAP *map)
+void Init_Map(REBVAL *out, REBMAP *map)
 {
     if (MAP_HASHLIST(map))
         ENSURE_SERIES_MANAGED(MAP_HASHLIST(map));

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -720,7 +720,7 @@ void Change_Case(REBVAL *out, REBVAL *val, REBVAL *part, REBOOL upper)
 
     // String series:
 
-    FAIL_IF_LOCKED_SERIES(VAL_SERIES(val));
+    FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(val));
 
     len = Partial(val, 0, part);
     n = VAL_INDEX(val);

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -305,7 +305,7 @@ void Set_Bit_Str(REBSER *bset, const REBVAL *val, REBOOL set)
 //
 REBOOL Set_Bits(REBSER *bset, const REBVAL *val, REBOOL set)
 {
-    FAIL_IF_LOCKED_SERIES(bset);
+    FAIL_IF_READ_ONLY_SERIES(bset);
 
     REBCNT n;
     REBCNT c;
@@ -630,7 +630,7 @@ set_bits:
         return (VAL_LEN_HEAD(value) == 0) ? R_TRUE : R_FALSE;
 
     case SYM_CLEAR:
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
         Clear_Series(VAL_SERIES(value));
         break;
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -576,7 +576,7 @@ REBINT PD_Array(REBPVS *pvs)
     }
 
     if (pvs->opt_setval)
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(pvs->value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(pvs->value));
 
     pvs->value_specifier = IS_SPECIFIC(pvs->value)
         ? VAL_SPECIFIER(const_KNOWN(pvs->value))
@@ -662,7 +662,7 @@ REBTYPE(Array)
                 return R_VOID;
             }
         } else {
-            FAIL_IF_LOCKED_ARRAY(array);
+            FAIL_IF_READ_ONLY_ARRAY(array);
             if (IS_VOID(D_OUT)) {
                 assert(!slot);
                 fail (Error_Out_Of_Range(arg));
@@ -679,7 +679,7 @@ REBTYPE(Array)
 
         REBCNT len;
 
-        FAIL_IF_LOCKED_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(array);
 
         if (REF(part)) {
             Partial1(value, ARG(limit), &len);
@@ -782,7 +782,7 @@ REBTYPE(Array)
             &len
         );
 
-        FAIL_IF_LOCKED_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(array);
         index = VAL_INDEX(value);
 
         REBFLGS flags = 0;
@@ -806,7 +806,7 @@ REBTYPE(Array)
     }
 
     case SYM_CLEAR: {
-        FAIL_IF_LOCKED_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(array);
         if (index < cast(REBINT, VAL_LEN_HEAD(value))) {
             if (index == 0) Reset_Array(array);
             else {
@@ -856,7 +856,7 @@ REBTYPE(Array)
 
     case SYM_TRIM: {
         INCLUDE_PARAMS_OF_TRIM;
-        FAIL_IF_LOCKED_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(array);
 
         if (REF(auto) || REF(with) || REF(all) || REF(lines))
             fail (Error(RE_BAD_REFINES));
@@ -904,8 +904,8 @@ REBTYPE(Array)
         if (!ANY_ARRAY(arg))
             fail (Error_Invalid_Arg(arg));
 
-        FAIL_IF_LOCKED_ARRAY(array);
-        FAIL_IF_LOCKED_ARRAY(VAL_ARRAY(arg));
+        FAIL_IF_READ_ONLY_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(VAL_ARRAY(arg));
 
         if (
             index < cast(REBINT, VAL_LEN_HEAD(value))
@@ -925,7 +925,7 @@ REBTYPE(Array)
         REBCNT len;
         Partial1(value, D_ARG(3), &len);
 
-        FAIL_IF_LOCKED_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(array);
 
         if (len != 0) {
             //
@@ -946,7 +946,7 @@ REBTYPE(Array)
     case SYM_SORT: {
         INCLUDE_PARAMS_OF_SORT;
 
-        FAIL_IF_LOCKED_ARRAY(array);
+        FAIL_IF_READ_ONLY_ARRAY(array);
         Sort_Block(
             value,
             REF(case),

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -951,7 +951,7 @@ REBTYPE(Image)
 
     // Check must be in this order (to avoid checking a non-series value);
     if (action >= SYM_TAKE && action <= SYM_SORT)
-        FAIL_IF_LOCKED_SERIES(series);
+        FAIL_IF_READ_ONLY_SERIES(series);
 
     // Dispatch action:
     switch (action) {
@@ -1008,7 +1008,7 @@ REBTYPE(Image)
         return R_OUT;
 
     case SYM_POKE:
-        Poke_Image_Fail_If_Locked(value, arg, D_ARG(3));
+        Poke_Image_Fail_If_Read_Only(value, arg, D_ARG(3));
         *D_OUT = *D_ARG(3);
         return R_OUT;
 
@@ -1261,15 +1261,15 @@ void Pick_Image(REBVAL *out, const REBVAL *value, const REBVAL *picker)
 
 
 //
-//  Poke_Image_Fail_If_Locked: C
+//  Poke_Image_Fail_If_Read_Only: C
 //
-void Poke_Image_Fail_If_Locked(
+void Poke_Image_Fail_If_Read_Only(
     REBVAL *value,
     const REBVAL *picker,
     const REBVAL *poke
 ) {
     REBSER *series = VAL_SERIES(value);
-    FAIL_IF_LOCKED_SERIES(series);
+    FAIL_IF_READ_ONLY_SERIES(series);
 
     REBINT index = cast(REBINT, VAL_INDEX(value));
     REBINT len = VAL_LEN_HEAD(value) - index;
@@ -1379,7 +1379,7 @@ void Poke_Image_Fail_If_Locked(
 REBINT PD_Image(REBPVS *pvs)
 {
     if (pvs->opt_setval) {
-        Poke_Image_Fail_If_Locked(
+        Poke_Image_Fail_If_Read_Only(
             KNOWN(pvs->value), pvs->selector, pvs->opt_setval
         );
         return PE_OK;

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -303,7 +303,12 @@ static REBCNT Find_Map_Entry(
     // Just a GET of value:
     if (!val) return n;
 
-    if (ANY_ARRAY(key) && !GET_ARR_FLAG(VAL_ARRAY(key), SERIES_FLAG_LOCKED))
+    // If not just a GET, it may try to set the value in the map.  Which means
+    // the key may need to be stored.  Since copies of keys are never made,
+    // a SET must always be done with an immutable key...because if it were
+    // changed, there'd be no notification to rehash the map.
+    //
+    if (!Is_Value_Immutable(key))
         fail (Error(RE_MAP_KEY_UNLOCKED, key));
 
     // Must set the value:
@@ -315,7 +320,7 @@ static REBCNT Find_Map_Entry(
     if (IS_VOID(val)) return 0; // trying to remove non-existing key
 
     // Create new entry.  Note that it does not copy underlying series (e.g.
-    // the data of a string)
+    // the data of a string), which is why the immutability test is necessary
     //
     Append_Value_Core(pairlist, key, key_specifier);
     Append_Value_Core(pairlist, val, val_specifier);
@@ -334,7 +339,7 @@ REBINT PD_Map(REBPVS *pvs)
     assert(IS_MAP(pvs->value));
 
     if (setting)
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(pvs->value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(pvs->value));
 
     if (IS_BLANK(pvs->selector))
         return PE_NONE;
@@ -407,7 +412,7 @@ void MAKE_Map(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
     if (ANY_NUMBER(arg)) {
         REBMAP *map = Make_Map(Int32s(arg, 0));
-        Val_Init_Map(out, map);
+        Init_Map(out, map);
     }
     else {
         // !!! R3-Alpha TO of MAP! was like MAKE but wouldn't accept just
@@ -449,7 +454,7 @@ void TO_Map(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     REBMAP *map = Make_Map(len / 2); // [key value key value...] + END
     Append_Map(map, array, index, specifier, len);
     Rehash_Map(map);
-    Val_Init_Map(out, map);
+    Init_Map(out, map);
 }
 
 
@@ -607,7 +612,7 @@ REBTYPE(Map)
     case SYM_APPEND: {
         INCLUDE_PARAMS_OF_INSERT;
 
-        FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
+        FAIL_IF_READ_ONLY_ARRAY(MAP_PAIRLIST(map));
 
         if (!IS_BLOCK(arg))
             fail (Error_Invalid_Arg(val));
@@ -629,7 +634,7 @@ REBTYPE(Map)
     case SYM_REMOVE: {
         INCLUDE_PARAMS_OF_REMOVE;
 
-        FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
+        FAIL_IF_READ_ONLY_ARRAY(MAP_PAIRLIST(map));
 
         if (NOT(REF(map)))
             fail (Error_Illegal_Action(REB_MAP, action));
@@ -641,7 +646,7 @@ REBTYPE(Map)
         return R_OUT; }
 
     case SYM_POKE:  // CHECK all pokes!!! to be sure they check args now !!!
-        FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
+        FAIL_IF_READ_ONLY_ARRAY(MAP_PAIRLIST(map));
 
         n = Find_Map_Entry(
             map, arg, SPECIFIED, D_ARG(3), SPECIFIED, TRUE
@@ -663,7 +668,7 @@ REBTYPE(Map)
         return R_OUT; }
 
     case SYM_CLEAR:
-        FAIL_IF_LOCKED_ARRAY(MAP_PAIRLIST(map));
+        FAIL_IF_READ_ONLY_ARRAY(MAP_PAIRLIST(map));
 
         Reset_Array(MAP_PAIRLIST(map));
 
@@ -672,7 +677,7 @@ REBTYPE(Map)
         //
         Clear_Series(MAP_HASHLIST(map));
 
-        Val_Init_Map(D_OUT, map);
+        Init_Map(D_OUT, map);
         return R_OUT;
 
     case SYM_REFLECT: {

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -196,7 +196,7 @@ static void Append_To_Context(REBCTX *context, REBVAL *arg)
         REBVAL *key = CTX_KEY(context, i);
         REBVAL *var = CTX_VAR(context, i);
 
-        if (GET_VAL_FLAG(key, TYPESET_FLAG_LOCKED))
+        if (GET_VAL_FLAG(key, TYPESET_FLAG_PROTECTED))
             fail (Error_Protected_Key(key));
 
         if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
@@ -470,9 +470,9 @@ REBINT PD_Context(REBPVS *pvs)
     if (
         pvs->opt_setval
         && IS_END(pvs->item + 1)
-        && GET_VAL_FLAG(CTX_KEY(context, n), TYPESET_FLAG_LOCKED)
+        && GET_VAL_FLAG(CTX_KEY(context, n), TYPESET_FLAG_PROTECTED)
     ) {
-        fail (Error(RE_LOCKED_WORD, pvs->selector));
+        fail (Error(RE_PROTECTED_WORD, pvs->selector));
     }
 
     pvs->value = CTX_VAR(context, n);
@@ -567,6 +567,45 @@ REBNATIVE(set_meta)
 
 
 //
+//  Copy_Context_Core: C
+//
+// R3-Alpha hadn't factored out a routine to copy objects, it was just in the
+// COPY action.  This is a basic factoring of that, which had the ability to
+// specify what types would be copied and whether they would be done deeply.
+//
+REBCTX *Copy_Context_Core(REBCTX *original, REBOOL deep, REBU64 types)
+{
+    REBARR *varlist = Copy_Array_Shallow(CTX_VARLIST(original), SPECIFIED);
+    SET_ARR_FLAG(varlist, ARRAY_FLAG_VARLIST);
+
+    // The type information and fields in the rootvar (at head of the varlist)
+    // are filled in because it's a copy, but the varlist needs to be updated
+    // in the copy to the one just created.
+    //
+    ARR_HEAD(varlist)->payload.any_context.varlist = varlist;
+
+    REBCTX *copy = AS_CONTEXT(varlist); // now a well-formed context
+
+    // Reuse the keylist of the original.  (If the context of the source or
+    // the copy are expanded, the sharing is unlinked and a copy is made).
+    //
+    INIT_CTX_KEYLIST_SHARED(copy, CTX_KEYLIST(original));
+
+    if (types != 0) {
+        Clonify_Values_Len_Managed(
+            CTX_VARS_HEAD(copy),
+            SPECIFIED,
+            CTX_LEN(copy),
+            deep,
+            types
+        );
+    }
+
+    return copy;
+}
+
+
+//
 //  REBTYPE: C
 //
 // Handles object!, module!, and error! datatypes.
@@ -579,7 +618,7 @@ REBTYPE(Context)
 
     switch (action) {
     case SYM_APPEND:
-        FAIL_IF_LOCKED_CONTEXT(VAL_CONTEXT(value));
+        FAIL_IF_READ_ONLY_CONTEXT(VAL_CONTEXT(value));
         if (!IS_OBJECT(value) && !IS_MODULE(value))
             fail (Error_Illegal_Action(VAL_TYPE(value), action));
         Append_To_Context(VAL_CONTEXT(value), arg);
@@ -598,33 +637,23 @@ REBTYPE(Context)
         if (REF(part))
             fail (Error(RE_BAD_REFINES));
 
-        REBU64 types = 0;
-        if (REF(deep))
-            types |= REF(types) ? 0 : TS_STD_SERIES;
+        REBU64 types;
         if (REF(types)) {
             if (IS_DATATYPE(ARG(kinds)))
-                types |= FLAGIT_KIND(VAL_TYPE_KIND(ARG(kinds)));
+                types = FLAGIT_KIND(VAL_TYPE_KIND(ARG(kinds)));
             else
-                types |= VAL_TYPESET_BITS(ARG(kinds));
+                types = VAL_TYPESET_BITS(ARG(kinds));
         }
+        else if (REF(deep))
+            types = TS_STD_SERIES;
+        else
+            types = 0;
 
-        context = AS_CONTEXT(
-            Copy_Array_Shallow(CTX_VARLIST(VAL_CONTEXT(value)), SPECIFIED)
+        Val_Init_Context(
+            D_OUT,
+            VAL_TYPE(value),
+            Copy_Context_Core(VAL_CONTEXT(value), REF(deep), types)
         );
-        INIT_CTX_KEYLIST_SHARED(context, CTX_KEYLIST(VAL_CONTEXT(value)));
-        SET_ARR_FLAG(CTX_VARLIST(context), ARRAY_FLAG_VARLIST);
-        CTX_VALUE(context)->payload.any_context.varlist = CTX_VARLIST(context);
-
-        if (types != 0) {
-            Clonify_Values_Len_Managed(
-                CTX_VARS_HEAD(context),
-                SPECIFIED,
-                CTX_LEN(context),
-                REF(deep),
-                types
-            );
-        }
-        Val_Init_Context(D_OUT, VAL_TYPE(value), context);
         return R_OUT; }
 
     case SYM_SELECT:

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -600,7 +600,7 @@ REBINT PD_String(REBPVS *pvs)
         return PE_USE_STORE;
     }
 
-    FAIL_IF_LOCKED_SERIES(ser);
+    FAIL_IF_READ_ONLY_SERIES(ser);
     setval = pvs->opt_setval;
 
     if (n < 0 || cast(REBCNT, n) >= SER_LEN(ser))
@@ -769,7 +769,7 @@ REBTYPE(String)
     case SYM_CHANGE: {
         INCLUDE_PARAMS_OF_INSERT;
 
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         Partial1((action == SYM_CHANGE) ? value : arg, ARG(limit), cast(REBCNT*, &len));
         index = VAL_INDEX(value);
@@ -873,7 +873,7 @@ REBTYPE(String)
 
     //-- Picking:
     case SYM_POKE:
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
     case SYM_PICK:
         len = Get_Num_From_Arg(arg); // Position
         //if (len > 0) index--;
@@ -923,7 +923,7 @@ pick_it:
     case SYM_TAKE: {
         INCLUDE_PARAMS_OF_TAKE;
 
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         if (REF(part)) {
             len = Partial(value, 0, ARG(limit));
@@ -963,7 +963,7 @@ pick_it:
         break; }
 
     case SYM_CLEAR:
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         if (index < tail) {
             if (index == 0)
@@ -1006,7 +1006,7 @@ pick_it:
 
     case SYM_TRIM: {
         INCLUDE_PARAMS_OF_TRIM;
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         ser = VAL_SERIES(value);
 
@@ -1037,19 +1037,19 @@ pick_it:
         break; }
 
     case SYM_SWAP:
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         if (VAL_TYPE(value) != VAL_TYPE(arg))
             fail (Error(RE_NOT_SAME_TYPE));
 
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(arg));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(arg));
 
         if (index < tail && VAL_INDEX(arg) < VAL_LEN_HEAD(arg))
             swap_chars(value, arg);
         break;
 
     case SYM_REVERSE:
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         len = Partial(value, 0, D_ARG(3));
         if (len > 0) reverse_string(value, len);
@@ -1058,7 +1058,7 @@ pick_it:
     case SYM_SORT: {
         INCLUDE_PARAMS_OF_SORT;
 
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         Sort_String(
             value,
@@ -1074,7 +1074,7 @@ pick_it:
     case SYM_RANDOM: {
         INCLUDE_PARAMS_OF_RANDOM;
 
-        FAIL_IF_LOCKED_SERIES(VAL_SERIES(value));
+        FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
         if (REF(seed)) {
             //

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -801,7 +801,7 @@ static void Parse_Field_Type_May_Fail(
         // be overwritten in the struct cases).
         //
         Val_Init_Word(FLD_AT(field, IDX_FIELD_TYPE), REB_WORD, Canon(sym));
-         
+
         switch (sym) {
         case SYM_UINT8:
             SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 1);

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -520,15 +520,15 @@ void Pick_Vector(REBVAL *out, const REBVAL *value, const REBVAL *picker) {
 
 
 //
-//  Poke_Vector_Fail_If_Locked: C
+//  Poke_Vector_Fail_If_Read_Only: C
 //
-void Poke_Vector_Fail_If_Locked(
+void Poke_Vector_Fail_If_Read_Only(
     REBVAL *value,
     const REBVAL *picker,
     const REBVAL *poke
 ) {
     REBSER *vect = VAL_SERIES(value);
-    FAIL_IF_LOCKED_SERIES(vect);
+    FAIL_IF_READ_ONLY_SERIES(vect);
 
     REBINT n;
     if (IS_INTEGER(picker) || IS_DECIMAL(picker))
@@ -576,7 +576,7 @@ void Poke_Vector_Fail_If_Locked(
 REBINT PD_Vector(REBPVS *pvs)
 {
     if (pvs->opt_setval) {
-        Poke_Vector_Fail_If_Locked(
+        Poke_Vector_Fail_If_Read_Only(
             KNOWN(pvs->value), pvs->selector, pvs->opt_setval
         );
         return PE_OK;
@@ -612,7 +612,7 @@ REBTYPE(Vector)
         return R_OUT;
 
     case SYM_POKE:
-        Poke_Vector_Fail_If_Locked(value, arg, D_ARG(3));
+        Poke_Vector_Fail_If_Read_Only(value, arg, D_ARG(3));
         *D_OUT = *D_ARG(3);
         return R_OUT;
 
@@ -631,7 +631,7 @@ REBTYPE(Vector)
     case SYM_RANDOM: {
         INCLUDE_PARAMS_OF_RANDOM;
 
-        FAIL_IF_LOCKED_SERIES(vect);
+        FAIL_IF_READ_ONLY_SERIES(vect);
 
         if (REF(seed) || REF(only))
             fail (Error(RE_BAD_REFINES));

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -143,9 +143,6 @@ inline static void TERM_SERIES(REBSER *s) {
 #define GET_ARR_FLAG(a,f) \
     GET_SER_FLAG(ARR_SERIES(a), (f))
 
-#define FAIL_IF_LOCKED_ARRAY(a) \
-    FAIL_IF_LOCKED_SERIES(ARR_SERIES(a))
-
 #define IS_ARRAY_MANAGED(array) \
     IS_SERIES_MANAGED(ARR_SERIES(array))
 
@@ -178,6 +175,32 @@ inline static void DROP_GUARD_ARRAY_CONTENTS(REBARR *a) {
 #endif
     DROP_GUARD_SERIES(ARR_SERIES(a));
 }
+
+
+//
+// Locking
+//
+
+inline static REBOOL Is_Array_Deeply_Frozen(REBARR *a) {
+    return LOGICAL(
+        ARR_SERIES(a)->header.bits & REBSER_REBVAL_FLAG_FROZEN
+    ); // should be frozen all the way down (can only freeze arrays deeply)
+}
+
+inline static void Deep_Freeze_Array(REBARR *a) {
+    Protect_Series(
+        ARR_SERIES(a),
+        0, // start protection at index 0
+        FLAGIT(PROT_DEEP) | FLAGIT(PROT_SET) | FLAGIT(PROT_FREEZE)
+    );
+    Uncolor_Array(a);
+}
+
+#define Is_Array_Shallow_Read_Only(a) \
+    Is_Series_Read_Only(a)
+
+#define FAIL_IF_READ_ONLY_ARRAY(a) \
+    FAIL_IF_READ_ONLY_SERIES(ARR_SERIES(a))
 
 
 // Make a series that is the right size to store REBVALs (and

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -334,7 +334,7 @@ inline static REBVAL *Get_Var_Core(
     else {
         assert(*eval_type == REB_FUNCTION || *eval_type == REB_0_LOOKBACK);
 
-        if (GET_VAL_FLAG(key, TYPESET_FLAG_LOCKED)) {
+        if (GET_VAL_FLAG(key, TYPESET_FLAG_PROTECTED)) {
             //
             // The key corresponding to the var being looked up contains
             // some flags, including one of whether or not the variable is
@@ -343,7 +343,7 @@ inline static REBVAL *Get_Var_Core(
 
             if (flags & GETVAR_UNBOUND_OK) return NULL;
 
-            fail (Error(RE_LOCKED_WORD, any_word));
+            fail (Error(RE_PROTECTED_WORD, any_word));
         }
 
         // If we are writing, then we write the state of the lookback boolean

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -212,8 +212,8 @@ inline static REBVAL *CTX_STACKVARS(REBCTX *c) {
     return CTX_FRAME(c)->args_head;
 }
 
-#define FAIL_IF_LOCKED_CONTEXT(c) \
-    FAIL_IF_LOCKED_ARRAY(CTX_VARLIST(c))
+#define FAIL_IF_READ_ONLY_CONTEXT(c) \
+    FAIL_IF_READ_ONLY_ARRAY(CTX_VARLIST(c))
 
 inline static void FREE_CONTEXT(REBCTX *c) {
     Free_Array(CTX_KEYLIST(c));
@@ -361,6 +361,27 @@ inline static REBVAL *Append_Context(
     REBSTR *name
 ) {
     return Append_Context_Core(context, any_word, name, FALSE);
+}
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// LOCKING
+//
+//=////////////////////////////////////////////////////////////////////////=//
+
+inline static void Deep_Freeze_Context(REBCTX *c) {
+    Protect_Context(
+        c,
+        FLAGIT(PROT_SET) | FLAGIT(PROT_DEEP) | FLAGIT(PROT_FREEZE)
+    );
+    Uncolor_Array(CTX_VARLIST(c));
+}
+
+inline static REBOOL Is_Context_Deeply_Frozen(REBCTX *c) {
+    return LOGICAL(
+        ARR_SERIES(CTX_VARLIST(c))->header.bits & REBSER_REBVAL_FLAG_FROZEN
+    );
 }
 
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -391,6 +391,7 @@ enum {
     PROT_DEEP,
     PROT_HIDE,
     PROT_WORD,
+    PROT_FREEZE,
     PROT_MAX
 };
 

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -248,10 +248,6 @@ inline static REBYTE *SER_LAST_RAW(size_t w, REBSER *s) {
 #define Is_Array_Series(s) \
     GET_SER_FLAG((s), SERIES_FLAG_ARRAY)
 
-inline static void FAIL_IF_LOCKED_SERIES(REBSER *s) {
-    if (GET_SER_FLAG(s, SERIES_FLAG_LOCKED))
-        fail (Error(RE_LOCKED));
-}
 
 //
 // Optimized expand when at tail (but, does not reterminate)
@@ -396,6 +392,51 @@ static inline void Flip_Series_To_White(REBSER *s) {
 #if !defined(NDEBUG)
     --TG_Num_Black_Series;
 #endif
+}
+
+
+//
+// Freezing and Locking
+//
+
+inline static void Freeze_Sequence(REBSER *s) { // there is no unfreeze!
+    assert(!Is_Array_Series(s)); // Must use Deep_Freeze_Array()
+    s->header.bits |= REBSER_REBVAL_FLAG_FROZEN;
+}
+
+inline static REBOOL Is_Series_Frozen(REBSER *s) {
+    assert(!Is_Array_Series(s)); // Must use Is_Array_Deeply_Frozen()
+    return LOGICAL(s->header.bits & REBSER_REBVAL_FLAG_FROZEN);
+}
+
+inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
+    return LOGICAL(
+        s->header.bits & (
+            REBSER_REBVAL_FLAG_FROZEN
+            | REBSER_FLAG_RUNNING
+            | REBSER_FLAG_PROTECTED
+        )
+    );
+}
+
+// Gives the appropriate kind of error message for the reason the series is
+// read only (frozen, running, protected).
+//
+// !!! Should probably report if more than one form of locking is in effect,
+// but if only one error is to be reported then this is probably the right
+// priority ordering.
+//
+inline static void FAIL_IF_READ_ONLY_SERIES(REBSER *s) {
+    if (Is_Series_Read_Only(s)) {
+        if (s->header.bits & REBSER_FLAG_RUNNING)
+            fail (Error(RE_SERIES_RUNNING));
+
+        if (s->header.bits & REBSER_REBVAL_FLAG_FROZEN)
+            fail (Error(RE_SERIES_FROZEN));
+
+        assert(s->header.bits & REBSER_FLAG_PROTECTED);
+        fail (Error(RE_SERIES_PROTECTED));
+    }
 }
 
 

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -152,7 +152,7 @@ enum Reb_Param_Class {
 
 // Can't be changed (set with PROTECT)
 //
-#define TYPESET_FLAG_LOCKED TYPESET_FLAG(3)
+#define TYPESET_FLAG_PROTECTED TYPESET_FLAG(3)
 
 // Can't be reflected (set with PROTECT/HIDE) or local in spec as `foo:`
 //

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -187,9 +187,14 @@ intern: function [
 
 load: function [
     {Simple load of a file, URL, or string/binary - minimal boot version.}
+
     source [file! url! string! binary!]
-    /header  {Includes REBOL header object if present}
-    /all     {Load all values, including header (as block)}
+    /header
+        {Includes REBOL header object if present}
+    /all
+        {Load all values, including header (as block)}
+    /unlocked
+        {Do not lock the source from modification.}
     ;/unbound {Do not bind the block}
 ][
     load_ALL: all
@@ -224,7 +229,12 @@ load: function [
         ][data: first data]
     ]
 
-    :data
+    ; This is the low-level LOAD code.  It seems to work all right when it
+    ; assumes it locks things, so keep that as a default.  (User-level LOAD
+    ; does not lock by default, but code that uses it to load code to run
+    ; locks it, e.g. DO %filename.reb)
+    ;
+    either unlocked [:data] [lock :data]
 ]
 
 ; Reserve these slots near LOAD:

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -595,6 +595,12 @@ for-back: redescribe [
     specialize 'for-skip [skip: -1]
 )
 
+lock-of: redescribe [
+    "If value is already locked, return it...otherwise CLONE it and LOCK it."
+](
+    specialize 'lock [clone: true]
+)
+
 
 ; To help for discoverability, there is SET-INFIX and INFIX?.  However, the
 ; term can be a misnomer if the function is more advanced, and using the

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -160,6 +160,13 @@ join-of: redescribe [
     ]
 )
 
+append-of: redescribe [
+    "APPEND variation that copies the input series first."
+](
+    adapt 'append [
+        series: copy series
+    ]
+)
 
 reform: redescribe [
     "Forms a reduced block and returns a string."

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -660,7 +660,6 @@ set 'r3-legacy* func [<local> if-flags] [
         lit-word-decay: true
         broken-case-semantics: true
         exit-functions-only: true
-        mutable-function-bodies: true
         refinements-blank: true
         no-switch-evals: true
         no-switch-fallthrough: true
@@ -674,6 +673,7 @@ set 'r3-legacy* func [<local> if-flags] [
         get-will-get-anything: true
         no-reduce-nested-print: true
         sets-unsuppress-lookahead: true
+        unlocked-source: true
     ]
 
     append system/contexts/user compose [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -228,9 +228,6 @@ reword: function [
     case/all [
         not escape [char: "$"]
         block? char [
-            ;
-            ; !!! Have to use parse here because ASSERT/type is broken
-            ;
             rule: [char! | any-string! | binary!]
             unless parse c: char [set char rule set char-end opt rule] [
                 cause-error 'script 'invalid-arg reduce [c]
@@ -272,8 +269,7 @@ reword: function [
                 ]
                 unless empty? w [
                     unless empty? char-end [w: append copy w char-end]
-                    poke vals w
-                    :v ;-- may be void
+                    poke vals lock-of w :v ; v may be void...can we use LOCK?
                 ]
             ]
         ]
@@ -291,8 +287,7 @@ reword: function [
                 ]
                 unless empty? w [
                     unless empty? char-end [w: append copy w char-end]
-                    poke vals w
-                    :v ;-- may be void
+                    poke vals lock-of w :v ; v may be void...can we use LOCK?
                 ]
             ]
         ]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -26,10 +26,16 @@ REBOL [
 native: _ ; for boot only
 action: _ ; for boot only
 
+; DO of functions, blocks, paths, and other do-able types is done directly by
+; C code in REBNATIVE(do).  But that code delegates to this Rebol function
+; for ANY-STRING! and BINARY! types (presumably because it would be laborious
+; to express as C).
+;
 do*: function [
     {SYS: Called by system for DO on datatypes that require special handling.}
     return: [<opt> any-value!]
-    value [file! url! string! binary! tag!]
+    source [file! url! string! binary! tag!]
+        {Files, urls and modules evaluate as scripts, other strings don't.}
     args [logic!]
         "Positional workaround of /ARGS"
     arg [any-value!]
@@ -39,40 +45,36 @@ do*: function [
     var [blank! word!]
         "If do next expression only, variable updated with new block position"
 ][
+    next_DO*: next
+    next: :lib/next
+
     ; !!! These were refinements on the original DO* which were called from
     ; the system using positional order.  Under the Ren-C model you cannot
-    ; select refinements positionally, nor can you pass "void" cells.  It
-    ; would be *possible* to keep these going as refinements and have the
-    ; system build a path to make a call, but this is easier.  Revisit this
-    ; (also revisit the use of the word "next")
+    ; select refinements positionally, nor can you pass "void" cells in
+    ; a variadic invocation (because variadics may be reified to blocks which
+    ; are user-exposed, and arrays with voids in them are only allowed for
+    ; cases like the internal varlist of objects).
     ;
-    arg: either args [arg] [void]
-    var: either next [var] [void]
-
-    ; This code is only called for urls, files, strings, and tags.
-    ; DO of functions, blocks, paths, and other do-able types is done in the
-    ; native, and this code is not called.
-    ; Note that DO of file path evaluates in the directory of the target file.
-    ; Files, urls and modules evaluate as scripts, other strings don't.
-    ; Note: LOAD/header returns a block with the header object in the first
-    ;       position, or will cause an error. No exceptions, not even for
-    ;       directories or media.
-    ;       Currently, load of URL has no special block forms.
+    ; It would be *possible* to keep these going as refinements and have the
+    ; system build a path to make a call, but this is easier.
+    ;
+    if not args [unset 'args]
+    if not next_DO* [unset 'var]
 
     ; !!! DEMONSTRATION OF CONCEPT... this translates a tag into a URL!, but
     ; it should be using a more "official" URL instead of on individuals
     ; websites.  There should also be some kind of local caching facility.
     ;
-    if tag? value [
-        if value = <r3-legacy> [
+    if tag? source [
+        if source = <r3-legacy> [
             ; Special compatibility tag... Rebol2 and R3-Alpha will ignore the
             ; DO of a <tag>, so this is a no-op in them.
             ;
-            return r3-legacy* ;-- defined in %mezz-legacy.r
+            return r3-legacy* ;-- calls function defined in %mezz-legacy.r
         ]
 
         ; Convert value into a URL!
-        value: switch/default value [
+        source: switch/default source [
             ; Encodings and data formats
             <json> [http://reb4.me/r3/json.reb]
             <xml> [http://reb4.me/r3/altxml.reb]
@@ -86,37 +88,59 @@ do*: function [
             <rebmu> [https://raw.githubusercontent.com/hostilefork/rebmu/master/rebmu.reb]
         ][
             fail [
-                {Module} value {not in "rebol.org index" (hardcoded for now)}
+                {Module} source {not in "rebol.org index" (hardcoded for now)}
             ]
         ]
     ]
 
+    ; Note that DO of file path evaluates in the directory of the target file.
+    ;
     original-path: what-dir
 
     ; If a file is being mentioned as a DO location and the "current path"
-    ; is a URL!, then adjust the value to be a URL! based from that path.
-    if all [url? original-path  file? value] [
-         value: join-of original-path value
+    ; is a URL!, then adjust the source to be a URL! based from that path.
+    ;
+    if all [url? original-path | file? source] [
+         source: join-of original-path source
     ]
 
-    ; Load the data, first so it will error before change-dir
-    data: load/header/type value 'unbound ; unbound so DO-NEEDS runs before INTERN
-    ; Get the header and advance 'data to the code position
-    hdr: first+ data  ; object or blank
-    ; data is a block! here, with the header object in the first position back
+    ; Load the code (do this before CHANGE-DIR so if there's an error in the
+    ; LOAD it will trigger before the failure of changing the working dir)
+    ; It is loaded as UNBOUND so that DO-NEEDS runs before INTERN.
+    ;
+    code: ensure block! (load/header/type source 'unbound)
+
+    ; LOAD/header returns a block with the header object in the first
+    ; position, or will cause an error.  No exceptions, not even for
+    ; directories or media.  "Load of URL has no special block forms." <-- ???
+    ;
+    ; !!! Should the header always be locked by LOAD?
+    ;
+    hdr: lock ensure [object! blank!] first code
     is-module: 'module = select hdr 'type
+    code: next code
 
-    either all [string? value  not is-module] [
-        ; Return result without script overhead
+    either all [string? source | not is-module] [
+        ;
+        ; Return result without "script overhead" (e.g. don't change the
+        ; working directory to the base of the file path supplied)
+        ;
         do-needs hdr  ; Load the script requirements
-        if empty? data [if next [set var data] return ()]
-        intern data   ; Bind the user script
-        catch/quit [do/next data :var]
-    ][ ; Otherwise we are in script mode
-
-        ; When we run a script, the "current" directory is changed to the
-        ; directory of that script.  This way, relative path lookups to
-        ; find dependent files will look relative to the script.
+        intern code   ; Bind the user script
+        result: catch/quit [
+            ;
+            ; The source string may have been mutable or immutable, but the
+            ; loaded code is not locked for this case.  So this works:
+            ;
+            ;     do "append {abc} {de}"
+            ;
+            do/next code :var ;-- If var is void, /NEXT is revoked
+        ]
+    ][
+        ; Otherwise we are in script mode.  When we run a script, the
+        ; "current" directory is changed to the directory of that script.
+        ; This way, relative path lookups to find dependent files will look
+        ; relative to the script.
         ;
         ; We want this behavior for both FILE! and for URL!, which means
         ; that the "current" path may become a URL!.  This can be processed
@@ -125,11 +149,18 @@ do*: function [
         ; define a standard for that)
         ;
         if all [
-            any [file? value  url? value]
-            file: find/last/tail value slash
+            maybe? [file! url!] source
+            file: find/last/tail source slash
         ][
-            change-dir copy/part value file
+            change-dir copy/part source file
         ]
+
+        ; Also in script mode, the code is immutable by default.
+        ;
+        ; !!! Note that this does not currently protect the code from binding
+        ; changes, and it gets INTERNed below, or by "module/mixin" (?!)
+        ;
+        lock code
 
         ; Make the new script object
         scr: system/script  ; and save old one
@@ -144,31 +175,30 @@ do*: function [
         ; Print out the script info
         boot-print [
             (either is-module "Module:" "Script:") select hdr 'title
-                "Version:" opt select hdr 'version
-                "Date:" opt select hdr 'date
+                "Version:" select hdr 'version
+                "Date:" select hdr 'date
         ]
 
-        also (
-            ; Eval the block or make the module, returned
-            either is-module [ ; Import the module and set the var
-                also (
-                    import catch/quit [
-                        module/mixin hdr data (opt do-needs/no-user hdr)
-                    ]
-                )(
-                    if next [set var tail data]
-                )
-            ][
-                do-needs hdr  ; Load the script requirements
-                intern data   ; Bind the user script
-                catch/quit [do/next data :var]
+        ; Eval the block or make the module, returned
+        either is-module [ ; Import the module and set the var
+            result: import catch/quit [
+                module/mixin hdr code (opt do-needs/no-user hdr)
             ]
-        )(
-            ; Restore system/script and the dir
-            system/script: :scr
-            if original-path [change-dir original-path]
-        )
+            if next_DO* [set var tail code]
+        ][
+            do-needs hdr  ; Load the script requirements
+            intern code   ; Bind the user script
+            result: catch/quit [
+                do/next code :var ;-- If var is void, /NEXT is revoked
+            ]
+        ]
+
+        ; Restore system/script and the dir
+        system/script: :scr
+        if original-path [change-dir original-path]
     ]
+
+    :result
 ]
 
 ; MOVE some of these to SYSTEM?

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -260,7 +260,9 @@ load-header: function [
     ensure [binary! blank!] hdr/checksum
     ensure [block! blank!] hdr/options
 
-    reduce [
+    ; Return a BLOCK! with 3 elements in it
+    ;
+    return reduce [
         ensure object! hdr
         ensure [binary! block!] rest
         ensure binary! end

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -372,7 +372,18 @@ int Do_String(
         Bind_Values_Deep(ARR_HEAD(code), Lib_Context); */
     }
 
-    if (Do_At_Throws(out, code, 0, SPECIFIED)) { // `code` will be GC protected
+    // The new policy for source code in Ren-C is that it loads read only.
+    // This didn't go through the LOAD Rebol function (should it?  it never
+    // did before.  :-/)  For now, stick with simple binding but lock it.
+    //
+#if defined(NDEBUG)
+    Deep_Freeze_Array(code);
+#else
+    if (!LEGACY(OPTIONS_UNLOCKED_SOURCE))
+        Deep_Freeze_Array(code);
+#endif
+
+    if (Do_At_Throws(out, code, 0, SPECIFIED)) { // array gets GC protected
         if (at_breakpoint) {
             if (
                 IS_FUNCTION(out)

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -250,9 +250,15 @@ proto-parser: context [
             )
         ]
 
-        other-segment: [thru newline]
+        ; We COPY/DEEP here because this part gets invasively modified by
+        ; the source analysis tools.
+        ;
+        other-segment: copy/deep [thru newline]
 
-        format2015-func-section: [
+        ; we COPY/DEEP here because this part gets invasively modified by
+        ; the source analysis tools.
+        ;
+        format2015-func-section: copy/deep [
             doubleslashed-lines
             and is-format2015-intro
             function-proto some white-space

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -382,8 +382,8 @@ emit {
 #define IS_ANY_VALUE(v) \
     LOGICAL(VAL_TYPE(v) != REB_MAX_VOID)
 
-#define IS_SCALAR(v) \
-    LOGICAL(VAL_TYPE(v) <= REB_DATE)
+#define ANY_SCALAR(v) \
+    LOGICAL(VAL_TYPE(v) >= REB_LOGIC && VAL_TYPE(v) <= REB_DATE)
 
 #define ANY_SERIES(v) \
     LOGICAL(VAL_TYPE(v) >= REB_PATH && VAL_TYPE(v) <= REB_VECTOR)

--- a/tests/catch-any.r
+++ b/tests/catch-any.r
@@ -14,12 +14,11 @@ Rebol [
 ]
 
 make object! [
-    do-block: func [
+    do-block: function [
         ; helper for catching BREAK, CONTINUE, THROW or QUIT
         return: [<opt> any-value!]
         block [block!]
         exception [word!]
-        /local result
     ] [
         ; TRY wraps CATCH/QUIT to circumvent bug#851
         try [
@@ -29,7 +28,7 @@ make object! [
                         try [
                             set exception 'return
                             print mold block ;-- !!! make this an option
-                            set/opt 'result do block
+                            result: do block
                             set exception blank
                             return :result
                         ]

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -88,8 +88,7 @@
 [error? make error! [type: 'math id: 'size-limit]]
 [error? make error! [type: 'math id: 'out-of-range]]
 
-[error? make error! [type: 'access id: 'locked-word]]
-[error? make error! [type: 'access id: 'locked]]
+[error? make error! [type: 'access id: 'protected-word]]
 [error? make error! [type: 'access id: 'hidden]]
 [error? make error! [type: 'access id: 'cannot-open]]
 [error? make error! [type: 'access id: 'not-open]]


### PR DESCRIPTION
When specific binding was implemented, function bodies became
immutable.  This was because the same body block was being "invisibly"
shared among recursions of a function, even though words in it were
being viewed as having a different binding.  If the body were allowed
to be changed by one recursion, the other bodies which were effectively
their own unique blocks of code, would also be changed.  While a
generally dangerous idea to begin with, it became moreso because any
references to locals or arguments would be "specific" yet then
inserted into a relativized body which would have meaning only for
that execution frame.

That was a fairly loose form of immutability, because it used R3-Alpha's
PROTECT bit.  That bit was user-owned, and could be cleared.  This
strengthens immutability in the system by making 3 distinct bits:

* PROTECTED - the user-controllable protection bit that can be added
  shallowly or deeply, and removed at any time.  It's more of a debug
  feature or convenience than anything.

* RUNNING - this is a transient state of read-only-ness which lasts
  as long as a series is being held onto by the evaluator.  This
  prevents things like `code: [insert code 'print] | do code`.  That
  is a questionable feature to begin with--and more likely a bug.
  But moreover, allowing such mutation means that DO has to be
  somewhat "crash-proofed" because pointers can move out from under
  it.  In fact, such modifications could fully invalidate the pointer
  to the block if it had to expand.  The difficulty of providing a
  useful behavior semantic combined with the runtime cost of crash
  proofing makes protecting the series a better bet.  The user cannot
  disable this protection, but it's released on completion/FAIL/THROW

* FROZEN - This is the new form of immutability that source code gets.
  The user may request any series to be frozen with the new primitive
  LOCK, but unlike with PROTECT/UNPROTECT there is no UNLOCK.

Source freezing is done whenever code is loaded "as a script".  This
does not apply to LOAD of a STRING!, so it's legal to write
`do load "append {abc} {de}"`.  However, if that code appeared in a
file or module then the append would be an error.

A new requirement is that any series which is to be used as a key in
a map must be locked.  This addresses a longstanding bug in R3-Alpha
where strings inserted as keys in maps could be modified without
updating the hash, and strengthens the feature of Ren-C of being
able to allow blocks and other arrays as hash keys--so long as they
are locked.  Since literals in source qualify, many values will be
"pre-approved" to act as map keys.

One aspect of immutable source that is not currently enforced (nor did
the PROTECT bit enforce it) was immutability of the *bindings* in that
source.  Adding that is a goal in Ren-C, but is not practical until there is
a solution for things like **for-each x [print x]** which does not rely on
mutating **[print x]** to bind to a context created by the FOR-EACH that
contains x.

*(Note: Red chose to avoid the binding problem by simply not creating
a new context and using a pre-existing x in such cases, which changes
the semantics of the language.  However, @HostileFork feels that Rebol
had this right, and that what's really needed is a way to create rebound
"images" of blocks without copying them...using a similar mechanism to
what enables specific binding in functions.  It might be good to allow
re-use of variables as well, however, e.g. with **for-each 'x [print x]**...

...and immutability makes the possibility of implementing this feature
a lot more likely!)*
