### PR TITLE
Byte-Order Sensitive Bit Flags & Masking

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -756,8 +756,13 @@ static void Init_Root_Context(void)
     // These values are simple isolated VOID, NONE, TRUE, and FALSE values
     // that can be used in lieu of initializing them.  They are initialized
     // as two-element series in order to ensure that their address is not
-    // treated as an array.  They are unsettable (in debug builds), to avoid
-    // their values becoming overwritten.
+    // treated as an array.
+    //
+    // They should only be accessed by macros which retrieve their values
+    // as `const`, to avoid the risk of accidentally changing them.  (This
+    // rule is broken by some special system code which `m_cast`s them for
+    // the purpose of using them as directly recognizable pointers which
+    // also look like values.)
     //
     // It is presumed that these types will never need to have GC behavior,
     // and thus can be stored safely in program globals without mention in
@@ -766,23 +771,18 @@ static void Init_Root_Context(void)
 
     SET_VOID(&PG_Void_Cell[0]);
     SET_TRASH_IF_DEBUG(&PG_Void_Cell[1]);
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(&PG_Void_Cell[1]);
 
     SET_BLANK(&PG_Blank_Value[0]);
     SET_TRASH_IF_DEBUG(&PG_Blank_Value[1]);
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(&PG_Blank_Value[1]);
 
     SET_BAR(&PG_Bar_Value[0]);
     SET_TRASH_IF_DEBUG(&PG_Bar_Value[1]);
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(&PG_Bar_Value[1]);
 
     SET_FALSE(&PG_False_Value[0]);
     SET_TRASH_IF_DEBUG(&PG_False_Value[1]);
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(&PG_False_Value[1]);
 
     SET_TRUE(&PG_True_Value[0]);
     SET_TRASH_IF_DEBUG(&PG_True_Value[1]);
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(&PG_True_Value[1]);
 
     // We can't actually put an end value in the middle of a block, so we poke
     // this one into a program global.  It is not legal to bit-copy an
@@ -806,7 +806,6 @@ static void Init_Root_Context(void)
     // Used by REBNATIVE(print)
     //
     SET_CHAR(ROOT_SPACE_CHAR, ' ');
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(ROOT_SPACE_CHAR);
 
     // Can't ASSERT_CONTEXT here; no keylist yet...
 }

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -788,7 +788,7 @@ static void Init_Root_Context(void)
     // this one into a program global.  It is not legal to bit-copy an
     // END (you always use SET_END), so we can make it unwritable.
     //
-    PG_End_Cell.header.bits = 0; // read-only end
+    PG_End_Cell.header.bits = END_MASK; // read-only end
     assert(IS_END(END_CELL)); // sanity check that it took
 
     // The EMPTY_BLOCK provides EMPTY_ARRAY.  It is locked for protection.

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -114,7 +114,7 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
         fflush(stdout);
         Panic_Value_Debug(v, file, line);
     }
