### PR TITLE
ANY and ALL chain "opt-outs" (return void)...add ANY? and ALL?

### DIFF
--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -377,7 +377,7 @@ redescribe: function [
                 fail [{archetype META-OF doesn't have DESCRIPTION slot} meta]
             ]
 
-            not notes: any [:meta/parameter-notes] [
+            not notes: to-value :meta/parameter-notes [
                 return () ; specialized or adapted, HELP uses original notes
             ]
 
@@ -537,13 +537,13 @@ catch?: redescribe [
 any?: redescribe [
     {Shortcut OR, ignores voids. Unlike plain ANY, forces result to LOGIC!}
 ](
-    chain [:any :true?]
+    chain [:any | :to-value | :true?]
 )
 
 all?: redescribe [
     {Shortcut AND, ignores voids. Unlike plain ALL, forces result to LOGIC!}
 ](
-    chain [:all :true?]
+    chain [:all | func [x [<opt> any-value!]] [any [:x | true]]]
 )
 
 maybe?: redescribe [

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -51,8 +51,8 @@ save: function [
     length: :lib/length
 
     ; Default `method` and `header-data` to blank
-    method: any [:method]
-    header-data: any [:header-data]
+    method: to-value :method
+    header-data: to-value :header-data
 
     ;-- Special datatypes use codecs directly (e.g. PNG image file):
     if all [

--- a/tests/control/all.test.reb
+++ b/tests/control/all.test.reb
@@ -1,6 +1,6 @@
 ; functions/control/all.r
 ; zero values
-[true == all []]
+[void? all []]
 ; one value
 [:abs = all [:abs]]
 [
@@ -97,7 +97,7 @@
 ]
 [0:00 == all [0:00]]
 [0.0.0 == all [0.0.0]]
-[true == all [()]] ;-- Ren/C change
+[void? all [()]]
 ['a == all ['a]]
 ; two values
 [:abs = all [true :abs]]
@@ -193,7 +193,7 @@
 ]
 [0:00 == all [true 0:00]]
 [0.0.0 == all [true 0.0.0]]
-[true == all [1020 ()]] ;-- Ren/C change
+[1020 == all [1020 ()]]
 ['a == all [true 'a]]
 [true = all [:abs true]]
 [

--- a/tests/control/any.test.reb
+++ b/tests/control/any.test.reb
@@ -1,6 +1,6 @@
 ; functions/control/any.r
 ; zero values
-[blank? any []]
+[void? any []]
 ; one value
 [:abs = any [:abs]]
 [
@@ -98,7 +98,7 @@
 ]
 [0:00 == any [0:00]]
 [0.0.0 == any [0.0.0]]
-[blank? any [()]]
+[void? any [()]]
 ['a == any ['a]]
 ; two values
 [:abs = any [false :abs]]


### PR DESCRIPTION
R3-Alpha's logic for handling "unset!" in ANY and ALL was to consider
it neither true nor false.  Yet still, it would overwrite the output
if it was in the last position.

This gave a somewhat unusual smattering of results:

    >> all [1 () 2]
    == 2

    >> all [1 2 ()]
    ;-- no value

    >> all []
    == true

    >> all [()]
    ;-- no value

Ren-C formalized this to where voids would "opt-out", yet would always
return a value.  This made ANY and ALL safe to use in conditionals.
Yet it still was throwing away information (`all [1 2 ()]` was true,
not 2).  The damage this did to ALL's ability to act as a chaining
operation wasn't a good "optimization", so this changes that.

Yet another problem in chaining was that the `any [()] => false` and
`any [()] => true` concept made it not possible to chain the idea of
opting-out.  These kinds of cases don't usually come up in conventional
coding, but when trying to compose operations they do...and the right
answer is to make them return void, so that they can chain.

This corrects the issues, making chaining work correctly:

    >> all [1 () 2]
    == 2

    >> all [1 2 ()]
    == 2

    >> all []
    ;-- no value

    >> all [()]
    ;-- no value

For a friendly version that guarantees it will work in conditionals,
this introduces the ANY? and ALL? variations, which guarantee returning
LOGIC!.  ANY? returns FALSE where it would have returned void (all opt
out mean "there weren't any) and ALL? returns TRUE when it would have
returned void (all opt out mean "nothing failed").

    if any? [() ()] [
        print "this won't print...all opt-out means false"
    ]

    if all? [() ()] [
        print "this will print...all opt-out means true"
    ]