### PR TITLE
Legitimize the "tight" convention as new parameter class

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -36,7 +36,6 @@ opt-tag         ; FUNC+PROC use as alternative to _ to mark optional void? args
 end-tag         ; FUNC+PROC use as alternative to | to mark endable args
 local-tag       ; marks the beginning of a list of "pure locals"
 durable-tag     ; !!! In progress - argument word lookup survives call ending
-tight-tag       ; Argument completes shortest legal expression (not longest)
 
 ;; !!! See notes on FUNCTION-META in %sysobj.r
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -454,7 +454,6 @@ static void Init_Function_Tags(void)
     Init_Function_Tag("end", ROOT_END_TAG);
     Init_Function_Tag("local", ROOT_LOCAL_TAG);
     Init_Function_Tag("durable", ROOT_DURABLE_TAG);
-    Init_Function_Tag("tight", ROOT_TIGHT_TAG);
 }
 
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -76,7 +76,7 @@ inline static REB_R If_Unless_Core(REBFRM *frame_, REBOOL trigger)
         if (REF(q))
             return R_FALSE; // !!! Support this?  It is like having EITHER?
 
-        return R_VOID; // default if nothing run (and not /?)
+        return R_OUT_VOID_IF_UNWRITTEN; // defaults void if nothing run
     }
 
     if (Run_Success_Branch_Throws(D_OUT, ARG(branch), REF(only)))

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -870,8 +870,11 @@ REBNATIVE(tighten)
     SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST); // flags not auto-copied
 
     RELVAL *param = ARR_AT(paramlist, 1); // first parameter (0 is FUNCTION!)
-    for (; NOT_END(param); ++param)
-        SET_VAL_FLAG(param, TYPESET_FLAG_TIGHT);
+    for (; NOT_END(param); ++param) {
+        enum Reb_Param_Class pclass = VAL_PARAM_CLASS(param);
+        if (pclass == PARAM_CLASS_NORMAL)
+            INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_TIGHT);
+    }
 
     // !!! This does not make a unique copy of the meta information context.
     // Hence updates to the title/parameter-descriptions/etc. of the tightened

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1109,7 +1109,7 @@ REBTYPE(String)
                     if (*b == 0) {
                         if (wheel == VAL_INDEX(value))
                             fail (Error(RE_OVERFLOW));
-                            
+
                         *b = 255;
                         --wheel;
                         continue;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -173,16 +173,6 @@ REBOOL Update_Typeset_Bits_Core(
             SET_VAL_FLAG(typeset, TYPESET_FLAG_VARIADIC);
         }
         else if (
-            keywords && IS_TAG(item) && (
-                0 == Compare_String_Vals(item, ROOT_TIGHT_TAG, TRUE)
-            )
-        ) {
-            // Makes enfixed first arguments "lazy" and other arguments will
-            // use the DO_FLAG_NO_LOOKAHEAD.
-            //
-            SET_VAL_FLAG(typeset, TYPESET_FLAG_TIGHT);
-        }
-        else if (
             IS_BAR(item) || (keywords && IS_TAG(item) && (
                 0 == Compare_String_Vals(item, ROOT_END_TAG, TRUE)
             ))

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1047,8 +1047,6 @@ inline static REBOOL Maybe_Run_Failed_Branch_Throws(
             return TRUE;
         }
     }
-    else
-        SET_VOID(out);
 
     return FALSE;
 }


### PR DESCRIPTION
After significant philosophical debate, it was determined that there
is likely no getting around the need for having a parameter class
which is evaluative like normal parameters, but stops evaluation at
the point of seeing a function which acquires its first argument from
the left hand side.

This convention was only seen in R3-Alpha in OP!.  However, Ren-C has
embraced functions which get their first argument from the left hand
side that do not wish to associate that with a difference in how they
gather their right hand arguments.  It also has a difference in
wanting to have operations which "defer" their lookback arguments,
e.g. the precedence manipulators:

    x: 1
    y: 2
    z: (x + y <| print "Stuff" print "Afterward")

The <| wants `x + y` to fully evaluate, then run the successive
prints, then have the entire expression evaluate to 3.  This is
now considered the "normal" behavior, while the "tight" version of
this behavior on the left hand argument would be evaluative of y, but
aggressively run the enfixed function and then pass the whole result
as the right hand argument of `+`.

The new parameter convention joins "normal" (WORD!), "hard quote"
(GET-WORD!), "soft quote" (LIT-WORD!), and "local" (SET-WORD!).  The
preliminary choice for denoting a "tight" parameter is with ISSUE!.

This commit also adapts the behavior with variadics.  This means that
one is able to get traditional OP!-like behavior out of a variadic,
which will perceive the rightward-looking view of an enfixed operator
to be an `<end>` (as if it had hit an expression barrier, end of block
or end of group)

    sum-normal: function [x [integer! <...>]] [
        sum: 0 | while [not tail? x] [sum: sum + take x] | sum
    ]

    sum-tight: function [#x [integer! <...>]] [
        sum: 0 | while [not tail? x] [sum: sum + take x] | sum
    ]

    >> sum-normal 1 2 3 * 10
    == 33

    >> sum-tight 1 2 3 * 10
    == 60