### PR TITLE
fail() clears partial outputs, fix Ctrl-C Heisenbug in console

### DIFF
--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -86,8 +86,6 @@ ATTRIBUTE_NO_RETURN void Panic_Value_Debug(const RELVAL *v) {
 }
 
 
-#if defined(__cplusplus)
-
 //
 //  Assert_Cell_Writable: C
 //
@@ -115,8 +113,6 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
         panic_at (v, file, line);
     }
 }
-
-#endif
 
 
 //

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -139,6 +139,8 @@ void Do_Core_Entry_Checks_Debug(REBFRM *f)
     assert(!IN_DATA_STACK_DEBUG(f->out));
 #endif
 
+    Assert_Cell_Writable(f->out, __FILE__, __LINE__);
+
     // Caller should have pushed the frame, such that it is the topmost.
     // This way, repeated calls to Do_Core(), e.g. by routines like ANY []
     // don't keep pushing and popping on each call.

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -69,7 +69,7 @@ REBIXO Do_Vararg_Op_May_Throw(
     if (op == VARARG_OP_TAIL_Q)
         assert(out == NULL); // not expecting return result
     else
-        SET_TRASH_IF_DEBUG(out);
+        SET_END(out); // don't want trash in frame output on FAIL
 #endif
 
     const RELVAL *param; // for type checking

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -444,6 +444,11 @@ void Host_Repl(
             //
             Put_Str(halt_str);
             last_failed = FALSE;
+
+            // The output value will be an END marker on halt, to signal the
+            // unusability of the interrupted result.
+            //
+            SET_VOID(out);
         }
         else if (do_result == -2) {
             //

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -5,7 +5,7 @@ REBOL [
         "Ren-C" branch @ https://github.com/metaeducation/ren-c
 
         Copyright 2012 REBOL Technologies
-        Copyright 2012-2015 Rebol Open Source Contributors
+        Copyright 2012-2017 Rebol Open Source Contributors
         REBOL is a trademark of REBOL Technologies
     }
     License: {


### PR DESCRIPTION
When the evaluator is called, it is given the memory address of where
the result value is to be written.  This address is known to the frame,
and the list of frames is known to the garbage collector--which allows
this arbitrary location in memory to keep any series it refers to
during the evaluation alive.

One issue with this that had not been addressed was what would become
of the bit pattern at that location in the event of an evaluation
that did not finish.  This could happen either due to a fail() partway
through, or something like a Ctrl-C.

This formalizes the decision such that an END marker is written into
every output slot when unwinding the frame stack, up to the level
that traps it.  A reason for choosing END instead of trash is because
the slot may be a function local which is guarded by GC, and the
caller shouldn't have to be burdened by the potential introduction of
an unsafe value in such slots by evaluation.  The use of END instead
of unreadable blank is since these slots are not supposed to be in
the middle of blocks or in the data stack, so writing END helps add
an extra check to alert callers to if they have done this.