### PR TITLE
Correct bug in help / dump-obj: spec-of does not allow datatype!

### DIFF
--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -25,7 +25,7 @@ dump-obj: function [
     clip-str: func [str] [
         ; Keep string to one line.
         trim/lines str
-        if (length str) > 45 [str: append copy/part str 45 "..."]
+        if (length str) > 48 [str: append copy/part str 45 "..."]
         str
     ]
 
@@ -33,7 +33,7 @@ dump-obj: function [
         ; Form a limited string from the value provided.
         if any-block? :val [return spaced ["length:" length val]]
         if image? :val [return spaced ["size:" val/size]]
-        if datatype? :val [return get in spec-of val 'title]
+        if datatype? :val [return form val] 
         if function? :val [
             return clip-str any [title-of :val mold spec-of :val]
         ]


### PR DESCRIPTION
Correction for: 

>> help self
SELF is an object of value:** Script error: spec-of does not allow datatype! for its value argument
** Where: if form-val if spaced if for-each --anonymous-- either collect dump-obj either --anonymous-- either collect unless help
** Near: in spec-of val ?? 'title
** Note: use WHY for more error information

additionally

Change clip-str logic to clip only if longer than 48 characters which changes help output like this:

before
```
   print-newline   function! [ {Write text to standard output, or raw BINA...
   make            function! Constructs or allocates the specified datatyp...
   ==              function! Returns TRUE if the values are strictly equal...
   breakpoint      function! Signal breakpoint to the host (simple variant...
```

after

```
   print-newline   function! [ {Write text to standard output, or raw BINA...
   make            function! Constructs or allocates the specified datatype.
   ==              function! Returns TRUE if the values are strictly equal.
   breakpoint      function! Signal breakpoint to the host (simple variant...
```
 
See issue #451
   