### PR TITLE
Add experimental SET-UDP-MULTICAST and SET-UDP-TTL natives

### DIFF
--- a/src/include/sys-net.h
+++ b/src/include/sys-net.h
@@ -38,6 +38,8 @@
 
 #ifdef TO_WINDOWS
     #include <winsock.h>
+    #include <ws2tcpip.h> // needed for ip_mreq definition for multicast
+
 
     #define GET_ERROR       WSAGetLastError()
     #define IOCTL           ioctlsocket


### PR DESCRIPTION
This adds natives which intend to be equivalent to the Rebol2 SET-MODES:

    set-modes port [multicast-groups: [[(...) (...)]]]
    set-modes port [multicast-ttl: (...)]

They simply are independent calls:

    set-udp-multicast port (...) (...)
    set-udp-ttl port (...)

The code is based on observations and findings discussed here, and
it seems reasonable to believe it would work:

https://github.com/zsx/r3/issues/38

Having it work is contingent upon UDP receiving ports working, which
would need to be demonstrated.

In order to pass parameters through from the core to the OS-specific
network code, this embraces the direction of not prohibiting "host"
or "extension" code from being able to call the implementation
functions of the interpreter.  This means that port files such as
%p-net.c could hopefully be moved into their own extension as well,
and merged with the "device" code that they are artificially separated
from at this time.