### PR TITLE
Replace EXTERNAL series with HANDLE + LENGTH

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1318,18 +1318,18 @@ RL_API void RL_Init_Val_Index(REBVAL *v, REBCNT i) {
 }
 
 //
-//  RL_Val_Handle_Data: C
+//  RL_Val_Handle_Pointer: C
 //
-RL_API void *RL_Val_Handle_Data(const REBVAL *v) {
-    return VAL_HANDLE_DATA(v);
+RL_API void *RL_Val_Handle_Pointer(const REBVAL *v) {
+    return VAL_HANDLE_POINTER(v);
 }
 
 //
-//  RL_Set_Handle_Data: C
+//  RL_Set_Handle_Pointer: C
 //
-RL_API void RL_Set_Handle_Data(REBVAL *v, void *p) {
+RL_API void RL_Set_Handle_Pointer(REBVAL *v, void *p) {
     v->extra.singular = NULL; // !!! only support "dumb" handles for now
-    SET_HANDLE_DATA(v, p);
+    SET_HANDLE_POINTER(v, p);
 }
 
 //

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1058,8 +1058,8 @@ void Register_Codec(
     REBVAL handle;
     Init_Handle_Simple(
         &handle,
-        cast(CFUNC*, dispatcher), // code
-        NULL // data
+        cast(void*, dispatcher), // code
+        0 // optional length-sized data
     );
 
     REBVAL suffixes_value;

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -27,20 +27,10 @@
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// Word table is a block composed of symbols, each of which contain
-// a canon word number, alias word number (if it exists), and an
-// index that refers to the string for the text itself.
-//
-// The canon number for a word is unique and is used to compare
-// words. The word table is independent of context frames and
-// words are never garbage collected.
-//
-// The alias is used mainly for upper and lower case equality,
-// but can also be used to create ALIASes.
-//
-// The word strings are stored as a single large string series.
-// NEVER CACHE A WORD NAME POINTER if new words may be added (e.g.
-// LOAD), because the series may get moved in memory.
+// In R3-Alpha, words were not garbage collected, and their UTF-8 data was
+// kept in a separate table from the REBSERs.  In Ren-C, words use REBSERs,
+// and are merely *indexed* by hashes of their canon forms via an external
+// table.  This table grows and shrinks as canons are added and removed.
 //
 
 #include "sys-core.h"

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -132,7 +132,7 @@ REBNATIVE(load_extension)
     else {
         // Hosted extension:
         src = VAL_SERIES(val);
-        call = VAL_HANDLE_CODE(ARG(function));
+        call = cast(CFUNC*, VAL_HANDLE_POINTER(ARG(function)));
         dll = 0;
     }
 
@@ -150,8 +150,8 @@ REBNATIVE(load_extension)
     // Set extension fields needed:
     Init_Handle_Simple(
         CTX_VAR(context, STD_EXTENSION_LIB_BASE),
-        NULL, // code
-        cast(void*, cast(REBUPT, ext->index)) // data
+        cast(void*, cast(REBUPT, ext->index)), // data
+        0 // optional length-sized data
     );
 
     if (NOT(REF(dispatch)))
@@ -188,7 +188,7 @@ void Make_Command(
         REBEXT *rebext;
         REBVAL *handle = VAL_CONTEXT_VAR(extension, SELFISH(1));
         if (!IS_HANDLE(handle)) goto bad_func_def;
-        rebext = &Ext_List[cast(REBUPT, VAL_HANDLE_DATA(handle))];
+        rebext = &Ext_List[cast(REBUPT, VAL_HANDLE_POINTER(handle))];
         if (!rebext || !rebext->call) goto bad_func_def;
     }
 
@@ -283,7 +283,7 @@ REB_R Command_Dispatcher(REBFRM *f)
     //
     REBVAL *data = KNOWN(VAL_ARRAY_HEAD(FUNC_BODY(f->func)));
     REBEXT *handler = &Ext_List[
-        cast(REBUPT, VAL_HANDLE_DATA(VAL_CONTEXT_VAR(data, SELFISH(1))))
+        cast(REBUPT, VAL_HANDLE_POINTER(VAL_CONTEXT_VAR(data, SELFISH(1))))
     ];
     REBCNT cmd_num = cast(REBCNT, Int32(data + 1));
 

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -340,34 +340,3 @@ REBCNT Find_In_Array_Simple(REBARR *array, REBCNT index, const RELVAL *target)
 
     return ARR_LEN(array);
 }
-
-//
-//  Destroy_External_Storage: C
-//
-// Destroy the external storage pointed by `->data` by calling the routine
-// `free_func` if it's not NULL.  If it's NULL, only mark the external storage
-// non-accessible
-//
-REB_R Destroy_External_Storage(
-    REBVAL *out,
-    REBSER *ser,
-    REBVAL *free_func
-) {
-    if (NOT_SER_INFO(ser, SERIES_INFO_EXTERNAL))
-        fail (Error(RE_NO_EXTERNAL_STORAGE));
-
-    REBVAL pointer;
-    SET_INTEGER(&pointer, cast(REBUPT, SER_DATA_RAW(ser)));
-
-    if (GET_SER_INFO(ser, SERIES_INFO_INACCESSIBLE))
-        fail (Error(RE_ALREADY_DESTROYED, pointer));
-
-    SET_SER_INFO(ser, SERIES_INFO_INACCESSIBLE);
-
-    if (free_func != NULL) {
-        if (Do_Va_Throws(out, free_func, &pointer, END_CELL))
-            return R_OUT_IS_THROWN;
-    }
-
-    return R_VOID;
-}

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -31,31 +31,6 @@
 #include "sys-core.h"
 #include "sys-deci-funcs.h"
 
-//
-//  REBCNT_To_Bytes: C
-//
-void REBCNT_To_Bytes(REBYTE *out, REBCNT in)
-{
-    assert(sizeof(REBCNT) == 4);
-    out[0] = (REBYTE) in;
-    out[1] = (REBYTE)(in >> 8);
-    out[2] = (REBYTE)(in >> 16);
-    out[3] = (REBYTE)(in >> 24);
-}
-
-
-//
-//  Bytes_To_REBCNT: C
-//
-REBCNT Bytes_To_REBCNT(const REBYTE * const in)
-{
-    assert(sizeof(REBCNT) == 4);
-    return (REBCNT) in[0]          // & 0xFF
-        | (REBCNT)  in[1] <<  8    // & 0xFF00;
-        | (REBCNT)  in[2] << 16    // & 0xFF0000;
-        | (REBCNT)  in[3] << 24;   // & 0xFF000000;
-}
-
 
 //
 //  Get_Num_From_Arg: C

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -176,8 +176,6 @@ static void Queue_Mark_Array_Subclass_Deep(REBARR *a)
 
     if (!IS_ARRAY_MANAGED(a))
         panic (a);
-
-    assert(NOT_SER_INFO(a, SERIES_INFO_EXTERNAL));
 #endif
 
     // A marked array doesn't necessarily mean all references reached from it
@@ -403,8 +401,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
                 // references at once), the data pointers in all but the
                 // shared singular value are NULL.
                 //
-                assert(IS_POINTER_TRASH_DEBUG(v->payload.handle.code));
-                assert(IS_POINTER_TRASH_DEBUG(v->payload.handle.data));
+                assert(IS_POINTER_TRASH_DEBUG(v->payload.handle.pointer));
             }
         #endif
         }
