### PR TITLE
First try at RIGOROUS warning settings for GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - os: linux
           sudo: false #Force new container-based infrastructure.
           language: c
-          env: OS_ID=0.4.4 DEBUG=none STANDARD=c RIGOROUS=yes STATIC=yes
+          env: OS_ID=0.4.4 DEBUG=none STANDARD=gnu89 RIGOROUS=yes STATIC=yes
 
         # Linux x64, debug, gcc
         #
@@ -82,7 +82,7 @@ matrix:
         - os: osx
           osx_image: xcode8.2
           language: c
-          env: OS_ID=0.2.40 DEBUG=asserts STANDARD=c RIGOROUS=yes STATIC=no
+          env: OS_ID=0.2.40 DEBUG=asserts STANDARD=c99 RIGOROUS=no STATIC=no
 
         # OSX x64, debug, g++
         #
@@ -101,7 +101,7 @@ matrix:
         #
         - os: osx
           language: c
-          env: OS_ID=0.2.40 DEBUG=none STANDARD=c RIGOROUS=yes STATIC=no
+          env: OS_ID=0.2.40 DEBUG=none STANDARD=c RIGOROUS=no STATIC=no
 
 env:
     global:

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -105,8 +105,8 @@ static void Assert_Basics(void)
 
     flags = FLAGIT_LEFT(0) | FLAGIT_LEFT(1) | FLAGBYTE_RIGHT(13);
 