-    if (NOT((v)->header.bits & VALUE_FLAG_WRITABLE_CPP_DEBUG)) {
+    if (NOT((v)->header.bits & NOT_FREE_MASK)) {
         printf("Non-writable value passed to writing routine\n");
         fflush(stdout);
         Panic_Value_Debug(v, file, line);
@@ -134,8 +134,8 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
 //
 void SET_END_Debug(RELVAL *v, const char *file, int line) {
     ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
-    (v)->header.bits = HEADERIZE_KIND(REB_0) | CELL_MASK;
-    MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
+    (v)->header.bits =
+        HEADERIZE_KIND(REB_0) | NOT_FREE_MASK | CELL_MASK | NOT_FREE_MASK;
     Set_Track_Payload_Debug(v, file, line);
 }
 

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -134,7 +134,7 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
 //
 void SET_END_Debug(RELVAL *v, const char *file, int line) {
     ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
-    (v)->header.bits = TYPE_SHIFT_LEFT_FOR_HEADER(REB_0) | CELL_MASK;
+    (v)->header.bits = HEADERIZE_KIND(REB_0) | CELL_MASK;
     MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
     Set_Track_Payload_Debug(v, file, line);
 }

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -134,8 +134,7 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
 //
 void SET_END_Debug(RELVAL *v, const char *file, int line) {
     ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
-    (v)->header.bits =
-        HEADERIZE_KIND(REB_0) | NOT_FREE_MASK | CELL_MASK | NOT_FREE_MASK;
+    (v)->header.bits = HEADERIZE_KIND(REB_0) | FLAGVAL_FIRST(255);
     Set_Track_Payload_Debug(v, file, line);
 }
 
@@ -160,7 +159,13 @@ REBOOL IS_END_Debug(const RELVAL *v, const char *file, int line) {
         Panic_Value_Debug(v, file, line);
     }
 #endif
-    return IS_END_MACRO(v);
+
+    if (IS_END_MACRO(v)) {
+        if (v->header.bits & CELL_MASK)
+            assert(LEFT_N_BITS(v->header.bits, 8) == 255);
+        return TRUE;
+    }
+    return FALSE;
 }
 
 

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -170,6 +170,8 @@ void Do_Core_Entry_Checks_Debug(REBFRM *f)
     //
     assert(f->value);
 
+    assert((f->flags.bits & END_MASK) && NOT(f->flags.bits & CELL_MASK));
+
     f->label = NULL;
     f->label_debug = NULL;
 
@@ -217,7 +219,10 @@ static void Do_Core_Shared_Checks_Debug(REBFRM *f) {
 
     //=//// ^-- ABOVE CHECKS *ALWAYS* APPLY ///////////////////////////////=//
 
-    if (IS_END(f->value) || THROWN(f->out))
+    if (IS_END(f->value))
+        return;
+
+    if (NOT_END(f->out) && THROWN(f->out))
         return;
 
     assert(f->value_type == VAL_TYPE(f->value));

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -942,7 +942,6 @@ static void Get_Pending_Format_Delimiter(
     if (!IS_BLOCK(delimiters)) {
         if (depth == 0) {
             *out = *delimiters;
-            MARK_CELL_WRITABLE_IF_CPP_DEBUG(out); // read-only item may be used
         }
         else
             SET_BLANK(out);

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -698,7 +698,6 @@ static REBOOL Series_Data_Alloc(
         //
         for(; n < s->content.dynamic.rest - 1; n++) {
             INIT_CELL_IF_DEBUG(ARR_AT(AS_ARRAY(s), n));
-          /*MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(ARR_AT(AS_ARRAY(s), n);*/
         }
     #endif
 
@@ -873,10 +872,10 @@ REBSER *Make_Series(REBCNT capacity, REBYTE wide, REBCNT flags)
 
     REBSER *s = cast(REBSER*, Make_Node(SER_POOL));
 
-    // Header bits can't be zero.  For now, set the NOT_END_MASK always (the
-    // CELL_MASK is used by "Paireds").
+    // Header bits can't be zero.  The NOT_FREE_MASK is sufficient to identify
+    // this as a REBSER node that is not GC managed.
     //
-    s->header.bits = NOT_END_MASK;
+    s->header.bits = NOT_FREE_MASK;
 
     if ((GC_Ballast -= sizeof(REBSER)) <= 0) SET_SIGNAL(SIG_RECYCLE);
 
@@ -1045,10 +1044,12 @@ REBVAL *Alloc_Pairing(REBCTX *opt_owning_frame) {
 // Switching to managed mode means the key can no longer be changed--only
 // the value.
 //
+// !!! a const_Pairing_Key() accessor should help enforce the rule, only
+// allowing const access if managed.
+//
 void Manage_Pairing(REBVAL *paired) {
     REBVAL *key = PAIRING_KEY(paired);
     SET_VAL_FLAG(key, REBSER_REBVAL_FLAG_MANAGED);
-    MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(key);
 }
 
 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -80,7 +80,6 @@ void Init_Stacks(REBCNT size)
         DS_Movable_Base = KNOWN(ARR_HEAD(DS_Array)); // can't push RELVALs
 
         SET_UNREADABLE_BLANK(ARR_HEAD(DS_Array));
-        MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(ARR_HEAD(DS_Array));
 
         // The END marker will signal DS_PUSH that it has run out of space,
         // and it will perform the allocation at that time.
@@ -116,8 +115,9 @@ void Init_Stacks(REBCNT size)
 void Shutdown_Stacks(void)
 {
     assert(FS_TOP == NULL);
-
     assert(DSP == 0);
+    assert(IS_UNREADABLE_IF_DEBUG(ARR_HEAD(DS_Array)));
+
     Free_Array(DS_Array);
 
     assert(TG_Top_Chunk == cast(struct Reb_Chunk*, &TG_Root_Chunker->payload));

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -56,13 +56,13 @@ void Init_Stacks(REBCNT size)
 
     // Zero values for initial chunk, also sets offset to 0
     //
-    Init_Header_Aliased(&TG_Top_Chunk->header, 0);
+    Init_Endlike_Header(&TG_Top_Chunk->header, 0);
     TG_Top_Chunk->offset = 0;
     TG_Top_Chunk->size = BASE_CHUNK_SIZE;
 
-    // Implicit termination trick--see VALUE_FLAG_NOT_END and related notes
+    // Implicit termination trick--see CELL_MASK, END_FLAG and related notes
     //
-    Init_Header_Aliased(
+    Init_Endlike_Header(
         &cast(
             struct Reb_Chunk*, cast(REBYTE*, TG_Top_Chunk) + BASE_CHUNK_SIZE
         )->header,

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -54,17 +54,18 @@ void Init_Stacks(REBCNT size)
     TG_Top_Chunk = cast(struct Reb_Chunk*, &TG_Root_Chunker->payload);
     TG_Top_Chunk->prev = NULL;
 
-    // Zero values for initial chunk, also sets offset to 0 as high bits
+    // Zero values for initial chunk, also sets offset to 0
     //
-    Init_Header_Aliased(&TG_Top_Chunk->size_and_offset, BASE_CHUNK_SIZE);
-    assert(CHUNK_OFFSET(TG_Top_Chunk) == 0);
+    Init_Header_Aliased(&TG_Top_Chunk->header, 0);
+    TG_Top_Chunk->offset = 0;
+    TG_Top_Chunk->size = BASE_CHUNK_SIZE;
 
     // Implicit termination trick--see VALUE_FLAG_NOT_END and related notes
     //
     Init_Header_Aliased(
         &cast(
             struct Reb_Chunk*, cast(REBYTE*, TG_Top_Chunk) + BASE_CHUNK_SIZE
-        )->size_and_offset,
+        )->header,
         0
     );
     assert(IS_END(&TG_Top_Chunk->values[0]));

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1045,7 +1045,7 @@ void Assert_Array_Core(REBARR *array)
 #ifdef __cplusplus
         assert(rest > 0 && rest > i);
         for (; i < rest - 1; ++i, ++value) {
-            if (NOT(value->header.bits & VALUE_FLAG_WRITABLE_CPP_DEBUG)) {
+            if (NOT(value->header.bits & NOT_FREE_MASK)) {
                 printf("Unwritable cell found in array rest capacity\n");
                 fflush(stdout);
                 Panic_Array(array);

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1053,9 +1053,10 @@ void Assert_Array_Core(REBARR *array)
         }
         assert(value == ARR_AT(array, rest - 1));
 #endif
-        if (ARR_AT(array, rest - 1)->header.bits != 0) {
+        if (ARR_AT(array, rest - 1)->header.bits != END_MASK) {
             printf("Implicit termination/unwritable END missing from array\n");
             fflush(stdout);
+            assert(FALSE);
         }
     }
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -212,7 +212,7 @@ static REBOOL Subparse_Throws(
     f->func = NAT_FUNC(subparse);
     f->underlying = NAT_FUNC(subparse);
 
-    Init_Header_Aliased(&f->flags, 0); // will implicitly terminate f->cell
+    Init_Endlike_Header(&f->flags, 0); // implicitly terminate f->cell
     SET_END(&f->cell); // cell must have some form of initialization, though
 
     f->param = END_CELL; // informs infix lookahead

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -831,7 +831,7 @@ typedef REBUPT REBFLGS;
     #define FLAGIT_LEFT(n) \
         ((REBUPT)1 << PLATFORM_BITS - (n) - 1) // 63,62,61.. or 32,31,30..
 
-    #define FLAGVAL_FIRST(n) \
+    #define FLAGVAL_FIRST(val) \
         ((REBUPT)val << PLATFORM_BITS - 8) // val <= 255
 
     #define FLAGVAL_RIGHT(val) \
@@ -845,7 +845,7 @@ typedef REBUPT REBFLGS;
     #define FLAGIT_LEFT(n) \
         ((REBUPT)1 << 7 + ((n) / 8) * 8 - (n) % 8) // 7,6,5..0,15,14..8,23..
 
-    #define FLAGVAL_FIRST(n) \
+    #define FLAGVAL_FIRST(val) \
         ((REBUPT)val) // val <= 255
 
     #define FLAGVAL_RIGHT(val) \

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -831,6 +831,9 @@ typedef REBUPT REBFLGS;
     #define FLAGIT_LEFT(n) \
         ((REBUPT)1 << PLATFORM_BITS - (n) - 1) // 63,62,61.. or 32,31,30..
 
+    #define FLAGVAL_FIRST(n) \
+        ((REBUPT)val << PLATFORM_BITS - 8) // val <= 255
+
     #define FLAGVAL_RIGHT(val) \
         ((REBUPT)val) // little endian needs val <= 255
 
@@ -841,6 +844,9 @@ typedef REBUPT REBFLGS;
 
     #define FLAGIT_LEFT(n) \
         ((REBUPT)1 << 7 + ((n) / 8) * 8 - (n) % 8) // 7,6,5..0,15,14..8,23..
+
+    #define FLAGVAL_FIRST(n) \
+        ((REBUPT)val) // val <= 255
 
     #define FLAGVAL_RIGHT(val) \
         ((REBUPT)(val) << (PLATFORM_BITS - 8)) // val <= 255

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -125,44 +125,4 @@ struct Reb_Header {
     REBUPT bits;
 };
 
-
-//
-// With these definitions:
-//
-//     struct Foo_Type { struct Reb_Header header; int x; }
-//     struct Foo_Type *foo = ...;
-//
-//     struct Bar_Type { struct Reb_Header header; float x; }
-//     struct Bar_Type *bar = ...;
-//
-// This C code:
-//
-//     foo->header.bits = 1020;
-//
-// ...is actually different *semantically* from this code:
-//
-//     struct Reb_Header *alias = &foo->header;
-//     alias->bits = 1020;
-//
-// The first is considered as not possibly able to affect the header in a
-// Bar_Type.  It only is seen as being able to influence the header in other
-// Foo_Type instances.
-//
-// The second case, by forcing access through a generic aliasing pointer,
-// will cause the optimizer to realize all bets are off for any type which
-// might contain a `struct Reb_Header`.
-//
-// This is an important point to know, with certain optimizations of writing
-// headers through one type and then reading them through another.  That
-// trick is used for "implicit termination", see documentation of IS_END().
-//
-// (Note that this "feature" of writing through pointers actually slows
-// things down.  Desire to control this behavior is why the `restrict`
-// keyword exists in C99: https://en.wikipedia.org/wiki/Restrict )
-//
-inline static void Init_Header_Aliased(struct Reb_Header *alias, REBUPT bits)
-{
-    alias->bits = bits; // write from generic pointer to `struct Reb_Header`
-}
-
 #endif

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -245,11 +245,10 @@ inline static void FREE_CONTEXT(REBCTX *c) {
 
 #ifdef NDEBUG
     #define ANY_CONTEXT_FLAG(n) \
-        (1 << (TYPE_SPECIFIC_BIT + (n)))
+        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
 #else
     #define ANY_CONTEXT_FLAG(n) \
-        ((1 << (TYPE_SPECIFIC_BIT + (n))) \
-            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_OBJECT)) // means ANY-CONTEXT!
+        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_OBJECT))
 #endif
 
 // `ANY_CONTEXT_FLAG_OWNS_PAIRED` is particular to the idea of a "Paired"

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -185,7 +185,7 @@ inline static void PUSH_SAFE_ENUMERATOR(
     SET_FRAME_VALUE(f, VAL_ARRAY_AT(v));
     f->source.array = VAL_ARRAY(v);
 
-    Init_Header_Aliased(&f->flags, DO_FLAG_NORMAL);
+    Init_Endlike_Header(&f->flags, 0);
 
     f->gotten = NULL; // tells ET_WORD and ET_GET_WORD they must do a get
     f->index = VAL_INDEX(v) + 1;
@@ -727,7 +727,7 @@ no_optimization:
     SET_FRAME_VALUE(child, parent->value);
     child->index = parent->index;
     child->specifier = parent->specifier;
-    child->flags.bits = flags;
+    Init_Endlike_Header(&child->flags, flags);
     child->pending = parent->pending;
 
     Do_Core(child);
@@ -808,7 +808,7 @@ inline static REBIXO DO_NEXT_MAY_THROW(
     f->specifier = specifier;
     f->index = index + 1;
 
-    Init_Header_Aliased(&f->flags, 0); // ??? is this ever looked at?
+    Init_Endlike_Header(&f->flags, 0); // ??? is this ever looked at?
 
     f->pending = NULL;
     f->gotten = NULL;
@@ -864,7 +864,7 @@ inline static REBIXO Do_Array_At_Core(
     f.source.array = array;
     f.specifier = specifier;
 
-    Init_Header_Aliased(&f.flags, flags); // see notes on definition
+    Init_Endlike_Header(&f.flags, flags); // see notes on definition
 
     f.gotten = NULL; // so ET_WORD and ET_GET_WORD do their own Get_Var
     f.pending = NULL;
@@ -1061,7 +1061,7 @@ inline static REBIXO Do_Va_Core(
     f.specifier = SPECIFIED; // va_list values MUST be full REBVAL* already
     f.pending = VA_LIST_PENDING;
 
-    Init_Header_Aliased(&f.flags, flags | DO_FLAG_VA_LIST); // see notes
+    Init_Endlike_Header(&f.flags, flags | DO_FLAG_VA_LIST); // see notes
 
     f.eval_type = VAL_TYPE(f.value);
 

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -107,11 +107,10 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
 
 #ifdef NDEBUG
     #define FUNC_FLAG(n) \
-        (1 << (TYPE_SPECIFIC_BIT + (n)))
+        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
 #else
     #define FUNC_FLAG(n) \
-        ((1 << (TYPE_SPECIFIC_BIT + (n))) \
-            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_FUNCTION))
+        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_FUNCTION))
 #endif
 
 // RETURN will always be in the last paramlist slot (if present)

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -72,6 +72,8 @@ enum {
     // The default for a DO operation is just a single DO/NEXT, where args
     // to functions are evaluated (vs. quoted), and lookahead is enabled.
     //
+    // (This should also make headers based on it pass the IS_END() test)
+    //
     DO_FLAG_NORMAL = 0,
 
     // As exposed by the DO native and its /NEXT refinement, a call to the
@@ -86,7 +88,7 @@ enum {
     // achieve equivalent results.  There are nuances to preserve this
     // invariant and especially in light of interaction with lookahead.
     //
-    DO_FLAG_TO_END = 1 << (REBSER_REBVAL_BIT + 1),
+    DO_FLAG_TO_END = HEADERFLAG(REBSER_REBVAL_BIT + 1),
 
     // When we're in mid-dispatch of an infix function, the precedence is such
     // that we don't want to do further infix lookahead while getting the
@@ -97,7 +99,7 @@ enum {
     // to evaluate a form of source input that cannot be backtracked (e.g.
     // a C variable argument list) then it will not be possible to resume.
     //
-    DO_FLAG_NO_LOOKAHEAD = 1 << (REBSER_REBVAL_BIT + 2),
+    DO_FLAG_NO_LOOKAHEAD = HEADERFLAG(REBSER_REBVAL_BIT + 2),
 
     // Sometimes a DO operation has already calculated values, and does not
     // want to interpret them again.  e.g. the call to the function wishes
@@ -105,13 +107,13 @@ enum {
     // variable.  This is common when calling Rebol functions from C code
     // when the parameters are known, or what R3-Alpha called "APPLY/ONLY"
     //
-    DO_FLAG_NO_ARGS_EVALUATE = 1 << (REBSER_REBVAL_BIT + 3),
+    DO_FLAG_NO_ARGS_EVALUATE = HEADERFLAG(REBSER_REBVAL_BIT + 3),
 
     // A pre-built frame can be executed "in-place" without a new allocation.
     // It will be type checked, and also any BAR! parameters will indicate
     // a desire to acquire that argument (permitting partial specialization).
     //
-    DO_FLAG_EXECUTE_FRAME = 1 << (REBSER_REBVAL_BIT + 4),
+    DO_FLAG_EXECUTE_FRAME = HEADERFLAG(REBSER_REBVAL_BIT + 4),
 
     // Usually VA_LIST_FLAG is enough to tell when there is a source array to
     // examine or not.  However, when the end is reached it is written over
@@ -121,25 +123,25 @@ enum {
     // expression evaluation is complete.  Review to see if they actually
     // would rather know something else, but this is a cheap flag for now.
     //
-    DO_FLAG_VA_LIST = 1 << (REBSER_REBVAL_BIT + 5),
+    DO_FLAG_VA_LIST = HEADERFLAG(REBSER_REBVAL_BIT + 5),
 
     // While R3-Alpha permitted modifications of an array while it was being
     // executed, Ren-C does not.  It takes a lock if the source is not already
     // read only, and sets it back when Do_Core is finished (or on errors)
     //
-    DO_FLAG_TOOK_FRAME_LOCK = 1 << (REBSER_REBVAL_BIT + 6),
+    DO_FLAG_TOOK_FRAME_LOCK = HEADERFLAG(REBSER_REBVAL_BIT + 6),
 
     // DO_FLAG_APPLYING is used to indicate that the Do_Core code is entering
     // a situation where the frame was already set up.
     //
-    DO_FLAG_APPLYING = 1 << (REBSER_REBVAL_BIT + 7),
+    DO_FLAG_APPLYING = HEADERFLAG(REBSER_REBVAL_BIT + 7),
 
     // When a variadic operation is on the left hand side of a deferred
     // lookback operation, it needs to inform the evaluator that the take is
     // variadic, so it knows to defer.  Consider `summation 1 2 3 |> 100`
     // should be `(summation 1 2 3) |> 100` and not `summation 1 2 (3 |> 100)`
     //
-    DO_FLAG_VARIADIC_TAKE = 1 << (REBSER_REBVAL_BIT + 8)
+    DO_FLAG_VARIADIC_TAKE = HEADERFLAG(REBSER_REBVAL_BIT + 8)
 };
 
 

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -114,7 +114,7 @@ enum {
     // a location where they do double-duty serving as an END marker.  For a
     // description of the method see notes on NOT_END_MASK.
     //
-    SERIES_FLAG_0_IS_FALSE = 1 << 0,
+    SERIES_FLAG_0_IS_FALSE = HEADERFLAG(0),
 
     // `SERIES_FLAG_1_IS_FALSE` is the second lowest bit, and is set to zero
     // as a safety precaution.  In the debug build this is checked by value
@@ -123,14 +123,14 @@ enum {
     // thought a REBVAL* pointing at the memory had a full value's worth
     // of memory to write into.  See WRITABLE_MASK_DEBUG.
     //
-    SERIES_FLAG_1_IS_FALSE = 1 << 1,
+    SERIES_FLAG_1_IS_FALSE = HEADERFLAG(1),
 
     // `SERIES_FLAG_HAS_DYNAMIC` indicates that this series has a dynamically
     // allocated portion.  If it does not, then its data pointer is the
     // address of the embedded value inside of it (marked terminated by
     // the SERIES_FLAG_0_IS_ZERO if it has an element in it)
     //
-    SERIES_FLAG_HAS_DYNAMIC = 1 << 2,
+    SERIES_FLAG_HAS_DYNAMIC = HEADERFLAG(2),
 
     // `SERIES_FLAG_STRING` identifies that this series holds a string, which
     // is important to the GC in order to successfully
@@ -141,7 +141,7 @@ enum {
     // knowing the series is a string is important at GC time...to clean up
     // aliases and adjust canons.
     //
-    SERIES_FLAG_STRING = 1 << 3,
+    SERIES_FLAG_STRING = HEADERFLAG(3),
 
     // `STRING_FLAG_CANON` is used to indicate when a REBSTR series represents
     // the canon form of a word.  This doesn't mean anything special about
@@ -150,14 +150,14 @@ enum {
     // canon form, so it can use the REBSER.misc field for the purpose of
     // holding an index during binding.
     //
-    STRING_FLAG_CANON = 1 << 4,
+    STRING_FLAG_CANON = HEADERFLAG(4),
 
     // `ARRAY_FLAG_PARAMLIST` uses the same bit as STRING_FLAG_CANON, so the
     // meaning depends on whether the SERIES_FLAG_ARRAY or SERIES_FLAG_STRING
     // bit is set.  This indicates the array is the parameter list of a
     // FUNCTION! (the first element will be a canon value of the function)
     //
-    ARRAY_FLAG_PARAMLIST = 1 << 4,
+    ARRAY_FLAG_PARAMLIST = HEADERFLAG(4),
 
     // `SERIES_FLAG_ARRAY` indicates that this is a series of REBVAL values,
     // and suitable for using as the payload of an ANY-ARRAY! value.  When a
@@ -171,7 +171,7 @@ enum {
     // creation of series that contain items that incidentally happen to be
     // the same size as a REBVAL, while not actually being REBVALs.)
     //
-    SERIES_FLAG_ARRAY = 1 << 5,
+    SERIES_FLAG_ARRAY = HEADERFLAG(5),
 
     // `ARRAY_FLAG_VARLIST` indicates this series represents the
     // "varlist" of a context.  A second series can be reached from it via
@@ -180,7 +180,7 @@ enum {
     //
     // See notes on REBCTX for further details about what a context is.
     //
-    ARRAY_FLAG_VARLIST = 1 << 6,
+    ARRAY_FLAG_VARLIST = HEADERFLAG(6),
 
     // `SERIES_FLAG_LOCKED` indicates that the series size or values cannot
     // be modified.  This check is honored by some layers of abstraction, but
@@ -196,7 +196,7 @@ enum {
     // it is distinct as it's a protection on a series itself--which ends
     // up affecting all variable content with that series in the payload.
     //
-    SERIES_FLAG_LOCKED = 1 << 7,
+    SERIES_FLAG_LOCKED = HEADERFLAG(7),
 
     // `SERIES_FLAG_FIXED_SIZE` indicates the size is fixed, and the series
     // cannot be expanded or contracted.  Values within the series are still
@@ -213,7 +213,7 @@ enum {
     // from fixed size... if there would be a reason to reallocate besides
     // changing size (such as memory compaction).
     //
-    SERIES_FLAG_FIXED_SIZE  = 1 << 8,
+    SERIES_FLAG_FIXED_SIZE = HEADERFLAG(8),
 
     // `SERIES_FLAG_POWER_OF_2` is set when an allocation size was rounded to
     // a power of 2.  This flag was introduced in Ren-C when accounting was
@@ -236,7 +236,7 @@ enum {
     //
     // http://stackoverflow.com/questions/3190146/
     //
-    SERIES_FLAG_POWER_OF_2  = 1 << 9,
+    SERIES_FLAG_POWER_OF_2 = HEADERFLAG(9),
 
     // `SERIES_FLAG_EXTERNAL` indicates that when the series was created, the
     // `->data` pointer was poked in by the creator.  It takes responsibility
@@ -249,7 +249,7 @@ enum {
     // Ren-Cpp, but by relatively old extensions...so there may be no good
     // answer in the case of those clients (likely either leaks or crashes).
     //
-    SERIES_FLAG_EXTERNAL = 1 << 10,
+    SERIES_FLAG_EXTERNAL = HEADERFLAG(10),
 
     // `SERIES_FLAG_INACCESSIBLE` indicates that the external memory pointed by
     // `->data` has "gone bad". This is not checked at every access to the
@@ -258,7 +258,7 @@ enum {
     // used for STRUCT! and to note when a CONTEXT_FLAG_STACK series has its
     // stack level popped (there's no data to lookup for words bound to it)
     //
-    SERIES_FLAG_INACCESSIBLE = 1 << 11,
+    SERIES_FLAG_INACCESSIBLE = HEADERFLAG(11),
 
     // `CONTEXT_FLAG_STACK` indicates that varlist data lives on the stack.
     // This is a work in progress to unify objects and function call frames
@@ -271,7 +271,7 @@ enum {
     // of mapping index numbers in the function paramlist into either the
     // stack array or the dynamic array during binding in an efficient way.
     //
-    CONTEXT_FLAG_STACK = 1 << 12,
+    CONTEXT_FLAG_STACK = HEADERFLAG(12),
 
     // `KEYLIST_FLAG_SHARED` is indicated on the keylist array of a context
     // when that same array is the keylist for another object.  If this flag
@@ -283,7 +283,7 @@ enum {
     // sharing of the keylist.  That would make 100 copies of an arbitrary
     // long keylist that the GC would have to clean up.)
     //
-    KEYLIST_FLAG_SHARED = 1 << 13,
+    KEYLIST_FLAG_SHARED = HEADERFLAG(13),
 
     // `ARRAY_FLAG_VOIDS_LEGAL` identifies arrays in which it is legal to
     // have void elements.  This is used for instance on reified C va_list()s
@@ -294,7 +294,7 @@ enum {
     // Note: ARRAY_FLAG_VARLIST also implies legality of voids, which
     // are used to represent unset variables.
     //
-    ARRAY_FLAG_VOIDS_LEGAL = 1 << 14,
+    ARRAY_FLAG_VOIDS_LEGAL = HEADERFLAG(14),
 
     // `SERIES_FLAG_LEGACY` is a flag which is marked at the root set of the
     // body of legacy functions.  It can be used in a dynamic examination of
@@ -304,7 +304,7 @@ enum {
     // But it's good enough for casual compatibility in many cases.
     //
 #if !defined NDEBUG
-    SERIES_FLAG_LEGACY = 1 << 15,
+    SERIES_FLAG_LEGACY = HEADERFLAG(15),
 #endif
 
     SERIES_FLAG_NO_COMMA_NEEDED = 0 // solves dangling comma from above
@@ -378,7 +378,7 @@ enum {
     // These let native routines engage in marking and unmarking nodes
     // without potentially wrecking the garbage collector.  :-/
     //
-    REBSER_FLAG_BLACK = 1 << (GENERAL_VALUE_BIT + 0)
+    REBSER_FLAG_BLACK = HEADERFLAG(GENERAL_VALUE_BIT + 0)
 };
 
 struct Reb_Series {

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -111,7 +111,7 @@ enum {
     // `SERIES_FLAG_HAS_DYNAMIC` indicates that this series has a dynamically
     // allocated portion.  If it does not, then its data pointer is the
     // address of the embedded value inside of it (marked terminated by
-    // the SERIES_FLAG_1_IS_FALSE if it has an element in it)
+    // the SERIES_FLAG_1_IS_TRUE if it has an element in it)
     //
     // The bit position this corresponds to in ordinary headers would be the
     // NOT_FREE_MASK.
@@ -123,11 +123,11 @@ enum {
     //
     SERIES_FLAG_HAS_DYNAMIC = HEADERFLAG(0),
 
-    // `SERIES_FLAG_1_IS_FALSE` corresponds to NOT_END_MASK.  It is set to
-    // zero to denote an END marker if there is a REBVAL sitting inside the
+    // `SERIES_FLAG_1_IS_TRUE` corresponds to END_MASK.  It is set to
+    // one to denote an END marker if there is a REBVAL sitting inside the
     // node which needs to be implicitly terminated.
     //
-    SERIES_FLAG_1_IS_FALSE = HEADERFLAG(1),
+    SERIES_FLAG_1_IS_TRUE = HEADERFLAG(1),
 
     // `SERIES_FLAG_2_IS_FALSE` corresponds to CELL_MASK.  It is checked by
     // value writes to ensure that when the info flags are serving double duty
@@ -370,7 +370,7 @@ union Reb_Series_Content {
     // [0] full element is IS_END(), or the [0] element is another value
     // and the [1] element is read-only and passes IS_END() to terminate
     // (but can't have any other value written, as the info bits are
-    // marked as unwritable by SERIES_FLAG_1_IS_FALSE...this protects the
+    // marked as unwritable by SERIES_FLAG_2_IS_FALSE...this protects the
     // rest of the bits in the debug build as it is checked whenver a
     // REBVAL tries to write a new header.)
     //
@@ -428,7 +428,7 @@ struct Reb_Series {
     //
     // The second-to-left and third-to-left bits of info are required to be 0
     // when used with the trick of implicitly terminating series data.  See
-    // SERIES_FLAG_1_IS_FALSE and SERIES_FLAG_2_IS_FALSE for more information.
+    // SERIES_FLAG_1_IS_TRUE and SERIES_FLAG_2_IS_FALSE for more information.
     //
     // !!! Only 32-bits are used on 64-bit platforms.  There could be some
     // interesting added caching feature or otherwise that would use

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -140,7 +140,7 @@ inline static REBCNT SER_LEN(REBSER *s) {
     // "type" bits were it a value.  The same optimization is available in
     // that it can just be shifted out.
 
-    return s->header.bits >> HEADER_TYPE_SHIFT;
+    return RIGHT_N_BITS(s->header.bits, NUM_KIND_BITS); // !!! NUM_LEN_BITS
 }
 
 inline static void SET_SERIES_LEN(REBSER *s, REBCNT len) {
@@ -151,8 +151,8 @@ inline static void SET_SERIES_LEN(REBSER *s, REBCNT len) {
     }
     else {
         assert(len < sizeof(s->content));
-        s->header.bits &= ~HEADER_TYPE_MASK;
-        s->header.bits |= cast(REBUPT, len) << HEADER_TYPE_SHIFT;
+        CLEAR_N_RIGHT_BITS(s->header.bits, NUM_KIND_BITS); // !!! NUM_LEN_BITS
+        s->header.bits |= FLAGVAL_RIGHT(len);
         assert(SER_LEN(s) == len);
     }
 }

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -333,7 +333,7 @@ inline static REBVAL* Push_Value_Chunk_Of_Length(REBCNT num_values) {
             cast(REBYTE*, TG_Top_Chunk) + CHUNK_SIZE(TG_Top_Chunk)
         );
 
-        Init_Header_Aliased(&chunk->header, 0);
+        Init_Endlike_Header(&chunk->header, 0);
         chunk->size = size;
 
         // top's offset accounted for previous chunk, account for ours
@@ -368,7 +368,7 @@ inline static REBVAL* Push_Value_Chunk_Of_Length(REBCNT num_values) {
 
         chunk = cast(struct Reb_Chunk*, &chunker->next->payload);
 
-        Init_Header_Aliased(&chunk->header, 0);
+        Init_Endlike_Header(&chunk->header, 0);
         chunk->size = size;
         chunk->offset = 0;
     }
@@ -377,7 +377,7 @@ inline static REBVAL* Push_Value_Chunk_Of_Length(REBCNT num_values) {
     // Set header in next element to 0, so it can serve as a terminator
     // for the data range of this until it gets instantiated (if ever)
     //
-    Init_Header_Aliased(
+    Init_Endlike_Header(
         &cast(struct Reb_Chunk*, cast(REBYTE*, chunk) + size)->header,
         0
     );

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -338,16 +338,11 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 //
 
 #define VAL_RESET_HEADER_COMMON(v,kind) \
-    ((v)->header.bits = HEADERIZE_KIND(kind) | NOT_END_MASK | CELL_MASK)
+    ((v)->header.bits = \
+        HEADERIZE_KIND(kind) | NOT_FREE_MASK | NOT_END_MASK | CELL_MASK)
 
 #ifdef NDEBUG
     #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v,file,line) \
-        NOOP
-
-    #define MARK_CELL_WRITABLE_IF_CPP_DEBUG(v) \
-        NOOP
-
-    #define MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(v) \
         NOOP
 
     #define VAL_RESET_HEADER(v,t) \
@@ -359,21 +354,8 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     #ifdef __cplusplus
         #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v,file,line) \
             Assert_Cell_Writable((v), (file), (line))
-
-        // just adds bit
-        #define MARK_CELL_WRITABLE_IF_CPP_DEBUG(v) \
-            ((v)->header.bits |= VALUE_FLAG_WRITABLE_CPP_DEBUG)
-
-        #define MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(v) \
-            ((v)->header.bits &= ~cast(REBUPT, VALUE_FLAG_WRITABLE_CPP_DEBUG))
     #else
         #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v,file,line) \
-            NOOP
-
-        #define MARK_CELL_WRITABLE_IF_CPP_DEBUG(v) \
-            NOOP
-
-        #define MARK_CELL_UNWRITABLE_IF_CPP_DEBUG(v) \
             NOOP
     #endif
 
@@ -382,7 +364,6 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     ){
         ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
         VAL_RESET_HEADER_COMMON(v, kind);
-        MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
     }
 
     #define VAL_RESET_HEADER(v,k) \
@@ -393,7 +374,6 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     ){
         VAL_RESET_HEADER_COMMON(v, REB_MAX_VOID); // no VOID_FLAG_NOT_TRASH
         Set_Track_Payload_Debug(v, file, line);
-        MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
     }
 
     #define INIT_CELL_IF_DEBUG(v) \
@@ -571,7 +551,7 @@ inline static REBOOL IS_VOID(const RELVAL *v)
 
 inline static void SET_BLANK_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_BLANK) \
-        | VALUE_FLAG_FALSE | NOT_END_MASK | CELL_MASK;
+        | NOT_FREE_MASK | VALUE_FLAG_FALSE | NOT_END_MASK | CELL_MASK;
 }
 
 #ifdef NDEBUG
@@ -595,7 +575,6 @@ inline static void SET_BLANK_COMMON(RELVAL *v) {
     ){
         ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
         SET_BLANK_COMMON(v);
-        MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
         Set_Track_Payload_Debug(v, file, line);
     }
     #define SET_BLANK(v) \
@@ -665,12 +644,12 @@ inline static void SET_BLANK_COMMON(RELVAL *v) {
 
 inline static void SET_TRUE_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_LOGIC) \
-        | NOT_END_MASK | CELL_MASK;
+        | NOT_FREE_MASK | NOT_END_MASK | CELL_MASK;
 }
 
 inline static void SET_FALSE_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_LOGIC) \
-        | NOT_END_MASK | CELL_MASK | VALUE_FLAG_FALSE;
+        | NOT_FREE_MASK | NOT_END_MASK | CELL_MASK | VALUE_FLAG_FALSE;
 }
 
 #define IS_CONDITIONAL_FALSE_COMMON(v) \
@@ -698,7 +677,6 @@ inline static void SET_FALSE_COMMON(RELVAL *v) {
     ){
         ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
         SET_TRUE_COMMON(v);
-        MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
         Set_Track_Payload_Debug(v, file, line);
     }
 
@@ -707,7 +685,6 @@ inline static void SET_FALSE_COMMON(RELVAL *v) {
     ){
         ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
         SET_FALSE_COMMON(v);
-        MARK_CELL_WRITABLE_IF_CPP_DEBUG(v);
         Set_Track_Payload_Debug(v, file, line);
     }
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -339,7 +339,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 
 #define VAL_RESET_HEADER_COMMON(v,kind) \
     ((v)->header.bits = \
-        HEADERIZE_KIND(kind) | NOT_FREE_MASK | NOT_END_MASK | CELL_MASK)
+        HEADERIZE_KIND(kind) | NOT_FREE_MASK | CELL_MASK)
 
 #ifdef NDEBUG
     #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v,file,line) \
@@ -551,7 +551,7 @@ inline static REBOOL IS_VOID(const RELVAL *v)
 
 inline static void SET_BLANK_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_BLANK) \
-        | NOT_FREE_MASK | VALUE_FLAG_FALSE | NOT_END_MASK | CELL_MASK;
+        | NOT_FREE_MASK | VALUE_FLAG_FALSE | CELL_MASK;
 }
 
 #ifdef NDEBUG
@@ -644,12 +644,12 @@ inline static void SET_BLANK_COMMON(RELVAL *v) {
 
 inline static void SET_TRUE_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_LOGIC) \
-        | NOT_FREE_MASK | NOT_END_MASK | CELL_MASK;
+        | NOT_FREE_MASK | CELL_MASK;
 }
 
 inline static void SET_FALSE_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_LOGIC) \
-        | NOT_FREE_MASK | NOT_END_MASK | CELL_MASK | VALUE_FLAG_FALSE;
+        | NOT_FREE_MASK | CELL_MASK | VALUE_FLAG_FALSE;
 }
 
 #define IS_CONDITIONAL_FALSE_COMMON(v) \

--- a/src/include/sys-varargs.h
+++ b/src/include/sys-varargs.h
@@ -47,11 +47,10 @@
 
 #ifdef NDEBUG
     #define VARARGS_FLAG(n) \
-        (cast(REBUPT, 1) << (TYPE_SPECIFIC_BIT + (n))) 
+        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
 #else
     #define VARARGS_FLAG(n) \
-        ((cast(REBUPT, 1) << (TYPE_SPECIFIC_BIT + (n))) \
-            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_VARARGS))
+        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_VARARGS))
 #endif
 
 // Was made with a call to MAKE VARARGS! with data from an ANY-ARRAY!

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -43,11 +43,10 @@
 
 #ifdef NDEBUG
     #define WORD_FLAG(n) \
-        (1 << (TYPE_SPECIFIC_BIT + (n)))
+        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
 #else
     #define WORD_FLAG(n) \
-        ((1 << (TYPE_SPECIFIC_BIT + (n))) \
-            | TYPE_SHIFT_LEFT_FOR_HEADER(REB_WORD)) // interpreted as ANY-WORD!
+        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_WORD))
 #endif
 
 // `WORD_FLAG_BOUND` answers whether a word is bound, but it may be


### PR DESCRIPTION
All things being equal in the external C API, it would be desirable to
variadically mix strings with Rebol values, without pre-declaring
which is which.

In pseudocode matching libRed's "look" in [the recent published code](https://github.com/red/red/blob/master/tests/libRed-test.c):

    reb_value block = rebLoad("[a b c]");
    reb_value date = rebLoad("12-Dec-2012");
    rebDo("poke", block, "2", date);

But though C has variadic functions (like printf), the callee receives
no type information from the callsite.  Before asking for each argument
the variadic function must know what type to ask for.

(Note: printf works around this by always taking one `char*` format
string as a first argument.  By analyzing the format string it then
"knows" the number and types of arguments to ask for.  Of course that
is risky, because the caller might get it wrong.  :-/)

One workaround for mixing string pointers and Rebol value pointers
would be if the variadic function asked for `void*` parameters...and
could then "sniff" each pointer to tell if it were a string or not.  If
the string literals are assumed to be in UTF-8, this is technically
possible... *if* the Rebol value headers are stylized to always look
like invalid UTF-8 strings.

It's made complicated because Rebol value headers want to be able to be
initialized, masked, and shifted like unsigned platform-natural
integers.  But since integers are mapped into memory differently by
different compilers on different architectures, getting the proper
imprint to register as "invalid UTF-8 string" has no good way that
is standards and/or performant.

This introduces macros for "Byte-Order Sensitive Bit Flags & Masking"
which try to address the problem.  The commit gets the bit positions
under control for an initial test, without changing the meanings of
the bits.  Once that's settled, selecting the bits so that Rebol
value headers are always invalid ways to begin a UTF-8 string will
be tackled.