@@ -585,7 +582,9 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         // lifetime can be longer than the struct which they represent
         // a "slice" out of.
         //
-        Mark_Rebser_Only(VAL_STRUCT_DATA_BIN(v));
+        // Note this may be a singular array handle, or it could be a BINARY!
+        //
+        Mark_Rebser_Only(v->payload.structure.data);
         break; }
 
     case REB_LIBRARY: {

--- a/src/core/n-crypt.c
+++ b/src/core/n-crypt.c
@@ -97,10 +97,7 @@ void Shutdown_Crypto(void)
 static void cleanup_rc4_ctx(const REBVAL *val)
 {
     assert(IS_HANDLE(val));
-    assert(val->payload.handle.code == NULL);
-    assert(val->payload.handle.data != NULL);
-
-    RC4_CTX *rc4_ctx = cast(RC4_CTX*, val->payload.handle.data);
+    RC4_CTX *rc4_ctx = cast(RC4_CTX*, val->payload.handle.pointer);
     FREE(RC4_CTX, rc4_ctx);
 }
 
@@ -130,7 +127,7 @@ REBNATIVE(rc4)
     if (REF(stream)) {
         REBVAL *data = ARG(data);
 
-        RC4_CTX *rc4_ctx = cast(RC4_CTX*, VAL_HANDLE_DATA(ARG(ctx)));
+        RC4_CTX *rc4_ctx = cast(RC4_CTX*, VAL_HANDLE_POINTER(ARG(ctx)));
 
         RC4_crypt(
             rc4_ctx,
@@ -150,7 +147,7 @@ REBNATIVE(rc4)
 
         RC4_setup(rc4_ctx, VAL_BIN_AT(ARG(key)), VAL_LEN_AT(ARG(key)));
 
-        Init_Handle_Managed(D_OUT, NULL, rc4_ctx, &cleanup_rc4_ctx);
+        Init_Handle_Managed(D_OUT, rc4_ctx, 0, &cleanup_rc4_ctx);
         return R_OUT;
     }
 
@@ -475,10 +472,9 @@ REBNATIVE(dh_compute_key)
 static void cleanup_aes_ctx(const REBVAL *val)
 {
     assert(IS_HANDLE(val));
-    assert(val->payload.handle.code == NULL);
-    assert(val->payload.handle.data != NULL);
+    assert(val->payload.handle.pointer != NULL);
 
-    AES_CTX *aes_ctx = cast(AES_CTX*, val->payload.handle.data);
+    AES_CTX *aes_ctx = cast(AES_CTX*, val->payload.handle.pointer);
     FREE(AES_CTX, aes_ctx);
 }
 
@@ -510,7 +506,7 @@ REBNATIVE(aes)
     INCLUDE_PARAMS_OF_AES;
 
     if (REF(stream)) {
-        AES_CTX *aes_ctx = cast(AES_CTX*, VAL_HANDLE_DATA(ARG(ctx)));
+        AES_CTX *aes_ctx = cast(AES_CTX*, VAL_HANDLE_POINTER(ARG(ctx)));
 
         REBYTE *dataBuffer = VAL_BIN_AT(ARG(data));
         REBINT len = VAL_LEN_AT(ARG(data));
@@ -591,7 +587,7 @@ REBNATIVE(aes)
         if (REF(decrypt))
             AES_convert_key(aes_ctx);
 
-        Init_Handle_Managed(D_OUT, NULL, aes_ctx, &cleanup_aes_ctx);
+        Init_Handle_Managed(D_OUT, aes_ctx, 0, &cleanup_aes_ctx);
         return R_OUT;
     }
 

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -168,9 +168,8 @@ static REBCTX* add_path(
 static void cleanup(const REBVAL *val)
 {
     assert(IS_HANDLE(val));
-    assert(val->payload.handle.code == NULL);
-    assert(val->payload.handle.data != NULL);
-    tcc_delete(cast(TCCState*, val->payload.handle.data));
+    assert(val->payload.handle.pointer != NULL);
+    tcc_delete(cast(TCCState*, val->payload.handle.pointer));
 }
 
 
@@ -606,8 +605,8 @@ REBNATIVE(compile)
     REBVAL handle;
     Init_Handle_Managed(
         &handle,
-        NULL, // no "code" pointer
         state, // "data" pointer
+        0,
         cleanup // called upon GC
     );
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -414,7 +414,7 @@ REBNATIVE(do_codec)
 {
     INCLUDE_PARAMS_OF_DO_CODEC;
 
-    codo fun = cast(codo, VAL_HANDLE_CODE(ARG(handle)));
+    codo fun = cast(codo, VAL_HANDLE_POINTER(ARG(handle)));
 
     REBCDI codi;
     CLEAR(&codi, sizeof(codi));

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -700,9 +700,6 @@ REBTYPE(Array)
         UNUSED(PAR(series));
         UNUSED(PAR(value)); // aliased as arg
 
-        if (REF(last))
-            fail (Error(RE_BAD_REFINES));
-
         REBINT len = ANY_ARRAY(arg) ? VAL_ARRAY_LEN_AT(arg) : 1;
 
         REBCNT limit;
@@ -716,6 +713,7 @@ REBTYPE(Array)
             | (REF(match) ? AM_FIND_MATCH : 0)
             | (REF(reverse) ? AM_FIND_REVERSE : 0)
             | (REF(case) ? AM_FIND_CASE : 0)
+            | (REF(last) ? AM_FIND_LAST : 0)
         );
 
         REBCNT skip = REF(skip) ? Int32s(ARG(size), 1) : 1;

--- a/src/include/reb-ext.h
+++ b/src/include/reb-ext.h
@@ -226,7 +226,7 @@ typedef int (*RXICAL)(int cmd, const REBVAL *frame, REBCEC *ctx);
     RL_VAL_INDEX(RL_FRM_ARG((f), (n)))
 
 #define RXA_HANDLE(f,n) \
-    RL_VAL_HANDLE_DATA(RL_FRM_ARG((f), (n)))
+    RL_VAL_HANDLE_POINTER(RL_FRM_ARG((f), (n)))
 
 #define RXA_OBJECT(f,n) \
     RL_VAL_CONTEXT(RL_FRM_ARG((f), (n)))

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -369,21 +369,6 @@
     FLAGIT_LEFT(9)
 
 
-//=//// SERIES_INFO_EXTERNAL //////////////////////////////////////////////=//
-//
-// This indicates that when the series was created, the `->data` pointer was
-// poked in by the creator.  It takes responsibility for freeing it, so don't
-// free() on GC.
-//
-// !!! This is a somewhat questionable feature, only used by the FFI.  It's
-// not clear that the right place to hook in the behavior is to have a
-// series physically allow external `->data` pointers vs. at a higher level
-// test some condition, using the series data or handle based on that.
-//
-#define SERIES_INFO_EXTERNAL \
-    FLAGIT_LEFT(10)
-
-
 // ^-- STOP AT FLAGIT_LEFT(15) --^
 //
 // The rightmost 16 bits of the series info is used to store an 8 bit length
@@ -391,7 +376,7 @@
 // flags need to stop at FLAGIT_LEFT(15).
 //
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
-    static_assert(10 < 16, "SERIES_INFO_XXX too high");
+    static_assert(9 < 16, "SERIES_INFO_XXX too high");
 #endif
 
 

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -436,9 +436,16 @@ struct Reb_Varargs {
 // Note that the ->extra field of the REBVAL may contain a singular REBARR
 // that is leveraged for its GC-awareness.
 //
+// Since a function pointer and a data pointer aren't necessarily the same
+// size, the initial two elements of the payload were a code pointer and
+// a data pointer, so that handles could hold both independently.  However,
+// it's more generically useful for handles to hold a pointer and a size...
+// as well as letting handles serve as a stand-in for a binary REBSER.  So
+// function pointers need to be cast to void*.
+//
 struct Reb_Handle {
-    CFUNC *code;
-    void *data;
+    void *pointer;
+    REBUPT length;
 };
 
 

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -261,11 +261,6 @@ inline static REBYTE *SER_AT_RAW(REBYTE w, REBSER *s, REBCNT i) {
         );
 }
 
-inline static void SER_SET_EXTERNAL_DATA(REBSER *s, void *p) {
-    SET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC);
-    s->content.dynamic.data = cast(REBYTE*, p);
-}
-
 
 //
 // In general, requesting a pointer into the series data requires passing in


### PR DESCRIPTION
When the FFI was added by Atronix, it was able to "image" a structure
schema on top of memory that was not owned by Rebol, and then poke and
peek values out of it.  This was used for reading data created by
a non-Rebol DLL without having to copy its memory into a Rebol
series first.

However, there was also a desire to have Rebol provide the memory
backing the structures.  So a special kind of series was added which
could have its memory not controlled by Rebol, or an "external series".

While it may be tempting to consider this as a general feature of the
system, the notion that all code has to be bulletproofed generically
against the idea of not owning a series pointer is daunting.  That
adds a lot of edge cases for which the system is not prepared--not to
mention a consistent processing "tax" on knowing whether series data
is external or not.

There's now another approach to the same problem--namely that the
data which backs a struct could be *either* a BINARY! (owned by Rebol)
or a managed HANDLE! (arbitrary memory).  This pushes the
responsibility for checking if data is external over to the STRUCT!
implementation, rather than requiring that every access of a BINARY!
needs to weigh in mind whether its underlying data is external or not.

To support this feature, the ability to store two pointers in a HANDLE!
(which was already questionable) was changed to store a pointer and
a length.  That gives the intended feature--a managed node which has
data and a length but cannot be otherwise modified, and which shared
instances can mark as unavailable through the common pointer.