### PR TITLE
Crude draft of ADD and SUBTRACT on BINARY!

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -21,13 +21,13 @@ REBOL [
 
 add: action [
     {Returns the addition of two values.}
-    value1 [any-scalar! date!]
+    value1 [any-scalar! date! binary!]
     value2
 ]
 
 subtract: action [
     {Returns the second value subtracted from the first.}
-    value1 [any-scalar! date!]
+    value1 [any-scalar! date! binary!]
     value2 [any-scalar! date!]
 ]
 
@@ -234,8 +234,8 @@ reflect: action [
 
 copy: action [
     {Copies a series, object, or other value.}
-    value [blank! any-series! port! map! object! frame! bitset! function! pair!]
-        {At position}
+    value [any-value!]
+        {If an ANY-SERIES!, it is only copied from its current position}
     /part
         {Limits to a given length or position}
     limit [any-number! any-series! pair!]

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1191,6 +1191,9 @@ reevaluate:;
             CLEAR_FRAME_LABEL(f);
             goto reevaluate; // we don't move index!
 
+        case R_UNHANDLED: // internal use only, shouldn't be returned
+            assert(FALSE);
+
         default:
             assert(FALSE);
         }

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -34,17 +34,13 @@
 #define THE_SIGN(v) ((v < 0) ? -1 : (v > 0) ? 1 : 0)
 
 //
-//  Series_Common_Action_Returns: C
+//  Series_Common_Action_Maybe_Unhandled: C
 //
 // This routine is called to handle actions on ANY-SERIES! that can be taken
 // care of without knowing what specific kind of series it is.  So generally
 // index manipulation, and things like LENGTH/etc.
 //
-// The strange name is to convey the result in an if statement, in the same
-// spirit as the `if (XXX_Throws(...)) { /* handle throw */ }` pattern.
-//
-REBOOL Series_Common_Action_Returns(
-    REB_R *r, // `r_out` would be slightly confusing, considering R_OUT
+REB_R Series_Common_Action_Maybe_Unhandled(
     REBFRM *frame_,
     REBSYM action
 ) {
@@ -64,20 +60,17 @@ REBOOL Series_Common_Action_Returns(
         break;
 
     case SYM_TAIL:
-        VAL_INDEX(value) = (REBCNT)tail;
+        VAL_INDEX(value) = cast(REBCNT, tail);
         break;
 
     case SYM_HEAD_Q:
-        *r = (index == 0) ? R_TRUE : R_FALSE;
-        return TRUE; // handled
+        return R_FROM_BOOL(LOGICAL(index == 0));
 
     case SYM_TAIL_Q:
-        *r = (index >= tail) ? R_TRUE : R_FALSE;
-        return TRUE; // handled
+        return R_FROM_BOOL(LOGICAL(index >= tail));
 
     case SYM_PAST_Q:
-        *r = (index > tail) ? R_TRUE : R_FALSE;
-        return TRUE; // handled
+        return R_FROM_BOOL(LOGICAL(index > tail));
 
     case SYM_SKIP:
     case SYM_AT:
@@ -97,13 +90,11 @@ REBOOL Series_Common_Action_Returns(
 
     case SYM_INDEX_OF:
         SET_INTEGER(D_OUT, cast(REBI64, index) + 1);
-        *r = R_OUT;
-        return TRUE; // handled
+        return R_OUT; // handled
 
     case SYM_LENGTH:
         SET_INTEGER(D_OUT, tail > index ? tail - index : 0);
-        *r = R_OUT;
-        return TRUE; // handled
+        return R_OUT; // handled
 
     case SYM_REMOVE: {
         INCLUDE_PARAMS_OF_REMOVE;
@@ -122,24 +113,12 @@ REBOOL Series_Common_Action_Returns(
             Remove_Series(VAL_SERIES(value), VAL_INDEX(value), len);
         break; }
 
-    case SYM_ADD:         // Join_Strings(value, arg);
-    case SYM_SUBTRACT:    // "test this" - 10
-    case SYM_MULTIPLY:    // "t" * 4 = "tttt"
-    case SYM_DIVIDE:
-    case SYM_REMAINDER:
-    case SYM_POWER:
-    case SYM_ODD_Q:
-    case SYM_EVEN_Q:
-    case SYM_ABSOLUTE:
-        fail (Error_Illegal_Action(VAL_TYPE(value), action));
-
     default:
-        return FALSE; // not a common operation, not handled
+        return R_UNHANDLED; // not a common operation, not handled
     }
 
     *D_OUT = *value;
-    *r = R_OUT;
-    return TRUE; // handled
+    return R_OUT;
 }
 
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -615,8 +615,8 @@ REBTYPE(Array)
 
     // Common operations for any series type (length, head, etc.)
     {
-        REB_R r;
-        if (Series_Common_Action_Returns(&r, frame_, action))
+        REB_R r = Series_Common_Action_Maybe_Unhandled(frame_, action);
+        if (r != R_UNHANDLED)
             return r;
     }
 

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -417,6 +417,10 @@ REBTYPE(Decimal)
         // unary actions
         switch (action) {
 
+        case SYM_COPY:
+            *D_OUT = *val;
+            return R_OUT;
+
         case SYM_NEGATE:
             d1 = -d1;
             goto setDec;

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -425,6 +425,10 @@ REBTYPE(Integer)
 
     switch (action) {
 
+    case SYM_COPY:
+        *D_OUT = *val;
+        return R_OUT;
+
     case SYM_ADD:
         if (REB_I64_ADD_OF(num, arg, &anum)) fail (Error(RE_OVERFLOW));
         num = anum;

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -605,8 +605,8 @@ REBTYPE(Vector)
 
     // Common operations for any series type (length, head, etc.)
     {
-        REB_R r;
-        if (Series_Common_Action_Returns(&r, frame_, action))
+        REB_R r = Series_Common_Action_Maybe_Unhandled(frame_, action);
+        if (r != R_UNHANDLED)
             return r;
     }
 

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -114,7 +114,13 @@ enum Reb_Result {
     // "eval cell".
     //
     R_REEVALUATE,
-    R_REEVALUATE_ONLY
+    R_REEVALUATE_ONLY,
+
+    // This is a signal that isn't accepted as a return value from a native,
+    // so it can be used by common routines that return REB_R values and need
+    // an "escape" code.
+    //
+    R_UNHANDLED
 };
 typedef enum Reb_Result REB_R;
 


### PR DESCRIPTION
Arithmetic operations should be allowed on BINARY!, because it's too
limiting to not allow `#{4B} + 1` => `#{4C}`.

Allowing the operations requires a default semantic of binaries as
unsigned arithmetic, since one does not want `#{FF} + 1` to be #{FE}.

It uses a big endian interpretation, so `#{00FF} + 1` is #{0100}

Since Rebol is a language with mutable semantics by default, `add x y`
will mutate x by default (if X is not an immediate type).  Today `+`
is a synonym for ADD, but after some technical changes are made to
permit TIGHTEN of ADAPTed functions, it will be an enfixing of ADD-OF,
which will copy the first argument before adding.

To try and maximize usefulness, the semantic chosen is that any
arithmetic that would go beyond the bounds of the length is considered
an overflow.  Hence the size of the binary will not change.  This means
that `#{0100} - 1` is #{00FF}, not #{FF}.

!!! The code is extremely slow and crude--using an odometer-style
loop to do the math.  What's actually required is effectively "bigint"
math, and it might be that it would share code with whatever big
integer implementation was used; e.g. integers which exceeded the size
of the platform REBI64 would use BINARY! under the hood.