### PR TITLE
Universal panic()!

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -22,24 +22,12 @@ Special: [
 ]
 
 Internal: [
-    ; Some of these internal errors can happen prior to when the error
-    ; catalog (e.g. the blocks in this file) have been loaded as Rebol data.
-    ; Those strings need to be accessible another way, so %make-boot.r takes
-    ; the string data and duplicates it as C literals usable by Panic_Core()
-    ;
-    ; Note: Because these are flattened into printf-style format strings
-    ; instead of using the ordinary error-building mechanism, argument
-    ; ordering is not honored when an error is raised using the mechanism
-    ; from before when booting is ready.  It's also probably a bad idea to
-    ; use sophisticated REBVALs as arguments, because it may be too early
-    ; in the boot process for them to be molded properly.
-    ;
     code: 1000
     type: "internal"
 
     ; Because adding an error code has the overhead of modifying this file and
     ; coming up with a good name, errors for testing or that you don't think
-    ; will happen can be put here.  A debug build will identify the line
+    ; will happen can use RE_MISC.  A debug build will identify the line
     ; number and file source of the error, so provides some info already.
     ;
     misc:               {RE_MISC error (if actually happens, add to %errors.r)}
@@ -51,36 +39,18 @@ Internal: [
 
     not-done:           {reserved for future use (or not yet implemented)}
 
-    ; !!! Should boot errors be their own category?  Even if they were,
-    ; there will still be some errors that are not boot-specific which can
-    ; happen during boot (such as out of memory) which can't rely on boot
-    ;
     no-memory:          [{not enough memory:} :arg1 {bytes}]
     corrupt-memory:     {Check_Memory() found a problem}
-    boot-data:          {no boot.r text found}
-    native-boot:        {bad boot.r native ordering}
-    bad-boot-string:    {boot strings area is invalid}
-    bad-boot-type-block: {boot block is wrong size}
-    max-natives:        {too many natives}
-    action-overflow:    {more actions than we should have}
-    rebval-alignment:   {sizeof(REBVAL) not 4x 32-bits or 4x 64-bits}
-    pool-alignment:     {Memory pool width not 64-bit aligned}
 
     io-error:           {problem with IO}
-    max-words:          {too many words}
     locked-series:      {locked series expansion}
-    max-events:         {event queue overflow}
     unexpected-case:    {no case in switch statement}
-    bad-size:           {expected size did not match}
-    no-buffer:          {buffer not yet allocated}
     invalid-datatype:   [{invalid datatype #} :arg1]
     bad-path:           [{bad path:} :arg1]
     not-here:           [:arg1 {not supported on your system}]
     globals-full:       {no more global variable space}
-    limit-hit:          [{internal limit reached:} :arg1]
     bad-sys-func:       [{invalid or missing system function:} :arg1]
     invalid-error:      [{error object or fields were not valid:} :arg1]
-    bad-evaltype:       {invalid datatype for evaluation}
     hash-overflow:      {Hash ran out of space}
     no-print-ptr:       {print is missing string pointer}
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1372,10 +1372,8 @@ inline static REBFRM *Extract_Live_Rebfrm_May_Fail(const REBVAL *frame) {
         fail(Error(RE_MISC)); // !!! improve
 
     REBCTX *frame_ctx = VAL_CONTEXT(frame);
-    if (GET_CTX_FLAG(frame_ctx, SERIES_FLAG_INACCESSIBLE)) {
-        assert(GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK));
+    if (IS_INACCESSIBLE(frame_ctx))
         fail (Error(RE_MISC)); // !!! improve
-    }
 
     REBFRM *f = CTX_FRAME(frame_ctx);
     assert(Is_Any_Function_Frame(f));

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -768,7 +768,7 @@ static void Init_Root_Context(void)
     // this one into a program global.  It is not legal to bit-copy an
     // END (you always use SET_END), so we can make it unwritable.
     //
-    PG_End_Cell.header.bits = END_MASK; // read-only end
+    PG_End_Cell.header.bits = NODE_FLAG_END; // read-only end
     assert(IS_END(END_CELL)); // sanity check that it took
 
     // The EMPTY_BLOCK provides EMPTY_ARRAY.  It is locked for protection.
@@ -1466,7 +1466,7 @@ void Init_Core(REBARGS *rargs)
     ASSERT_CONTEXT(PG_Root_Context);
 
     ARR_SERIES(CTX_VARLIST(PG_Root_Context))->header.bits
-        |= REBSER_REBVAL_FLAG_ROOT;
+        |= NODE_FLAG_ROOT;
 
     // Get the words of the TASK context (to avoid it being an exception case)
     //
@@ -1480,7 +1480,7 @@ void Init_Core(REBARGS *rargs)
     ASSERT_CONTEXT(TG_Task_Context);
 
     ARR_SERIES(CTX_VARLIST(TG_Task_Context))->header.bits
-        |= REBSER_REBVAL_FLAG_ROOT;
+        |= NODE_FLAG_ROOT;
 
     // Create main values:
     DOUT("Level 3");
@@ -1624,9 +1624,9 @@ void Shutdown_Core(void)
     // created by Alloc_Pairing() with an owning context should be freed.
     //
     ARR_SERIES(CTX_VARLIST(PG_Root_Context))->header.bits
-        &= (~REBSER_REBVAL_FLAG_ROOT);
+        &= (~NODE_FLAG_ROOT);
     ARR_SERIES(CTX_VARLIST(TG_Task_Context))->header.bits
-        &= (~REBSER_REBVAL_FLAG_ROOT);
+        &= (~NODE_FLAG_ROOT);
     Recycle_Core(TRUE);
 
     FREE_N(REBYTE*, RS_MAX, PG_Boot_Strs);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -51,8 +51,7 @@ void Snap_State_Core(struct Reb_State *s)
     //
     assert(ARR_LEN(BUF_COLLECT) == 0);
 
-    s->series_guard_len = SER_LEN(GC_Series_Guard);
-    s->value_guard_len = SER_LEN(GC_Value_Guard);
+    s->guarded_len = SER_LEN(GC_Guarded);
     s->frame = FS_TOP;
 
     s->manuals_len = SER_LEN(GC_Manuals);
@@ -91,28 +90,15 @@ void Assert_State_Balanced_Debug(
 
     assert(ARR_LEN(BUF_COLLECT) == 0);
 
-    if (s->series_guard_len != SER_LEN(GC_Series_Guard)) {
+    if (s->guarded_len != SER_LEN(GC_Guarded)) {
         printf(
-            "PUSH_GUARD_SERIES()x%d without DROP_GUARD_SERIES\n",
-            SER_LEN(GC_Series_Guard) - s->series_guard_len
+            "PUSH_GUARD()x%d without DROP_GUARD()\n",
+            SER_LEN(GC_Guarded) - s->guarded_len
         );
-        REBSER *guarded = *SER_AT(
-            REBSER*,
-            GC_Series_Guard,
-            SER_LEN(GC_Series_Guard) - 1
-        );
-        panic_at (guarded, file, line);
-    }
-
-    if (s->value_guard_len != SER_LEN(GC_Value_Guard)) {
-        printf(
-            "PUSH_GUARD_VALUE()x%d without DROP_GUARD_VALUE\n",
-            SER_LEN(GC_Value_Guard) - s->value_guard_len
-        );
-        REBVAL *guarded = *SER_AT(
-            REBVAL*,
-            GC_Value_Guard,
-            SER_LEN(GC_Value_Guard) - 1
+        REBNOD *guarded = *SER_AT(
+            REBNOD*,
+            GC_Guarded,
+            SER_LEN(GC_Guarded) - 1
         );
         panic_at (guarded, file, line);
     }
@@ -217,8 +203,7 @@ REBOOL Trapped_Helper_Halted(struct Reb_State *s)
         );
     }
 
-    SET_SERIES_LEN(GC_Series_Guard, s->series_guard_len);
-    SET_SERIES_LEN(GC_Value_Guard, s->value_guard_len);
+    SET_SERIES_LEN(GC_Guarded, s->guarded_len);
     TG_Frame_Stack = s->frame;
     TERM_SEQUENCE_LEN(UNI_BUF, s->uni_buf_len);
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -826,12 +826,11 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
     const REBSYM *arg1_arg2_arg3 = legacy_data;
 #endif
 
-
     if (PG_Boot_Phase < BOOT_ERRORS) {
         char buf[1024];
         strncat(buf, "fail() before object table initialized, code = ", 1024);
         Form_Int(b_cast(buf + strlen(buf)), code); // !!! no bounding...
-    
+
     #if defined(NDEBUG)
         panic (buf);
     #else

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -793,7 +793,7 @@ reevaluate:;
                 //
                 if (
                     f->varlist == NULL
-                    || !GET_ARR_FLAG(f->varlist, ARRAY_FLAG_VARLIST)
+                    || NOT_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST)
                 ){
                     // Don't use ordinary call to Context_For_Frame_May_Reify
                     // because this special case allows reification even

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1304,6 +1304,10 @@ reevaluate:;
             f->gotten = Get_Var_Core(
                 &f->eval_type, f->value, f->specifier, GETVAR_READ_ONLY
             );
+        else { // failed optimizations only run prefix functions
+            if (IS_FUNCTION(f->gotten))
+                f->eval_type = REB_FUNCTION;
+        }
 
         // eval_type will be set to either REB_0_LOOKBACK or REB_FUNCTION
 

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -199,11 +199,10 @@ REBOOL Do_Path_Throws_Core(
         assert(specifier != SPECIFIED);
 
         if (VAL_RELATIVE(path) != VAL_FUNC(CTX_FRAME_FUNC_VALUE(specifier))) {
-            Debug_Fmt("Specificity mismatch found in path dispatch");
-            PROBE_MSG(path, "the path being evaluated");
-            PROBE_MSG(FUNC_VALUE(VAL_RELATIVE(path)), "expected func");
-            PROBE_MSG(CTX_FRAME_FUNC_VALUE(specifier), "actual func");
-            assert(FALSE);
+            printf("Specificity mismatch in path dispatch, expected:\n");
+            PROBE(CTX_FRAME_FUNC_VALUE(specifier));
+            printf("Panic on actual path\n");
+            panic (path);
         }
     #endif
         pvs.item_specifier = specifier;

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -468,7 +468,7 @@ REBOOL Redo_Func_Throws(REBFRM *f, REBFUN *func_new)
 //
 REB_R Do_Port_Action(REBFRM *frame_, REBCTX *port, REBSYM action)
 {
-    assert(GET_ARR_FLAG(CTX_VARLIST(port), ARRAY_FLAG_VARLIST));
+    assert(GET_SER_FLAG(CTX_VARLIST(port), ARRAY_FLAG_VARLIST));
 
     // Verify valid port (all of these must be false):
     if (
@@ -547,7 +547,7 @@ void Secure_Port(REBSYM sym_kind, REBREQ *req, REBVAL *name, REBSER *path)
 void Validate_Port(REBCTX *port, REBCNT action)
 {
     if (
-        !GET_ARR_FLAG(CTX_VARLIST(port), ARRAY_FLAG_VARLIST)
+        NOT_SER_FLAG(CTX_VARLIST(port), ARRAY_FLAG_VARLIST)
         || !IS_OBJECT(CTX_VAR(port, STD_PORT_SPEC))
     ) {
         fail (Error(RE_INVALID_PORT));

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -103,11 +103,11 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
     //
     assert(cast(REBUPT, (v)) % sizeof(REBUPT) == 0);
 
-    if (NOT((v)->header.bits & CELL_MASK)) {
+    if (NOT((v)->header.bits & NODE_FLAG_CELL)) {
         printf("Non-cell passed to writing routine\n");
         panic_at (v, file, line);
     }
-    if (NOT((v)->header.bits & NOT_FREE_MASK)) {
+    if (NOT((v)->header.bits & NODE_FLAG_VALID)) {
         printf("Non-writable value passed to writing routine\n");
         panic_at (v, file, line);
     }
@@ -137,7 +137,7 @@ void SET_END_Debug(RELVAL *v, const char *file, int line) {
 REBOOL IS_END_Debug(const RELVAL *v, const char *file, int line) {
 #ifdef __cplusplus
     if (
-        (v->header.bits & CELL_MASK)
+        (v->header.bits & NODE_FLAG_CELL)
         //
         // Note: a non-writable value could have any bit pattern in the
         // type slot, so we only check for trash in writable ones.
@@ -152,7 +152,7 @@ REBOOL IS_END_Debug(const RELVAL *v, const char *file, int line) {
 #endif
 
     if (IS_END_MACRO(v)) {
-        if (v->header.bits & CELL_MASK)
+        if (v->header.bits & NODE_FLAG_CELL)
             assert(LEFT_N_BITS(v->header.bits, 8) == 255);
         return TRUE;
     }
@@ -273,7 +273,7 @@ void Probe_Core_Debug(
     fflush(stdout);
     fflush(stderr);
 
-    if (h->bits & CELL_MASK)
+    if (h->bits & NODE_FLAG_CELL)
         Debug_Fmt("%r\n", cast(const REBVAL*, p));
     else
         Debug_Series(m_cast(REBSER*, cast(const REBSER*, p)));

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -126,7 +126,7 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
 //
 void SET_END_Debug(RELVAL *v, const char *file, int line) {
     ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v, file, line);
-    (v)->header.bits = HEADERIZE_KIND(REB_0) | FLAGVAL_FIRST(255);
+    (v)->header.bits = HEADERIZE_KIND(REB_0) | FLAGBYTE_FIRST(255);
     Set_Track_Payload_Debug(v, file, line);
 }
 
@@ -180,7 +180,7 @@ REBCTX *VAL_SPECIFIC_Debug(const REBVAL *v)
         //
         // Basic sanity check: make sure it's a context at all
         //
-        if (!GET_CTX_FLAG(specific, ARRAY_FLAG_VARLIST)) {
+        if (NOT_SER_FLAG(CTX_VARLIST(specific), ARRAY_FLAG_VARLIST)) {
             printf("Non-CONTEXT found as specifier in specific value\n");
             panic (specific); // may not be a series, either
         }

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -592,9 +592,9 @@ void Init_Symbols(REBARR *words)
     // Do some sanity checks
 
     if (COMPARE_BYTES(cb_cast("blank!"), STR_HEAD(Canon(SYM_BLANK_X))) != 0)
-        panic (Error(RE_BAD_BOOT_STRING));
+        panic (Canon(SYM_BLANK_X));
     if (COMPARE_BYTES(cb_cast("true"), STR_HEAD(Canon(SYM_TRUE))) != 0)
-        panic (Error(RE_BAD_BOOT_STRING));
+        panic (Canon(SYM_TRUE));
 }
 
 

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -111,10 +111,8 @@ REBOOL Do_Breakpoint_Throws(
         //
         if (error) {
         #if !defined(NDEBUG)
-            REBVAL error_value;
-            Val_Init_Error(&error_value, error);
-            PROBE_MSG(&error_value, "Error not trapped during breakpoint:");
-            Panic_Array(CTX_VARLIST(error));
+            printf("Error not trapped during breakpoint\n");
+            panic (error);
         #endif
 
             // In release builds, if an error managed to leak out of the

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -79,8 +79,8 @@ static enum Reb_Pointer_Guess Guess_Rebol_Pointer(const void *p) {
 
     case 4:
     case 5:
-        // END_MASK (0x4) is set, but other bits aren't set...including
-        // CELL_MASK (0x2).  This *could* be an internal END marker, as
+        // NODE_FLAG_END (0x4) is set, but other bits aren't set...including
+        // NODE_FLAG_CELL (0x2).  This *could* be an internal END marker, as
         // opposed to a UTF-8 string.  A debug check might try doing a UTF-8
         // decode, and if it fails, it's probably an internal END.
         //

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -187,8 +187,7 @@ void Dump_Info(void)
 
     Debug_Fmt("    Ballast: %d", GC_Ballast);
     Debug_Fmt("    Disable: %d", GC_Disabled);
-    Debug_Fmt("    Guarded Series: %d", SER_LEN(GC_Series_Guard));
-    Debug_Fmt("    Guarded Values: %d", SER_LEN(GC_Value_Guard));
+    Debug_Fmt("    Guarded Nodes: %d", SER_LEN(GC_Guarded));
 }
 
 

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -170,7 +170,7 @@ void Do_Core_Entry_Checks_Debug(REBFRM *f)
     //
     assert(f->value);
 
-    assert((f->flags.bits & END_MASK) && NOT(f->flags.bits & CELL_MASK));
+    assert((f->flags.bits & NODE_FLAG_END) && NOT(f->flags.bits & NODE_FLAG_CELL));
 
     f->label = NULL;
     f->label_debug = NULL;

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -122,7 +122,7 @@ void Do_Core_Entry_Checks_Debug(REBFRM *f)
     REBSER *containing = Try_Find_Containing_Series_Debug(f->out);
 
     if (containing) {
-        if (GET_SER_FLAG(series, SERIES_FLAG_FIXED_SIZE)) {
+        if (GET_SER_FLAG(containing, SERIES_FLAG_FIXED_SIZE)) {
             //
             // Currently it's considered OK to be writing into a fixed size
             // series, for instance the durable portion of a function's
@@ -131,8 +131,8 @@ void Do_Core_Entry_Checks_Debug(REBFRM *f)
             //
         }
         else {
-            Debug_Fmt("Request for ->out location in movable series memory");
-            assert(FALSE);
+            printf("Request for ->out location in movable series memory\n");
+            panic (containing);
         }
     }
 #else

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -65,7 +65,8 @@ void Dump_Frame_Location(REBFRM *f)
     REBVAL dump;
     Derelativize(&dump, f->value, f->specifier);
 
-    PROBE_MSG(&dump, "Dump_Frame_Location() value");
+    printf("Dump_Frame_Location() value\n");
+    PROBE(&dump);
 
     if (f->flags.bits & DO_FLAG_VA_LIST) {
         //
@@ -80,14 +81,12 @@ void Dump_Frame_Location(REBFRM *f)
 
     if (f->pending && NOT_END(f->pending)) {
         assert(IS_SPECIFIC(f->pending));
-        PROBE_MSG(
-            const_KNOWN(f->pending),
-            "EVAL in progress, so next will be..."
-        );
+        printf("EVAL in progress, so next will be...\n");
+        PROBE(const_KNOWN(f->pending));
     }
 
     if (IS_END(f->value)) {
-        Debug_Fmt("...then Dump_Frame_Location() at end of array");
+        printf("...then Dump_Frame_Location() at end of array\n");
     }
     else {
         REBVAL dump;
@@ -99,7 +98,8 @@ void Dump_Frame_Location(REBFRM *f)
             f->specifier
         );
 
-        PROBE_MSG(&dump, "Dump_Frame_Location() next input");
+        printf("Dump_Frame_Location() next input\n");
+        PROBE(&dump);
     }
 }
 

--- a/src/core/d-legacy.c
+++ b/src/core/d-legacy.c
@@ -68,7 +68,7 @@ REBOOL In_Legacy_Function_Debug(void)
 
     // Check the flag on the source series
     //
-    if (GET_ARR_FLAG(frame->source.array, SERIES_FLAG_LEGACY))
+    if (GET_SER_FLAG(frame->source.array, SERIES_FLAG_LEGACY))
         return TRUE;
 
     return FALSE;

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -56,7 +56,8 @@ void Init_StdIO(void)
 {
     //OS_CALL_DEVICE(RDI_STDIO, RDC_INIT);
     Req_SIO = OS_MAKE_DEVREQ(RDI_STDIO);
-    if (!Req_SIO) panic (Error(RE_IO_ERROR));
+    if (!Req_SIO)
+        fail (Error(RE_IO_ERROR));
 
     // The device is already open, so this call will just setup
     // the request fields properly.
@@ -91,7 +92,8 @@ void Print_OS_Line(void)
 
     OS_DO_DEVICE(Req_SIO, RDC_WRITE);
 
-    if (Req_SIO->error) panic (Error(RE_IO_ERROR));
+    if (Req_SIO->error)
+        panic ("IO error in Print_OS_Line"); // !!! could/should this fail()?
 }
 
 
@@ -113,7 +115,8 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
     const REBYTE *bp = unicode ? NULL : cast(const REBYTE *, p);
     const REBUNI *up = unicode ? cast(const REBUNI *, p) : NULL;
 
-    if (!p) panic (Error(RE_NO_PRINT_PTR));
+    if (p == NULL)
+        fail (Error(RE_NO_PRINT_PTR));
 
     // Determine length if not provided:
     if (len == UNKNOWN) len = unicode ? Strlen_Uni(up) : LEN_BYTES(bp);
@@ -146,7 +149,8 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
         Req_SIO->common.data = m_cast(REBYTE *, bp);
 
         OS_DO_DEVICE(Req_SIO, RDC_WRITE);
-        if (Req_SIO->error) panic (Error(RE_IO_ERROR));
+        if (Req_SIO->error)
+            fail (Error(RE_IO_ERROR));
     }
     else {
         while ((len2 = len) > 0) {
@@ -174,7 +178,8 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
             len -= len2;
 
             OS_DO_DEVICE(Req_SIO, RDC_WRITE);
-            if (Req_SIO->error) panic (Error(RE_IO_ERROR));
+            if (Req_SIO->error)
+                fail (Error(RE_IO_ERROR));
         }
     }
 }
@@ -387,17 +392,19 @@ void Debug_Series(REBSER *ser)
     else if (SER_WIDE(ser) == sizeof(REBUNI))
         Debug_Uni(ser);
     else if (ser == PG_Canons_By_Hash) {
-        // Dump hashes somehow?
-        Panic_Series(ser);
-    } else if (ser == GC_Series_Guard) {
-        // Dump protected series pointers somehow?
-        Panic_Series(ser);
-    } else if (ser == GC_Value_Guard) {
-        // Dump protected value pointers somehow?
-        Panic_Series(ser);
+        printf("can't probe PG_Canons_By_Hash\n");
+        panic (ser);
+    }
+    else if (ser == GC_Series_Guard) {
+        printf("can't probe GC_Series_Guard\n");
+        panic (ser);
+    }
+    else if (ser == GC_Value_Guard) {
+        printf("can't probe GC_Value_Guard\n");
+        panic (ser);
     }
     else
-        Panic_Series(ser);
+        panic (ser);
 
     assert(GC_Disabled == TRUE);
     GC_Disabled = disabled;

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -395,12 +395,8 @@ void Debug_Series(REBSER *ser)
         printf("can't probe PG_Canons_By_Hash\n");
         panic (ser);
     }
-    else if (ser == GC_Series_Guard) {
-        printf("can't probe GC_Series_Guard\n");
-        panic (ser);
-    }
-    else if (ser == GC_Value_Guard) {
-        printf("can't probe GC_Value_Guard\n");
+    else if (ser == GC_Guarded) {
+        printf("can't probe GC_Guarded\n");
         panic (ser);
     }
     else

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -674,10 +674,8 @@ return_maybe_set_number_out:
 //
 REBOOL Is_Context_Running_Or_Pending(REBCTX *frame_ctx)
 {
-    if (GET_CTX_FLAG(frame_ctx, SERIES_FLAG_INACCESSIBLE)) {
-        assert(GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK));
+    if (IS_INACCESSIBLE(frame_ctx))
         return FALSE;
-    }
 
     REBFRM *f = CTX_FRAME(frame_ctx);
 
@@ -704,10 +702,8 @@ REBNATIVE(running_q)
     INCLUDE_PARAMS_OF_RUNNING_Q;
 
     REBCTX *frame_ctx = VAL_CONTEXT(ARG(frame));
-    if (GET_CTX_FLAG(frame_ctx, SERIES_FLAG_INACCESSIBLE)) {
-        assert(GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK));
+    if (IS_INACCESSIBLE(frame_ctx))
         return R_FALSE;
-    }
 
     REBFRM *f = CTX_FRAME(frame_ctx);
 
@@ -734,10 +730,8 @@ REBNATIVE(pending_q)
     INCLUDE_PARAMS_OF_PENDING_Q;
 
     REBCTX *frame_ctx = VAL_CONTEXT(ARG(frame));
-    if (GET_CTX_FLAG(frame_ctx, SERIES_FLAG_INACCESSIBLE)) {
-        assert(GET_CTX_FLAG(frame_ctx, CONTEXT_FLAG_STACK));
+    if (IS_INACCESSIBLE(frame_ctx))
         return R_FALSE;
-    }
 
     REBFRM *f = CTX_FRAME(frame_ctx);
 

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -212,7 +212,7 @@ void Clonify_Values_Len_Managed(
             REBSER *series;
             if (ANY_CONTEXT(value)) {
             #if !defined(NDEBUG)
-                legacy = GET_ARR_FLAG(
+                legacy = GET_SER_FLAG(
                     CTX_VARLIST(VAL_CONTEXT(value)),
                     SERIES_FLAG_LEGACY
                 );
@@ -226,7 +226,7 @@ void Clonify_Values_Len_Managed(
             else {
                 if (Is_Array_Series(VAL_SERIES(value))) {
                 #if !defined(NDEBUG)
-                    legacy = GET_ARR_FLAG(VAL_ARRAY(value), SERIES_FLAG_LEGACY);
+                    legacy = GET_SER_FLAG(VAL_ARRAY(value), SERIES_FLAG_LEGACY);
                 #endif
 
                     series = ARR_SERIES(
@@ -342,8 +342,8 @@ REBARR *Copy_Array_Core_Managed(
     // be marked legacy.  Then if it runs, the SWITCH can dispatch to return
     // blank instead of the Ren-C behavior of returning `2`.
     //
-    if (GET_ARR_FLAG(original, SERIES_FLAG_LEGACY))
-        SET_ARR_FLAG(copy, SERIES_FLAG_LEGACY);
+    if (GET_SER_FLAG(original, SERIES_FLAG_LEGACY))
+        SET_SER_FLAG(copy, SERIES_FLAG_LEGACY);
 #endif
 
     ASSERT_NO_RELATIVE(copy, deep);

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -354,16 +354,16 @@ REB_R Destroy_External_Storage(
     REBSER *ser,
     REBVAL *free_func
 ) {
-    if (!GET_SER_FLAG(ser, SERIES_FLAG_EXTERNAL))
+    if (NOT_SER_INFO(ser, SERIES_INFO_EXTERNAL))
         fail (Error(RE_NO_EXTERNAL_STORAGE));
 
     REBVAL pointer;
     SET_INTEGER(&pointer, cast(REBUPT, SER_DATA_RAW(ser)));
 
-    if (GET_SER_FLAG(ser, SERIES_FLAG_INACCESSIBLE))
+    if (GET_SER_INFO(ser, SERIES_INFO_INACCESSIBLE))
         fail (Error(RE_ALREADY_DESTROYED, pointer));
 
-    SET_SER_FLAG(ser, SERIES_FLAG_INACCESSIBLE);
+    SET_SER_INFO(ser, SERIES_INFO_INACCESSIBLE);
 
     if (free_func != NULL) {
         if (Do_Va_Throws(out, free_func, &pointer, END_CELL))

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -431,7 +431,7 @@ void Val_Init_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *c) {
     if (CTX_KEYLIST(c) == NULL)
         panic (c);
 
-    assert(GET_ARR_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
+    assert(GET_SER_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
 
     if (IS_FRAME(CTX_VALUE(c)))
         assert(IS_FUNCTION(CTX_FRAME_FUNC_VALUE(c)));

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1882,7 +1882,7 @@ exit_block:
     //
 #if !defined(NDEBUG)
     if (LEGACY(OPTIONS_REFINEMENTS_BLANK))
-        SET_ARR_FLAG(result, SERIES_FLAG_LEGACY);
+        SET_SER_FLAG(result, SERIES_FLAG_LEGACY);
 #endif
 
     return result;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -126,8 +126,8 @@ static inline void Mark_Rebser_Only(REBSER *s)
 {
 #if !defined(NDEBUG)
     if (NOT(IS_SERIES_MANAGED(s))) {
-        Debug_Fmt("Link to non-MANAGED item reached by GC");
-        Panic_Series(s);
+        printf("Link to non-MANAGED item reached by GC\n");
+        panic (s);
     }
 #endif
     s->header.bits |= REBSER_REBVAL_FLAG_MARK;
@@ -168,23 +168,16 @@ static inline REBOOL Unmark_Rebser(REBSER *rebser) {
 static void Queue_Mark_Array_Subclass_Deep(REBARR *a)
 {
 #if !defined(NDEBUG)
-    if (ARR_SERIES(a)->header.bits == 0) {
-        printf("GC is queueing a freed array for marking.\n");
-        Panic_Array(a);
-    }
+    if (IS_FREE_NODE(ARR_SERIES(a)))
+        panic (a);
 
-    if (!GET_ARR_FLAG(a, SERIES_FLAG_ARRAY)) {
-        printf("GC is queuing a non-array in the array marking queue\n");
-        Panic_Array(a);
-    }
+    if (!GET_ARR_FLAG(a, SERIES_FLAG_ARRAY))
+        panic (a);
 
-    if (!IS_ARRAY_MANAGED(a)) {
-        printf("GC is queuing an unmanaged array for marking.\n");
-        Panic_Array(a);
-    }
+    if (!IS_ARRAY_MANAGED(a))
+        panic (a);
 
     assert(!GET_ARR_FLAG(a, SERIES_FLAG_EXTERNAL)); // external arrays illegal
-
 #endif
 
     // A marked array doesn't necessarily mean all references reached from it
@@ -271,7 +264,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         // Should not be possible, REB_0 instances should not exist or
         // be filtered out by caller.
         //
-        panic (Error(RE_MISC));
+        panic (v);
 
     case REB_FUNCTION: {
         REBFUN *func = VAL_FUNC(v);
@@ -612,8 +605,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         break;
 
     default:
-        assert(FALSE);
-        panic (Error(RE_MISC));
+        panic (v);
     }
 
 #if !defined(NDEBUG)
@@ -625,7 +617,7 @@ inline static void Queue_Mark_Value_Deep(const RELVAL *v)
 {
 #if !defined(NDEBUG)
     if (IS_VOID(v))
-        Panic_Value(v);
+        panic (v);
 #endif
     Queue_Mark_Opt_Value_Deep(v);
 }

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1466,7 +1466,9 @@ void Guard_Node_Core(const REBNOD *node)
         // being able to resize and reallocate the data pointer.  But this is
         // a somewhat expensive check, so only feasible to run occasionally.
         //
-        ASSERT_NOT_IN_SERIES_DATA(value);
+        REBSER *containing = Try_Find_Containing_Series_Debug(value);
+        if (containing != NULL)
+            panic (containing);
     #endif
     }
     else {

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -202,7 +202,7 @@ void Remove_Series(REBSER *s, REBCNT index, REBINT len)
 {
     if (len <= 0) return;
 
-    REBOOL is_dynamic = GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC);
+    REBOOL is_dynamic = GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC);
     REBCNT len_old = SER_LEN(s);
 
     REBCNT start = index * SER_WIDE(s);
@@ -316,7 +316,7 @@ void Unbias_Series(REBSER *s, REBOOL keep)
 void Reset_Sequence(REBSER *s)
 {
     assert(!Is_Array_Series(s));
-    if (GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)) {
+    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
         Unbias_Series(s, FALSE);
         s->content.dynamic.len = 0;
         TERM_SEQUENCE(s);
@@ -334,7 +334,7 @@ void Reset_Sequence(REBSER *s)
 //
 void Reset_Array(REBARR *a)
 {
-    if (GET_ARR_FLAG(a, SERIES_FLAG_HAS_DYNAMIC))
+    if (GET_SER_INFO(a, SERIES_INFO_HAS_DYNAMIC))
         Unbias_Series(ARR_SERIES(a), FALSE);
     TERM_ARRAY_LEN(a, 0);
 }
@@ -348,9 +348,9 @@ void Reset_Array(REBARR *a)
 //
 void Clear_Series(REBSER *s)
 {
-    assert(!GET_SER_FLAG(s, SERIES_FLAG_LOCKED));
+    assert(NOT_SER_INFO(s, SERIES_INFO_LOCKED));
 
-    if (GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)) {
+    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
         Unbias_Series(s, FALSE);
         CLEAR(s->content.dynamic.data, SER_REST(s) * SER_WIDE(s));
     }
@@ -369,7 +369,7 @@ void Clear_Series(REBSER *s)
 //
 void Resize_Series(REBSER *s, REBCNT size)
 {
-    if (GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)) {
+    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
         s->content.dynamic.len = 0;
         Unbias_Series(s, TRUE);
     }
@@ -468,6 +468,13 @@ void Assert_Series_Core(REBSER *s)
 {
     if (IS_FREE_NODE(s))
         panic (s);
+
+    assert(
+        GET_SER_INFO(s, SERIES_INFO_0_IS_TRUE)
+        && GET_SER_INFO(s, SERIES_INFO_1_IS_TRUE)
+        && NOT_SER_INFO(s, SERIES_INFO_2_IS_FALSE)
+        && NOT_SER_INFO(s, SERIES_INFO_8_IS_FALSE)
+    );
 
     assert(SER_LEN(s) < SER_REST(s));
 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -60,7 +60,7 @@ void Init_Stacks(REBCNT size)
     TG_Top_Chunk->offset = 0;
     TG_Top_Chunk->size = BASE_CHUNK_SIZE;
 
-    // Implicit termination trick--see CELL_MASK, END_FLAG and related notes
+    // Implicit termination trick, see notes on NODE_FLAG_END
     //
     Init_Endlike_Header(
         &cast(

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -248,7 +248,7 @@ REBNATIVE(do)
         // kind of frames that come in as "objects plus function the object
         // is for" flavor.
         //
-        assert(!GET_ARR_FLAG(
+        assert(NOT_SER_FLAG(
             CTX_VARLIST(VAL_CONTEXT(source)), CONTEXT_FLAG_STACK)
         );
 

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -77,7 +77,9 @@ REBNATIVE(trap)
 
                 return R_OUT;
             }
-            else if (IS_FUNCTION(handler)) {
+            else {
+                assert (IS_FUNCTION(handler));
+
                 REBVAL arg;
                 Val_Init_Error(&arg, error);
 
@@ -92,8 +94,6 @@ REBNATIVE(trap)
 
                 return R_OUT;
             }
-
-            panic (Error(RE_MISC)); // should not be possible (type-checking)
         }
 
         if (REF(q)) return R_TRUE;

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -293,7 +293,7 @@ REBNATIVE(typechecker)
     Val_Init_Typeset(param, ALL_64, Canon(SYM_VALUE));
     INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
 
-    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *fun = Make_Function(
@@ -362,11 +362,11 @@ REBNATIVE(brancher)
     rootkey->extra.binding = NULL;
 
     REBVAL *param = SINK(ARR_AT(paramlist, 1));
-    Val_Init_Typeset(param, FLAGIT_64(REB_LOGIC), Canon(SYM_CONDITION));
+    Val_Init_Typeset(param, FLAGIT_KIND(REB_LOGIC), Canon(SYM_CONDITION));
     INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
     TERM_ARRAY_LEN(paramlist, 2);
 
-    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *func = Make_Function(
@@ -478,7 +478,7 @@ REBNATIVE(chain)
         VAL_FUNC_PARAMLIST(ARR_HEAD(chainees)), SPECIFIED
     );
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
-    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *specializer;
@@ -573,7 +573,7 @@ REBNATIVE(adapt)
         VAL_FUNC_PARAMLIST(adaptee), SPECIFIED
     );
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
-    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     REBFUN *fun = Make_Function(
@@ -706,7 +706,7 @@ REBNATIVE(hijack)
         ARR_HEAD(proxy_paramlist)->payload.function.paramlist
             = proxy_paramlist;
         ARR_SERIES(proxy_paramlist)->link.meta = VAL_FUNC_META(victim);
-        SET_ARR_FLAG(proxy_paramlist, ARRAY_FLAG_PARAMLIST);
+        SET_SER_FLAG(proxy_paramlist, ARRAY_FLAG_PARAMLIST);
 
         // If the proxy had a body, then that body will be bound relative
         // to the original paramlist that's getting hijacked.  So when the
@@ -857,7 +857,7 @@ REBNATIVE(tighten)
         FUNC_PARAMLIST(original),
         SPECIFIED // no relative values in parameter lists
     );
-    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST); // flags not auto-copied
+    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST); // flags not auto-copied
 
     RELVAL *param = ARR_AT(paramlist, 1); // first parameter (0 is FUNCTION!)
     for (; NOT_END(param); ++param)

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -528,7 +528,8 @@ REBNATIVE(wake_up)
     REBOOL awakened = TRUE; // start by assuming success
     REBVAL *value;
 
-    if (CTX_LEN(port) < STD_PORT_MAX - 1) panic (Error(RE_MISC));
+    if (CTX_LEN(port) < STD_PORT_MAX - 1)
+        panic (port);
 
     value = CTX_VAR(port, STD_PORT_ACTOR);
     if (IS_FUNCTION(value)) {

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -247,7 +247,7 @@ REBNATIVE(make_native)
 
     REBARR *info = Make_Array(3); // [source name tcc_state]
 
-    if (GET_SER_FLAG(VAL_SERIES(source), SERIES_FLAG_LOCKED))
+    if (GET_SER_INFO(VAL_SERIES(source), SERIES_INFO_LOCKED))
         Append_Value(info, source); // no need to copy it...
     else {
         // have to copy it (might change before COMPILE is called)
@@ -265,7 +265,7 @@ REBNATIVE(make_native)
     if (REF(linkname)) {
         REBVAL *name = ARG(name);
 
-        if (GET_SER_FLAG(VAL_SERIES(name), SERIES_FLAG_LOCKED))
+        if (GET_SER_INFO(VAL_SERIES(name), SERIES_INFO_LOCKED))
             Append_Value(info, name);
         else {
             Val_Init_String(

--- a/src/core/n-protect.c
+++ b/src/core/n-protect.c
@@ -77,9 +77,9 @@ void Protect_Series(REBSER *series, REBCNT index, REBFLGS flags)
         return; // avoid loop
 
     if (GET_FLAG(flags, PROT_SET))
-        SET_SER_FLAG(series, SERIES_FLAG_LOCKED);
+        SET_SER_INFO(series, SERIES_INFO_LOCKED);
     else
-        CLEAR_SER_FLAG(series, SERIES_FLAG_LOCKED);
+        CLEAR_SER_INFO(series, SERIES_INFO_LOCKED);
 
     if (!Is_Array_Series(series) || !GET_FLAG(flags, PROT_DEEP)) return;
 
@@ -105,9 +105,9 @@ void Protect_Object(RELVAL *value, REBFLGS flags)
         return; // avoid loop
 
     if (GET_FLAG(flags, PROT_SET))
-        SET_ARR_FLAG(CTX_VARLIST(context), SERIES_FLAG_LOCKED);
+        SET_SER_INFO(CTX_VARLIST(context), SERIES_INFO_LOCKED);
     else
-        CLEAR_ARR_FLAG(CTX_VARLIST(context), SERIES_FLAG_LOCKED);
+        CLEAR_SER_INFO(CTX_VARLIST(context), SERIES_INFO_LOCKED);
 
     for (value = CTX_KEY(context, 1); NOT_END(value); value++) {
         Protect_Key(KNOWN(value), flags);

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -300,7 +300,7 @@ REBNATIVE(evoke)
                 Reb_Opts->watch_recycle = NOT(Reb_Opts->watch_recycle);
                 break;
             case SYM_CRASH:
-                panic (Error(RE_MISC));
+                panic ("evoke 'crash was executed");
             default:
                 Out_Str(cb_cast(evoke_help), 1);
             }

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -83,23 +83,19 @@ REBVAL *Append_Event(void)
 
     // Append to tail if room:
     if (SER_FULL(VAL_SERIES(state))) {
-        if (VAL_LEN_HEAD(state) > EVENTS_LIMIT) {
-            panic (Error(RE_MAX_EVENTS));
-        } else {
-            Extend_Series(VAL_SERIES(state), EVENTS_CHUNK);
-            //RL_Print("event queue increased to :%d\n", SER_REST(VAL_SERIES(state)));
-        }
+        if (VAL_LEN_HEAD(state) > EVENTS_LIMIT)
+            panic (state);
+
+        Extend_Series(VAL_SERIES(state), EVENTS_CHUNK);
     }
     TERM_ARRAY_LEN(VAL_ARRAY(state), VAL_LEN_HEAD(state) + 1);
 
     REBVAL *value = SINK(ARR_LAST(VAL_ARRAY(state)));
     SET_BLANK(value);
 
-    //Dump_Series(VAL_SERIES(state), "state");
-    //Print("Tail: %d %d", VAL_LEN_HEAD(state), nn++);
-
     return value;
 }
+
 
 //
 //  Find_Last_Event: C

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -122,9 +122,6 @@ REBOOL Match_Sub_Path(REBSER *s1, REBSER *s2)
     REBUNI c1 = 0;
     REBUNI c2;
 
-//  Debug_Series(s1);
-//  Debug_Series(s2);
-
     // s1 len must be <= s2 len
     if (len > SER_LEN(s2)) return FALSE;
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -663,13 +663,6 @@ static void Mold_Block(const RELVAL *value, REB_MOLD *mold)
     REBSER *series = mold->series;
     REBOOL over = FALSE;
 
-#if !defined(NDEBUG)
-    if (SER_WIDE(VAL_SERIES(value)) == 0) {
-        Debug_Fmt("** Mold_Block() zero series wide, t=%d", VAL_TYPE(value));
-        Panic_Series(VAL_SERIES(value));
-    }
-#endif
-
     // Optimize when no index needed:
     if (VAL_INDEX(value) == 0 && !IS_MAP(value)) // && (VAL_TYPE(value) <= REB_LIT_PATH))
         all = FALSE;
@@ -1461,7 +1454,7 @@ void Mold_Value(REB_MOLD *mold, const RELVAL *value, REBOOL molded)
         break;
 
     default:
-        panic (Error_Invalid_Datatype(VAL_TYPE(value)));
+        panic (value);
     }
     goto check_and_return;
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -982,9 +982,8 @@ static void Mold_Object(const REBVAL *value, REB_MOLD *mold)
     REBVAL *key;
     REBVAL *var;
 
-    if (GET_CTX_FLAG(VAL_CONTEXT(value), SERIES_FLAG_INACCESSIBLE)) {
-        assert(GET_CTX_FLAG(VAL_CONTEXT(value), CONTEXT_FLAG_STACK));
-
+    if (IS_INACCESSIBLE(VAL_CONTEXT(value))) {
+        //
         // If something like a function call has gone of the stack, the data
         // for the vars will no longer be available.  The keys should still
         // be good, however.

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1036,14 +1036,14 @@ void Assert_Array_Core(REBARR *a)
 #ifdef __cplusplus
         assert(rest > 0 && rest > i);
         for (; i < rest - 1; ++i, ++item) {
-            if (NOT(item->header.bits & NOT_FREE_MASK)) {
+            if (NOT(item->header.bits & NODE_FLAG_VALID)) {
                 printf("Unwritable cell found in array rest capacity\n");
                 panic (a);
             }
         }
         assert(item == ARR_AT(a, rest - 1));
 #endif
-        if (ARR_AT(a, rest - 1)->header.bits != END_MASK) {
+        if (ARR_AT(a, rest - 1)->header.bits != NODE_FLAG_END) {
             printf("Implicit termination/unwritable END missing from array\n");
             panic (a);
         }

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1015,7 +1015,7 @@ void Assert_Array_Core(REBARR *a)
     //
     Assert_Series_Core(ARR_SERIES(a));
 
-    if (NOT(GET_ARR_FLAG(a, SERIES_FLAG_ARRAY)))
+    if (NOT(GET_SER_FLAG(a, SERIES_FLAG_ARRAY)))
         panic (a);
 
     RELVAL *item = ARR_HEAD(a);
@@ -1030,7 +1030,7 @@ void Assert_Array_Core(REBARR *a)
     if (NOT_END(item))
         panic (item);
 
-    if (GET_ARR_FLAG(a, SERIES_FLAG_HAS_DYNAMIC)) {
+    if (GET_SER_INFO(a, SERIES_INFO_HAS_DYNAMIC)) {
         REBCNT rest = SER_REST(ARR_SERIES(a));
 
 #ifdef __cplusplus

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -427,11 +427,16 @@ REBTYPE(Decimal)
             goto setDec;
 
         case SYM_EVEN_Q:
-        case SYM_ODD_Q:
             d1 = fabs(fmod(d1, 2.0));
-            if ((action == SYM_ODD_Q) != ((d1 < 0.5) || (d1 >= 1.5)))
+            if (d1 < 0.5 || d1 >= 1.5)
                 return R_TRUE;
             return R_FALSE;
+
+        case SYM_ODD_Q:
+            d1 = fabs(fmod(d1, 2.0));
+            if (d1 < 0.5 || d1 >= 1.5)
+                return R_FALSE;
+            return R_TRUE;
 
         case SYM_ROUND: {
             INCLUDE_PARAMS_OF_ROUND;

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -303,8 +303,12 @@ static REBCNT Find_Map_Entry(
     // Just a GET of value:
     if (!val) return n;
 
-    if (ANY_ARRAY(key) && !GET_ARR_FLAG(VAL_ARRAY(key), SERIES_FLAG_LOCKED))
+    if (
+        ANY_ARRAY(key)
+        && NOT_SER_INFO(VAL_ARRAY(key), SERIES_INFO_LOCKED)
+    ){
         fail (Error(RE_MAP_KEY_UNLOCKED, key));
+    }
 
     // Must set the value:
     if (n) {  // re-set it:

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -612,7 +612,7 @@ REBTYPE(Context)
             Copy_Array_Shallow(CTX_VARLIST(VAL_CONTEXT(value)), SPECIFIED)
         );
         INIT_CTX_KEYLIST_SHARED(context, CTX_KEYLIST(VAL_CONTEXT(value)));
-        SET_ARR_FLAG(CTX_VARLIST(context), ARRAY_FLAG_VARLIST);
+        SET_SER_FLAG(CTX_VARLIST(context), ARRAY_FLAG_VARLIST);
         CTX_VALUE(context)->payload.any_context.varlist = CTX_VARLIST(context);
 
         if (types != 0) {

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -222,7 +222,7 @@ static void Schema_From_Block_May_Fail(
         // one structure in the place of another.  Actual struct compatibility
         // is not checked until runtime, when the call happens.
         //
-        Val_Init_Typeset(param_out, FLAGIT_64(REB_STRUCT), NULL);
+        Val_Init_Typeset(param_out, FLAGIT_KIND(REB_STRUCT), NULL);
         return;
     }
 
@@ -238,57 +238,57 @@ static void Schema_From_Block_May_Fail(
         switch (VAL_WORD_SYM(item)) {
         case SYM_VOID:
             SET_BLANK(schema_out); // only valid for return types
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_MAX_VOID), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_MAX_VOID), NULL);
             break;
 
         case SYM_UINT8:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_INT8:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_UINT16:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_INT16:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_UINT32:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_INT32:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_UINT64:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_INT64:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_INTEGER), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_INTEGER), NULL);
             break;
 
         case SYM_FLOAT:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_DECIMAL), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_DECIMAL), NULL);
             break;
 
         case SYM_DOUBLE:
-            Val_Init_Typeset(param_out, FLAGIT_64(REB_DECIMAL), NULL);
+            Val_Init_Typeset(param_out, FLAGIT_KIND(REB_DECIMAL), NULL);
             break;
 
         case SYM_POINTER:
             Val_Init_Typeset(
                 param_out,
-                FLAGIT_64(REB_INTEGER)
-                    | FLAGIT_64(REB_STRING)
-                    | FLAGIT_64(REB_BINARY)
-                    | FLAGIT_64(REB_VECTOR)
-                    | FLAGIT_64(REB_FUNCTION), // legal if routine or callback
+                FLAGIT_KIND(REB_INTEGER)
+                    | FLAGIT_KIND(REB_STRING)
+                    | FLAGIT_KIND(REB_BINARY)
+                    | FLAGIT_KIND(REB_VECTOR)
+                    | FLAGIT_KIND(REB_FUNCTION), // legal if routine or callback
                 NULL
             );
             break;
@@ -1316,7 +1316,7 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
 
     // The "body" value of a routine is the routine info array.
     //
-    SET_ARR_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
     REBFUN *fun = Make_Function(
         paramlist,

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -100,11 +100,11 @@
         void *user_data,
         void *codeloc
     ){
-        panic (Error(RE_NOT_FFI_BUILD));
+        fail (Error(RE_NOT_FFI_BUILD));
     }
 
     void ffi_closure_free(void *closure) {
-        panic (Error(RE_NOT_FFI_BUILD));
+        fail (Error(RE_NOT_FFI_BUILD));
     }
 #endif
 

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -675,7 +675,7 @@ static REBSER *make_ext_storage(
     );
 
     SER_SET_EXTERNAL_DATA(ser, cast(REBYTE*, raw_addr));
-    assert(!GET_SER_FLAG(ser, SERIES_FLAG_INACCESSIBLE));
+    assert(NOT_SER_INFO(ser, SERIES_INFO_INACCESSIBLE));
     SET_SERIES_LEN(ser, len);
 
     MANAGE_SERIES(ser);

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -147,10 +147,8 @@ REBIXO Do_Vararg_Op_May_Throw(
         // call pointer it first ran with is dead.  There needs to be a solution
         // for other reasons, so use that solution when it's ready.
         //
-        if (GET_CTX_FLAG(context, SERIES_FLAG_INACCESSIBLE)) {
-            assert(GET_CTX_FLAG(context, CONTEXT_FLAG_STACK));
+        if (IS_INACCESSIBLE(context))
             fail (Error(RE_VARARGS_NO_STACK));
-        }
 
         f = CTX_FRAME(context);
 
@@ -497,13 +495,12 @@ void Mold_Varargs(const REBVAL *value, REB_MOLD *mold) {
             //
             Append_Unencoded(mold->series, "** varargs frame not fulfilled");
         }
-        else if (
-            GET_CTX_FLAG(
-                VAL_VARARGS_FRAME_CTX(value), SERIES_FLAG_INACCESSIBLE
-            )
-        ) {
+        else if (IS_INACCESSIBLE(VAL_VARARGS_FRAME_CTX(value))) {
             assert(
-                GET_CTX_FLAG(VAL_VARARGS_FRAME_CTX(value), CONTEXT_FLAG_STACK)
+                GET_SER_FLAG(
+                    CTX_VARLIST(VAL_VARARGS_FRAME_CTX(value)),
+                    CONTEXT_FLAG_STACK
+                )
             );
             Append_Unencoded(mold->series, "**unavailable: call ended **");
         }

--- a/src/include/mem-series.h
+++ b/src/include/mem-series.h
@@ -40,8 +40,9 @@
 
 #define MAX_SERIES_WIDE 0x100
 
-inline static void SER_SET_WIDE(REBSER *s, REBCNT w) {
-    s->info.bits = (s->info.bits & 0xffff) | (w << 16);
+inline static void SER_SET_WIDE(REBSER *s, REBYTE w) {
+    CLEAR_8_RIGHT_BITS(s->info.bits);
+    s->info.bits |= FLAGBYTE_RIGHT(w);
 }
 
 //
@@ -49,14 +50,14 @@ inline static void SER_SET_WIDE(REBSER *s, REBCNT w) {
 //
 
 inline static REBCNT SER_BIAS(REBSER *s) {
-    assert(GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC));
+    assert(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC));
     return cast(REBCNT, ((s)->content.dynamic.bias >> 16) & 0xffff);
 }
 
 #define MAX_SERIES_BIAS 0x1000
 
 inline static void SER_SET_BIAS(REBSER *s, REBCNT bias) {
-    assert(GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC));
+    assert(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC));
     s->content.dynamic.bias =
         (s->content.dynamic.bias & 0xffff) | (bias << 16);
 }

--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -330,8 +330,10 @@ typedef unsigned long   REBUPT;     // unsigned counterpart of void*
     // is a valid pointer value.  However, this case is tested for by the
     // enum method of declaration in ordinary non-Windows builds.
     //
-    struct Bool_Dummy { int dummy; };
-    typedef struct Bool_Dummy *REBOOL;
+    // Use a #define and not a typedef so it can be selectively overridden.
+    //
+    typedef struct Bool_Dummy { int dummy; } * DUMMYBOOL;
+    #define REBOOL DUMMYBOOL
     #define FALSE cast(struct Bool_Dummy*, 0x6466AE99)
     #define TRUE cast(struct Bool_Dummy*, 0x0421BD75)
 #else

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -120,9 +120,4 @@
     } REBVAL;
 #endif
 
-
-struct Reb_Header {
-    REBUPT bits;
-};
-
 #endif

--- a/src/include/reb-host.h
+++ b/src/include/reb-host.h
@@ -66,7 +66,9 @@
 #include "reb-filereq.h"
 #include "reb-codec.h"
 
+#include "sys-rebnod.h" // !!! Legacy dependency, REBGOB should not be REBNOD
 #include "reb-gob.h"
+
 #include "reb-lib.h"
 
 // !!! None of the above currently include anything that *necessarily* defines

--- a/src/include/reb-host.h
+++ b/src/include/reb-host.h
@@ -31,6 +31,21 @@
 
 #include "reb-c.h"
 
+#ifdef STRICT_BOOL_COMPILER_TEST
+    //
+    // %reb-host.h is often used in third party code that was not written to
+    // use REBOOL.  Hence the definitions of TRUE and FALSE used in the "fake"
+    // build will trip it up.  We substitute in normal definitions for this
+    // file.  See explanations of this test in %reb-c.h for more information.
+    //
+    #undef REBOOL
+    #define REBOOL int
+    #undef TRUE
+    #undef FALSE
+    #define TRUE 1
+    #define FALSE 0
+#endif
+
 // Must be defined at the end of reb-c.h, but not *in* reb-c.h so that
 // files including sys-core.h and reb-host.h can have differing
 // definitions of REBCHR.  (We want it opaque to the core, but the
@@ -63,17 +78,4 @@
 #include <stdlib.h>
 
 #include "host-lib.h"
-
-#ifdef STRICT_BOOL_COMPILER_TEST
-    //
-    // %reb-host.h is often used in third party code that was not written to
-    // use REBOOL.  Hence the definitions of TRUE and FALSE used in the "fake"
-    // build will trip it up.  We substitute in normal definitions for this
-    // file.  See explanations of this test in %reb-c.h for more information.
-    //
-    #undef TRUE
-    #undef FALSE
-    #define TRUE 1
-    #define FALSE 0
-#endif
 

--- a/src/include/reb-struct.h
+++ b/src/include/reb-struct.h
@@ -406,8 +406,8 @@ inline static REBCNT STU_OFFSET(REBSTU *stu) {
 
 inline static REBOOL VAL_STRUCT_INACCESSIBLE(const RELVAL *v) {
     REBSER *bin = VAL_STRUCT_DATA_BIN(v);
-    if (GET_SER_FLAG(bin, SERIES_FLAG_INACCESSIBLE)) {
-        assert(GET_SER_FLAG(bin, SERIES_FLAG_EXTERNAL));
+    if (GET_SER_INFO(bin, SERIES_INFO_INACCESSIBLE)) {
+        assert(GET_SER_INFO(bin, SERIES_INFO_EXTERNAL));
         return TRUE;
     }
     return FALSE;

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -125,7 +125,11 @@ inline static REB_R R_OUT_Q(REBOOL q) {
 // Specially chosen 0 and 1 values for R_FALSE and R_TRUE enable this. 
 //
 inline static REB_R R_FROM_BOOL(REBOOL b) {
+#ifdef STRICT_BOOL_COMPILER_TEST
+    return b ? R_TRUE : R_FALSE;
+#else
     return cast(REB_R, b);
+#endif
 }
 
 // R3-Alpha's concept was that all words got persistent integer values, which

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -166,7 +166,7 @@ inline static void TERM_SERIES(REBSER *s) {
 
 inline static void PUSH_GUARD_ARRAY_CONTENTS(REBARR *a) {
     assert(!IS_ARRAY_MANAGED(a)); // if managed, just use PUSH_GUARD_ARRAY
-    Guard_Series_Core(ARR_SERIES(a));
+    Guard_Node_Core(cast(REBNOD*, a));
 }
 
 inline static void DROP_GUARD_ARRAY_CONTENTS(REBARR *a) {

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -134,18 +134,6 @@ inline static void TERM_SERIES(REBSER *s) {
 // Setting and getting array flags is common enough to want a macro for it
 // vs. having to extract the ARR_SERIES to do it each time.
 //
-#define SET_ARR_FLAG(a,f) \
-    SET_SER_FLAG(ARR_SERIES(a), (f))
-
-#define SET_ARR_FLAGS(a,f) \
-    SET_SER_FLAGS(ARR_SERIES(a), (f))
-
-#define CLEAR_ARR_FLAG(a,f) \
-    CLEAR_SER_FLAG(ARR_SERIES(a), (f))
-
-#define GET_ARR_FLAG(a,f) \
-    GET_SER_FLAG(ARR_SERIES(a), (f))
-
 #define FAIL_IF_LOCKED_ARRAY(a) \
     FAIL_IF_LOCKED_SERIES(ARR_SERIES(a))
 
@@ -192,8 +180,8 @@ inline static REBARR *Make_Array(REBCNT capacity)
     REBSER *s = Make_Series(capacity + 1, sizeof(REBVAL), MKS_ARRAY);
     assert(
         capacity <= 1
-            ? NOT(GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC))
-            : GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)
+            ? NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
+            : GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
     );
 
     REBARR *a = AS_ARRAY(s);
@@ -211,10 +199,10 @@ inline static REBARR *Make_Array(REBCNT capacity)
 //
 inline static REBARR *Alloc_Singular_Array(void) {
     REBSER *s = Make_Series(2, sizeof(REBVAL), MKS_ARRAY); // no real 2nd slot
-    assert(NOT(GET_SER_FLAG(s, SERIES_FLAG_HAS_DYNAMIC)));
+    assert(NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)));
 
     REBARR *a = AS_ARRAY(s);
-    SET_ARR_FLAG(a, SERIES_FLAG_FIXED_SIZE);
+    SET_SER_FLAG(a, SERIES_FLAG_FIXED_SIZE);
 
     SET_SERIES_LEN(s, 1); // currently needs length bits set
     assert(IS_END(ARR_TAIL(a)));

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -62,7 +62,7 @@ struct Reb_Array {
 static inline REBARR* AS_ARRAY(REBSER *s) {
 #if !defined(NDEBUG)
     if (!Is_Array_Series(s))
-        Panic_Series(s);
+        panic (s);
 #endif
     return cast(REBARR*, s);
 }
@@ -362,12 +362,6 @@ inline static RELVAL *VAL_ARRAY_TAIL(const RELVAL *v) {
 
     #define ASSERT_ARRAY_MANAGED(array) \
         ASSERT_SERIES_MANAGED(ARR_SERIES(array))
-
-    #define Panic_Array(a) \
-        Panic_Series(ARR_SERIES(a))
-
-    #define Debug_Array(a) \
-        Debug_Series(ARR_SERIES(a))
 
     static inline void ASSERT_SERIES(REBSER *s) {
         if (Is_Array_Series(s))

--- a/src/include/sys-binary.h
+++ b/src/include/sys-binary.h
@@ -41,13 +41,8 @@
 
 // Is it a byte-sized series?
 //
-// !!! This trick in R3-Alpha "works because no other odd size allowed".  Is
-// it worth it to prohibit odd sizes for this trick?  An assertion that the
-// size is not odd was added to Make_Series; reconsider if this becomes an
-// issue at some point.
-//
 #define BYTE_SIZE(s) \
-    LOGICAL(((s)->info.bits) & (1 << 16))
+    LOGICAL(SER_WIDE(s) == 1)
 
 
 //

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -314,9 +314,18 @@ inline static REBVAL *Get_Var_Core(
         // evaluator wants to know when it fetches the value for a word
         // if it wants to lookback for infix purposes, if it's a function)
         //
+        // Efficient cast trick: REB_FUNCTION = 1, REB_0_LOOKBACK = 0
+        // which requires REBOOL only be allowed to hold 1 and 0.
+        //
+    #ifdef STRICT_BOOL_COMPILER_TEST
+        *eval_type = GET_VAL_FLAG(key, TYPESET_FLAG_NO_LOOKBACK)
+            ? REB_FUNCTION
+            : REB_0_LOOKBACK;
+    #else
         *eval_type = cast(
             enum Reb_Kind, GET_VAL_FLAG(key, TYPESET_FLAG_NO_LOOKBACK)
-        ); // REB_FUNCTION = 1, REB_0_LOOKBACK = 0
+        );
+    #endif
     }
     else {
         assert(*eval_type == REB_FUNCTION || *eval_type == REB_0_LOOKBACK);
@@ -364,7 +373,14 @@ inline static REBVAL *Get_Var_Core(
             else
                 CLEAR_VAL_FLAG(key, TYPESET_FLAG_NO_LOOKBACK);
 
+        #ifdef STRICT_BOOL_COMPILER_TEST
+            *eval_type =
+                (*eval_type == REB_0_LOOKBACK)
+                    ? REB_FUNCTION
+                    : REB_0_LOOKBACK;
+        #else
             *eval_type = cast(enum Reb_Kind, NOT(cast(REBOOL, *eval_type)));
+        #endif
         }
         else {
             // We didn't have to change the lookback, so it must have matched

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -245,11 +245,8 @@ inline static REBVAL *Get_Var_Core(
         assert(GET_VAL_FLAG(any_word, WORD_FLAG_BOUND)); // should be set too
 
         if (specifier == SPECIFIED) {
-            Debug_Fmt("Get_Var_Core on relative value without specifier");
-            PROBE_MSG(any_word, "the word");
-            assert(IS_FUNCTION(FUNC_VALUE(VAL_WORD_FUNC(any_word))));
-            PROBE_MSG(FUNC_VALUE(VAL_WORD_FUNC(any_word)), "the function");
-            PANIC_VALUE(any_word);
+            printf("Get_Var_Core on relative value without specifier\n");
+            panic (any_word);
         }
         assert(
             VAL_WORD_FUNC(any_word)
@@ -428,20 +425,17 @@ inline static void Derelativize(
     #if !defined(NDEBUG)
         assert(ANY_WORD(v) || ANY_ARRAY(v));
         if (specifier == SPECIFIED) {
-            Debug_Fmt("Internal Error: Relative item used with SPECIFIED");
-            PROBE_MSG(v, "word or array");
-            PROBE_MSG(FUNC_VALUE(VAL_RELATIVE(v)), "func");
-            assert(FALSE);
+            printf("Relative item used with SPECIFIED\n");
+            panic (v);
         }
         else if (
             VAL_RELATIVE(v)
             != VAL_FUNC(CTX_FRAME_FUNC_VALUE(specifier))
         ){
-            Debug_Fmt("Internal Error: Function mismatch in specific binding");
-            PROBE_MSG(v, "word or array");
-            PROBE_MSG(FUNC_VALUE(VAL_RELATIVE(v)), "expected func");
-            PROBE_MSG(CTX_FRAME_FUNC_VALUE(specifier), "actual func");
-            assert(FALSE);
+            printf("Function mismatch in specific binding, expected:\n");
+            PROBE(FUNC_VALUE(VAL_RELATIVE(v)));
+            printf("Panic on relative value\n");
+            panic (v);
         }
     #endif
 

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -279,8 +279,8 @@ inline static REBVAL *Get_Var_Core(
 
     REBVAL *var;
 
-    if (GET_CTX_FLAG(context, CONTEXT_FLAG_STACK)) {
-        if (GET_CTX_FLAG(context, SERIES_FLAG_INACCESSIBLE)) {
+    if (GET_SER_FLAG(CTX_VARLIST(context), CONTEXT_FLAG_STACK)) {
+        if (IS_INACCESSIBLE(context)) {
             //
             // Currently if a context has a stack component, then the vars
             // are "all stack"...so when that level is popped, all the vars
@@ -358,7 +358,7 @@ inline static REBVAL *Get_Var_Core(
             // words, so if a solution were engineered for one it would
             // likely be able to apply to both.
             //
-            if (GET_CTX_FLAG(context, CONTEXT_FLAG_STACK))
+            if (GET_SER_FLAG(CTX_VARLIST(context), CONTEXT_FLAG_STACK))
                 fail (Error(RE_MISC));
 
             // Make sure if this context shares a keylist that we aren't

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -82,20 +82,6 @@ inline static REBARR *CTX_VARLIST(REBCTX *c) {
     return &c->varlist;
 }
 
-// It's convenient to not have to extract the array just to check/set flags
-//
-inline static void SET_CTX_FLAG(REBCTX *c, REBUPT f) {
-    SET_ARR_FLAG(CTX_VARLIST(c), f);
-}
-
-inline static void CLEAR_CTX_FLAG(REBCTX *c, REBUPT f) {
-    CLEAR_ARR_FLAG(CTX_VARLIST(c), f);
-}
-
-inline static REBOOL GET_CTX_FLAG(REBCTX *c, REBUPT f) {
-    return GET_ARR_FLAG(CTX_VARLIST(c), f);
-}
-
 // If you want to talk generically about a context just for the purposes of
 // setting its series flags (for instance) and not to access the "varlist"
 // data, then use CTX_SERIES(), as actual var access is hybridized
@@ -113,12 +99,12 @@ inline static REBARR *CTX_KEYLIST(REBCTX *c) {
 }
 
 static inline void INIT_CTX_KEYLIST_SHARED(REBCTX *c, REBARR *keylist) {
-    SET_ARR_FLAG(keylist, KEYLIST_FLAG_SHARED);
+    SET_SER_INFO(keylist, SERIES_INFO_SHARED_KEYLIST);
     ARR_SERIES(CTX_VARLIST(c))->link.keylist = keylist;
 }
 
 static inline void INIT_CTX_KEYLIST_UNIQUE(REBCTX *c, REBARR *keylist) {
-    assert(NOT(GET_ARR_FLAG(keylist, KEYLIST_FLAG_SHARED)));
+    assert(NOT_SER_INFO(keylist, SERIES_INFO_SHARED_KEYLIST));
     ARR_SERIES(CTX_VARLIST(c))->link.keylist = keylist;
 }
 
@@ -158,7 +144,7 @@ inline static REBVAL *CTX_KEYS_HEAD(REBCTX *c) {
 // REBSER node data itself.
 //
 inline static REBVAL *CTX_VALUE(REBCTX *c) {
-    return GET_CTX_FLAG(c, CONTEXT_FLAG_STACK)
+    return GET_SER_FLAG(CTX_VARLIST(c), CONTEXT_FLAG_STACK)
         ? KNOWN(&ARR_SERIES(CTX_VARLIST(c))->content.values[0])
         : KNOWN(ARR_HEAD(CTX_VARLIST(c))); // not a RELVAL
 }
@@ -168,7 +154,7 @@ inline static REBFRM *CTX_FRAME(REBCTX *c) {
 }
 
 inline static REBVAL *CTX_VARS_HEAD(REBCTX *c) {
-    return GET_CTX_FLAG(c, CONTEXT_FLAG_STACK)
+    return GET_SER_FLAG(CTX_VARLIST(c), CONTEXT_FLAG_STACK)
         ? CTX_FRAME(c)->args_head // if NULL, this will crash
         : SER_AT(REBVAL, ARR_SERIES(CTX_VARLIST(c)), 1);
 }
@@ -183,7 +169,7 @@ inline static REBVAL *CTX_KEY(REBCTX *c, REBCNT n) {
 inline static REBVAL *CTX_VAR(REBCTX *c, REBCNT n) {
     REBVAL *var;
     assert(n != 0 && n <= CTX_LEN(c));
-    assert(GET_ARR_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
+    assert(GET_SER_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
 
     var = CTX_VARS_HEAD(c) + (n) - 1;
 
@@ -227,6 +213,20 @@ inline static void FREE_CONTEXT(REBCTX *c) {
     DROP_GUARD_ARRAY(CTX_VARLIST(c))
 
 
+inline static REBOOL IS_INACCESSIBLE(REBCTX *c) {
+    //
+    // Mechanically any array can become inaccessible, but really the varlist
+    // of a stack context is the only case that should happen today (outside
+    // FFI, which should probably do what it does another way.)
+    //
+    if (GET_SER_INFO(CTX_VARLIST(c), SERIES_INFO_INACCESSIBLE)) {
+        assert(GET_SER_FLAG(CTX_VARLIST(c), CONTEXT_FLAG_STACK));
+        return TRUE;
+    }
+    return FALSE;
+}
+
+
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // ANY-CONTEXT! (`struct Reb_Any_Context`)
@@ -240,10 +240,10 @@ inline static void FREE_CONTEXT(REBCTX *c) {
 
 #ifdef NDEBUG
     #define ANY_CONTEXT_FLAG(n) \
-        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
+        FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n))
 #else
     #define ANY_CONTEXT_FLAG(n) \
-        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_OBJECT))
+        (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_OBJECT))
 #endif
 
 // `ANY_CONTEXT_FLAG_OWNS_PAIRED` is particular to the idea of a "Paired"

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -226,11 +226,6 @@ inline static void FREE_CONTEXT(REBCTX *c) {
 #define DROP_GUARD_CONTEXT(c) \
     DROP_GUARD_ARRAY(CTX_VARLIST(c))
 
-#if! defined(NDEBUG)
-    #define Panic_Context(c) \
-        Panic_Array(CTX_VARLIST(c))
-#endif
-
 
 //=////////////////////////////////////////////////////////////////////////=//
 //

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -105,19 +105,30 @@
 //
 // DISABLE STDIO.H IN RELEASE BUILD
 //
-// The core build of Rebol seeks to not be dependent on stdio.h.  The premise
-// was to be free of historical baggage of the implementation of things like
-// printf and to speak alternative protocols.  Hence it is decoupled from the
-// "host".  (There are other choices related to this decoupling, such as not
-// assuming the allocator is malloc())
+// The core build of Rebol published in R3-Alpha sought to not be dependent
+// on <stdio.h>.  The intent--ostensibly--was since Rebol had richer tools
+// like WORD!s and BLOCK! for dialecting, that including a brittle historic
+// string-based C "mini-language" of printf into the executable was a
+// wasteful dependency.  Also, many implementations are clunky:
 //
-// The alternative interface spoken (Host Kit) is questionable, and generally
-// the only known hosts are "fat" and wind up including things like printf
-// anyway.  However, the idea of not setting printf in stone and replacing it
-// with Rebol's string logic is reasonable.
+// http://blog.hostilefork.com/where-printf-rubber-meets-road/
 //
-// These definitions will help catch uses of <stdio.h> in the release build,
-// and give a hopefully informative error.
+// Hence formatted output was not presumed as a host service, which only
+// provided raw character string output.
+//
+// This "radical decoupling" idea was undermined by including a near-rewrite
+// of printf() called Debug_Fmt().  This was a part of release builds, and
+// added format specifiers for Rebol values ("%r") or series, as well as
+// handling a subset of basic C types.
+//
+// Ren-C's long-term goal is to not include any string-based dialect for
+// formatting output.  Low-level diagnostics in the debug build will rely on
+// printf, while all release build formatting will be done through Rebol
+// code...where the format specification is done with a Rebol BLOCK! dialect
+// that could be used by client code as well.
+//
+// To formalize this rule, these definitions will help catch uses of <stdio.h>
+// in the release build, and give a hopefully informative error.
 //
 #ifdef NDEBUG
     #if !defined(REN_C_STDIO_OK)

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -218,27 +218,7 @@ extern void reb_qsort_r(void *a, size_t n, size_t es, void *thunk, cmp_t *cmp);
 #include "reb-math.h"
 #include "reb-codec.h"
 
-// !!! These definitions used to be in %sys-mem.h, which is now %mem-pools.h
-// REBNOD appears in the Free_Node API, while REBPOL is used in globals
-// The rest is not necessary to expose to the whole system, but perhaps
-// these two shouldn't be in this specific location.
-//
-typedef struct Reb_Node {
-    struct Reb_Header header; // will be header.bits = 0 if node is free
-
-    struct Reb_Node *next_if_free; // if not free, entire node is available
-
-    // Size of a node must be a multiple of 64-bits.  This is because there
-    // must be a baseline guarantee for node allocations to be able to know
-    // where 64-bit alignment boundaries are.
-    //
-    /*struct REBI64 payload[N];*/
-} REBNOD;
-
-#define IS_FREE_NODE(n) \
-    (cast(struct Reb_Node*, (n))->header.bits == 0)
-
-typedef struct rebol_mem_pool REBPOL;
+#include "sys-rebnod.h"
 
 #include "sys-deci.h"
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -143,8 +143,8 @@ inline static void PUSH_CALL(REBFRM *f)
     f->prior = TG_Frame_Stack;
     TG_Frame_Stack = f;
     if (NOT(f->flags.bits & DO_FLAG_VA_LIST))
-        if (!GET_ARR_FLAG(f->source.array, SERIES_FLAG_LOCKED)) {
-            SET_ARR_FLAG(f->source.array, SERIES_FLAG_LOCKED);
+        if (NOT_SER_INFO(f->source.array, SERIES_INFO_LOCKED)) {
+            SET_SER_INFO(f->source.array, SERIES_INFO_LOCKED);
             f->flags.bits |= DO_FLAG_TOOK_FRAME_LOCK;
         }
 }
@@ -156,8 +156,8 @@ inline static void UPDATE_EXPRESSION_START(REBFRM *f) {
 
 inline static void DROP_CALL(REBFRM *f) {
     if (f->flags.bits & DO_FLAG_TOOK_FRAME_LOCK) {
-        assert(GET_ARR_FLAG(f->source.array, SERIES_FLAG_LOCKED));
-        CLEAR_ARR_FLAG(f->source.array, SERIES_FLAG_LOCKED);
+        assert(GET_SER_INFO(f->source.array, SERIES_INFO_LOCKED));
+        CLEAR_SER_INFO(f->source.array, SERIES_INFO_LOCKED);
     }
     assert(TG_Frame_Stack == f);
     TG_Frame_Stack = f->prior;
@@ -969,15 +969,15 @@ inline static void Reify_Va_To_Array_In_Frame(
         f->source.array = Pop_Stack_Values(dsp_orig); // may contain voids
         MANAGE_ARRAY(f->source.array); // held alive while frame running
 
-        SET_ARR_FLAG(f->source.array, SERIES_FLAG_LOCKED);
-        SET_ARR_FLAG(f->source.array, ARRAY_FLAG_VOIDS_LEGAL);
+        SET_SER_INFO(f->source.array, SERIES_INFO_LOCKED);
+        SET_SER_FLAG(f->source.array, ARRAY_FLAG_VOIDS_LEGAL);
         f->flags.bits |= DO_FLAG_TOOK_FRAME_LOCK;
     }
     else {
         // The series needs to be locked during Do_Core, but it doesn't have
         // to be unique.  Use empty array but don't say we locked it.
 
-        assert(GET_ARR_FLAG(EMPTY_ARRAY, SERIES_FLAG_LOCKED));
+        assert(GET_SER_INFO(EMPTY_ARRAY, SERIES_INFO_LOCKED));
         f->source.array = EMPTY_ARRAY;
     }
 

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -527,7 +527,7 @@ inline static void Push_Or_Alloc_Args_For_Underlying_Func(REBFRM *f) {
         //
         f->varlist = Make_Array(num_args + 1);
         TERM_ARRAY_LEN(f->varlist, num_args + 1);
-        SET_ARR_FLAG(f->varlist, SERIES_FLAG_FIXED_SIZE);
+        SET_SER_FLAG(f->varlist, SERIES_FLAG_FIXED_SIZE);
 
         // Skip the [0] slot which will be filled with the CTX_VALUE
         // !!! Note: Make_Array made the 0 slot an end marker
@@ -635,7 +635,7 @@ inline static void Drop_Function_Args_For_Frame_Core(
             goto finished;
     }
 
-    assert(GET_ARR_FLAG(f->varlist, SERIES_FLAG_ARRAY));
+    assert(GET_SER_FLAG(f->varlist, SERIES_FLAG_ARRAY));
 
     if (NOT(IS_ARRAY_MANAGED(f->varlist))) {
         //
@@ -653,24 +653,24 @@ inline static void Drop_Function_Args_For_Frame_Core(
 
     ASSERT_ARRAY_MANAGED(f->varlist);
 
-    if (NOT(GET_ARR_FLAG(f->varlist, CONTEXT_FLAG_STACK))) {
+    if (NOT(GET_SER_FLAG(f->varlist, CONTEXT_FLAG_STACK))) {
         //
         // If there's no stack memory being tracked by this context, it
         // has dynamic memory and is being managed by the garbage collector
         // so there's nothing to do.
         //
-        assert(GET_ARR_FLAG(f->varlist, SERIES_FLAG_HAS_DYNAMIC));
+        assert(GET_SER_INFO(f->varlist, SERIES_INFO_HAS_DYNAMIC));
         goto finished;
     }
 
     // It's reified but has its data pointer into the chunk stack, which
     // means we have to free it and mark the array inaccessible.
 
-    assert(GET_ARR_FLAG(f->varlist, ARRAY_FLAG_VARLIST));
-    assert(NOT(GET_ARR_FLAG(f->varlist, SERIES_FLAG_HAS_DYNAMIC)));
+    assert(GET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST));
+    assert(NOT_SER_INFO(f->varlist, SERIES_INFO_HAS_DYNAMIC));
 
-    assert(!GET_ARR_FLAG(f->varlist, SERIES_FLAG_INACCESSIBLE));
-    SET_ARR_FLAG(f->varlist, SERIES_FLAG_INACCESSIBLE);
+    assert(NOT_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE));
+    SET_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE);
 
 finished:
 
@@ -688,7 +688,7 @@ inline static REBCTX *Context_For_Frame_May_Reify_Managed(REBFRM *f)
 {
     assert(NOT(Is_Function_Frame_Fulfilling(f)));
 
-    if (f->varlist == NULL || !GET_ARR_FLAG(f->varlist, ARRAY_FLAG_VARLIST))
+    if (f->varlist == NULL || NOT_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST))
         Reify_Frame_Context_Maybe_Fulfilling(f); // it's not fulfilling, here
 
     return AS_CONTEXT(f->varlist);

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -46,7 +46,7 @@ struct Reb_Func {
 #endif
 
 inline static REBARR *FUNC_PARAMLIST(REBFUN *f) {
-    assert(GET_ARR_FLAG(&f->paramlist, ARRAY_FLAG_PARAMLIST));
+    assert(GET_SER_FLAG(&f->paramlist, ARRAY_FLAG_PARAMLIST));
     return &f->paramlist;
 }
 
@@ -104,10 +104,10 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
 
 #ifdef NDEBUG
     #define FUNC_FLAG(n) \
-        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
+        FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n))
 #else
     #define FUNC_FLAG(n) \
-        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_FUNCTION))
+        (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_FUNCTION))
 #endif
 
 // RETURN will always be in the last paramlist slot (if present)

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -46,10 +46,7 @@ struct Reb_Func {
 #endif
 
 inline static REBARR *FUNC_PARAMLIST(REBFUN *f) {
-#if !defined(NDEBUG)
-    if (!GET_ARR_FLAG(&f->paramlist, ARRAY_FLAG_PARAMLIST))
-        Panic_Array(&f->paramlist);
-#endif
+    assert(GET_ARR_FLAG(&f->paramlist, ARRAY_FLAG_PARAMLIST));
     return &f->paramlist;
 }
 

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -132,8 +132,7 @@ TVAR REBPOL *Mem_Pools;     // Memory pool array
 TVAR REBOOL GC_Recycling;    // True when the GC is in a recycle
 TVAR REBINT GC_Ballast;     // Bytes allocated to force automatic GC
 TVAR REBOOL GC_Disabled;      // TRUE when RECYCLE/OFF is run
-TVAR REBSER *GC_Series_Guard; // A stack of protected series (removed by pop)
-TVAR REBSER *GC_Value_Guard; // A stack of protected series (removed by pop)
+TVAR REBSER *GC_Guarded; // A stack of GC protected series and values
 PVAR REBSER *GC_Mark_Stack; // Series pending to mark their reachables as live
 TVAR REBSER **Prior_Expand; // Track prior series expansions (acceleration)
 

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -72,8 +72,6 @@ enum {
     // The default for a DO operation is just a single DO/NEXT, where args
     // to functions are evaluated (vs. quoted), and lookahead is enabled.
     //
-    // (This should also make headers based on it pass the IS_END() test)
-    //
     DO_FLAG_NORMAL = 0,
 
     // As exposed by the DO native and its /NEXT refinement, a call to the
@@ -88,7 +86,25 @@ enum {
     // achieve equivalent results.  There are nuances to preserve this
     // invariant and especially in light of interaction with lookahead.
     //
-    DO_FLAG_TO_END = HEADERFLAG(REBSER_REBVAL_BIT + 1),
+    // !!! All things being equal, it might be nice if this flag were FALSE
+    // to indicate NOT(NODE_FLAG_VALID) for anything that mistakenly tried to
+    // interpret this as the header of a REBVAL* or a REBSER*.  But that is
+    // covered by the next 2 bits already...so it would be "wasting" a bit.
+    //
+    DO_FLAG_TO_END = HEADERFLAG(0),
+
+    // This flag will be set to TRUE by Init_Endlike_Header, so that the
+    // Reb_Frame->flags can act as NODE_FLAG_END.  This implicitly terminates
+    // the Reb_Frame->cell at the head of the structure.
+    //
+    DO_FLAG_1_IS_TRUE = HEADERFLAG(1),
+
+    // This flag will be set to FALSE by Init_Endlike_Header, so that the
+    // Reb_Frame->flags will not signal NODE_FLAG_CELL.  That helps avoid
+    // any traversals that think this header signals IS_END() from then
+    // trying to "overwrite the end" of the implicit marker.
+    //
+    DO_FLAG_2_IS_FALSE = HEADERFLAG(2),
 
     // When we're in mid-dispatch of an infix function, the precedence is such
     // that we don't want to do further infix lookahead while getting the
@@ -99,7 +115,7 @@ enum {
     // to evaluate a form of source input that cannot be backtracked (e.g.
     // a C variable argument list) then it will not be possible to resume.
     //
-    DO_FLAG_NO_LOOKAHEAD = HEADERFLAG(REBSER_REBVAL_BIT + 2),
+    DO_FLAG_NO_LOOKAHEAD = HEADERFLAG(3),
 
     // Sometimes a DO operation has already calculated values, and does not
     // want to interpret them again.  e.g. the call to the function wishes
@@ -107,13 +123,13 @@ enum {
     // variable.  This is common when calling Rebol functions from C code
     // when the parameters are known, or what R3-Alpha called "APPLY/ONLY"
     //
-    DO_FLAG_NO_ARGS_EVALUATE = HEADERFLAG(REBSER_REBVAL_BIT + 3),
+    DO_FLAG_NO_ARGS_EVALUATE = HEADERFLAG(4),
 
     // A pre-built frame can be executed "in-place" without a new allocation.
     // It will be type checked, and also any BAR! parameters will indicate
     // a desire to acquire that argument (permitting partial specialization).
     //
-    DO_FLAG_EXECUTE_FRAME = HEADERFLAG(REBSER_REBVAL_BIT + 4),
+    DO_FLAG_EXECUTE_FRAME = HEADERFLAG(5),
 
     // Usually VA_LIST_FLAG is enough to tell when there is a source array to
     // examine or not.  However, when the end is reached it is written over
@@ -123,25 +139,25 @@ enum {
     // expression evaluation is complete.  Review to see if they actually
     // would rather know something else, but this is a cheap flag for now.
     //
-    DO_FLAG_VA_LIST = HEADERFLAG(REBSER_REBVAL_BIT + 5),
+    DO_FLAG_VA_LIST = HEADERFLAG(6),
 
     // While R3-Alpha permitted modifications of an array while it was being
     // executed, Ren-C does not.  It takes a lock if the source is not already
     // read only, and sets it back when Do_Core is finished (or on errors)
     //
-    DO_FLAG_TOOK_FRAME_LOCK = HEADERFLAG(REBSER_REBVAL_BIT + 6),
+    DO_FLAG_TOOK_FRAME_LOCK = HEADERFLAG(7),
 
     // DO_FLAG_APPLYING is used to indicate that the Do_Core code is entering
     // a situation where the frame was already set up.
     //
-    DO_FLAG_APPLYING = HEADERFLAG(REBSER_REBVAL_BIT + 7),
+    DO_FLAG_APPLYING = HEADERFLAG(8),
 
     // When a variadic operation is on the left hand side of a deferred
     // lookback operation, it needs to inform the evaluator that the take is
     // variadic, so it knows to defer.  Consider `summation 1 2 3 |> 100`
     // should be `(summation 1 2 3) |> 100` and not `summation 1 2 (3 |> 100)`
     //
-    DO_FLAG_VARIADIC_TAKE = HEADERFLAG(REBSER_REBVAL_BIT + 8)
+    DO_FLAG_VARIADIC_TAKE = HEADERFLAG(9)
 };
 
 

--- a/src/include/sys-rebnod.h
+++ b/src/include/sys-rebnod.h
@@ -1,0 +1,270 @@
+//
+//  File: %sys-rebnod.h
+//  Summary: {Definitions for the Rebol_Header-having "superclass" structure}
+//  Project: "Rebol 3 Interpreter and Run-time (Ren-C branch)"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2012 REBOL Technologies
+// Copyright 2012-2016 Rebol Open Source Contributors
+// REBOL is a trademark of REBOL Technologies
+//
+// See README.md and CREDITS.md for more information
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// In order to implement several "tricks", the first pointer-size slots of
+// many datatypes is a `Reb_Header` structure.  The bit layout of this header
+// is chosen in such a way that not only can Rebol value pointers (REBVAL*)
+// be distinguished from Rebol series pointers (REBSER*), but these can be
+// discerned from a valid UTF-8 string just by looking at the first byte.
+//
+// On a semi-superficial level, this permits a kind of dynamic polymorphism,
+// such as that used by panic():
+//
+//     REBVAL *value = ...;
+//     panic (value); // can tell this is a value
+//
+//     REBSER *series = ...;
+//     panic (series) // can tell this is a series
+//
+//     const char *utf8 = ...;
+//     panic (utf8); // can tell this is UTF-8 data (not a series or value)
+//
+// But a more compelling case is the planned usage through the API, so that
+// variadic combinations of strings and values can be intermixed, as in:
+//
+//     rebDo("[", "poke", series, "1", value, "]") 
+//
+// Internally, the ability to discern these types helps certain structures or
+// arrangements from having to find a place to store a kind of "flavor" bit
+// for a stored pointer's type.  They can just check the first byte instead.
+//
+// For lack of a better name, the generic type covering the superclass is
+// called a "Rebol Node".
+//
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE HEADER a.k.a `struct Reb_Header` (for REBVAL and REBSER uses)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Assignments to bits and fields in the header are done through a native
+// platform-sized integer...while still being able to control the underlying
+// ordering of those bits in memory.  See FLAGIT_LEFT() in %reb-c.h for how
+// this is achieved.
+//
+// This control allows the leftmost byte of a Rebol header (the one you'd
+// get by casting REBVAL* to an unsigned char*) to always start with the bit
+// pattern `10`.  This pattern corresponds to what UTF-8 calls "continuation
+// bytes", which may never legally start a UTF-8 string:
+//
+// https://en.wikipedia.org/wiki/UTF-8#Codepage_layout
+//
+// There are also applications of Reb_Header as an "implicit terminator".
+// Such header patterns don't actually start valid REBNODs, but have a bit
+// pattern able to signal the IS_END() test for REBVAL.  See notes on
+// NODE_FLAG_END and NODE_FLAG_CELL.
+//
+
+struct Reb_Header {
+    //
+    // Uses REBUPT which is 32-bits on 32 bit platforms and 64-bits on 64 bit
+    // machines.  Note the numbers and layout in the headers will not be
+    // directly comparable across architectures.
+    //
+    // !!! A clever future application of the 32 unused header bits on 64-bit
+    // architectures might be able to add optimization or instrumentation
+    // abilities as a bonus.
+    //
+    REBUPT bits;
+};
+
+#define HEADERFLAG(n) \
+    FLAGIT_LEFT(n)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE_FLAG_VALID (leftmost bit)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The first bit will be 1 for all Reb_Header in the system that are not free.
+// Freed nodes actually have *all* 0 bits in the header.
+//
+// The C++ debug build is actually able to enforce that a 0 in this position
+// makes a cell unwritable by routines like VAL_RESET_HEADER().  It can do
+// this because constructors provide a hook point to ensure valid REBVAL
+// cells on the stack have the bit pre-initialized to 1.
+//
+// !!! UTF-8 empty strings (just a 0 terminator byte) are indistingushable,
+// since only one byte may be valid to examine without crashing.  But in a
+// working state, the system should never be in a position of needing to
+// distinguish a freed node from an empty string.  Debug builds can use
+// heuristics to guess which it is when providing diagnostics.
+//
+#define NODE_FLAG_VALID \
+    HEADERFLAG(0)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE_FLAG_END (second-leftmost bit)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// If set, it means this header should signal the termination of an array
+// of REBVAL, as in `for (; NOT_END(value); ++value) {}` loops.  In this
+// sense it means the header is functioning much like a null-terminator for
+// C strings.
+//
+// *** This bit being set does not necessarily mean the header is sitting at
+// the head of a full REBVAL-sized slot! ***
+//
+// Some data structures punctuate arrays of REBVALs with a Reb_Header that
+// has the NODE_FLAG_END bit set, and the NODE_FLAG_CELL bit clear.  This
+// functions fine as the terminator for a finite number of REBVAL cells, but
+// can only be read with IS_END() with no other operations legal.
+//
+// It's only valid to overwrite end markers when NODE_FLAG_CELL is set.
+//
+#define NODE_FLAG_END \
+    HEADERFLAG(1)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE_FLAG_CELL (third-leftmost bit)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// If this bit is set in the header, it indicates the slot the header is for
+// is `sizeof(REBVAL)`.
+//
+// Originally it was just for the debug build, to make it safer to use the
+// implementation trick of "implicit END markers".  Checking NODE_FLAG_CELL
+// before allowing an operation like Val_Init_Word() to write a location
+// avoided clobbering NODE_FLAG_END signals that were backed by only
+// `sizeof(struct Reb_Header)`.
+//
+// However, in the release build it became used to distinguish "pairing"
+// nodes (holders for two REBVALs in the same pool as ordinary REBSERs)
+// from an ordinary REBSER node.  Plain REBSERs have the cell mask clear,
+// while paring values have it set.
+//
+#define NODE_FLAG_CELL \
+    HEADERFLAG(2)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE_FLAG_MANAGED (fourth-leftmost bit)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// The GC-managed bit is used on series to indicate that its lifetime is
+// controlled by the garbage collector.  If this bit is not set, then it is
+// still manually managed...and during the GC's sweeping phase the simple fact
+// that it isn't NODE_FLAG_MARKED won't be enough to consider it for freeing.
+//
+// See MANAGE_SERIES for details on the lifecycle of a series (how it starts
+// out manually managed, and then must either become managed or be freed
+// before the evaluation that created it ends).
+//
+#define NODE_FLAG_MANAGED \
+    HEADERFLAG(3)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE_FLAG_MARKED (fifth-leftmost bit)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// This flag is used by the mark-and-sweep of the garbage collector, and
+// should not be referenced outside of %m-gc.c.
+//
+// See `REBSER_FLAG_BLACK` for a generic bit available to other routines
+// that wish to have an arbitrary marker on series (for things like
+// recursion avoidance in algorithms).
+//
+#define NODE_FLAG_MARKED \
+    HEADERFLAG(4)
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE_FLAG_ROOT (fifth-leftmost bit)
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// This indicates the node should be treated as a root for GC purposes.  It
+// only means anything on a REBVAL if that REBVAL happens to live in the key
+// slot of a paired REBSER--it should not generally be set otherwise.
+//
+// !!! Review the implications of this flag "leaking" if a key is ever bit
+// copied out of a pairing that uses it.  It might not be a problem so long
+// as the key is ensured read-only, so that the bit is just noise on any
+// non-key that has it...but the consequences may be more sinister.
+//
+#define NODE_FLAG_ROOT \
+    HEADERFLAG(5)
+
+
+// v-- BEGIN GENERAL VALUE BITS HERE
+
+#define GENERAL_VALUE_BIT 6
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+//  NODE STRUCTURE
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Though the name Node is used for a superclass that can be "in use" or
+// "free", this is the definition of the structure for its layout when it
+// does *not* have NODE_FLAG_VALID set.  In that case, the memory manager
+// will set the header bits to 0 and use the pointer slot right after the
+// header for its linked list of free nodes.
+//
+
+typedef struct Reb_Node {
+    struct Reb_Header header; // will be header.bits = 0 if node is free
+
+    struct Reb_Node *next_if_free; // if not free, entire node is available
+
+    // Size of a node must be a multiple of 64-bits.  This is because there
+    // must be a baseline guarantee for node allocations to be able to know
+    // where 64-bit alignment boundaries are.
+    //
+    /*struct REBI64 payload[N];*/
+} REBNOD;
+
+#define IS_FREE_NODE(n) \
+    (cast(struct Reb_Node*, (n))->header.bits == 0)
+
+
+// !!! Definitions for the memory allocator generally don't need to be
+// included by all clients, though currently it is necessary to indicate
+// whether a "node" is to be allocated from the REBSER pool or the REBGOB
+// pool.  Hence, the REBPOL has to be exposed to be included in the
+// function prototypes.  Review this necessity when REBGOB is changed.
+//
+typedef struct rebol_mem_pool REBPOL;

--- a/src/include/sys-rebnod.h
+++ b/src/include/sys-rebnod.h
@@ -95,9 +95,6 @@ struct Reb_Header {
     REBUPT bits;
 };
 
-#define HEADERFLAG(n) \
-    FLAGIT_LEFT(n)
-
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
@@ -120,7 +117,7 @@ struct Reb_Header {
 // heuristics to guess which it is when providing diagnostics.
 //
 #define NODE_FLAG_VALID \
-    HEADERFLAG(0)
+    FLAGIT_LEFT(0)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -145,7 +142,7 @@ struct Reb_Header {
 // It's only valid to overwrite end markers when NODE_FLAG_CELL is set.
 //
 #define NODE_FLAG_END \
-    HEADERFLAG(1)
+    FLAGIT_LEFT(1)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -169,7 +166,7 @@ struct Reb_Header {
 // while paring values have it set.
 //
 #define NODE_FLAG_CELL \
-    HEADERFLAG(2)
+    FLAGIT_LEFT(2)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -188,7 +185,7 @@ struct Reb_Header {
 // before the evaluation that created it ends).
 //
 #define NODE_FLAG_MANAGED \
-    HEADERFLAG(3)
+    FLAGIT_LEFT(3)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -200,12 +197,12 @@ struct Reb_Header {
 // This flag is used by the mark-and-sweep of the garbage collector, and
 // should not be referenced outside of %m-gc.c.
 //
-// See `REBSER_FLAG_BLACK` for a generic bit available to other routines
+// See `SERIES_INFO_BLACK` for a generic bit available to other routines
 // that wish to have an arbitrary marker on series (for things like
 // recursion avoidance in algorithms).
 //
 #define NODE_FLAG_MARKED \
-    HEADERFLAG(4)
+    FLAGIT_LEFT(4)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -224,12 +221,13 @@ struct Reb_Header {
 // non-key that has it...but the consequences may be more sinister.
 //
 #define NODE_FLAG_ROOT \
-    HEADERFLAG(5)
+    FLAGIT_LEFT(5)
 
 
-// v-- BEGIN GENERAL VALUE BITS HERE
+// v-- BEGIN GENERAL VALUE AND SERIES BITS WITH THIS INDEX
 
 #define GENERAL_VALUE_BIT 6
+#define GENERAL_SERIES_BIT 6
 
 
 //=////////////////////////////////////////////////////////////////////////=//

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -114,7 +114,7 @@ enum {
     // the SERIES_FLAG_1_IS_TRUE if it has an element in it)
     //
     // The bit position this corresponds to in ordinary headers would be the
-    // NOT_FREE_MASK.
+    // NODE_FLAG_VALID.
     //
     // !!! All things being equal, this bit would ideally always be zero just
     // to make it clearer that this is not the start of a REBSER (signaled by
@@ -123,14 +123,14 @@ enum {
     //
     SERIES_FLAG_HAS_DYNAMIC = HEADERFLAG(0),
 
-    // `SERIES_FLAG_1_IS_TRUE` corresponds to END_MASK.  It is set to
+    // `SERIES_FLAG_1_IS_TRUE` corresponds to NODE_FLAG_END.  It is set to
     // one to denote an END marker if there is a REBVAL sitting inside the
     // node which needs to be implicitly terminated.
     //
     SERIES_FLAG_1_IS_TRUE = HEADERFLAG(1),
 
-    // `SERIES_FLAG_2_IS_FALSE` corresponds to CELL_MASK.  It is checked by
-    // value writes to ensure that when the info flags are serving double duty
+    // `SERIES_FLAG_2_IS_FALSE` corresponds to NODE_FLAG_CELL.  Value writes
+    // check this to ensure that when the info flags are serving double duty
     // as an END marker, they do not get overwritten by rogue code that
     // thought a REBVAL* pointing at the memory had a full value's worth
     // of memory to write into.

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -30,8 +30,8 @@
 // It is a small-ish descriptor for a series (though if the amount of data
 // in the series is small enough, it is embedded into the structure itself.)
 //
-// Every string and block in REBOL has a REBSER, and the code implementing
-// them is reused in many places where Rebol needs a general-purpose
+// Every string, block, path, etc. in Rebol has a REBSER.  The implementation
+// of them is reused in many places where Rebol needs a general-purpose
 // dynamically growing structure.  It is also used for fixed size structures
 // which would like to participate in garbage collection.
 //
@@ -49,40 +49,6 @@
 // by the GC to reclaim or optimize space.)  Hence pointers into data in a
 // managed series *must not be held onto across evaluations*, without
 // special protection or accomodation.
-//
-//=//// LAYOUT ////////////////////////////////////////////////////////////=//
-//
-// A REBSER node is the size of two REBVALs, and there are 3 basic layouts
-// which can be overlaid inside the node:
-//
-//      Dynamic: [header [allocation tracking] info link misc]
-//     Singular: [header [REBVAL cell] info link misc]
-//         Pair: [[REBVAL cell] [REBVAL cell]]
-//
-// The `info` bitflags are implemented in a special way, such that the low
-// two flags are clear.  That signals an END to a "Singular" array's cell
-// if a traversal attempts to step out of it (and indicates it unwritable).
-// That makes it a legal payload for traversable arrays of length 1 or 0.
-//
-// Singulars have widespread applications in the system, notably the
-// efficient implementation of FRAME!.  They also narrow the gap in overhead
-// between COMPOSE [A (B) C] vs. REDUCE ['A B 'C] such that the memory cost
-// of the array is about the same as just having another value in the array.
-//
-// Pair REBSERs are allocated from the REBSER pool instead of their own to
-// help exchange a common "currency" of allocation size more efficiently.
-// They are planned for use in the PAIR! and MAP! datatypes, and anticipated
-// to play a crucial part in the API--allowing a persistent handle for a
-// GC'able REBVAL and associated "meta" value (which can be used for
-// reference counting or other tracking.)
-//
-// Most of the time, code does not need to be concerned about distinguishing
-// Pair from the Dynamic and Singular layouts--because it already knows
-// which kind it has.  Only the GC needs to be concerned when marking
-// and sweeping.  For this purpose, the node is considered to be free when
-// the header bits are all 0 (low bits 00), Singular when 01, Dynamic when
-// 10, and a Pair when 11.  Dynamic allocation can thus be tested on non-free
-// series when the low bit in the header is 0.
 //
 //=//// NOTES /////////////////////////////////////////////////////////////=//
 //
@@ -105,215 +71,368 @@
 //   blocks of nearly all variable-size structures in the system.
 //
 
-// Series Flags
+
+//=////////////////////////////////////////////////////////////////////////=//
 //
-enum {
-    // `SERIES_FLAG_HAS_DYNAMIC` indicates that this series has a dynamically
-    // allocated portion.  If it does not, then its data pointer is the
-    // address of the embedded value inside of it (marked terminated by
-    // the SERIES_FLAG_1_IS_TRUE if it has an element in it)
-    //
-    // The bit position this corresponds to in ordinary headers would be the
-    // NODE_FLAG_VALID.
-    //
-    // !!! All things being equal, this bit would ideally always be zero just
-    // to make it clearer that this is not the start of a REBSER (signaled by
-    // 10).  If the requirements for the number of bits can be brought down,
-    // then make that change.
-    //
-    SERIES_FLAG_HAS_DYNAMIC = HEADERFLAG(0),
+// SERIES <<HEADER>> FLAGS
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Series have two places to store bits...in the "header" and in the "info".
+// The following are the SERIES_FLAG_XXX that are used in the header, while
+// the SERIES_INFO_XXX flags will be found in the info.
+//
+// As a general rule for choosing which place to put a bit, if it may be
+// interesting to test/set multiple bits at the same time, then they should
+// be in the same flag group.
+//
+// !!! Perhaps things that don't change for the lifetime of the series should
+// also prefer the header vs. info?  Such separation might help with caching.
+//
 
-    // `SERIES_FLAG_1_IS_TRUE` corresponds to NODE_FLAG_END.  It is set to
-    // one to denote an END marker if there is a REBVAL sitting inside the
-    // node which needs to be implicitly terminated.
-    //
-    SERIES_FLAG_1_IS_TRUE = HEADERFLAG(1),
 
-    // `SERIES_FLAG_2_IS_FALSE` corresponds to NODE_FLAG_CELL.  Value writes
-    // check this to ensure that when the info flags are serving double duty
-    // as an END marker, they do not get overwritten by rogue code that
-    // thought a REBVAL* pointing at the memory had a full value's worth
-    // of memory to write into.
-    //
-    SERIES_FLAG_2_IS_FALSE = HEADERFLAG(2),
+//=//// SERIES_FLAG_FIXED_SIZE ////////////////////////////////////////////=//
+//
+// This means a series cannot be expanded or contracted.  Values within the
+// series are still writable (assuming SERIES_INFO_LOCKED isn't set).
+//
+// !!! Is there checking in all paths?  Do series contractions check this?
+//
+// One important reason for ensuring a series is fixed size is to avoid
+// the possibility of the data pointer being reallocated.  This allows
+// code to ignore the usual rule that it is unsafe to hold a pointer to
+// a value inside the series data.
+//
+// !!! Strictly speaking, SERIES_FLAG_NO_RELOCATE could be different
+// from fixed size... if there would be a reason to reallocate besides
+// changing size (such as memory compaction).
+//
+#define SERIES_FLAG_FIXED_SIZE \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 0)
 
-    // `SERIES_FLAG_STRING` identifies that this series holds a string, which
-    // is important to the GC in order to successfully
-    //
-    // !!! While there are advantages to having symbols be a compatible shape
-    // with other series for clients convenience, it may be that using a
-    // different memory pool for tracking some bits make sense.  For instance,
-    // knowing the series is a string is important at GC time...to clean up
-    // aliases and adjust canons.
-    //
-    SERIES_FLAG_STRING = HEADERFLAG(3),
 
-    // `STRING_FLAG_CANON` is used to indicate when a REBSTR series represents
-    // the canon form of a word.  This doesn't mean anything special about
-    // the case of its letters--just that it was loaded first.  A canon
-    // string is unique because it does not need to store a pointer to its
-    // canon form, so it can use the REBSER.misc field for the purpose of
-    // holding an index during binding.
-    //
-    STRING_FLAG_CANON = HEADERFLAG(4),
+//=//// SERIES_FLAG_UTF8_STRING ///////////////////////////////////////////=//
+//
+// Indicates the series holds a UTF-8 encoded string.
+//
+// !!! Currently this is only used to store ANY-WORD! symbols, which are
+// read-only and cannot be indexed into, e.g. with `next 'foo`.  This is
+// because UTF-8 characters are encoded at variable sizes, and the series
+// indexing does not support that at this time.  However, it would be nice
+// if a way could be figured out to unify ANY-STRING! with ANY-WORD! somehow
+// in order to implement the "UTF-8 Everywhere" manifesto:
+//
+// http://utf8everywhere.org/
+//
+#define SERIES_FLAG_UTF8_STRING \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 1)
 
-    // `ARRAY_FLAG_PARAMLIST` uses the same bit as STRING_FLAG_CANON, so the
-    // meaning depends on whether the SERIES_FLAG_ARRAY or SERIES_FLAG_STRING
-    // bit is set.  This indicates the array is the parameter list of a
-    // FUNCTION! (the first element will be a canon value of the function)
-    //
-    ARRAY_FLAG_PARAMLIST = HEADERFLAG(4),
 
-    // `SERIES_FLAG_ARRAY` indicates that this is a series of REBVAL values,
-    // and suitable for using as the payload of an ANY-ARRAY! value.  When a
-    // series carries this bit, that means that if it is also SER_MANAGED
-    // then the garbage collector will process its transitive closure to
-    // make sure all the values it contains (and the values its references
-    // contain) do not have series GC'd out from under them.
-    //
-    // (In R3-Alpha, whether a series was an array or not was tested by if
-    // its width was sizeof(REBVAL).  The Ren-C approach allows for the
-    // creation of series that contain items that incidentally happen to be
-    // the same size as a REBVAL, while not actually being REBVALs.)
-    //
-    SERIES_FLAG_ARRAY = HEADERFLAG(5),
+//=//// STRING_FLAG_CANON /////////////////////////////////////////////////=//
+//
+// This is used to indicate when a SERIES_FLAG_UTF8_STRING series represents
+// the canon form of a word.  This doesn't mean anything special about the
+// case of its letters--just that it was loaded first.  Canon forms can be
+// GC'd and then delegate the job of being canon to another spelling.
+//
+// A canon string is unique because it does not need to store a pointer to
+// its canon form.  So it can use the REBSER.misc field for the purpose of
+// holding an index during binding.
+//
+#define STRING_FLAG_CANON \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 2)
 
-    // `ARRAY_FLAG_VARLIST` indicates this series represents the
-    // "varlist" of a context.  A second series can be reached from it via
-    // the `->misc` field in the series node, which is a second array known
-    // as a "keylist".
-    //
-    // See notes on REBCTX for further details about what a context is.
-    //
-    ARRAY_FLAG_VARLIST = HEADERFLAG(6),
 
-    // `SERIES_FLAG_LOCKED` indicates that the series size or values cannot
-    // be modified.  This check is honored by some layers of abstraction, but
-    // if one manages to get a raw pointer into a value in the series data
-    // then by that point it cannot be enforced.
-    //
-    // !!! Could the 'writable' flag be used for this in the debug build,
-    // if the locking process went through and cleared writability...then
-    // put it back if the series were unlocked?
-    //
-    // This is related to the feature in PROTECT (OPT_TYPESET_LOCKED) which
-    // protects a certain variable in a context from being changed.  Yet
-    // it is distinct as it's a protection on a series itself--which ends
-    // up affecting all variable content with that series in the payload.
-    //
-    SERIES_FLAG_LOCKED = HEADERFLAG(7),
+//=//// SERIES_FLAG_ARRAY /////////////////////////////////////////////////=//
+//
+// Indicates that this is a series of REBVAL value cells, and suitable for
+// using as the payload of an ANY-ARRAY! value.  When a series carries this
+// bit, then if it is also NODE_FLAG_MANAGED the garbage ollector will process
+// its transitive closure to make sure all the values it contains (and the
+// values its references contain) do not have series GC'd out from under them.
+//
+// Note: R3-Alpha used `SER_WIDE(s) == sizeof(REBVAL)` as the test for if
+// something was an array.  But this allows creation of series that have
+// items which are incidentally the size of a REBVAL, but not actually arrays.
+//
+#define SERIES_FLAG_ARRAY \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 3)
 
-    // `SERIES_FLAG_FIXED_SIZE` indicates the size is fixed, and the series
-    // cannot be expanded or contracted.  Values within the series are still
-    // writable, assuming SERIES_FLAG_LOCKED isn't set.
-    //
-    // !!! Is there checking in all paths?  Do series contractions check this?
-    //
-    // One important reason for ensuring a series is fixed size is to avoid
-    // the possibility of the data pointer being reallocated.  This allows
-    // code to ignore the usual rule that it is unsafe to hold a pointer to
-    // a value inside the series data.
-    //
-    // !!! Strictly speaking, SERIES_FLAG_NO_RELOCATE could be different
-    // from fixed size... if there would be a reason to reallocate besides
-    // changing size (such as memory compaction).
-    //
-    SERIES_FLAG_FIXED_SIZE = HEADERFLAG(8),
 
-    // `SERIES_FLAG_POWER_OF_2` is set when an allocation size was rounded to
-    // a power of 2.  This flag was introduced in Ren-C when accounting was
-    // added to make sure the system's notion of how much memory allocation
-    // was outstanding would balance out to zero by the time of exiting the
-    // interpreter.
-    //
-    // The problem was that the allocation size was measured in terms of the
-    // number of elements.  If the elements themselves were not the size of
-    // a power of 2, then to get an even power-of-2 size of memory allocated
-    // the memory block would not be an even multiple of the element size.
-    // Rather than track the actual memory allocation size as a 32-bit number,
-    // a single bit flag remembering that the allocation was a power of 2
-    // was enough to recreate the number to balance accounting at free time.
-    //
-    // !!! The rationale for why series were ever allocated to a power of 2
-    // should be revisited.  Current conventional wisdom suggests that asking
-    // for the amount of memory you need and not using powers of 2 is
-    // generally a better idea:
-    //
-    // http://stackoverflow.com/questions/3190146/
-    //
-    SERIES_FLAG_POWER_OF_2 = HEADERFLAG(9),
+//=//// ARRAY_FLAG_VOIDS_LEGAL ////////////////////////////////////////////=//
+//
+// Identifies arrays in which it is legal to have void elements.  This is true
+// for instance on reified C va_list()s which were being used for unevaluated
+// applies (like R3-Alpha's APPLY/ONLY).  When those va_lists need to be put
+// into arrays for the purposes of GC protection, they may contain voids which
+// they need to track.
+//
+// Note: ARRAY_FLAG_VARLIST also implies legality of voids, which
+// are used to represent unset variables.
+//
+#define ARRAY_FLAG_VOIDS_LEGAL \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 4)
 
-    // `SERIES_FLAG_EXTERNAL` indicates that when the series was created, the
-    // `->data` pointer was poked in by the creator.  It takes responsibility
-    // for freeing it, so don't free() on GC.
-    //
-    // !!! It's not clear what the lifetime management of data used in this
-    // way is.  If the external system receives no notice when Rebol is done
-    // with the data and GC's the series, how does it know when it's safe
-    // to free the data or not?  The feature is not used by the core or
-    // Ren-Cpp, but by relatively old extensions...so there may be no good
-    // answer in the case of those clients (likely either leaks or crashes).
-    //
-    SERIES_FLAG_EXTERNAL = HEADERFLAG(10),
 
-    // `SERIES_FLAG_INACCESSIBLE` indicates that the external memory pointed by
-    // `->data` has "gone bad". This is not checked at every access to the
-    // `->data` for the performance consideration, only on those that are
-    // known to have possible external memory storage.  Currently this is
-    // used for STRUCT! and to note when a CONTEXT_FLAG_STACK series has its
-    // stack level popped (there's no data to lookup for words bound to it)
-    //
-    SERIES_FLAG_INACCESSIBLE = HEADERFLAG(11),
+//=//// ARRAY_FLAG_PARAMLIST //////////////////////////////////////////////=//
+//
+// ARRAY_FLAG_PARAMLIST indicates the array is the parameter list of a
+// FUNCTION! (the first element will be a canon value of the function)
+//
+#define ARRAY_FLAG_PARAMLIST \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 5)
 
-    // `CONTEXT_FLAG_STACK` indicates that varlist data lives on the stack.
-    // This is a work in progress to unify objects and function call frames
-    // as a prelude to unifying FUNCTION! and CLOSURE!.
-    //
-    // !!! Ultimately this flag may be unnecessary because stack-based and
-    // dynamic series will "hybridize" so that they may have some stack
-    // fields and some fields in dynamic memory.  The foundation already
-    // exists, and both can be stored in the same REBSER.  It's just a problem
-    // of mapping index numbers in the function paramlist into either the
-    // stack array or the dynamic array during binding in an efficient way.
-    //
-    CONTEXT_FLAG_STACK = HEADERFLAG(12),
 
-    // `KEYLIST_FLAG_SHARED` is indicated on the keylist array of a context
-    // when that same array is the keylist for another object.  If this flag
-    // is set, then modifying an object using that keylist (such as by adding
-    // a key/value pair) will require that object to make its own copy.
-    //
-    // (Note: This flag did not exist in R3-Alpha, so all expansions would
-    // copy--even if expanding the same object by 1 item 100 times with no
-    // sharing of the keylist.  That would make 100 copies of an arbitrary
-    // long keylist that the GC would have to clean up.)
-    //
-    KEYLIST_FLAG_SHARED = HEADERFLAG(13),
+//=//// ARRAY_FLAG_VARLIST ////////////////////////////////////////////////=//
+//
+// This indicates this series represents the "varlist" of a context (which is
+// interchangeable with the identity of the varlist itself).  A second series
+// can be reached from it via the `->misc` field in the series node, which is
+// a second array known as a "keylist".
+//
+// See notes on REBCTX for further details about what a context is.
+//
+#define ARRAY_FLAG_VARLIST \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 6)
 
-    // `ARRAY_FLAG_VOIDS_LEGAL` identifies arrays in which it is legal to
-    // have void elements.  This is used for instance on reified C va_list()s
-    // which were being used for unevaluated applies.  When those va_lists
-    // need to be put into arrays for the purposes of GC protection, they may
-    // contain voids which they need to track.
-    //
-    // Note: ARRAY_FLAG_VARLIST also implies legality of voids, which
-    // are used to represent unset variables.
-    //
-    ARRAY_FLAG_VOIDS_LEGAL = HEADERFLAG(14),
 
-    // `SERIES_FLAG_LEGACY` is a flag which is marked at the root set of the
-    // body of legacy functions.  It can be used in a dynamic examination of
-    // a call to see if it "originates from legacy code".  This is a vague
-    // concept given the ability to create blocks and run them--so functions
-    // like COPY would have to propagate the flag to make it "more accurate".
-    // But it's good enough for casual compatibility in many cases.
+//=//// CONTEXT_FLAG_STACK ////////////////////////////////////////////////=//
+//
+// This indicates that a context's varlist data lives on the stack.  That
+// means that when the function terminates, the data will no longer be
+// accessible (so SERIES_INFO_INACCESSIBLE will be true).
+//
+// !!! Ultimately this flag may be unnecessary because stack-based and
+// dynamic series will "hybridize" so that they may have some stack
+// fields and some fields in dynamic memory.  For now it's a good sanity
+// check that things which should only happen to stack contexts (like becoming
+// inaccessible) are checked against this flag.
+//
+#define CONTEXT_FLAG_STACK \
+    FLAGIT_LEFT(GENERAL_SERIES_BIT + 7)
+
+
+#if !defined(NDEBUG)
+    //=//// SERIES_FLAG_LEGACY ////////////////////////////////////////////=//
     //
-#if !defined NDEBUG
-    SERIES_FLAG_LEGACY = HEADERFLAG(15),
+    // This is a flag which is marked at the root set of the body of legacy
+    // functions.  It can be used in a dynamic examination of a call to see if
+    // it "originates from legacy code".  This is a vague concept given the
+    // ability to create blocks and run them--so functions like COPY would
+    // have to propagate the flag to make it "more accurate".  But it's good
+    // enough for casual compatibility in many cases.
+    //
+    #define SERIES_FLAG_LEGACY \
+        FLAGIT_LEFT(GENERAL_SERIES_BIT + 8)
 #endif
 
-    SERIES_FLAG_NO_COMMA_NEEDED = 0 // solves dangling comma from above
-};
+// ^-- STOP AT FLAGIT_LEFT(15) --^
+//
+// The rightmost 16 bits of the series flags are used to store an arbitrary
+// per-series-type 16 bit number.  Right now, that's used by the string series
+// to save their REBSYM id integer(if they have one).  Note that the flags
+// are flattened in kind of a wasteful way...some are mutually exclusive and
+// could use the same bit, if needed.
+//
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+    static_assert(GENERAL_SERIES_BIT + 8 < 16, "SERIES_FLAG_XXX too high");
+#endif
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// SERIES <<INFO>> BITS
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// See remarks above about the two places where series store bits.  These
+// are the info bits, which are more likely to be changed over the lifetime
+// of the series--defaulting to FALSE.
+//
+// See Init_Endlike_Header() for why the leading bits are chosen the way they
+// are (and why SERIES_INFO_8_IS_FALSE is unused also).  This means that the
+// Reb_Series->info field can function as an implicit END for
+// Reb_Series->content, as well as be distinguished from a REBVAL*, a REBSER*,
+// or a UTF8 string.
+//
+
+#define SERIES_INFO_0_IS_TRUE FLAGIT_LEFT(0) // NODE_FLAG_VALID
+#define SERIES_INFO_1_IS_TRUE FLAGIT_LEFT(1) // NODE_FLAG_END
+#define SERIES_INFO_2_IS_FALSE FLAGIT_LEFT(2) // NOT(NODE_FLAG_CELL)
+
+
+//=//// SERIES_INFO_HAS_DYNAMIC ///////////////////////////////////////////=//
+//
+// Indicates that this series has a dynamically allocated portion.  If it does
+// not, then its data pointer is the address of the embedded value inside of
+// it, and that the length is stored in the rightmost byte of the header
+// bits (of which this is one bit).
+//
+// This bit will be flipped if a series grows.  (In the future it should also
+// be flipped when the series shrinks, but no shrinking in the GC yet.)
+//
+#define SERIES_INFO_HAS_DYNAMIC \
+    FLAGIT_LEFT(3)
+
+
+//=//// SERIES_INFO_BLACK /////////////////////////////////////////////////=//
+//
+// This is a generic bit for the "coloring API", e.g. Is_Series_Black(),
+// Flip_Series_White(), etc.  These let native routines engage in marking
+// and unmarking nodes without potentially wrecking the garbage collector by
+// reusing NODE_FLAG_MARKED.  Purposes could be for recursion protection or
+// other features, to avoid having to make a map from REBSER to REBOOL.
+//
+#define SERIES_INFO_BLACK \
+    FLAGIT_LEFT(4)
+
+
+//=//// SERIES_INFO_LOCKED ////////////////////////////////////////////////=//
+//
+// This indicates that the series size or values cannot be modified.  The
+// check is honored by some layers of abstraction, but if one manages to get
+// a raw non-const pointer into a value in the series data...then by that
+// point it cannot be enforced.
+//
+// Note: There is a feature in PROTECT (TYPESET_FLAG_LOCKED) which protects a
+// certain variable in a context from being changed.  It is similar, but
+// distinct.  SERIES_INFO_LOCKED is a protection on a series itself--which
+// ends up affecting all values with that series in the payload.
+//
+#define SERIES_INFO_LOCKED \
+    FLAGIT_LEFT(5)
+
+
+//=//// SERIES_INFO_INACCESSIBLE //////////////////////////////////////////=//
+//
+// This indicates that the memory pointed at by `->data` has "gone bad".
+//
+// Currently this used to note when a CONTEXT_FLAG_STACK series has had its
+// stack level popped (there's no data to lookup for words bound to it).
+//
+// !!! The FFI also uses this for STRUCT! when an interface to a C structure
+// is using external memory instead of a Rebol series, and that external
+// memory goes away.  Since FFI is shifting to becoming a user extension, it
+// might approach this problem in a different way in the future.
+//
+#define SERIES_INFO_INACCESSIBLE \
+    FLAGIT_LEFT(6)
+
+
+//=//// SERIES_INFO_POWER_OF_2 ////////////////////////////////////////////=//
+//
+// This is set when an allocation size was rounded to a power of 2.  The bit
+// was introduced in Ren-C when accounting was added to make sure the system's
+// notion of how much memory allocation was outstanding would balance out to
+// zero by the time of exiting the interpreter.
+//
+// The problem was that the allocation size was measured in terms of the
+// number of elements in the series.  If the elements themselves were not the
+// size of a power of 2, then to get an even power-of-2 size of memory
+// allocated, the memory block would not be an even multiple of the element
+// size.  So rather than track the "actual" memory allocation size as a 32-bit
+// number, a single bit flag remembering that the allocation was a power of 2
+// was enough to recreate the number to balance accounting at free time.
+//
+// !!! The original code which created series with items which were not a
+// width of a power of 2 was in the FFI.  It has been rewritten to not use
+// such custom structures, but the support for this remains in case there
+// was a good reason to have a non-power-of-2 size in the future.
+//
+// !!! ...but rationale for why series were ever allocated to a power of 2
+// should be revisited.  Current conventional wisdom suggests that asking
+// for the amount of memory you need and not using powers of 2 is
+// generally a better idea:
+//
+// http://stackoverflow.com/questions/3190146/
+//
+#define SERIES_INFO_POWER_OF_2 \
+    FLAGIT_LEFT(7)
+
+
+#define SERIES_INFO_8_IS_FALSE FLAGIT_LEFT(8) // see Init_Endlike_Header()
+
+
+//=//// SERIES_INFO_SHARED_KEYLIST ////////////////////////////////////////=//
+//
+// This is indicated on the keylist array of a context when that same array
+// is the keylist for another object.  If this flag is set, then modifying an
+// object using that keylist (such as by adding a key/value pair) will require
+// that object to make its own copy.
+//
+// Note: This flag did not exist in R3-Alpha, so all expansions would copy--
+// even if expanding the same object by 1 item 100 times with no sharing of
+// the keylist.  That would make 100 copies of an arbitrary long keylist that
+// the GC would have to clean up.
+//
+#define SERIES_INFO_SHARED_KEYLIST \
+    FLAGIT_LEFT(9)
+
+
+//=//// SERIES_INFO_EXTERNAL //////////////////////////////////////////////=//
+//
+// This indicates that when the series was created, the `->data` pointer was
+// poked in by the creator.  It takes responsibility for freeing it, so don't
+// free() on GC.
+//
+// !!! This is a somewhat questionable feature, only used by the FFI.  It's
+// not clear that the right place to hook in the behavior is to have a
+// series physically allow external `->data` pointers vs. at a higher level
+// test some condition, using the series data or handle based on that.
+//
+#define SERIES_INFO_EXTERNAL \
+    FLAGIT_LEFT(10)
+
+
+// ^-- STOP AT FLAGIT_LEFT(15) --^
+//
+// The rightmost 16 bits of the series info is used to store an 8 bit length
+// for non-dynamic series and an 8 bit width of the series.  So the info
+// flags need to stop at FLAGIT_LEFT(15).
+//
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+    static_assert(10 < 16, "SERIES_INFO_XXX too high");
+#endif
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// SERIES NODE ("REBSER") STRUCTURE DEFINITION
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// A REBSER node is the size of two REBVALs, and there are 3 basic layouts
+// which can be overlaid inside the node:
+//
+//      Dynamic: [header [allocation tracking] info link misc]
+//     Singular: [header [REBVAL cell] info link misc]
+//      Pairing: [[REBVAL cell] [REBVAL cell]]
+//
+// `info` is not the start of a "Rebol Node" (REBNODE, e.g. either a REBSER or
+// a REBVAL cell).  But in the singular case it is positioned right where
+// the next cell after the embedded cell *would* be.  Hence the bit in the
+// info corresponding to NODE_FLAG_END is set, making it conform to the
+// "terminating array" pattern.  To lower the risk of this implicit terminator
+// being accidentally overwritten (which would corrupt link and misc), the
+// bit corresponding to NODE_FLAG_CELL is clear.
+//
+// Singulars have widespread applications in the system, notably the
+// efficient implementation of FRAME!.  They also narrow the gap in overhead
+// between COMPOSE [A (B) C] vs. REDUCE ['A B 'C] such that the memory cost
+// of the array is nearly the same as just having another value in the array.
+//
+// Pair REBSERs are allocated from the REBSER pool instead of their own to
+// help exchange a common "currency" of allocation size more efficiently.
+// They are planned for use in the PAIR! and MAP! datatypes, and anticipated
+// to play a crucial part in the API--allowing a persistent handle for a
+// GC'able REBVAL and associated "meta" value (which can be used for
+// reference counting or other tracking.)
+//
+// Most of the time, code does not need to be concerned about distinguishing
+// Pair from the Dynamic and Singular layouts--because it already knows
+// which kind it has.  Only the GC needs to be concerned when marking
+// and sweeping.
+//
 
 struct Reb_Series_Dynamic {
     //
@@ -362,29 +481,15 @@ union Reb_Series_Content {
     //
     struct Reb_Series_Dynamic dynamic;
 
-    // If not SERIES_FLAG_HAS_DYNAMIC, 0 or 1 length arrays can be held
-    // directly in the series node.  The SERIES_FLAG_0_IS_FALSE bit is set
-    // to zero and signals an IS_END().
+    // If not SERIES_INFO_HAS_DYNAMIC, 0 or 1 length arrays can be held in
+    // the series node.  This trick is accomplished via "implicit termination"
+    // in the ->info bits that come directly after ->content.
     //
-    // It is thus an "array" of effectively up to length two.  Either the
-    // [0] full element is IS_END(), or the [0] element is another value
-    // and the [1] element is read-only and passes IS_END() to terminate
-    // (but can't have any other value written, as the info bits are
-    // marked as unwritable by SERIES_FLAG_2_IS_FALSE...this protects the
-    // rest of the bits in the debug build as it is checked whenver a
-    // REBVAL tries to write a new header.)
+    // (See NODE_FLAG_END and NODE_FLAG_CELL for how this is done.)
     //
     RELVAL values[1];
 };
 
-
-enum {
-    // `REBSER_FLAG_BLACK` is a generic bit for Is_Series_Black()/White().
-    // These let native routines engage in marking and unmarking nodes
-    // without potentially wrecking the garbage collector.  :-/
-    //
-    REBSER_FLAG_BLACK = HEADERFLAG(GENERAL_VALUE_BIT + 0)
-};
 
 struct Reb_Series {
 
@@ -426,9 +531,11 @@ struct Reb_Series {
     // `info` is the information about the series which needs to be known
     // even if it is not using a dynamic allocation.
     //
-    // The second-to-left and third-to-left bits of info are required to be 0
-    // when used with the trick of implicitly terminating series data.  See
-    // SERIES_FLAG_1_IS_TRUE and SERIES_FLAG_2_IS_FALSE for more information.
+    // It is purposefully positioned in the structure directly after the
+    // ->content field, because it has NODE_FLAG_END set to true.  Hence it
+    // appears to terminate an array of values if the content is not dynamic.
+    // Yet NODE_FLAG_CELL is set to false, so it is not a writable location
+    // (an "implicit terminator").
     //
     // !!! Only 32-bits are used on 64-bit platforms.  There could be some
     // interesting added caching feature or otherwise that would use
@@ -464,3 +571,41 @@ struct Reb_Series {
     REBUPT do_count; // also maintains sizeof(REBSER) % sizeof(REBI64) == 0
 #endif
 };
+
+
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// ARR_SERIES() COERCION
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// It is desirable to have series subclasses be different types, even though
+// there are some common routines for processing them.  e.g. not every
+// function that would take a REBSER* would actually be handled in the same
+// way for a REBARR*.  Plus, just because a REBCTX* is implemented as a
+// REBARR* with a link to another REBARR* doesn't mean most clients should
+// be accessing the array--in a C++ build this would mean it would have some
+// kind of protected inheritance scheme.
+//
+// The ARR_SERIES() macro provides a compromise besides a raw cast of a
+// pointer to a REBSER*, because in the C++ build it makes sure that the
+// incoming pointer type is to a simple series subclass.  (It's just a raw
+// cast in the C build.)
+//
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+    #include <type_traits>
+
+    template <class T>
+    inline REBSER* AS_SERIES(T *p) {
+        static_assert(
+            std::is_same<T, REBSER>::value
+            || std::is_same<T, REBSTR>::value
+            || std::is_same<T, REBARR>::value,
+            "AS_SERIES works on: REBSER*, REBSTR*, REBARR*"
+        );
+        return cast(REBSER*, p);
+    }
+#else
+    #define AS_SERIES(p) cast(REBSER*, (p))
+#endif

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -79,24 +79,6 @@
 //
 
 
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  DEBUG PANIC
-//
-//=////////////////////////////////////////////////////////////////////////=//
-//
-// "Series Panics" will (hopefully) trigger an alert under memory tools
-// like address sanitizer and valgrind that indicate the call stack at the
-// moment of allocation of a series.  Then you should have TWO stacks: the
-// one at the call of the Panic, and one where that series was alloc'd.
-//
-
-#if !defined(NDEBUG)
-    #define Panic_Series(s) \
-        Panic_Series_Debug((s), __FILE__, __LINE__);
-#endif
-
-
 //
 // Series flags
 //
@@ -179,7 +161,7 @@ inline static REBYTE *SER_DATA_RAW(REBSER *s) {
         : cast(REBYTE*, &s->content);
 }
 
-inline static REBYTE *SER_AT_RAW(size_t w, REBSER *s, REBCNT i) {
+inline static REBYTE *SER_AT_RAW(REBYTE w, REBSER *s, REBCNT i) {
 #if !defined(NDEBUG)
     if (w != SER_WIDE(s)) {
         //
@@ -187,8 +169,8 @@ inline static REBYTE *SER_AT_RAW(size_t w, REBSER *s, REBCNT i) {
         // caller passing in the wrong width (freeing sets width to 0).  But
         // give some debug tracking either way.
         //
-        Debug_Fmt("SER_AT_RAW asked %d on width=%d", w, SER_WIDE(s));
-        Panic_Series(s);
+        printf("SER_AT_RAW asked %d on width=%d\n", w, SER_WIDE(s));
+        panic (s);
     }
 #endif
 
@@ -340,7 +322,7 @@ inline static void ENSURE_SERIES_MANAGED(REBSER *s) {
 #else
     inline static void ASSERT_SERIES_MANAGED(REBSER *s) {
         if (NOT(IS_SERIES_MANAGED(s)))
-            Panic_Series(s);
+            panic (s);
     }
 
     #define ASSERT_VALUE_MANAGED(v) \

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -413,22 +413,23 @@ static inline void Flip_Series_To_White(REBSER *s) {
 
 inline static void PUSH_GUARD_SERIES(REBSER *s) {
     ASSERT_SERIES_MANAGED(s); // see PUSH_GUARD_ARRAY_CONTENTS if you need it
-    Guard_Series_Core(s);
+    Guard_Node_Core(cast(REBNOD*, s));
 }
 
 inline static void DROP_GUARD_SERIES(REBSER *s) {
-    assert(GET_SER_FLAG(GC_Series_Guard, SERIES_FLAG_HAS_DYNAMIC));
-    assert(s == *SER_LAST(REBSER*, GC_Series_Guard));
-    GC_Series_Guard->content.dynamic.len--;
+    assert(GET_SER_FLAG(GC_Guarded, SERIES_FLAG_HAS_DYNAMIC));
+    assert(s == *SER_LAST(REBSER*, GC_Guarded));
+    GC_Guarded->content.dynamic.len--;
 }
 
-#define PUSH_GUARD_VALUE(v) \
-    Guard_Value_Core(v)
+inline static void PUSH_GUARD_VALUE(RELVAL *v) {
+    Guard_Node_Core(cast(REBNOD*, v));
+}
 
 inline static void DROP_GUARD_VALUE(RELVAL *v) {
-    assert(GET_SER_FLAG(GC_Value_Guard, SERIES_FLAG_HAS_DYNAMIC));
-    assert(v == *SER_LAST(RELVAL*, GC_Value_Guard));
-    GC_Value_Guard->content.dynamic.len--;
+    assert(GET_SER_FLAG(GC_Guarded, SERIES_FLAG_HAS_DYNAMIC));
+    assert(v == *SER_LAST(RELVAL*, GC_Guarded));
+    GC_Guarded->content.dynamic.len--;
 }
 
 

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -302,7 +302,7 @@ inline static void TERM_SEQUENCE_LEN(REBSER *s, REBCNT len) {
 //
 
 inline static REBOOL IS_SERIES_MANAGED(REBSER *s) {
-    return LOGICAL(s->header.bits & REBSER_REBVAL_FLAG_MANAGED);
+    return LOGICAL(s->header.bits & NODE_FLAG_MANAGED);
 }
 
 #define MANAGE_SERIES(s) \

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -38,7 +38,7 @@ struct Reb_State {
     REBDSP dsp;
     struct Reb_Chunk *top_chunk;
     REBFRM *frame;
-    REBCNT series_guard_len;
+    REBCNT guarded_len;
     REBCNT value_guard_len;
     REBCTX *error;
 

--- a/src/include/sys-string.h
+++ b/src/include/sys-string.h
@@ -96,8 +96,8 @@ inline static REBSTR *STR_CANON(REBSTR *str) {
 }
 
 inline static OPT_REBSYM STR_SYMBOL(REBSTR *str) {
-    REBUPT sym = cast(REBSYM, (str->header.bits >> 8) & 0xFFFF);
-    assert(((STR_CANON(str)->header.bits >> 8) & 0xFFFF) == sym);
+    REBUPT sym = RIGHT_16_BITS(str->header.bits);
+    assert(RIGHT_16_BITS(STR_CANON(str)->header.bits) == sym);
     return cast(REBSYM, sym);
 }
 

--- a/src/include/sys-trap.h
+++ b/src/include/sys-trap.h
@@ -212,7 +212,7 @@
                     *(e) = (s)->error; \
             } \
             else { \
-               cast(void, Trapped_Helper_Halted(s)); \
+               (void)Trapped_Helper_Halted(s); /* ignore result */ \
                 *(e) = (s)->error; \
             } \
         } \

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -138,10 +138,10 @@ enum Reb_Param_Class {
 
 #ifdef NDEBUG
     #define TYPESET_FLAG(n) \
-        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
+        FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n))
 #else
     #define TYPESET_FLAG(n) \
-        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_TYPESET))
+        (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_TYPESET))
 #endif
 
 // Option flags used with GET_VAL_FLAG().  These describe properties of
@@ -279,7 +279,7 @@ inline static enum Reb_Param_Class VAL_PARAM_CLASS(const RELVAL *v) {
 
 inline static void INIT_VAL_PARAM_CLASS(RELVAL *v, enum Reb_Param_Class c) {
     CLEAR_N_MID_BITS(v->header.bits, PCLASS_NUM_BITS);
-    v->header.bits |= FLAGVAL_MID(c);
+    v->header.bits |= FLAGBYTE_MID(c);
 
     // !!! The "<tight>" mechanism is likely to be ultimately deprecated,
     // and quoting will replace it.  For now, though, the only kinds of

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -143,7 +143,7 @@
     ){
         enum Reb_Kind kind = VAL_TYPE_RAW(v);
         if (
-            (v->header.bits & CELL_MASK)
+            (v->header.bits & NODE_FLAG_CELL)
             && NOT(IS_END_MACRO(v)) // IS_END redundantly checks trash
             && NOT(
                 kind == REB_MAX_VOID
@@ -154,7 +154,7 @@
             return kind;
         }
 
-        assert(v->header.bits & CELL_MASK);
+        assert(v->header.bits & NODE_FLAG_CELL);
         printf("END marker or garbage/trash in VAL_TYPE()\n");
         panic_at (v, file, line);
     }
@@ -324,7 +324,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 
 #define VAL_RESET_HEADER_COMMON(v,kind) \
     ((v)->header.bits = \
-        HEADERIZE_KIND(kind) | NOT_FREE_MASK | CELL_MASK)
+        HEADERIZE_KIND(kind) | NODE_FLAG_VALID | NODE_FLAG_CELL)
 
 #ifdef NDEBUG
     #define ASSERT_CELL_WRITABLE_IF_CPP_DEBUG(v,file,line) \
@@ -536,7 +536,7 @@ inline static REBOOL IS_VOID(const RELVAL *v)
 
 inline static void SET_BLANK_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_BLANK) \
-        | NOT_FREE_MASK | VALUE_FLAG_FALSE | CELL_MASK;
+        | NODE_FLAG_VALID | VALUE_FLAG_CONDITIONALLY_FALSE | NODE_FLAG_CELL;
 }
 
 #ifdef NDEBUG
@@ -629,16 +629,16 @@ inline static void SET_BLANK_COMMON(RELVAL *v) {
 
 inline static void SET_TRUE_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_LOGIC) \
-        | NOT_FREE_MASK | CELL_MASK;
+        | NODE_FLAG_VALID | NODE_FLAG_CELL;
 }
 
 inline static void SET_FALSE_COMMON(RELVAL *v) {
     v->header.bits = HEADERIZE_KIND(REB_LOGIC) \
-        | NOT_FREE_MASK | CELL_MASK | VALUE_FLAG_FALSE;
+        | NODE_FLAG_VALID | NODE_FLAG_CELL | VALUE_FLAG_CONDITIONALLY_FALSE;
 }
 
 #define IS_CONDITIONAL_FALSE_COMMON(v) \
-    GET_VAL_FLAG((v), VALUE_FLAG_FALSE)
+    GET_VAL_FLAG((v), VALUE_FLAG_CONDITIONALLY_FALSE)
 
 #ifdef NDEBUG
     #define SET_TRUE(v) \
@@ -725,7 +725,7 @@ inline static REBOOL IS_CONDITIONAL_TRUE_SAFE(const REBVAL *v) {
 
 inline static REBOOL VAL_LOGIC(const RELVAL *v) {
     assert(IS_LOGIC(v));
-    return NOT(GET_VAL_FLAG((v), VALUE_FLAG_FALSE));
+    return NOT(GET_VAL_FLAG((v), VALUE_FLAG_CONDITIONALLY_FALSE));
 }
 
 

--- a/src/include/sys-varargs.h
+++ b/src/include/sys-varargs.h
@@ -47,10 +47,10 @@
 
 #ifdef NDEBUG
     #define VARARGS_FLAG(n) \
-        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
+        FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n))
 #else
     #define VARARGS_FLAG(n) \
-        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_VARARGS))
+        (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_VARARGS))
 #endif
 
 // Was made with a call to MAKE VARARGS! with data from an ANY-ARRAY!
@@ -68,11 +68,11 @@ inline static REBVAL *VAL_VARARGS_ARG(const RELVAL *v)
 
 inline static REBCTX *VAL_VARARGS_FRAME_CTX(const RELVAL *v) {
     ASSERT_ARRAY_MANAGED(v->extra.binding);
-    assert(GET_ARR_FLAG(v->extra.binding, ARRAY_FLAG_VARLIST));
+    assert(GET_SER_FLAG(v->extra.binding, ARRAY_FLAG_VARLIST));
     return AS_CONTEXT(v->extra.binding);
 }
 
 inline static REBARR *VAL_VARARGS_ARRAY1(const RELVAL *v) {
-    assert(!GET_ARR_FLAG(v->extra.binding, ARRAY_FLAG_VARLIST));
+    assert(NOT_SER_FLAG(v->extra.binding, ARRAY_FLAG_VARLIST));
     return v->extra.binding;
 }

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -43,10 +43,10 @@
 
 #ifdef NDEBUG
     #define WORD_FLAG(n) \
-        HEADERFLAG(TYPE_SPECIFIC_BIT + (n))
+        FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n))
 #else
     #define WORD_FLAG(n) \
-        (HEADERFLAG(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_WORD))
+        (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_WORD))
 #endif
 
 // `WORD_FLAG_BOUND` answers whether a word is bound, but it may be

--- a/src/tools/common-emitter.r
+++ b/src/tools/common-emitter.r
@@ -80,7 +80,7 @@ emit-item: proc [
     name: to-c-name name
     if upper [uppercase name]
     either assign [
-        emit-line/indent [name space "=" num ","]
+        emit-line/indent [name space "=" space num ","]
     ][
         emit-line/indent [name ","]
     ]

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -490,7 +490,6 @@ emit {
 }
 
 boot-strings: load %strings.r
-boot-errors: load %errors.r ;-- used also to make %tmp-errnums.r below
 
 code: ""
 n: 0
@@ -502,35 +501,6 @@ for-each str boot-strings [
     ][
         n: n + 1
         append code str
-        append code null
-    ]
-]
-
-; Some errors occur before we have the boot process is far enough along to
-; have the error messages loaded in as Rebol strings in the boot block's
-; CAT_ERRORS structure.  Adding their strings to %errors.r and keeping them
-; in sync with a "pre-boot" copy in %strings.r was a manual process.  This
-; makes format strings from the STRING! or BLOCK! in %errors.r automatically.
-;
-for-each [cat msgs] boot-errors [
-    unless cat = quote Internal: [continue]
-
-    emit-line ["#define RS_ERROR" space n]
-
-    for-each [word val] skip msgs 4 [
-        n: n + 1
-        case [
-            string? val [append code val]
-            block? val [
-                ; %strings.r strings use printf-like convention, %d tells
-                ; FORM to treat the vararg REBVAL* as an integer.
-                ;
-                append code rejoin map-each item val [
-                    either get-word? item [{ %v }] [item]
-                ]
-            ]
-            true [fail {Non-STRING! non-BLOCK! as %errors.r value}]
-        ]
         append code null
     ]
 ]
@@ -786,6 +756,8 @@ emit {
 ***********************************************************************/
 }
 emit-line "{"
+
+boot-errors: load %errors.r
 
 id-list: make block! 200
 

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -127,13 +127,11 @@
 
 [error? make error! [type: 'user id: 'message]]
 
-[error? make error! [type: 'internal id: 'no-buffer]]
 [error? make error! [type: 'internal id: 'bad-path]]
 [error? make error! [type: 'internal id: 'not-here]]
 [error? make error! [type: 'internal id: 'no-memory]]
 [error? make error! [type: 'internal id: 'stack-overflow]]
 [error? make error! [type: 'internal id: 'globals-full]]
-[error? make error! [type: 'internal id: 'max-natives]]
 [error? make error! [type: 'internal id: 'limit-hit]]
 [error? make error! [type: 'internal id: 'bad-sys-func]]
 [error? make error! [type: 'internal id: 'not-done]]

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -132,7 +132,6 @@
 [error? make error! [type: 'internal id: 'no-memory]]
 [error? make error! [type: 'internal id: 'stack-overflow]]
 [error? make error! [type: 'internal id: 'globals-full]]
-[error? make error! [type: 'internal id: 'limit-hit]]
 [error? make error! [type: 'internal id: 'bad-sys-func]]
 [error? make error! [type: 'internal id: 'not-done]]
 [error? make error! [type: 'internal id: 'bad-utf8]]


### PR DESCRIPTION
This commit takes advantage of the ability to discern a UTF-8 string
from a REBVAL* or a REBSER* subclass to make it possible to use a
single convenient `panic ()` macro to request diagnostics of Rebol
handles, or deliver the panic message if there is no smoking gun.

It also involves a reimagining of the role of `panic()`.  R3-Alpha's
error machinery had a separate "boot string" table for crash messages,
while Ren-C tried to unify the messages into the same table as used
in %errors.r -- to provide a central point for internationalization of
both categories.  But as time wore on, the messages in a panic were
of less importance than getting good diagnostics--such as those
returned by Panic_Series under Address Sanitizer.

So this pushes away from the unification with the error machinery or
potential internationalization of messages about things the user
should never see (and could probably do nothing about).  Instead,
panic moves toward supplying the precise file and line number--even
if the panic appears in a release build, so that the argument to
panic can be something that might offer an actual clue about what
went wrong.

So instead of making an error like this:

    bad-boot-result: {There was a bad result during the boot}

And then writing something like this in the C:

    if (!IS_VOID(result))
        panic (Error (RE_BAD_BOOT_RESULT));

... or trying to inject some kind of assistance like:

    if (!IS_VOID(result)) {
    #if !defined(NDEBUG)
        printf("The boot result type number was %d", VAL_TYPE(result));
    #endif
        panic (Error (RE_BAD_BOOT_RESULT));
    }

The simpler thing is to not make an error and just say:

    if (!IS_VOID(result))
        panic (result);

This makes the code more readable, lets panic() report as much about
the result as it can reasonably think of in the log (not just the
value's type, but when it was initialized...if it lives in an array
then what evaluator tick it was created on, etc.)  That plus the
file and line number is--for a panic--much more likely to provide
good information "in the field".

But if no "smoking gun" is available, you can just use a message.

    panic ("this will work too");