-    REBCNT left = LEFT_N_BITS(flags, 3); // == 6 (binary `110`)
-    REBCNT right = RIGHT_N_BITS(flags, 3); // == 5 (binary `101`)
+    unsigned int left = LEFT_N_BITS(flags, 3); // == 6 (binary `110`)
+    unsigned int right = RIGHT_N_BITS(flags, 3); // == 5 (binary `101`)
     if (left != 6 || right != 5) {
         printf("Expected 6 and 5, got %u and %u\n", left, right);
         panic ("Bad composed integer assignment for byte-ordering macro.");

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1361,10 +1361,10 @@ void Init_Core(void)
     REBARR *sys_array = VAL_ARRAY(&boot->sys);
     REBVAL *mezz_block = &boot->mezz;
 
-    boot = NULL;
-
     // With error trapping enabled, set up to catch them if they happen.
     PUSH_UNHALTABLE_TRAP(&error, &state);
+
+    boot = NULL;
 
 // The first time through the following code 'error' will be NULL, but...
 // `fail` can longjmp here, so 'error' won't be NULL *if* that happens!

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -108,7 +108,7 @@ static void Assert_Basics(void)
     REBCNT left = LEFT_N_BITS(flags, 3); // == 6 (binary `110`)
     REBCNT right = RIGHT_N_BITS(flags, 3); // == 5 (binary `101`)
     if (left != 6 || right != 5) {
-        printf("Expected 6 and 5, got %d and %d\n", left, right);
+        printf("Expected 6 and 5, got %u and %u\n", left, right);
         panic ("Bad composed integer assignment for byte-ordering macro.");
     }
 #endif
@@ -1360,6 +1360,8 @@ void Init_Core(void)
     REBARR *base_array = VAL_ARRAY(&boot->base);
     REBARR *sys_array = VAL_ARRAY(&boot->sys);
     REBVAL *mezz_block = &boot->mezz;
+
+    boot = NULL;
 
     // With error trapping enabled, set up to catch them if they happen.
     PUSH_UNHALTABLE_TRAP(&error, &state);

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -1423,7 +1423,7 @@ void Assert_Context_Core(REBCTX *c)
     REBCNT n;
     for (n = 1; n < keys_len; n++, var++, key++) {
         if (IS_END(key)) {
-            printf("** Early key end at index: %d\n", n);
+            printf("** Early key end at index: %d\n", cast(int, n));
             panic (c);
         }
 
@@ -1431,18 +1431,18 @@ void Assert_Context_Core(REBCTX *c)
             panic (key);
 
         if (IS_END(var)) {
-            printf("** Early var end at index: %d\n", n);
+            printf("** Early var end at index: %d\n", cast(int, n));
             panic (c);
         }
     }
 
     if (NOT_END(key)) {
-        printf("** Missing key end at index: %d\n", n);
+        printf("** Missing key end at index: %d\n", cast(int, n));
         panic (key);
     }
 
     if (NOT_END(var)) {
-        printf("** Missing var end at index: %d\n", n);
+        printf("** Missing var end at index: %d\n", cast(int, n));
         panic (var);
     }
 }

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -974,7 +974,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
                 #else
                     printf(
                         "too few args passed for error code %d at %s line %d",
-                        code,
+                        cast(int, code),
                         TG_Erroring_C_File ? TG_Erroring_C_File : "<unknown>",
                         TG_Erroring_C_File ? TG_Erroring_C_Line : -1
                     );

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -93,7 +93,7 @@ void Assert_State_Balanced_Debug(
     if (s->guarded_len != SER_LEN(GC_Guarded)) {
         printf(
             "PUSH_GUARD()x%d without DROP_GUARD()\n",
-            SER_LEN(GC_Guarded) - s->guarded_len
+            cast(int, SER_LEN(GC_Guarded) - s->guarded_len)
         );
         REBNOD *guarded = *SER_AT(
             REBNOD*,
@@ -122,7 +122,7 @@ void Assert_State_Balanced_Debug(
     else if (s->manuals_len < SER_LEN(GC_Manuals)) {
         printf(
             "Make_Series()x%d without Free_Series or MANAGE_SERIES\n",
-            SER_LEN(GC_Manuals) - s->manuals_len
+            cast(int, SER_LEN(GC_Manuals) - s->manuals_len)
         );
         REBSER *manual = *(SER_AT(
             REBSER*,
@@ -834,15 +834,16 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
 #endif
 
     if (PG_Boot_Phase < BOOT_ERRORS) {
-        char buf[1024] = "";
-        strncat(buf, "fail() before object table initialized, code = ", sizeof(buf) - 1);
-        Form_Int(b_cast(buf + strlen(buf)), code); // !!! no bounding...
-
-    #if defined(NDEBUG)
-        panic (buf);
-    #else
-        panic_at (buf, TG_Erroring_C_File, TG_Erroring_C_Line);
+    #if !defined(NDEBUG)
+        printf(
+            "fail() before object table initialized, code = %d\n", code
+        );
     #endif
+
+        DECLARE_LOCAL (code_value);
+        SET_INTEGER(code_value, code);
+
+        panic (code_value);
     }
 
     // Safe to initialize the root error now...

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -836,7 +836,8 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
     if (PG_Boot_Phase < BOOT_ERRORS) {
     #if !defined(NDEBUG)
         printf(
-            "fail() before object table initialized, code = %d\n", code
+            "fail() before object table initialized, code = %d\n",
+            cast(int, code)
         );
     #endif
 

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -76,7 +76,7 @@ void Set_Port_Open(REBCTX *port, REBOOL open)
 REBREQ *Ensure_Port_State(REBCTX *port, REBCNT device)
 {
     REBVAL *state = CTX_VAR(port, STD_PORT_STATE);
-    i32 req_size = OS_DEVREQ_SIZE(device);
+    REBCNT req_size = OS_DEVREQ_SIZE(device);
 
     if (!IS_BINARY(state)) {
         assert(IS_BLANK(state));

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -54,7 +54,10 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
     //
     GC_Disabled = TRUE;
 
-#if !defined(NDEBUG)
+#if defined(NDEBUG)
+    UNUSED(file);
+    UNUSED(line);
+#else
     //
     // First thing's first in the debug build, make sure the file and the
     // line are printed out.
@@ -143,6 +146,7 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
 
         Panic_Series_Debug(cast(REBSER*, s));
     #else
+        UNUSED(s);
         strncat(buf, "valid series", PANIC_BUF_SIZE - strlen(buf));
     #endif
         break; }

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -214,7 +214,7 @@ void Dump_Info(void)
     printf("^/--REBOL Kernel Dump--\n");
 
     printf("Evaluator:\n");
-    printf("    Cycles:  %ld\n", Eval_Cycles);
+    printf("    Cycles:  %ld\n", cast(unsigned long, Eval_Cycles));
     printf("    Counter: %d\n", cast(int, Eval_Count));
     printf("    Dose:    %d\n", cast(int, Eval_Dose));
     printf("    Signals: %lx\n", cast(unsigned long, Eval_Signals));

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -214,7 +214,7 @@ void Dump_Info(void)
     printf("^/--REBOL Kernel Dump--\n");
 
     printf("Evaluator:\n");
-    printf("    Cycles:  %lu\n", Eval_Cycles);
+    printf("    Cycles:  %ld\n", Eval_Cycles);
     printf("    Counter: %d\n", cast(int, Eval_Count));
     printf("    Dose:    %d\n", cast(int, Eval_Dose));
     printf("    Signals: %lx\n", cast(unsigned long, Eval_Signals));

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -131,9 +131,9 @@ void Dump_Series(REBSER *s, const char *memo)
     printf(" wide: %d\n", SER_WIDE(s));
     printf(" size: %ld\n", cast(unsigned long, SER_TOTAL_IF_DYNAMIC(s)));
     if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
-        printf(" bias: %d\n", SER_BIAS(s));
-    printf(" tail: %d\n", SER_LEN(s));
-    printf(" rest: %d\n", SER_REST(s));
+        printf(" bias: %d\n", cast(int, SER_BIAS(s)));
+    printf(" tail: %d\n", cast(int, SER_LEN(s)));
+    printf(" rest: %d\n", cast(int, SER_REST(s)));
 
     // flags includes len if non-dynamic
     printf(" flags: %lx\n", cast(unsigned long, s->header.bits));
@@ -214,18 +214,18 @@ void Dump_Info(void)
     printf("^/--REBOL Kernel Dump--\n");
 
     printf("Evaluator:\n");
-    printf("    Cycles:  %d\n", cast(REBINT, Eval_Cycles));
-    printf("    Counter: %d\n", Eval_Count);
-    printf("    Dose:    %d\n", Eval_Dose);
+    printf("    Cycles:  %lu\n", Eval_Cycles);
+    printf("    Counter: %d\n", cast(int, Eval_Count));
+    printf("    Dose:    %d\n", cast(int, Eval_Dose));
     printf("    Signals: %lx\n", cast(unsigned long, Eval_Signals));
     printf("    Sigmask: %lx\n", cast(unsigned long, Eval_Sigmask));
     printf("    DSP:     %d\n", DSP);
 
     printf("Memory/GC:\n");
 
-    printf("    Ballast: %d\n", GC_Ballast);
-    printf("    Disable: %d\n", GC_Disabled);
-    printf("    Guarded Nodes: %d\n", SER_LEN(GC_Guarded));
+    printf("    Ballast: %d\n", cast(int, GC_Ballast));
+    printf("    Disable: %s\n", GC_Disabled ? "yes" : "no");
+    printf("    Guarded Nodes: %d\n", cast(int, SER_LEN(GC_Guarded)));
     fflush(stdout);
 }
 
@@ -250,7 +250,7 @@ void Dump_Stack(REBFRM *f, REBCNT level)
 
    printf(
         "STACK[%d](%s) - %d\n",
-        level,
+        cast(int, level),
         STR_HEAD(FRM_LABEL(f)),
         f->eval_type // note: this is now an ordinary Reb_Kind, stringify it
     );

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -302,6 +302,7 @@ REBNATIVE(dump)
     INCLUDE_PARAMS_OF_DUMP;
 
 #ifdef NDEBUG
+    UNUSED(ARG(value));
     fail (Error_Debug_Only_Raw());
 #else
     REBVAL *value = ARG(value);

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -414,7 +414,9 @@ REBNATIVE(backtrace)
                 || temp_num != number
             ) {
                 printf(
-                    "%d != Frame_For_Stack_Level %d", number, temp_num
+                    "%d != Frame_For_Stack_Level %d",
+                    cast(int, number),
+                    cast(int, temp_num)
                 );
                 fflush(stdout);
                 assert(FALSE);

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -285,9 +285,9 @@ REBARR *Make_Extension_Module_Array(
 
     Init_Binary(ARR_AT(arr, 0), Copy_Bytes(spec, len));
 
-    Init_Handle_Managed_Cfunc(
-        ARR_AT(arr,1),
-        cast(CFUNC*, impl),
+    Init_Handle_Managed(
+        ARR_AT(arr, 1),
+        impl, // It's a *pointer to function pointer*, not a function pointer
         n,
         &cleanup_module_handler
     );
@@ -381,7 +381,7 @@ REBNATIVE(load_native)
 
     REBFUN *fun = Make_Function(
         Make_Paramlist_Managed_May_Fail(ARG(spec), MKF_KEYWORDS | MKF_FAKE_RETURN),
-        cast(REBNAT*, VAL_HANDLE_CFUNC(ARG(impl)))[VAL_INT64(ARG(index))], // unique
+        cast(REBNAT*, VAL_HANDLE_POINTER(ARG(impl)))[VAL_INT64(ARG(index))], // unique
         NULL, // no underlying function, this is fundamental
         NULL // not providing a specialization
     );

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -405,7 +405,8 @@ REBNATIVE(load_native)
 //
 static REB_R Unloaded_Dispatcher(REBFRM *f)
 {
-    assert(f != NULL); // unused argument warning otherwise
+    UNUSED(f);
+
     fail (Error_Native_Unloaded_Raw(FUNC_VALUE(f->func)));
 }
 

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -102,7 +102,7 @@ REB_R Series_Common_Action_Maybe_Unhandled(
         UNUSED(PAR(series)); // already accounted for
 
         if (REF(map)) {
-            assert(!IS_VOID(ARG(key)));
+            UNUSED(ARG(key));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -395,6 +395,9 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 // of the context's varlist.
 //
 void Init_Any_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *c) {
+#if defined(NDEBUG)
+    UNUSED(kind);
+#else
     //
     // In a debug build we check to make sure the type of the embedded value
     // matches the type of what is intended (so someone who thinks they are
@@ -402,7 +405,6 @@ void Init_Any_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *c) {
     // REB_ERROR, for instance.)  It's a point for several other integrity
     // checks as well.
     //
-#if !defined(NDEBUG)
     REBVAL *archetype = CTX_VALUE(c);
     assert(VAL_CONTEXT(archetype) == c);
 

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -1233,7 +1233,7 @@ REBNATIVE(scan_net_header)
         if (*cp != ':')
             break;
 
-        REBVAL *val;
+        REBVAL *val = NULL; // rigorous checks worry it could be uninitialized
 
         REBSTR *name = Intern_UTF8_Managed(start, cp - start);
         RELVAL *item;

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -505,7 +505,7 @@ ATTRIBUTE_NO_RETURN void Panic_Series_Debug(REBSER *s)
         printf("freed");
     else
         printf("created");
-    printf(" during evaluator tick: %d\n", cast(REBCNT, s->do_count));
+    printf(" during evaluator tick: %lu\n", cast(unsigned long, s->do_count));
 
     fflush(stdout);
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1567,7 +1567,7 @@ REBNATIVE(void_q)
 //
 REBNATIVE(void)
 {
-    assert(frame_ != NULL); // avoid unused parameter warning
+    UNUSED(frame_);
     return R_VOID;
 }
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -216,7 +216,7 @@ REBNATIVE(maybe)
         // !!! What should the behavior for `MAYBE [] ...` be?  Should that be
         // an error?  People wouldn't write it literally, but could wind up
         // with an empty array as the product of a COMPOSE or something.
-        // Consider it ambiguous for now and give back void.
+        // Consider it ambiguous for now and give back void...
         //
         r = R_VOID;
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -212,6 +212,14 @@ REBNATIVE(maybe)
 
     REB_R r;
     if (IS_BLOCK(test)) {
+        //
+        // !!! What should the behavior for `MAYBE [] ...` be?  Should that be
+        // an error?  People wouldn't write it literally, but could wind up
+        // with an empty array as the product of a COMPOSE or something.
+        // Consider it ambiguous for now and give back void.
+        //
+        r = R_VOID;
+
         const RELVAL *item;
         for (item = VAL_ARRAY_AT(test); NOT_END(item); ++item) {
             r = Do_Test_For_Maybe(
@@ -611,6 +619,7 @@ REBNATIVE(get)
         source = D_CELL;
         specifier = SPECIFIED;
         dest = D_OUT;
+        results = NULL; // wasteful but avoids maybe-used-uninitalized warning
     }
 
     DECLARE_LOCAL (temp);

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -185,10 +185,10 @@ REBNATIVE(exit)
 {
     INCLUDE_PARAMS_OF_EXIT;
 
+    UNUSED(REF(with)); // implied by non-void value 
+
     if (NOT(REF(from)))
         SET_INTEGER(ARG(level), 1); // default--exit one function stack level
-
-    assert(REF(with) || IS_VOID(ARG(value)));
 
     Make_Thrown_Exit_Value(D_OUT, ARG(level), ARG(value), frame_);
 

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -349,7 +349,7 @@ static REBCNT Milliseconds_From_Value(const RELVAL *v) {
         break;
 
     default:
-        assert(FALSE);
+        panic (NULL); // avoid uninitialized msec warning
     }
 
     if (msec < 0)

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -395,7 +395,7 @@ REBNATIVE(decompress)
         max = -1;
 
     REBCNT len;
-    assert(PAR(part) != NULL);
+    UNUSED(REF(part)); // implied by non-void lim
     Partial1(data, ARG(lim), &len);
 
     // This truncation rule used to be in Decompress, which passed len

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -41,7 +41,7 @@
 //
 REBNATIVE(halt)
 {
-    assert(frame_ != NULL); // avoid unused parameter warning
+    UNUSED(frame_);
     fail (VAL_CONTEXT(TASK_HALT_ERROR));
 }
 
@@ -222,6 +222,11 @@ REBNATIVE(stats)
     }
 
 #ifdef NDEBUG
+    UNUSED(REF(show));
+    UNUSED(REF(profile));
+    UNUSED(REF(dump_series));
+    UNUSED(ARG(pool_id));
+
     fail (Error_Debug_Only_Raw());
 #else
     if (REF(profile)) {
@@ -291,6 +296,8 @@ REBNATIVE(evoke)
     INCLUDE_PARAMS_OF_EVOKE;
 
 #ifdef NDEBUG
+    UNUSED(ARG(chant));
+
     fail (Error_Debug_Only_Raw());
 #else
     RELVAL *arg = ARG(chant);
@@ -397,6 +404,8 @@ REBNATIVE(check)
     INCLUDE_PARAMS_OF_CHECK;
 
 #ifdef NDEBUG
+    UNUSED(ARG(value));
+
     fail (Error_Debug_Only_Raw());
 #else
     REBVAL *value = ARG(value);

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -83,11 +83,11 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         UNUSED(PAR(source)); // already accounted for
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         UNUSED(PAR(string)); // handled in dispatcher
@@ -134,13 +134,13 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         UNUSED(PAR(data)); // used as arg
 
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(append))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(lines))
@@ -215,7 +215,7 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         if (REF(seek))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/p-console.c
+++ b/src/core/p-console.c
@@ -62,11 +62,11 @@ static REB_R Console_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         UNUSED(PAR(source));
 
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         UNUSED(PAR(string)); // handled in dispatcher

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -205,11 +205,11 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         UNUSED(PAR(source));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         UNUSED(PAR(string)); // handled in dispatcher
@@ -299,7 +299,7 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         if (REF(seek))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -61,12 +61,12 @@ static REB_R DNS_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         UNUSED(PAR(source));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
 
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -153,7 +153,7 @@ pick:
         if (REF(seek))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -208,7 +208,7 @@ act_blk:
         if (REF(seek))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -174,8 +174,12 @@ static void Read_File_Port(
     REBFLGS flags,
     REBCNT len
 ) {
+#ifdef NDEBUG
+    UNUSED(path);
+#else
     assert(IS_FILE(path));
-    assert(flags == 0); // currently not used
+#endif
+    UNUSED(flags);
 
     REBREQ *req = AS_REBREQ(file);
 
@@ -357,7 +361,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         UNUSED(PAR(destination));
 
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -419,7 +423,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         UNUSED(PAR(spec));
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -446,7 +450,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         if (REF(deep))
             fail (Error_Bad_Refines_Raw());
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -463,7 +467,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     case SYM_CLOSE: {
         INCLUDE_PARAMS_OF_CLOSE;
-        assert(PAR(port) != NULL);
+        UNUSED(PAR(port));
 
         if (IS_OPEN(req)) {
             OS_DO_DEVICE(req, RDC_CLOSE);
@@ -525,7 +529,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         UNUSED(PAR(target));
         if (REF(mode)) {
-            assert(!IS_VOID(ARG(field)));
+            UNUSED(ARG(field));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -223,11 +223,11 @@ static REB_R Transport_Actor(
         UNUSED(PAR(source));
 
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         UNUSED(PAR(string)); // handled in dispatcher
@@ -277,13 +277,13 @@ static REB_R Transport_Actor(
         UNUSED(PAR(destination));
 
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Misc_Raw());
         }
         if (REF(append))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(lines))

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -164,11 +164,11 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         UNUSED(PAR(source));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         UNUSED(PAR(string)); // handled in dispatcher
@@ -212,13 +212,13 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         UNUSED(PAR(destination));
 
         if (REF(seek)) {
-            assert(!IS_VOID(ARG(index)));
+            UNUSED(ARG(index));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(append))
             fail (Error_Bad_Refines_Raw());
         if (REF(allow)) {
-            assert(!IS_VOID(ARG(access)));
+            UNUSED(ARG(access));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(lines))

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -301,6 +301,8 @@ REBNATIVE(get_signal_actor_handle)
 // disabled #ifdef, so a definition for this has to be provided... even if
 // it's not a build where it should be available.
 {
+    UNUSED(frame_);
+
 #ifdef HAS_POSIX_SIGNAL
     Make_Port_Actor_Handle(D_OUT, &Signal_Actor);
     return R_OUT;

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -192,8 +192,7 @@ REBCNT Hash_Value(const RELVAL *v)
         // While a void might technically be hashed, it can't be a value *or*
         // a key in a map.
         //
-        assert(FALSE);
-        break;
+        panic (NULL);
 
     case REB_BAR:
     case REB_LIT_BAR:
@@ -365,10 +364,14 @@ REBCNT Hash_Value(const RELVAL *v)
         fail (Error_Invalid_Type(VAL_TYPE(v)));
 
     default:
-        assert(FALSE); // the list above should be comprehensive
+        // The list above should be comprehensive.  panic in order to keep
+        // there from being an uninitialized ret warning.
+        //
+        panic (NULL);
     }
 
-    if(!crc32_table) Make_CRC32_Table();
+    if (crc32_table == NULL)
+        Make_CRC32_Table();
 
     return ret ^ crc32_table[VAL_TYPE(v)];
 }

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -402,8 +402,14 @@ static void Mold_String_Series(const REBVAL *value, REB_MOLD *mold)
     if (!GET_MOPT(mold, MOPT_NON_ANSI_PARENED)) sf.paren = 0;
 
     // Source can be 8 or 16 bits:
-    if (unicode) up = UNI_HEAD(ser);
-    else bp = BIN_HEAD(ser);
+    if (unicode) {
+        up = UNI_HEAD(ser);
+        bp = NULL; // wasteful, but avoids may be used uninitialized warning
+    }
+    else {
+        up = NULL; // wasteful, but avoids may be used uninitialized warning
+        bp = BIN_HEAD(ser);
+    }
 
     // If it is a short quoted string, emit it as "string":
     if (len <= MAX_QUOTED_STR && sf.quote == 0 && sf.newline < 3) {

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -94,7 +94,11 @@ void Mold_Bitset(const REBVAL *value, REB_MOLD *mold)
 //  MAKE_Bitset: C
 //
 void MAKE_Bitset(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_BITSET);
+#endif
 
     REBINT len = Find_Max_Bit(arg);
 
@@ -575,13 +579,13 @@ REBTYPE(Bitset)
         UNUSED(PAR(series));
         UNUSED(PAR(value));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(only))
             fail (Error_Bad_Refines_Raw());
         if (REF(skip)) {
-            assert(!IS_VOID(ARG(size)));
+            UNUSED(ARG(size));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(last))
@@ -624,7 +628,7 @@ set_bits:
 
         UNUSED(PAR(series));
         if (REF(map)) {
-            assert(!IS_VOID(ARG(key)));
+            UNUSED(ARG(key));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -641,13 +645,13 @@ set_bits:
 
         UNUSED(PAR(value));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(deep))
             fail (Error_Bad_Refines_Raw());
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-blank.c
+++ b/src/core/t-blank.c
@@ -44,7 +44,7 @@ REBINT CT_Unit(const RELVAL *a, const RELVAL *b, REBINT mode)
 //  MAKE_Unit: C
 //
 void MAKE_Unit(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
-    assert(arg != NULL);
+    UNUSED(arg);
     VAL_RESET_HEADER(out, kind);
 }
 
@@ -53,7 +53,7 @@ void MAKE_Unit(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 //  TO_Unit: C
 //
 void TO_Unit(REBVAL *out, enum Reb_Kind kind, const REBVAL *data) {
-    assert(data != NULL);
+    UNUSED(data);
     VAL_RESET_HEADER(out, kind);
 }
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1038,7 +1038,7 @@ void Assert_Array_Core(REBARR *a)
     REBCNT i;
     for (i = 0; i < ARR_LEN(a); ++i, ++item) {
         if (IS_END(item)) {
-            printf("Premature array end at index %d\n", i);
+            printf("Premature array end at index %d\n", cast(int, i));
             panic (a);
         }
     }

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -863,7 +863,7 @@ REBTYPE(Array)
             fail (Error_Bad_Refines_Raw());
 
         if (REF(with)) {
-            assert(!IS_VOID(ARG(str)));
+            UNUSED(ARG(str));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -57,7 +57,11 @@ REBINT CT_Char(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void MAKE_Char(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_CHAR);
+#endif
 
     REBUNI uni;
 

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -486,6 +486,16 @@ void TO_Date(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 }
 
 
+static REBINT Int_From_Date_Arg(const REBVAL *opt_poke) {
+    if (IS_INTEGER(opt_poke) || IS_DECIMAL(opt_poke))
+        return Int32s(opt_poke, 0);
+    else if (IS_BLANK(opt_poke))
+        return 0;
+    else
+        fail (Error_Invalid_Arg(opt_poke));
+}
+
+
 //
 //  Pick_Or_Poke_Date: C
 //
@@ -611,28 +621,17 @@ void Pick_Or_Poke_Date(
         // done by changing the components that need to change which were
         // extracted, and building a new date out of the parts.
 
-        REBINT n;
-        if (IS_INTEGER(opt_poke) || IS_DECIMAL(opt_poke))
-            n = Int32s(opt_poke, 0);
-        else if (IS_BLANK(opt_poke))
-            n = 0;
-        else if (IS_TIME(opt_poke) && (sym == SYM_TIME || sym == SYM_ZONE))
-            NOOP;
-        else if (IS_DATE(opt_poke) && (sym == SYM_TIME || sym == SYM_ZONE))
-            NOOP;
-        else fail (Error_Invalid_Arg(opt_poke));
-
         switch (sym) {
         case SYM_YEAR:
-            year = n;
+            year = Int_From_Date_Arg(opt_poke);
             break;
 
         case SYM_MONTH:
-            month = n - 1;
+            month = Int_From_Date_Arg(opt_poke) - 1;
             break;
 
         case SYM_DAY:
-            day = n - 1;
+            day = Int_From_Date_Arg(opt_poke) - 1;
             break;
 
         case SYM_TIME:
@@ -644,7 +643,7 @@ void Pick_Or_Poke_Date(
             else if (IS_TIME(opt_poke) || IS_DATE(opt_poke))
                 secs = VAL_TIME(opt_poke);
             else if (IS_INTEGER(opt_poke))
-                secs = n * SEC_SEC;
+                secs = Int_From_Date_Arg(opt_poke) * SEC_SEC;
             else if (IS_DECIMAL(opt_poke))
                 secs = DEC_TO_SECS(VAL_DECIMAL(opt_poke));
             else
@@ -656,7 +655,7 @@ void Pick_Or_Poke_Date(
                 tz = cast(REBINT, VAL_TIME(opt_poke) / (ZONE_MINS * MIN_SEC));
             else if (IS_DATE(opt_poke))
                 tz = VAL_ZONE(opt_poke);
-            else tz = n * (60 / ZONE_MINS);
+            else tz = Int_From_Date_Arg(opt_poke) * (60 / ZONE_MINS);
             if (tz > MAX_ZONE || tz < -MAX_ZONE)
                 fail (Error_Out_Of_Range(opt_poke));
             break;
@@ -674,20 +673,20 @@ void Pick_Or_Poke_Date(
 
         case SYM_HOUR:
             Split_Time(secs, &time);
-            time.h = n;
+            time.h = Int_From_Date_Arg(opt_poke);
             secs = Join_Time(&time, FALSE);
             break;
 
         case SYM_MINUTE:
             Split_Time(secs, &time);
-            time.m = n;
+            time.m = Int_From_Date_Arg(opt_poke);
             secs = Join_Time(&time, FALSE);
             break;
 
         case SYM_SECOND:
             Split_Time(secs, &time);
             if (IS_INTEGER(opt_poke)) {
-                time.s = n;
+                time.s = Int_From_Date_Arg(opt_poke);
                 time.n = 0;
             }
             else {

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -388,7 +388,11 @@ REBINT Cmp_Date(const RELVAL *d1, const RELVAL *d2)
 //  MAKE_Date: C
 //
 void MAKE_Date(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_DATE);
+#endif
 
     if (IS_DATE(arg)) {
         Move_Value(out, arg);

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -125,7 +125,7 @@ void Init_Decimal_Bits(REBVAL *out, const REBYTE *bp)
     REBCNT n;
     for (n = 0; n < 8; ++n)
         dp[n] = bp[7 - n];
-#elif ENDIAN_BIG
+#elif defined(ENDIAN_BIG)
     REBCNT n;
     for (n = 0; n < 8; ++n)
         dp[n] = bp[n];
@@ -497,7 +497,11 @@ REBTYPE(Decimal)
                 fail (Error_Bad_Refines_Raw());
 
             if (REF(seed)) {
-                Set_Random(*cast(REBI64*, &VAL_DECIMAL(val))); // use IEEE bits
+                REBDEC d = VAL_DECIMAL(val);
+                REBI64 i;
+                assert(sizeof(d) == sizeof(i));
+                memcpy(&i, &d, sizeof(d));
+                Set_Random(i); // use IEEE bits
                 return R_VOID;
             }
             d1 = Random_Dec(d1, REF(secure));

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -371,7 +371,11 @@ is_blank:
 //  MAKE_Event: C
 //
 void MAKE_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_EVENT);
+#endif
 
     if (IS_BLOCK(arg)) {
         CLEARS(out);
@@ -393,8 +397,13 @@ void MAKE_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 //
 void TO_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    SET_TRASH_IF_DEBUG(out);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_EVENT);
+#endif
+
+    UNUSED(out);
     fail (Error_Invalid_Arg(arg));
 }
 
@@ -434,7 +443,8 @@ REBINT PD_Event(REBPVS *pvs)
 //
 REBTYPE(Event)
 {
-    assert(frame_ != NULL); // avoid unused parameter warning
+    UNUSED(frame_);
+
     fail (Error_Illegal_Action(REB_EVENT, action));
 }
 

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -112,13 +112,21 @@ void MAKE_Function(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 //  TO_Function: C
 //
+// `to function! 'x` might be an interesting optimized 0-arity function
+// generator, which made a function that returned that value every time you
+// called it.  Generalized alternative would be like `does [quote x]`,
+// which would be slower to generate the function and slower to run.
+//
 void TO_Function(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    // `to function! foo` is meaningless (and should not be given meaning,
-    // because `to function! [print "DOES exists for this, for instance"]`
-    //
-    SET_TRASH_IF_DEBUG(out);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_FUNCTION);
+#endif
+
+    UNUSED(out);
+
     fail (Error_Invalid_Arg(arg));
 }
 
@@ -137,11 +145,11 @@ REBTYPE(Function)
 
         UNUSED(PAR(value));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(deep)) {

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -691,6 +691,8 @@ REBARR *Gob_To_Array(REBGOB *gob)
         case GOBT_EFFECT:
             sym = SYM_EFFECT;
             break;
+        default:
+            fail (Error_Misc_Raw());
         }
         Init_Set_Word(val1, Canon(sym));
         Get_GOB_Var(gob, val1, val);

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -620,7 +620,6 @@ static void Set_GOB_Vars(REBGOB *gob, const RELVAL *blk, REBSPC *specifier)
     while (NOT_END(blk)) {
         assert(!IS_VOID(blk));
 
-
         Derelativize(var, blk, specifier);
         ++blk;
 
@@ -870,9 +869,13 @@ void Extend_Gob_Core(REBGOB *gob, const REBVAL *arg) {
 //
 //  MAKE_Gob: C
 //
-void MAKE_Gob(REBVAL *out, enum Reb_Kind type, const REBVAL *arg)
+void MAKE_Gob(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    assert(type == REB_GOB);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
+    assert(kind == REB_GOB);
+#endif
 
     REBGOB *gob = Make_Gob();
 
@@ -895,10 +898,16 @@ void MAKE_Gob(REBVAL *out, enum Reb_Kind type, const REBVAL *arg)
 //
 //  TO_Gob: C
 //
-void TO_Gob(REBVAL *out, enum Reb_Kind type, const REBVAL *arg)
+void TO_Gob(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    SET_TRASH_IF_DEBUG(out);
-    assert(type == REB_GOB);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
+    assert(kind == REB_GOB);
+#endif
+
+    UNUSED(out);
+
     fail (Error_Invalid_Arg(arg));
 }
 
@@ -1077,7 +1086,7 @@ REBTYPE(Gob)
         UNUSED(PAR(series));
 
         if (REF(map)) {
-            assert(!IS_VOID(ARG(key)));
+            UNUSED(ARG(key));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -209,7 +209,11 @@ bad_make:
 //
 void TO_Image(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_IMAGE);
+#endif
 
     if (IS_IMAGE(arg)) {
         Copy_Image_Value(out, arg, VAL_IMAGE_LEN(arg));
@@ -1091,7 +1095,7 @@ REBTYPE(Image)
         UNUSED(PAR(series));
 
         if (REF(map)) {
-            assert(!IS_VOID(ARG(key)));
+            UNUSED(ARG(key));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -1136,7 +1140,7 @@ REBTYPE(Image)
             fail (Error_Bad_Refines_Raw());
 
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -357,14 +357,10 @@ REBTYPE(Integer)
 {
     REBVAL *val = D_ARG(1);
     REBVAL *val2 = D_ARGC > 1 ? D_ARG(2) : NULL;
-    REBI64 num;
+    
     REBI64 arg;
-    REBCNT n;
 
-    REBI64 p;
-    REBI64 anum;
-
-    num = VAL_INT64(val);
+    REBI64 num = VAL_INT64(val);
 
     // !!! This used to rely on IS_BINARY_ACT, which is no longer available
     // in the symbol based dispatch.  Consider doing another way.
@@ -380,11 +376,13 @@ REBTYPE(Integer)
         || action == SYM_XOR_T
         || action == SYM_REMAINDER
     ){
-        if (IS_INTEGER(val2)) arg = VAL_INT64(val2);
-        else if (IS_CHAR(val2)) arg = VAL_CHAR(val2);
+        if (IS_INTEGER(val2))
+            arg = VAL_INT64(val2);
+        else if (IS_CHAR(val2))
+            arg = VAL_CHAR(val2);
         else {
             // Decimal or other numeric second argument:
-            n = 0; // use to flag special case
+            REBCNT n = 0; // use to flag special case
             switch(action) {
             // Anything added to an integer is same as adding the integer:
             case SYM_ADD:
@@ -416,7 +414,8 @@ REBTYPE(Integer)
                         VAL_SET_TYPE_BITS(val, REB_TIME);
                         return T_Time(frame_, action);
                     }
-                    if (IS_DATE(val2)) return T_Date(frame_, action);
+                    if (IS_DATE(val2))
+                        return T_Date(frame_, action);
                 }
 
             default:
@@ -425,6 +424,8 @@ REBTYPE(Integer)
             fail (Error_Math_Args(REB_INTEGER, action));
         }
     }
+    else
+        arg = 0xDECAFBAD; // wasteful, but avoid maybe unassigned warning
 
     switch (action) {
 
@@ -432,20 +433,26 @@ REBTYPE(Integer)
         Move_Value(D_OUT, val);
         return R_OUT;
 
-    case SYM_ADD:
-        if (REB_I64_ADD_OF(num, arg, &anum)) fail (Error_Overflow_Raw());
+    case SYM_ADD: {
+        REBI64 anum;
+        if (REB_I64_ADD_OF(num, arg, &anum))
+            fail (Error_Overflow_Raw());
         num = anum;
-        break;
+        break; }
 
-    case SYM_SUBTRACT:
-        if (REB_I64_SUB_OF(num, arg, &anum)) fail (Error_Overflow_Raw());
+    case SYM_SUBTRACT: {
+        REBI64 anum;
+        if (REB_I64_SUB_OF(num, arg, &anum))
+            fail (Error_Overflow_Raw());
         num = anum;
-        break;
+        break; }
 
-    case SYM_MULTIPLY:
-        if (REB_I64_MUL_OF(num, arg, &p)) fail (Error_Overflow_Raw());
+    case SYM_MULTIPLY: {
+        REBI64 p;
+        if (REB_I64_MUL_OF(num, arg, &p))
+            fail (Error_Overflow_Raw());
         num = p;
-        break;
+        break; }
 
     case SYM_DIVIDE:
         if (arg == 0)
@@ -457,14 +464,14 @@ REBTYPE(Integer)
             break;
         }
         // Fall thru
-
     case SYM_POWER:
         SET_DECIMAL(val, (REBDEC)num);
         SET_DECIMAL(val2, (REBDEC)arg);
         return T_Decimal(frame_, action);
 
     case SYM_REMAINDER:
-        if (arg == 0) fail (Error_Zero_Divide_Raw());
+        if (arg == 0)
+            fail (Error_Zero_Divide_Raw());
         num = (arg != -1) ? (num % arg) : 0; // !!! was macro called REM2 (?)
         break;
 
@@ -481,7 +488,8 @@ REBTYPE(Integer)
         break;
 
     case SYM_NEGATE:
-        if (num == MIN_I64) fail (Error_Overflow_Raw());
+        if (num == MIN_I64)
+            fail (Error_Overflow_Raw());
         num = -num;
         break;
 
@@ -490,8 +498,10 @@ REBTYPE(Integer)
         break;
 
     case SYM_ABSOLUTE:
-        if (num == MIN_I64) fail (Error_Overflow_Raw());
-        if (num < 0) num = -num;
+        if (num == MIN_I64)
+            fail (Error_Overflow_Raw());
+        if (num < 0)
+            num = -num;
         break;
 
     case SYM_EVEN_Q:

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -49,7 +49,11 @@ REBINT CT_Integer(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void MAKE_Integer(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_INTEGER);
+#endif
 
     if (IS_LOGIC(arg)) {
         //
@@ -85,7 +89,11 @@ void MAKE_Integer(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 void TO_Integer(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_INTEGER);
+#endif
 
     // use signed logic by default (use TO-INTEGER/UNSIGNED to force
     // unsigned interpretation or error if that doesn't make sense)

--- a/src/core/t-library.c
+++ b/src/core/t-library.c
@@ -48,7 +48,11 @@ REBINT CT_Library(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void MAKE_Library(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_LIBRARY);
+#endif
 
     if (!IS_FILE(arg))
         fail (Error_Unexpected_Type(REB_FILE, VAL_TYPE(arg)));

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -162,9 +162,12 @@ REBINT CT_Logic(const RELVAL *a, const RELVAL *b, REBINT mode)
 //  MAKE_Logic: C
 //
 void MAKE_Logic(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_LOGIC);
+#endif
 
-    //
     // As a construction routine, MAKE takes more liberties in the
     // meaning of its parameters, so it lets zero values be false.
     //
@@ -191,7 +194,11 @@ void MAKE_Logic(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 //  TO_Logic: C
 //
 void TO_Logic(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_LOGIC);
+#endif
 
     // As a "Rebol conversion", TO falls in line with the rest of the
     // interpreter canon that all non-none non-logic-false values are

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -438,7 +438,11 @@ void MAKE_Map(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 void TO_Map(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_MAP);
+#endif
 
     REBARR* array;
     REBCNT len;
@@ -614,13 +618,13 @@ REBTYPE(Map)
         UNUSED(PAR(value)); // handled as `arg`
 
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(only))
             fail (Error_Bad_Refines_Raw());
         if (REF(skip)) {
-            assert(!IS_VOID(ARG(size)));
+            UNUSED(ARG(size));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(last))
@@ -692,7 +696,7 @@ REBTYPE(Map)
         UNUSED(PAR(series));
 
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (NOT(REF(map)))
@@ -733,13 +737,13 @@ REBTYPE(Map)
 
         UNUSED(PAR(value));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(deep))
             fail (Error_Bad_Refines_Raw());
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -56,7 +56,11 @@ REBINT CT_Money(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void MAKE_Money(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_MONEY);
+#endif
 
     switch (VAL_TYPE(arg)) {
     case REB_INTEGER:

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -644,7 +644,7 @@ REBTYPE(Context)
         UNUSED(PAR(value));
 
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -716,7 +716,7 @@ REBTYPE(Context)
         }
 
         if (REF(with)) {
-            assert(!IS_VOID(ARG(str)));
+            UNUSED(ARG(str));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -49,9 +49,13 @@ REBINT CT_Pair(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 //  MAKE_Pair: C
 //
-void MAKE_Pair(REBVAL *out, enum Reb_Kind type, const REBVAL *arg)
+void MAKE_Pair(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    assert(type == REB_PAIR);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
+    assert(kind == REB_PAIR);
+#endif
 
     if (IS_PAIR(arg)) {
         Move_Value(out, arg);

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -49,7 +49,11 @@ REBINT CT_Port(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void MAKE_Port(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_PORT);
+#endif
 
     const REBOOL fully = TRUE; // error if not all arguments consumed
 
@@ -71,7 +75,11 @@ void MAKE_Port(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 void TO_Port(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_PORT);
+#endif
 
     if (!IS_OBJECT(arg))
         fail (Error_Bad_Make(REB_PORT, arg));

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -852,7 +852,13 @@ REB_R Routine_Dispatcher(REBFRM *f)
             RIN_RET_SCHEMA(rin),
             NULL // param: none (it's a return value/output)
         ));
-    };
+    }
+    else {
+        // Shouldn't be used (assigned to NULL later) but avoid maybe
+        // uninitialized warning.
+        //
+        ret_offset = cast(void*, cast(REBUPT, 0xDECAFBAD)); 
+    }
 
     REBSER *arg_offsets;
     if (num_args == 0)

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -274,7 +274,7 @@ static REBSER *Make_Binary_BE64(const REBVAL *arg)
     REBCNT n;
     for (n = 0; n < 8; ++n)
         bp[n] = cp[7 - n];
-#elif ENDIAN_BIG
+#elif defined(ENDIAN_BIG)
     REBCNT n;
     for (n = 0; n < 8; ++n)
         bp[n] = cp[n];

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -686,12 +686,14 @@ REBSER *File_Or_Url_Path_Dispatch(REBPVS *pvs)
     //     >> (x)/("bar")
     //     == %foo/bar
     //
-    REBUNI ch_last;
     REBCNT len = SER_LEN(ser);
-    if (len > 0)
-        ch_last = GET_ANY_CHAR(ser, len - 1);
-    if (len == 0 || ch_last != '/')
+    if (len == 0)
         Append_Codepoint_Raw(ser, '/');
+    else {
+        REBUNI ch_last = GET_ANY_CHAR(ser, len - 1);
+        if (ch_last != '/')
+            Append_Codepoint_Raw(ser, '/');
+    }
 
     REB_MOLD mo;
     CLEARS(&mo);

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1019,7 +1019,7 @@ REBTYPE(String)
         if (REF(deep))
             fail (Error_Bad_Refines_Raw());
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
 

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -622,7 +622,11 @@ static void parse_attr (REBVAL *blk, REBINT *raw_size, REBUPT *raw_addr)
 // have to test for NULL.
 //
 static void cleanup_noop(const REBVAL *v) {
+#ifdef NDEBUG
+    UNUSED(v);
+#else
     assert(IS_HANDLE(v));
+#endif
 }
 
 
@@ -1045,7 +1049,11 @@ void Init_Struct_Fields(REBVAL *ret, REBVAL *spec)
 //     ]
 //
 void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_STRUCT);
+#endif
 
     if (!IS_BLOCK(arg))
         fail (Error_Invalid_Arg(arg));
@@ -1099,6 +1107,8 @@ void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     REBSER *data_bin;
     if (raw_addr == 0)
         data_bin = Make_Binary(max_fields << 2);
+    else
+        data_bin = NULL; // not used, but avoid maybe uninitialized warning
 
     REBINT field_idx = 0; // for field index
     REBIXO eval_idx = 0; // for spec block evaluation

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -292,9 +292,13 @@ REBI64 Make_Time(const REBVAL *val)
 //
 //  MAKE_Time: C
 //
-void MAKE_Time(REBVAL *out, enum Reb_Kind type, const REBVAL *arg)
+void MAKE_Time(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    assert(type == REB_TIME);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
+    assert(kind == REB_TIME);
+#endif
 
     REBI64 secs = Make_Time(arg);
     if (secs == NO_TIME)

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -228,7 +228,11 @@ REBOOL Update_Typeset_Bits_Core(
 //
 void MAKE_Typeset(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_TYPESET);
+#endif
 
     if (IS_TYPESET(arg)) {
         Move_Value(out, arg);

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -357,8 +357,14 @@ void MAKE_Varargs(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 void TO_Varargs(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-    SET_TRASH_IF_DEBUG(out);
+#ifdef NDEBUG
+    UNUSED(kind);
+#else
     assert(kind == REB_VARARGS);
+#endif
+
+    UNUSED(out);
+
     fail (Error_Invalid_Arg(arg));
 }
 
@@ -402,7 +408,6 @@ REBTYPE(Varargs)
         INCLUDE_PARAMS_OF_TAKE;
 
         REBDSP dsp_orig = DSP;
-        REBINT limit;
 
         UNUSED(PAR(series));
         if (REF(deep))
@@ -421,13 +426,17 @@ REBTYPE(Varargs)
             return R_OUT;
         }
 
+        REBINT limit;
         if (IS_INTEGER(ARG(limit))) {
             limit = VAL_INT32(ARG(limit));
-            if (limit < 0) limit = 0;
+            if (limit < 0)
+                limit = 0;
         }
-        else if (!IS_BAR(ARG(limit))) {
+        else if (IS_BAR(ARG(limit))) {
+            limit = 0; // not used, but avoid maybe uninitalized warning
+        }
+        else
             fail (Error_Invalid_Arg(ARG(limit)));
-        }
 
         while (IS_BAR(ARG(limit)) || limit-- > 0) {
             indexor = Do_Vararg_Op_May_Throw(D_OUT, value, VARARG_OP_TAKE);
@@ -512,14 +521,21 @@ void Mold_Varargs(const REBVAL *v, REB_MOLD *mold) {
                 case PARAM_CLASS_NORMAL:
                     kind = REB_WORD;
                     break;
+
+                case PARAM_CLASS_TIGHT:
+                    kind = REB_ISSUE;
+                    break;
+
                 case PARAM_CLASS_HARD_QUOTE:
                     kind = REB_GET_WORD;
                     break;
+
                 case PARAM_CLASS_SOFT_QUOTE:
                     kind = REB_LIT_WORD;
                     break;
+
                 default:
-                    assert(FALSE);
+                    panic (NULL);
             };
 
             // Note varargs_param is distinct from f->param!

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -179,6 +179,8 @@ REBIXO Do_Vararg_Op_May_Throw(
             Derelativize(out, f->value, f->specifier);
             return VA_LIST_FLAG;
         }
+
+        shared = NULL; // not used but avoid maybe uninitialized warning
     }
 
     // The invariant here is that `f` has been prepared for fetching/doing

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -570,6 +570,8 @@ void Poke_Vector_Fail_If_Read_Only(
         f = VAL_DECIMAL(poke);
         if (bits <= VTUI64)
             i = cast(REBINT, f);
+        else
+            i = 0xDECAFBAD; // not used, but avoid maybe uninitalized warning
     }
     else fail (Error_Invalid_Arg(poke));
 

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -637,13 +637,13 @@ REBTYPE(Vector)
 
         UNUSED(PAR(value));
         if (REF(part)) {
-            assert(!IS_VOID(ARG(limit)));
+            UNUSED(ARG(limit));
             fail (Error_Bad_Refines_Raw());
         }
         if (REF(deep))
             fail (Error_Bad_Refines_Raw());
         if (REF(types)) {
-            assert(!IS_VOID(ARG(kinds)));
+            UNUSED(ARG(kinds));
             fail (Error_Bad_Refines_Raw());
         }
 
@@ -654,7 +654,7 @@ REBTYPE(Vector)
 
     case SYM_RANDOM: {
         INCLUDE_PARAMS_OF_RANDOM;
-        assert(PAR(value) != NULL);
+        UNUSED(PAR(value));
 
         FAIL_IF_READ_ONLY_SERIES(vect);
 

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -196,6 +196,7 @@ REBSER *Compress(
     TERM_BIN_LEN(output, buf_size - strm.avail_out);
 
     if (gzip) {
+    #if !defined(NDEBUG)
         //
         // GZIP contains its own CRC.  It also has a 32-bit uncompressed
         // length, conveniently (and perhaps confusingly) at the tail in the
@@ -208,6 +209,7 @@ REBSER *Compress(
             - sizeof(REBCNT)
         );
         assert(len == gzip_len);
+    #endif
     }
     else if (!raw) {
         //

--- a/src/extensions/mod-bmp.c
+++ b/src/extensions/mod-bmp.c
@@ -172,7 +172,7 @@ void Map_Bytes(void *dstp, const REBYTE **srcp, const char *map) {
             break;
 
         case 's':
-            *((short *)dst) = *((short *)src);
+            *((short *)dst) = *((const short *)src);
             dst += sizeof(short);
             src += 2;
             break;
@@ -182,7 +182,7 @@ void Map_Bytes(void *dstp, const REBYTE **srcp, const char *map) {
                 while(((REBUPT)dst)&3)
                     dst++;
             }
-            *((REBCNT *)dst) = *((REBCNT *)src);
+            *((REBCNT *)dst) = *((const REBCNT *)src);
             dst += sizeof(REBCNT);
             src += 4;
             break;
@@ -399,6 +399,9 @@ REBNATIVE(decode_bmp)
     REBCNT *dp = cast(REBCNT *, IMG_DATA(ser));
     
     dp += w * h - w;
+
+    c = 0xDECAFBAD; // should be overwritten, but avoid uninitialized warning
+    x = 0xDECAFBAD; // should be overwritten, but avoid uninitialized warning
 
     for (y = 0; y<h; y++) {
         switch(compression) {

--- a/src/extensions/mod-jpg.c
+++ b/src/extensions/mod-jpg.c
@@ -57,13 +57,13 @@ REBNATIVE(identify_jpeg_q)
 {
     INCLUDE_PARAMS_OF_IDENTIFY_JPEG_Q;
 
-    REBYTE *data = VAL_BIN_AT(ARG(data));
-    REBCNT len = VAL_LEN_AT(ARG(data));
-
     // Handle JPEG error throw:
     if (setjmp(jpeg_state)) {
         return R_FALSE;
     }
+
+    REBYTE *data = VAL_BIN_AT(ARG(data));
+    REBCNT len = VAL_LEN_AT(ARG(data));
 
     int w, h;
     jpeg_info(s_cast(data), len, &w, &h); // may longjmp above

--- a/src/extensions/mod-jpg.c
+++ b/src/extensions/mod-jpg.c
@@ -84,13 +84,13 @@ REBNATIVE(decode_jpeg)
 {
     INCLUDE_PARAMS_OF_DECODE_JPEG;
 
-    REBYTE *data = VAL_BIN_AT(ARG(data));
-    REBCNT len = VAL_LEN_AT(ARG(data));
-
     // Handle JPEG error throw:
     if (setjmp(jpeg_state)) {
         fail (Error_Bad_Media_Raw()); // generic
     }
+
+    REBYTE *data = VAL_BIN_AT(ARG(data));
+    REBCNT len = VAL_LEN_AT(ARG(data));
 
     int w, h;
     jpeg_info(s_cast(data), len, &w, &h); // may longjmp above

--- a/src/extensions/u-png.c
+++ b/src/extensions/u-png.c
@@ -870,17 +870,17 @@ REBNATIVE(identify_png_q)
 {
     INCLUDE_PARAMS_OF_IDENTIFY_PNG_Q;
 
-    REBYTE *data = VAL_BIN_AT(ARG(data));
-    REBCNT len = VAL_LEN_AT(ARG(data));
-
     // Error hook in the PNG decoder from R3-Alpha is done via longjmp.
     //
     if (setjmp(png_state)) {
         return R_FALSE;
     }
 
+    REBYTE *data = VAL_BIN_AT(ARG(data));
+    REBCNT len = VAL_LEN_AT(ARG(data));
+
     // !!! Should codec identifiers return any optional information they just
-    // happen to get?  Intsead of passing NULL for the addresses of the width
+    // happen to get?  Instead of passing NULL for the addresses of the width
     // and the height, this could incidentally get that information back
     // to return it.  Then any non-FALSE result could be "identified" while
     // still being potentially more informative about what was found out.
@@ -904,14 +904,14 @@ REBNATIVE(decode_png)
 {
     INCLUDE_PARAMS_OF_DECODE_PNG;
 
-    REBYTE *data = VAL_BIN_AT(ARG(data));
-    REBCNT len = VAL_LEN_AT(ARG(data));
-
     // Error hook in the PNG decoder from R3-Alpha is done via longjmp.
     //
     if (setjmp(png_state)) {
         fail (Error_Bad_Media_Raw()); // can the error be more specific?
     }
+
+    REBYTE *data = VAL_BIN_AT(ARG(data));
+    REBCNT len = VAL_LEN_AT(ARG(data));
 
     int w, h;
     if (0 == png_info(data, len, &w, &h))

--- a/src/extensions/u-png.c
+++ b/src/extensions/u-png.c
@@ -249,7 +249,7 @@ static unsigned int calc_color(unsigned int color,unsigned short alpha) {
 
 static void process_row_0_1(unsigned char *p,int width,int r,int hoff,int hskip) {
     int c;
-    unsigned char m;
+    unsigned char m = 0xAE; // overwritten, but avoid uninitialized warning 
     unsigned int v,*imgp;
     imgp=img_output+r*png_ihdr.width+hoff;
     for(c=0;c<width;c++) {
@@ -270,7 +270,7 @@ static void process_row_0_1(unsigned char *p,int width,int r,int hoff,int hskip)
 
 static void process_row_0_2(unsigned char *p,int width,int r,int hoff,int hskip) {
     int c;
-    unsigned char m;
+    unsigned char m = 0xAE; // overwritten, but avoid uninitialized warning 
     unsigned int v,*imgp;
 
     imgp=img_output+r*png_ihdr.width+hoff;
@@ -292,7 +292,7 @@ static void process_row_0_2(unsigned char *p,int width,int r,int hoff,int hskip)
 
 static void process_row_0_4(unsigned char *p,int width,int r,int hoff,int hskip) {
     int c;
-    unsigned char m;
+    unsigned char m = 0xAE; // overwritten, but avoid uninitialized warning 
     unsigned int v,*imgp;
 
     imgp=img_output+r*png_ihdr.width+hoff;
@@ -388,7 +388,7 @@ static void process_row_2_16(unsigned char *p,int width,int r,int hoff,int hskip
 
 static void process_row_3_1(unsigned char *p,int width,int r,int hoff,int hskip) {
     int c;
-    unsigned char m;
+    unsigned char m = 0xAE; // overwritten, but avoid uninitialized warning 
     unsigned int v,*imgp;
 
     imgp=img_output+r*png_ihdr.width+hoff;
@@ -404,7 +404,7 @@ static void process_row_3_1(unsigned char *p,int width,int r,int hoff,int hskip)
 
 static void process_row_3_2(unsigned char *p,int width,int r,int hoff,int hskip) {
     int c;
-    unsigned char m;
+    unsigned char m = 0xAE; // overwritten, but avoid uninitialized warning 
     unsigned int v,*imgp;
 
     imgp=img_output+r*png_ihdr.width+hoff;
@@ -420,7 +420,7 @@ static void process_row_3_2(unsigned char *p,int width,int r,int hoff,int hskip)
 
 static void process_row_3_4(unsigned char *p,int width,int r,int hoff,int hskip) {
     int c;
-    unsigned char m;
+    unsigned char m = 0xAE; // overwritten, but avoid uninitialized warning 
     unsigned int v,*imgp;
 
     imgp=img_output+r*png_ihdr.width+hoff;

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -91,7 +91,7 @@ PVAR REB_OPTS *Reb_Opts;
 // arrays--they are singular values, and the second element is set to
 // be trash to trap any unwanted access.
 //
-PVAR REBNOD PG_End_Node;
+PVAR RELVAL PG_End_Node;
 PVAR REBVAL PG_Void_Cell[2];
 
 PVAR REBVAL PG_Blank_Value[2];

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -725,7 +725,7 @@ inline static REBOOL VAL_LOGIC(const RELVAL *v) {
     ((v)->payload.datatype.spec)
 
 #define IS_KIND_SYM(s) \
-    ((s) < REB_MAX)
+    ((s) < cast(REBSYM, REB_MAX))
 
 inline static enum Reb_Kind KIND_FROM_SYM(REBSYM s) {
     assert(IS_KIND_SYM(s));

--- a/src/os/dev-net.c
+++ b/src/os/dev-net.c
@@ -687,7 +687,7 @@ DEVICE_CMD Accept_Socket(REBREQ *req)
 
 i32 Request_Size_Net(REBREQ *sock)
 {
-    (void)(sock);
+    UNUSED(sock);
     return sizeof(struct devreq_net);
 }
 

--- a/src/os/host-device.c
+++ b/src/os/host-device.c
@@ -531,6 +531,6 @@ REBINT OS_Wait(REBCNT millisec, REBCNT res)
 //
 i32 Request_Size_Rebreq(REBREQ *req)
 {
-    (void)req; //unused
+    UNUSED(req);
     return sizeof(REBREQ); //no special fields
 }

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -732,6 +732,8 @@ int main(int argc, char **argv_ansi)
     REBARR *argv = Make_Array(argc);
 
 #ifdef TO_WINDOWS
+    UNUSED(argv_ansi);
+
     //
     // Were we using WinMain we'd be getting our arguments in Unicode, but
     // since we're using an ordinary main() we do not.  However, this call

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -832,7 +832,8 @@ int main(int argc, char **argv_ansi)
 // `fail` can longjmp here, so 'error' won't be NULL *if* that happens!
 
     int exit_status;
-    REBOOL finished;
+
+    volatile REBOOL finished; // without volatile, gets "clobbered" warning
 
     Prep_Global_Cell(&HG_Host_Repl);
     SET_BLANK(&HG_Host_Repl);

--- a/src/os/posix/dev-serial.c
+++ b/src/os/posix/dev-serial.c
@@ -352,7 +352,7 @@ DEVICE_CMD Query_Serial(REBREQ *req)
 //
 static i32 Request_Size_Serial(REBREQ *req)
 {
-    (void)req; //unused
+    UNUSED(req);
     return sizeof(struct devreq_serial);
 }
 

--- a/src/os/posix/dev-stdio.c
+++ b/src/os/posix/dev-stdio.c
@@ -265,7 +265,7 @@ DEVICE_CMD Open_Echo(REBREQ *req)
 //
 static i32 Request_Size_IO(REBREQ *req)
 {
-    (void)req; //unused
+    UNUSED(req);
     return sizeof(struct devreq_file);
 }
 

--- a/src/os/windows/dev-clipboard.c
+++ b/src/os/windows/dev-clipboard.c
@@ -182,6 +182,7 @@ DEVICE_CMD Write_Clipboard(REBREQ *req)
 //
 DEVICE_CMD Poll_Clipboard(REBREQ *req)
 {
+    UNUSED(req);
     return DR_DONE;
 }
 

--- a/src/os/windows/dev-file.c
+++ b/src/os/windows/dev-file.c
@@ -452,6 +452,7 @@ DEVICE_CMD Rename_File(REBREQ *req)
 //
 DEVICE_CMD Poll_File(REBREQ *file)
 {
+    UNUSED(file);
     return DR_DONE;     // files are synchronous (currently)
 }
 
@@ -460,7 +461,7 @@ DEVICE_CMD Poll_File(REBREQ *file)
 //
 static i32 Request_Size_File(REBREQ *req)
 {
-    (void)req; //unused
+    UNUSED(req);
     return sizeof(struct devreq_file);
 }
 

--- a/src/os/windows/dev-serial.c
+++ b/src/os/windows/dev-serial.c
@@ -268,7 +268,7 @@ DEVICE_CMD Query_Serial(REBREQ *req)
 //
 static i32 Request_Size_Serial(REBREQ *req)
 {
-    (void)req; //unused
+    UNUSED(req);
     return sizeof(struct devreq_serial);
 }
 

--- a/src/os/windows/dev-stdio.c
+++ b/src/os/windows/dev-stdio.c
@@ -56,11 +56,6 @@ static wchar_t *Std_Buf = NULL; // Used for UTF-8 conversion of stdin/stdout.
 static BOOL Redir_Out = 0;
 static BOOL Redir_Inp = 0;
 
-static BOOL Con_Out = 1;        //controls the console text output
-
-// Special access:
-extern REBDEV *Devices[];
-
 extern i32 Request_Size_Rebreq(REBREQ *);
 
 //**********************************************************************

--- a/src/os/windows/dev-stdio.c
+++ b/src/os/windows/dev-stdio.c
@@ -290,7 +290,7 @@ DEVICE_CMD Open_Echo(REBREQ *req)
 //
 static i32 Request_Size_IO(REBREQ *req)
 {
-    (void)req; //unused
+    UNUSED(req);
     return sizeof(struct devreq_file);
 }
 

--- a/src/os/windows/host-lib.c
+++ b/src/os/windows/host-lib.c
@@ -680,8 +680,8 @@ int OS_Create_Process(
     unsigned char flag_console = FALSE;
     unsigned char flag_shell = FALSE;
     unsigned char flag_info = FALSE;
-    (void)flag_info; // Suppress -Wunused-but-set-variable
-    (void)flag_console; // Suppress -Wunused-but-set-variable
+    UNUSED(flag_info);
+    UNUSED(flag_console);
 
     if (flags & FLAG_WAIT) flag_wait = TRUE;
     if (flags & FLAG_CONSOLE) flag_console = TRUE;

--- a/src/os/windows/host-lib.c
+++ b/src/os/windows/host-lib.c
@@ -61,9 +61,6 @@ REBSER* Gob_To_Image(REBGOB *gob);
 //used to detect non-modal OS dialogs
 BOOL osDialogOpen = FALSE;
 
-// Semaphore lock to sync sub-task launch:
-static void *Task_Ready;
-
 
 //
 //  Convert_Date: C
@@ -163,6 +160,7 @@ REBINT OS_Get_UID()
 //
 REBINT OS_Set_UID(REBINT uid)
 {
+    UNUSED(uid);
     return OS_ENA;
 }
 
@@ -183,6 +181,7 @@ REBINT OS_Get_GID()
 //
 REBINT OS_Set_GID(REBINT gid)
 {
+    UNUSED(gid);
     return OS_ENA;
 }
 
@@ -203,6 +202,7 @@ REBINT OS_Get_EUID()
 //
 REBINT OS_Set_EUID(REBINT uid)
 {
+    UNUSED(uid);
     return OS_ENA;
 }
 
@@ -223,6 +223,7 @@ REBINT OS_Get_EGID()
 //
 REBINT OS_Set_EGID(REBINT gid)
 {
+    UNUSED(gid);
     return OS_ENA;
 }
 
@@ -233,6 +234,8 @@ REBINT OS_Set_EGID(REBINT gid)
 //
 REBINT OS_Send_Signal(REBINT pid, REBINT signal)
 {
+    UNUSED(pid);
+    UNUSED(signal);
     return OS_ENA;
 }
 
@@ -277,6 +280,8 @@ REBINT OS_Kill(REBINT pid)
 //
 REBINT OS_Config(int id, REBYTE *result)
 {
+    UNUSED(result);
+
 #define OCID_STACK_SIZE 1  // needs to move to .h file
 
     switch (id) {
@@ -504,6 +509,8 @@ void OS_Get_Time(REBVAL *out)
 //
 i64 OS_Delta_Time(i64 base, int flags)
 {
+    UNUSED(flags);
+
     LARGE_INTEGER freq;
     LARGE_INTEGER time;
 
@@ -625,8 +632,25 @@ CFUNC *OS_Find_Function(void *dll, const char *funcname)
 // Return -1 on error.
 // For right now, set flags to 1 for /wait.
 //
-int OS_Create_Process(const REBCHR *call, int argc, const REBCHR* argv[], u32 flags, u64 *pid, int *exit_code, u32 input_type, char *input, u32 input_len, u32 output_type, char **output, u32 *output_len, u32 err_type, char **err, u32 *err_len)
-{
+int OS_Create_Process(
+    const REBCHR *call,
+    int argc,
+    const REBCHR* argv[],
+    u32 flags, u64 *pid,
+    int *exit_code,
+    u32 input_type,
+    char *input,
+    u32 input_len,
+    u32 output_type,
+    char **output,
+    u32 *output_len,
+    u32 err_type,
+    char **err,
+    u32 *err_len
+) {
+    UNUSED(argc);
+    UNUSED(argv);
+
 #define INHERIT_TYPE 0
 #define NONE_TYPE 1
 #define STRING_TYPE 2
@@ -1105,15 +1129,20 @@ input_error:
 //  OS_Reap_Process: C
 //
 // pid:
-//      > 0, a signle process
+//      > 0, a single process
 //      -1, any child process
 // flags:
 //      0: return immediately
 //
 //      Return -1 on error
+//
 int OS_Reap_Process(int pid, int *status, int flags)
 {
-    /* It seems that process doesn't need to be reaped on Windows */
+    UNUSED(pid);
+    UNUSED(status);
+    UNUSED(flags);
+
+    // !!! It seems that process doesn't need to be reaped on Windows
     return 0;
 }
 
@@ -1122,13 +1151,14 @@ int OS_Reap_Process(int pid, int *status, int flags)
 //
 int OS_Browse(const REBCHR *url, int reserved)
 {
+    UNUSED(reserved);
+
     #define MAX_BRW_PATH 2044
     DWORD flag;
     DWORD len;
     DWORD type;
     HKEY key;
     wchar_t *path;
-    HWND hWnd = GetFocus();
     int exit_code = 0;
 
     if (RegOpenKeyEx(HKEY_CLASSES_ROOT, L"http\\shell\\open\\command", 0, KEY_READ, &key) != ERROR_SUCCESS)
@@ -1208,6 +1238,8 @@ REBOOL OS_Request_File(REBRFR *fr)
 
 int CALLBACK ReqDirCallbackProc( HWND hWnd, UINT uMsg, LPARAM lParam, LPARAM lpData )
 {
+    UNUSED(lParam);
+
     static REBOOL inited = FALSE;
     switch (uMsg) {
         case BFFM_INITIALIZED:

--- a/src/tools/file-base.r
+++ b/src/tools/file-base.r
@@ -178,7 +178,13 @@ modules: [
 
     GIF ../extensions/mod-gif.c []
 
-    JPG ../extensions/mod-jpg.c [../extensions/u-jpg.c]
+    JPG ../extensions/mod-jpg.c [
+        ;
+        ; The JPG sources come from elsewhere; invasive maintenance for
+        ; compiler rigor is not worthwhile to be out of sync with original.
+        ;
+        [../extensions/u-jpg.c <no-unused-parameter> <no-shift-negative-value>]
+    ]
 
     BMP ../extensions/mod-bmp.c []
 ]

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -190,7 +190,6 @@ newline
     ][
         ; http://stackoverflow.com/questions/9229978/
         ;
-        print "WTF mate"
         "-DNDEBUG -O2"
     ]
 ) newline
@@ -219,7 +218,7 @@ newline
         cplusplus: false
         ""
     ]
-    find ["c99" "gnu99"] args/STANDARD [
+    find ["gnu89" "c99" "gnu99" "c11"] args/STANDARD [
         cplusplus: false
         unspaced ["--std=" args/STANDARD]
     ]
@@ -227,13 +226,13 @@ newline
         cplusplus: true
         "-x c++"
     ]
-    find ["c++0x" "c++11" "c++14" "c++17"] args/STANDARD [
+    find ["c++98" "c++0x" "c++11" "c++14" "c++17"] args/STANDARD [
         cplusplus: true
         unspaced ["-x c++" space "--std=" args/STANDARD]
     ]
     true [
         fail [
-            "STANDARD needs to be c, c99, gnu99, c++, c++11, c++14, c++17,"
+            "STANDARD should be [c gnu89 gnu99 c99 c11 c++ c++11 c++14 c++17]"
             "not" (args/STANDARD)
         ]
     ]
@@ -263,14 +262,58 @@ newline
             spaced [
                 "-Werror" ;-- convert warnings to errors
 
-                ; !!! Coming soon, need to vet the source for max warnings
+                ; If you use pedantic in a C build on an older GNU compiler,
+                ; (that defaults to thinking it's a C89 compiler), it will
+                ; complain about using `//` style comments.  There is no
+                ; way to turn this complaint off.  So don't use pedantic
+                ; warnings unless you're at c99 or higher, or C++.
+                ;
+                (
+                    either any [
+                        cplusplus | not find ["c" "gnu89"] args/STANDARD
+                    ][
+                        "--pedantic"
+                    ][
+                        ""
+                    ]
+                )
 
-                ;"--pedantic" "-Wextra" "-Wall" "-Wchar-subscripts"
-                ;"-Wwrite-strings" "-Wundef" "-Wformat=2"
-                ;"-Wdisabled-optimization" "-Wcast-qual"
-                ;"-Wlogical-op" "-Wstrict-overflow=5" "-Wredundant-decls"
-                ;"-Woverflow" "-Wpointer-arith" "-Wparentheses" "-Wmain"
-                ;"-Wsign-compare" "-Wtype-limits"
+                "-Wextra"
+                "-Wall"
+                
+                "-Wchar-subscripts"
+                "-Wwrite-strings"
+                "-Wundef"
+                "-Wformat=2"
+                "-Wdisabled-optimization"
+                "-Wlogical-op"
+                "-Wredundant-decls"
+                "-Woverflow"
+                "-Wpointer-arith"
+                "-Wparentheses"
+                "-Wmain"
+                "-Wsign-compare"
+                "-Wtype-limits"
+                "-Wclobbered"
+
+                ; When constness is being deliberately cast away, `m_cast` is
+                ; used (for "m"utability).  However, this is just a plain cast
+                ; in C as it has no const_cast.  Since the C language has no
+                ; way to say you're doing a mutability cast on purpose, the
+                ; warning can't be used... but assume the C++ build covers it.
+                ;
+                (either cplusplus ["-Wcast-qual"] ["-Wno-cast-qual"])
+
+                ; The majority of Rebol's C code was written with little
+                ; attention to overflow in arithmetic.  Frequently REBUPT
+                ; is assigned to REBCNT, size_t to REBYTE, etc.  The issue
+                ; needs systemic review, but will be most easy to do so when
+                ; the core is broken out fully from less critical code
+                ; in optional extensions.
+                ;
+                ;"-Wstrict-overflow=5"
+                "-Wno-conversion"
+                "-Wno-strict-overflow"
             ]
 
         ]
@@ -405,7 +448,8 @@ emit newline
 ;
 
 emit [
-    {HOST_FLAGS= $(LANGUAGE_FLAGS) $(DEBUG_FLAGS) $(SANITIZE_FLAGS) -DREB_EXE}
+    {HOST_FLAGS= $(LANGUAGE_FLAGS) $(DEBUG_FLAGS) $(SANITIZE_FLAGS)}
+        space {$(RIGOROUS_FLAGS) -DREB_EXE}
 ]
 
 for-each [flag switches] compiler-flags [
@@ -717,7 +761,12 @@ emit-file-deps: function [
     /dir path  ; from path
 ][
     for-each item file-list [
+        ;
+        ; Item may be like foo.c, or [foo.c <option1> <option2>]
+        ; Make sure it's a block so it can be uniformly searched for options
+        ;
         unless block? item [item: reduce [item]]
+        
         file: first item
 
         obj: unspaced [%objs/ (to-obj file)]
@@ -731,12 +780,18 @@ emit-file-deps: function [
         emit-line [obj ":" space src]
 
         file-specific-flags: copy ""
-        case/all [
-            all [rigorous | find item <no-uninitialized>] [
+        if rigorous [
+            for-each [setting switches] [
+                <no-uninitialized> "-Wno-uninitialized"
+                <no-unused-parameter> "-Wno-unused-parameter"
+                <no-shift-negative-value> "-Wno-shift-negative-value"
+            ][
+                if not find item setting [continue]
+
                 if not empty? file-specific-flags [
                     append file-specific-flags space
                 ]
-                append file-specific-flags "-Wno-uninitialized"
+                append file-specific-flags switches
             ]
         ]
 

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -296,6 +296,11 @@ newline
                 "-Wtype-limits"
                 "-Wclobbered"
 
+                ; Neither C++98 nor C89 had "long long" integers, but they
+                ; were fairly pervasive before being present in the standard.
+                ;
+                "-Wno-long-long"
+
                 ; When constness is being deliberately cast away, `m_cast` is
                 ; used (for "m"utability).  However, this is just a plain cast
                 ; in C as it has no const_cast.  Since the C language has no


### PR DESCRIPTION
When Ren-C was started ("Coherence One") the goal was to make it
compile without warnings in C, C99, C++, C++11, C++14, etc. with
those levels turned up pretty high.  Then, as a practice, to treat
any warnings in the builds as errors.

While that got fairly far at the time, it was not completed, and the
switch to higher-than-default warning levels with warnings as errors
never did get done.  With the RIGOROUS setting, this attempts to
start putting that into practice.  It also provides a way to put in
per-file exemptions, which is particularly useful when compiling code
that did not originate from this project and shouldn't be edited
directly to fix pedantic errors--due to going out of sync being a
bad idea vs. sending patches to the official source.

Settings used are:

"-Werror" ;-- convert warnings to errors

"--pedantic"
"-Wextra"
"-Wall"

"-Wchar-subscripts"
"-Wwrite-strings"
"-Wundef"
"-Wformat=2"
"-Wdisabled-optimization"
"-Wlogical-op"
"-Wredundant-decls"
"-Woverflow"
"-Wpointer-arith"
"-Wparentheses"
"-Wmain"
"-Wsign-compare"
"-Wtype-limits"

When constness is being deliberately cast away, `m_cast` is used
(for "m"utability).  However, this is just a plain cast in C as it has
no const_cast.  Since the C language has no way to say you're doing a
mutability cast on purpose, the warning can't be used there... but
assume the C++ build covers it.

"-Wcast-qual" ; C++ only

Unfortunately, the majority of Rebol's C code was written with little
attention to overflow in arithmetic.  Frequently REBUPT is assigned to
REBCNT, size_t to REBYTE, etc.  The issue needs systemic review, but
will be most easy to do so when the core is broken out fully from less
critical code in optional extensions.

; DISABLED "-Wconversion"
; DISABLED "-Wstrict-overflow"