### PR TITLE
Update sys-base.r

### DIFF
--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -91,6 +91,7 @@ do*: function [
 
             ; Web services
             <amazon-s3> [http://reb4.me/r3/s3.reb]
+            <upgrade> [https://raw.githubusercontent.com/gchiu/rebol-misc/master/upgrade.reb]
             <twitter> [https://raw.githubusercontent.com/gchiu/rebolbot/master/twitter.r3]
             <trello> [http://codeconscious.com/rebol-scripts/trello.r]
 


### PR DESCRIPTION
added an <upgrade> option to get new binaries from the Travis builds

Many of these web utilities don't currently work under current ren-c