### PR TITLE
Update actions.r

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -394,7 +394,7 @@ read: action [
 write: action [
     {Writes to a file, URL, or port - auto-converts text strings.}
     destination [port! file! url! block!]
-    data [binary! string! block!] {Data to write (non-binary converts to UTF-8)}
+    data [binary! string! block! object!] {Data to write (non-binary converts to UTF-8)}
     /part {Partial write a given number of units}
         limit [any-number!]
     /seek {Write at a specific position}


### PR DESCRIPTION
Limiting __write__ to not allow object! makes sense if you're doing the open, write, close single use paradigm but reduces flexibility for working with schemes.  This is to allow an object! as data, and the role of the write actor will be to make it into the form for writing to the destination.