### PR TITLE
Put REPL and host startup code into lib, not user

### DIFF
--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -1086,18 +1086,22 @@ void Resolve_Context(
 ) {
     FAIL_IF_READ_ONLY_CONTEXT(target);
 
-    REBVAL *key;
-    REBVAL *var;
-    REBCNT i = 0;
+    REBCNT i;
+    if (IS_INTEGER(only_words)) { // Must be: 0 < i <= tail
+        i = VAL_INT32(only_words);
+        if (i == 0)
+            i = 1;
+        if (i > CTX_LEN(target))
+            return;
+    }
+    else
+        i = 0;
 
     struct Reb_Binder binder;
     INIT_BINDER(&binder);
 
-    if (IS_INTEGER(only_words)) { // Must be: 0 < i <= tail
-        i = VAL_INT32(only_words); // never <= 0
-        if (i == 0) i = 1;
-        if (i > CTX_LEN(target)) return;
-    }
+    REBVAL *key;
+    REBVAL *var;
 
     // !!! This function does its own version of resetting the bind table
     // and hence the Collect_Keys_End that would be performed in the case of
@@ -1139,8 +1143,10 @@ void Resolve_Context(
                 --n;
 
         // Expand context by the amount required:
-        if (n > 0) Expand_Context(target, n);
-        else expand = FALSE;
+        if (n > 0)
+            Expand_Context(target, n);
+        else
+            expand = FALSE;
     }
 
     // Maps a word to its value index in the source context.

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -781,20 +781,16 @@ int main(int argc, char **argv_ansi)
             BIN_HEAD(startup), BIN_LEN(startup)
         );
 
-        // First the scanned code is bound into the user context with a
-        // fallback to the lib context.
+        // Bind the REPL and startup code into the lib context.
         //
-        // !!! This code is very old, and is how the REPL has bound since
-        // R3-Alpha.  It comes from RL_Do_String, but should receive a modern
-        // review of why it's written exactly this way.
+        // !!! It's important not to load the REPL into user, because since it
+        // uses routines like PRINT to do it's I/O you (probably) don't want
+        // the REPL to get messed up if PRINT is redefined--for instance.  It
+        // should probably have its own context, which would entail a copy of
+        // every word in lib that it uses, but that mechanic hasn't been
+        // fully generalized--and might not be the right answer anyway.
         //
-        REBCTX *user_ctx = VAL_CONTEXT(Get_System(SYS_CONTEXTS, CTX_USER));
-
-        REBVAL vali;
-        SET_INTEGER(&vali, CTX_LEN(user_ctx) + 1);
-
-        Bind_Values_All_Deep(ARR_HEAD(array), user_ctx);
-        Resolve_Context(user_ctx, Lib_Context, &vali, FALSE, FALSE);
+        Bind_Values_All_Deep(ARR_HEAD(array), Lib_Context);
 
         // The new policy for source code in Ren-C is that it loads read only.
         // This didn't go through the LOAD Rebol function (should it?  it

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -380,7 +380,7 @@ host-start: function [
         o/boot: to file! take argv
     ]
 
-    while-not [tail? argv] [
+    until [tail? argv] [
 
         is-option: parse/case argv/1 [
 


### PR DESCRIPTION
When the REPL was moved into userspace code, it used routines like
PRINT for I/O, etc.  This meant redefining any of those constructs
would break the REPL--consequently breaking `<r3-legacy>`

In the absence of an obvious ideal solution, this does the easy thing
and just binds the host r3.exe's startup and REPL code into lib.