### PR TITLE
Make void illegal in SELECT and path selection

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -208,7 +208,7 @@ select: action [
     {Searches for a value; returns the value that follows, else void.}
     return: [<opt> any-value!]
     series [any-series! any-context! map! blank!]
-    value [<opt> any-value!]
+    value [any-value!]
     /part {Limits the search to a given length or position}
     limit [any-number! any-series! pair!]
     /only {Treats a series value as only a single value}

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -316,10 +316,10 @@ REBNATIVE(func_class_of)
 //
 REBINT PD_Function(REBPVS *pvs)
 {
-    if (IS_VOID(pvs->selector)) {
+    if (IS_BLANK(pvs->selector)) {
         //
         // Leave the function value as-is, and continue processing.  This
-        // enables things like `append/(if foo ['dup])/(if bar ['only])`...
+        // enables things like `append/(all [foo 'dup])/only`...
         // 
         return PE_OK;
     }

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -346,9 +346,6 @@ REBINT PD_Map(REBPVS *pvs)
     if (setting)
         FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(pvs->value));
 
-    if (IS_BLANK(pvs->selector))
-        return PE_NONE;
-
     REBINT n = Find_Map_Entry(
         VAL_MAP(pvs->value),
         pvs->selector,

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -785,7 +785,7 @@ has: func [
     /only
         "Values are kept as-is"
 ][
-    construct/(if only 'only) [] body
+    construct/(all [only 'only]) [] body
 ]
 
 module: func [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -344,7 +344,7 @@ get: function [
         any-context? :source
         block? :source
     ][
-        lib-get/(if any [opt_GET any_GET] 'opt) :source
+        lib-get/(all [any [opt_GET any_GET] 'opt]) :source
     ][
         if system/options/get-will-get-anything [:source]
         fail ["GET takes ANY-WORD!, ANY-PATH!, ANY-CONTEXT!, not" (:source)]
@@ -860,7 +860,7 @@ set 'r3-legacy* func [<local> if-flags] [
                 ]
 
                 true [
-                    lib/parse/(if case_PARSE 'case) input rules
+                    lib/parse/(all [case_PARSE 'case]) input rules
                 ]
             ]
         ])

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -67,7 +67,11 @@ remold: func [
     /all  {Mold in serialized format}
     /flat {No indentation}
 ][
-    mold/(if only 'only)/(if all 'all)/(if flat 'flat) reduce :value
+    all_REMOLD: all
+    all: :lib/all
+
+    mold/(all [only 'only])/(all [all_REMOLD 'all])/(all [flat 'flat])
+        reduce :value
 ]
 
 charset: func [
@@ -171,7 +175,7 @@ replace: function [
         true 1
     ]
 
-    while [pos: find/(if case_REPLACE 'case) target :pattern] [
+    while [pos: find/(all [case_REPLACE 'case]) target :pattern] [
         ; apply replacement if function, or drops pos if not
         ; the parens quarantine function invocation to maximum arity of 1
         (value: replacement pos)
@@ -332,7 +336,7 @@ reword: function [
         [a: any [to char b: char [escape | blank]] to end fout]
     ]
 
-    parse/(if case_REWORD 'case) source rule
+    parse/(all [case_REWORD 'case]) source rule
 
     ; Return end of output with /into, head otherwise
     either into [output] [head output]
@@ -405,6 +409,9 @@ alter: func [
     value
     /case "Case-sensitive comparison"
 ][
+    case_ALTER: case
+    case: :lib/case
+
     if bitset? series [
         return either find series :value [
             remove/part series :value false
@@ -412,7 +419,7 @@ alter: func [
             append series :value true
         ]
     ]
-    unless? remove (find/(if case ['case]) series :value) [
+    unless? remove (find/(all [case_ALTER ['case]]) series :value) [
         append series :value ;-- returns true if this branch runs, false if not
     ]
 ]
@@ -440,7 +447,7 @@ collect-with: func [
         value [<opt> any-value!]
         /only
     ][
-        output: insert/(if only 'only) output :value
+        output: insert/(all [only 'only]) output :value
         :value
     ]
 

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -226,7 +226,9 @@ update-proto-state: func [
     either any [
         blank? ctx/protocol-state
         all [
-            next-state: get-next-proto-state/(if write-state 'write-state) ctx
+            next-state:
+                get-next-proto-state/(all [write-state 'write-state]) ctx
+
             find next-state new-state
         ]
     ] [

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -327,7 +327,8 @@ load: function [
         ;-- Load multiple sources?
         block? source [
             return map-each item source [
-                load/type/(if header 'header)/(if all_LOAD 'all) item :ftype
+                load/type/(all [header 'header])/(all [all_LOAD 'all])
+                    item :ftype
             ]
         ]
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -45,7 +45,7 @@ boot-print: procedure [
     eval: :lib/eval
 
     unless system/options/quiet [
-        print/(if any [eval_BOOT_PRINT | semiquoted? 'data] ['eval]) :data
+        print/(all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
     ]
 ]
 
@@ -58,7 +58,7 @@ loud-print: procedure [
     eval: :lib/eval
 
     if system/options/verbose [
-        print/(if any [eval_BOOT_PRINT | semiquoted? 'data] ['eval]) :data
+        print/(all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
     ]
 ]
 
@@ -273,7 +273,7 @@ load-boot-exts: function [
                 <static> index (-1)
             ] compose [
                 index: index + 1
-                f: load-native/(if body 'body) spec (impl) index :code
+                f: load-native/(all [body 'body]) spec (impl) index :code
                 :f
             ]
         ]


### PR DESCRIPTION
Previously void was being used to "opt out" of a function refinement.
This made it easy to write:

    append/(if condition ['only]) blk data

This didn't seem very invasive because functions did not use ordinary
path dispatch.  However, it seems generally unsafe to ignore voids
in path processing and go on to the next path item.  Using blanks is
not all that much more code:

    append/(all [condition 'only]) blk data

However, the interpretation of blanks in path selection needs to be
type specific, because they are legal "values" and hence legal anywhere
an ANY-VALUE! is legal, such as a key in a MAP!

    m: make map! [_ 10]
    m/_ ;-- should be 10

This keeps the interpretation of BLANK! as being up to the type, and
makes void trigger an error in any path selection or with SELECT.