### PR TITLE
REDUCE leaves BAR! in blocks, SET and GET tolerate BAR!

### DIFF
--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -270,7 +270,7 @@ REBNATIVE(any)
 //
 //  {Short circuiting version of NOR, using a block of expressions as input.}
 //
-//      return: [<opt> logic! blank!]
+//      return: [<opt> bar! blank!]
 //          {TRUE if all expressions are FALSE?, or BLANK if any are TRUE?}
 //      block [block!]
 //          "Block of expressions.  Void evaluations are ignored."

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -449,7 +449,7 @@ REBNATIVE(chain)
         chainees = COPY_ANY_ARRAY_AT_DEEP_MANAGED(pipeline);
     }
     else {
-        if (Reduce_Any_Array_Throws(out, pipeline, FALSE))
+        if (Reduce_Any_Array_Throws(out, pipeline, REDUCE_FLAG_DROP_BARS))
             return R_OUT_IS_THROWN;
 
         chainees = VAL_ARRAY(out); // should be all specific values

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -426,7 +426,9 @@ REBNATIVE(wait)
     if (IS_BLOCK(ARG(value))) {
         REBVAL unsafe; // temporary not safe from GC
 
-        if (Reduce_Any_Array_Throws(&unsafe, ARG(value), FALSE)) {
+        if (Reduce_Any_Array_Throws(
+            &unsafe, ARG(value), REDUCE_FLAG_DROP_BARS
+        )){
             *D_OUT = unsafe;
             return R_OUT_IS_THROWN;
         }

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1164,8 +1164,11 @@ void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
                 REBVAL specified;
                 Derelativize(&specified, item, VAL_SPECIFIER(arg));
 
-                if (Reduce_Any_Array_Throws(&init, &specified, FALSE))
+                if (Reduce_Any_Array_Throws(
+                    &init, &specified, REDUCE_FLAG_DROP_BARS
+                )){
                     fail (Error_No_Catch_For_Throw(&init));
+                }
 
                 ++item;
             }

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1336,3 +1336,10 @@ inline static REBOOL Maybe_Run_Failed_Branch_Throws(
 
     return FALSE;
 }
+
+
+enum {
+    REDUCE_FLAG_INTO = 1 << 0,
+    REDUCE_FLAG_DROP_BARS = 1 << 1,
+    REDUCE_FLAG_KEEP_BARS = 1 << 2
+};

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -342,6 +342,7 @@ get: function [
         any-word? :source
         any-path? :source
         any-context? :source
+        block? :source
     ][
         lib-get/(if any [opt_GET any_GET] 'opt) :source
     ][

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -65,7 +65,7 @@ make-port*: func [
 
     ; Defaults:
     port/actor: get in scheme 'actor ; avoid evaluation
-    port/awake: any [get in port/spec 'awake :scheme/awake]
+    port/awake: any [get/opt in port/spec 'awake | :scheme/awake]
     unless port/spec/ref [port/spec/ref: spec]
     unless port/spec/title [port/spec/title: scheme/title]
     port: to port! port


### PR DESCRIPTION
The evaluator skips over BAR!s, so that DO/NEXT does not see them.
They are considered conceptually void and "opt-out", so that
**do [| | |]** is a void, **all [true | true]** is true and,
**any [false | false]** is false.

This raises the question of how they should be treated by a REDUCE
operation.  Originally, since a REDUCE was merely moving along in
DO/NEXT steps, they would be omitted from the result so that
**reduce [1 + 2 | 3 + 4]** would be **[3 7]**.  This change makes the
REDUCE itself preserve BAR!s, so it would be **[3 | 7]**.

In order to allow BAR!s to provide a structural check on SET operations
this extends SET to allow a BAR! in a position so long as it lines up
in the right position.  Hence you can write:

    set [a | b] [1 + 2 | 3 + 4]

For compatibility, GET is changed to allow blocks as well, with BAR!s
at the positions:

    a: 1
    b: 2
    get [a | b] ;-- would be [1 | 2]

This change also lets you use BLANK! to skip assigning some results,
with the following assigning 1 to a and 3 to b, but throwing away 2:

    set [a _ b] [1 2 3]