### PR TITLE
Update base-files.r

### DIFF
--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -16,11 +16,21 @@ REBOL [
     }
 ]
 
-info?: func [
+info?: function [
     {Returns an info object about a file or url.}
     target [file! url!]
 ][
-    query target
+    either file? target [
+        query target
+    ][
+        t: write target [HEAD]
+        make object! [
+            name: target
+            size: t/2
+            date: t/3
+            type: 'url
+        ]
+    ]
 ]
 
 exists?: func [


### PR DESCRIPTION
enables info? to return file size and date on urls if provided by the web server.

At present info? url returns an error.  This fixes this.

See https://github.com/metaeducation/ren-c/issues/430