### PR TITLE
Polymorphic fail() => takes UTF-8 C strings, REBVAL*, REBCTX*

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -25,13 +25,6 @@ Internal: [
     code: 1000
     type: "internal"
 
-    ; Because adding an error code has the overhead of modifying this file and
-    ; coming up with a good name, errors for testing or that you don't think
-    ; will happen can use RE_MISC.  A debug build will identify the line
-    ; number and file source of the error, so provides some info already.
-    ;
-    misc:               {RE_MISC error (if actually happens, add to %errors.r)}
-
     ; !!! Should there be a distinction made between different kinds of
     ; stack overflows?  (Call stack, Data stack?)
     ;

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -435,12 +435,12 @@ RL_API REBCNT RL_Encode_UTF8(
 
 inline static REBFRM *Extract_Live_Rebfrm_May_Fail(const REBVAL *frame) {
     if (!IS_FRAME(frame))
-        fail(Error_Misc_Raw()); // !!! improve
+        fail ("Not a FRAME!");
 
     REBCTX *frame_ctx = VAL_CONTEXT(frame);
     REBFRM *f = CTX_FRAME_IF_ON_STACK(frame_ctx);
     if (f == NULL)
-        fail (Error_Misc_Raw()); // !!! improve
+        fail ("FRAME! is no longer on stack.");
 
     assert(Is_Any_Function_Frame(f));
     assert(NOT(Is_Function_Frame_Fulfilling(f)));

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -883,17 +883,14 @@ REBCTX *Construct_Context(
 
     const RELVAL *value = head;
     for (; NOT_END(value); value += 2) {
-        //
-        // !!! Objects are a rewrite in progress; error messages need to
-        // be improved.
-
         if (!IS_SET_WORD(value))
             fail (Error_Invalid_Type(VAL_TYPE(value)));
 
         if (IS_END(value + 1))
-            fail (Error_Misc_Raw());
+            fail ("Unexpected end in context spec block.");
 
-        assert(!IS_SET_WORD(value + 1)); // TBD: support set words!
+        if (IS_SET_WORD(value + 1))
+            fail (Error_Invalid_Type(VAL_TYPE(value + 1))); // TBD: support
 
         REBVAL *var = Sink_Var_May_Fail(value, specifier);
         Derelativize(var, value + 1, specifier);

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -89,22 +89,13 @@ static inline REBOOL Start_New_Expression_Throws(REBFRM *f) {
         // it may spawn an entire interactive debugging session via
         // breakpoint before it returns.  It may also FAIL and longjmp out.
         //
+        SET_END(&f->cell);
         if (Do_Signals_Throws(&f->cell)) {
             Move_Value(f->out, &f->cell);
             return TRUE;
         }
 
-        if (!IS_VOID(&f->cell)) {
-            //
-            // !!! What to do with something like a Ctrl-C-based breakpoint
-            // session that does something like `resume/with 10`?  We are
-            // "in-between" evaluations, so that 10 really has no meaning
-            // and is just going to get discarded.  FAIL for now to alert
-            // the user that something is off, but perhaps the failure
-            // should be contained in a sandbox and restart the break?
-            //
-            fail (Error_Misc_Raw());
-        }
+        assert(IS_END(&f->cell));
     }
 
     UPDATE_EXPRESSION_START(f); // !!! See FRM_INDEX() for caveats

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -235,8 +235,9 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                     Copy_String_Slimming(VAL_SERIES(item), VAL_INDEX(item), -1)
                 );
             }
-            else if (IS_STRING(DS_TOP)) {
-                //
+            else {
+                assert(IS_STRING(DS_TOP));
+
                 // !!! A string was already pushed.  Should we append?
                 //
                 Init_String(
@@ -244,8 +245,6 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                     Copy_String_Slimming(VAL_SERIES(item), VAL_INDEX(item), -1)
                 );
             }
-            else
-                fail (Error_Misc_Raw()); // should not be possible.
 
             if (DS_TOP == DS_AT(dsp_orig + 3))
                 has_description = TRUE;
@@ -320,7 +319,9 @@ REBARR *Make_Paramlist_Managed_May_Fail(
 
                 typeset = DS_TOP - 1; // volatile if you DS_PUSH!
             }
-            else if (IS_STRING(DS_TOP)) { // !!! are blocks after notes good?
+            else {
+                assert(IS_STRING(DS_TOP)); // !!! are blocks after notes good?
+
                 if (IS_BLANK_RAW(DS_TOP - 2)) {
                     //
                     // No typesets pushed yet, so this is a block before any
@@ -349,8 +350,6 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                     )
                 );
             }
-            else
-                fail (Error_Misc_Raw()); // shouldn't be possible
 
             // Turn block into typeset for parameter at current index.
             // Leaves VAL_TYPESET_SYM as-is.
@@ -1670,7 +1669,7 @@ REBTYPE(Fail)
     UNUSED(frame_);
     UNUSED(action);
 
-    fail (Error_Misc_Raw());
+    fail ("Datatype does not have a dispatcher registered.");
 }
 
 

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -241,7 +241,7 @@ REBOOL Wait_Ports(REBARR *ports, REBCNT timeout, REBOOL only)
                 // meaning then there must be a way to deliver that result
                 // up the stack.
                 //
-                fail (Error_Misc_Raw());
+                fail ("Cannot deliver non-void result from Wait_Ports()");
             }
         }
 
@@ -452,8 +452,7 @@ REBOOL Redo_Func_Throws(REBFRM *f, REBFUN *func_new)
         // all not getting consumed, but we can raise an error now that it
         // did not.
         //
-        assert(FALSE);
-        fail (Error_Misc_Raw());
+        fail ("Function frame proxying did not consume all arguments");
     }
 
     return LOGICAL(indexor == THROWN_FLAG);
@@ -530,8 +529,8 @@ post_process_output:
         assert(r == R_OUT);
 
         if ((REF(string) || REF(lines)) && !IS_STRING(D_OUT)) {
-            if (!IS_BINARY(D_OUT))
-                fail (Error_Misc_Raw()); // !!! when can this happen?
+            if (NOT(IS_BINARY(D_OUT)))
+                fail ("/STRING or /LINES used on a non-BINARY!/STRING! read");
 
             REBSER *decoded = Decode_UTF_String(
                 VAL_BIN_AT(D_OUT),
@@ -544,8 +543,7 @@ post_process_output:
         }
 
         if (REF(lines)) { // caller wants a BLOCK! of STRING!s, not one string
-            if (!IS_STRING(D_OUT))
-                fail (Error_Misc_Raw()); // !!! when can this happen?
+            assert(IS_STRING(D_OUT));
 
             DECLARE_LOCAL (temp);
             Move_Value(temp, D_OUT);

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -438,7 +438,7 @@ REBNATIVE(resume)
         // handle (integers, functions for most recent call, literal FRAME!)
 
         if (!(frame = Frame_For_Stack_Level(NULL, ARG(level), TRUE)))
-            fail (Error_Invalid_Arg(ARG(level)));
+            fail (ARG(level));
 
         // !!! It's possible to specify a context to return at which is
         // "underneath" a breakpoint.  So being at a breakpoint and doing

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -127,18 +127,14 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
     Req_SIO->common.data = buf;
     buffer[0] = 0; // for debug tracing
 
-    if (opts & OPT_ENC_RAW) {
-        //
-        // !!! See notes on other invocations about the questions raised by
-        // calls to Do_Signals_Throws() by places that do not have a clear
-        // path up to return results from an interactive breakpoint.
-        //
-        DECLARE_LOCAL (result);
+    DECLARE_LOCAL (result);
+    SET_END(result);
 
+    if (opts & OPT_ENC_RAW) {
         if (Do_Signals_Throws(result))
             fail (Error_No_Catch_For_Throw(result));
-        if (IS_ANY_VALUE(result))
-            fail (Error_Misc_Raw());
+
+        assert(IS_END(result));
 
         // Used by verbatim terminal output, e.g. print of a BINARY!
         assert(!unicode);
@@ -153,18 +149,11 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
             fail (Error_Io_Error_Raw());
     }
     else {
-        DECLARE_LOCAL (result);
-
         while ((len2 = len) > 0) {
-            //
-            // !!! See notes on other invocations about the questions raised by
-            // calls to Do_Signals_Throws() by places that do not have a clear
-            // path up to return results from an interactive breakpoint.
-            //
             if (Do_Signals_Throws(result))
                 fail (Error_No_Catch_For_Throw(result));
-            if (IS_ANY_VALUE(result))
-                fail (Error_Misc_Raw());
+
+            assert(IS_END(result));
 
             Req_SIO->length = Encode_UTF8(
                 buf,

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -201,7 +201,7 @@ REBNATIVE(where_of)
 
     REBFRM *frame = Frame_For_Stack_Level(NULL, ARG(level), TRUE);
     if (frame == NULL)
-        fail (Error_Invalid_Arg(ARG(level)));
+        fail (ARG(level));
 
     Init_Block(D_OUT, Make_Where_For_Frame(frame));
     return R_OUT;
@@ -263,7 +263,7 @@ REBNATIVE(function_of)
     else {
         REBFRM *frame = Frame_For_Stack_Level(NULL, level, TRUE);
         if (!frame)
-            fail (Error_Invalid_Arg(level));
+            fail (level);
 
         Move_Value(D_OUT, FUNC_VALUE(frame->phase));
     }
@@ -337,7 +337,7 @@ REBNATIVE(backtrace)
         // See notes on handling of breakpoint below for why 0 is accepted.
         //
         if (IS_INTEGER(level) && VAL_INT32(level) < 0)
-            fail (Error_Invalid_Arg(level));
+            fail (level);
     }
 
     REBCNT max_rows; // The "frames" from /LIMIT, plus one (for ellipsis)
@@ -346,7 +346,7 @@ REBNATIVE(backtrace)
             max_rows = MAX_U32; // NONE is no limit--as many frames as possible
         else {
             if (VAL_INT32(ARG(frames)) < 0)
-                fail (Error_Invalid_Arg(ARG(frames)));
+                fail (ARG(frames));
             max_rows = VAL_INT32(ARG(frames)) + 1; // + 1 for ellipsis
         }
     }

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -227,7 +227,7 @@ REBNATIVE(trace)
             REBINT lines = Int32(mode);
             Trace_Flags = 0;
             if (lines < 0)
-                fail (Error_Invalid_Arg(mode));
+                fail (mode);
 
             Display_Backtrace(cast(REBCNT, lines));
             return R_VOID;

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -216,14 +216,14 @@ REBNATIVE(unload_extension_helper)
             != CTX_KEY_CANON(std, STD_EXTENSION_LIB_BASE)
         )
     ){
-        fail (Error_Invalid_Arg(ARG(ext)));
+        fail (ARG(ext));
     }
 
     int ret;
     if (!REF(cleanup)) {
         REBVAL *lib = CTX_VAR(context, STD_EXTENSION_LIB_BASE);
         if (!IS_LIBRARY(lib))
-            fail (Error_Invalid_Arg(ARG(ext)));
+            fail (ARG(ext));
 
         if (IS_LIB_CLOSED(VAL_LIBRARY(lib)))
             fail (Error_Bad_Library_Raw());
@@ -241,7 +241,7 @@ REBNATIVE(unload_extension_helper)
     }
     else {
         if (VAL_HANDLE_CLEANER(ARG(cleaner)) != cleanup_extension_quit_handler)
-            fail (Error_Invalid_Arg(ARG(cleaner)));
+            fail (ARG(cleaner));
 
         QUIT_FUNC quitter = cast(QUIT_FUNC, VAL_HANDLE_CFUNC(ARG(cleaner)));
         assert(quitter != NULL);
@@ -356,18 +356,18 @@ void Shutdown_Boot_Extensions(CFUNC **funcs, REBCNT n)
 //  "Load a native from a built-in extension"
 //
 //      return: [function!]
-//      "function value, will be created from the native implementation"
+//          "function value, will be created from the native implementation"
 //      spec [block!]
-//      "spec of the native"
+//          "spec of the native"
 //      impl [handle!]
-//      "a handle returned from RX_Init_ of the extension"
+//          "a handle returned from RX_Init_ of the extension"
 //      index [integer!]
-//      "Index of the native"
+//          "Index of the native"
 //      /body
 //      code [block!]
-//      "User-equivalent body"
+//          "User-equivalent body"
 //      /unloadable
-//      "The native can be unloaded later (when the extension is unloaded)"
+//          "The native can be unloaded later (when extension is unloaded)"
 //  ]
 //
 REBNATIVE(load_native)
@@ -375,11 +375,11 @@ REBNATIVE(load_native)
     INCLUDE_PARAMS_OF_LOAD_NATIVE;
 
     if (VAL_HANDLE_CLEANER(ARG(impl)) != cleanup_module_handler)
-        fail (Error_Misc_Raw());
+        fail ("HANDLE! passed to LOAD-NATIVE did not come from RX_Init");
 
     REBI64 index = VAL_INT64(ARG(index));
     if (index < 0 || cast(REBUPT, index) >= VAL_HANDLE_LEN(ARG(impl)))
-        fail (Error_Misc_Raw());
+        fail ("Index of native is outside range specified by RX_Init");
 
     REBNAT dispatcher = VAL_HANDLE_POINTER(REBNAT, ARG(impl))[index];
     REBFUN *fun = Make_Function(

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -203,7 +203,7 @@ REBCNT Modify_String(
             limit = -1;
         }
         else if (!IS_BINARY(src_val))
-            fail (Error_Invalid_Arg(src_val));
+            fail (src_val);
     }
     else if (IS_CHAR(src_val)) {
         src_ser = Make_Series_Codepoint(VAL_CHAR(src_val));

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -56,7 +56,7 @@ REBINT Get_Num_From_Arg(const REBVAL *val)
     else if (IS_LOGIC(val))
         n = (VAL_LOGIC(val) ? 1 : 2);
     else
-        fail (Error_Invalid_Arg(val));
+        fail (val);
 
     return n;
 }
@@ -157,7 +157,7 @@ REBI64 Int64(const REBVAL *val)
     if (IS_MONEY(val))
         return deci_to_int(VAL_MONEY_AMOUNT(val));
 
-    fail (Error_Invalid_Arg(val));
+    fail (val);
 }
 
 
@@ -173,7 +173,7 @@ REBDEC Dec64(const REBVAL *val)
     if (IS_MONEY(val))
         return deci_to_decimal(VAL_MONEY_AMOUNT(val));
 
-    fail (Error_Invalid_Arg(val));
+    fail (val);
 }
 
 

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -54,7 +54,7 @@ void MAKE_Fail(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     UNUSED(kind);
     UNUSED(arg);
 
-    fail (Error_Misc_Raw());
+    fail ("Datatype does not have a MAKE handler registered");
 }
 
 
@@ -172,7 +172,7 @@ void TO_Fail(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     UNUSED(kind);
     UNUSED(arg);
 
-    fail (Error_Misc_Raw());
+    fail ("Datatype does not have a TO handler registered");
 }
 
 
@@ -212,12 +212,12 @@ REBNATIVE(to)
     if (IS_BLANK(arg)) {
         if (kind == REB_BLANK)
             return R_BLANK;
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
     }
 
     TO_FUNC dispatcher = To_Dispatch[kind];
     if (dispatcher == NULL)
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     dispatcher(D_OUT, kind, arg); // may fail();
     return R_OUT;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -645,7 +645,7 @@ REBNATIVE(catch)
                     // !!! Should we test a typeset for illegal name types?
                     //
                     if (IS_BLOCK(candidate))
-                        fail (Error_Invalid_Arg(ARG(names)));
+                        fail (ARG(names));
 
                     Derelativize(temp1, candidate, VAL_SPECIFIER(ARG(names)));
                     Move_Value(temp2, D_OUT);

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -774,7 +774,7 @@ REBNATIVE(in)
             return R_BLANK;
         }
 
-        fail (Error_Invalid_Arg(word));
+        fail (word);
     }
 
     REBCTX *context = VAL_CONTEXT(val);
@@ -860,6 +860,8 @@ REBNATIVE(resolve)
 //  ]
 //
 REBNATIVE(set)
+//
+// !!! Should the /LOOKBACK refinement be called /ENFIX?
 {
     INCLUDE_PARAMS_OF_SET;
 
@@ -868,7 +870,7 @@ REBNATIVE(set)
 
     if (REF(lookback)) {
         if (!IS_FUNCTION(ARG(value)))
-            fail (Error_Misc_Raw());
+            fail ("Attempt to SET/LOOKBACK on a non-function");
 
         // SET-INFIX checks for properties of the function to ensure it is
         // actually infix, and INFIX? tests specifically for that.  The only
@@ -898,7 +900,7 @@ REBNATIVE(set)
     // a word in a context to one.
     //
     if (REF(lookback))
-        fail (Error_Misc_Raw());
+        fail ("Cannot currently SET/LOOKBACK on a PATH!");
 
     if (ANY_PATH(ARG(target))) {
         DECLARE_LOCAL (dummy);
@@ -1056,7 +1058,7 @@ REBNATIVE(set)
 
             if (IS_BAR(value))
                 if (!IS_BAR(target))
-                    fail (Error_Misc_Raw());
+                    fail ("BAR! can only line up with other BAR! in SET");
 
             switch (VAL_TYPE(target)) {
             case REB_BLANK:
@@ -1085,7 +1087,7 @@ REBNATIVE(set)
                 // legal but `set [a | b] [1 2 3]` is not.
                 //
                 if (!IS_BAR(value))
-                    fail (Error_Misc_Raw());
+                    fail ("BAR! can only line up with other BAR! in SET");
                 break;
 
             default:
@@ -1259,7 +1261,7 @@ REBNATIVE(lookback_q)
 
         // Not implemented yet...
 
-        fail (Error_Misc_Raw());
+        fail ("LOOKBACK? testing is not currently implemented on PATH!");
     }
 }
 
@@ -1337,7 +1339,7 @@ REBNATIVE(as)
     case REB_LIT_PATH:
     case REB_GET_PATH:
         if (!ANY_ARRAY(value))
-            fail (Error_Invalid_Arg(value));
+            fail (value);
         break;
 
     case REB_STRING:
@@ -1345,7 +1347,7 @@ REBNATIVE(as)
     case REB_FILE:
     case REB_URL:
         if (!ANY_BINSTR(value) || IS_BINARY(value))
-            fail (Error_Invalid_Arg(value));
+            fail (value);
         break;
 
     case REB_WORD:
@@ -1355,7 +1357,7 @@ REBNATIVE(as)
     case REB_ISSUE:
     case REB_REFINEMENT:
         if (!ANY_WORD(value))
-            fail (Error_Invalid_Arg(value));
+            fail (value);
         break;
 
     default:

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -392,7 +392,7 @@ REBNATIVE(chain)
     REBVAL *check = first;
     while (NOT_END(check)) {
         if (!IS_FUNCTION(check))
-            fail (Error_Invalid_Arg(check));
+            fail (check);
         ++check;
     }
 
@@ -586,13 +586,13 @@ REBNATIVE(hijack)
     REBSTR *opt_victim_name;
     Get_If_Word_Or_Path_Arg(victim, &opt_victim_name, ARG(victim));
     if (!IS_FUNCTION(victim))
-        fail (Error_Misc_Raw());
+        fail ("Victim of HIJACK must be a FUNCTION!");
 
     DECLARE_LOCAL (hijacker);
     REBSTR *opt_hijacker_name;
     Get_If_Word_Or_Path_Arg(hijacker, &opt_hijacker_name, ARG(hijacker));
     if (!IS_FUNCTION(hijacker))
-        fail (Error_Misc_Raw());
+        fail ("Hijacker in HIJACK must be a FUNCTION!");
 
     if (VAL_FUNC(victim) == VAL_FUNC(hijacker)) {
         //

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -477,7 +477,7 @@ REBNATIVE(to_rebol_file)
 
     REBSER *ser = Value_To_REBOL_Path(arg, FALSE);
     if (ser == NULL)
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     Init_File(D_OUT, ser);
     return R_OUT;
@@ -502,7 +502,7 @@ REBNATIVE(to_local_file)
 
     REBSER *ser = Value_To_Local_Path(arg, REF(full));
     if (ser == NULL)
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     Init_String(D_OUT, ser);
     return R_OUT;
@@ -549,7 +549,8 @@ REBNATIVE(what_dir)
     else {
         // Lousy error, but ATM the user can directly edit system/options.
         // They shouldn't be able to (or if they can, it should be validated)
-        fail (Error_Invalid_Arg(current_path));
+        //
+        fail (current_path);
     }
 
     return R_OUT;
@@ -582,15 +583,15 @@ REBNATIVE(change_dir)
         assert(IS_FILE(arg));
 
         REBSER *ser = Value_To_OS_Path(arg, TRUE);
-        if (!ser)
-            fail (Error_Invalid_Arg(arg)); // !!! ERROR MSG
+        if (ser == NULL)
+            fail (arg);
 
         DECLARE_LOCAL (val);
         Init_String(val, ser); // may be unicode or utf-8
         Check_Security(Canon(SYM_FILE), POL_EXEC, val);
 
         if (!OS_SET_CURRENT_DIR(SER_HEAD(REBCHR, ser)))
-            fail (Error_Invalid_Arg(arg)); // !!! ERROR MSG
+            fail (arg);
     }
 
     Move_Value(current_path, arg);
@@ -765,7 +766,7 @@ REBNATIVE(call)
             input_type = NONE_TYPE;
         }
         else
-            fail (Error_Invalid_Arg(param));
+            fail (param);
     }
 
     // Note that os_output is actually treated as an *input* parameter in the
@@ -795,7 +796,7 @@ REBNATIVE(call)
             output_type = NONE_TYPE;
         }
         else
-            fail (Error_Invalid_Arg(param));
+            fail (param);
     }
 
     (void)input; // suppress unused warning but keep variable
@@ -823,7 +824,7 @@ REBNATIVE(call)
             err_type = NONE_TYPE;
         }
         else
-            fail (Error_Invalid_Arg(param));
+            fail (param);
     }
 
     if (
@@ -927,7 +928,7 @@ REBNATIVE(call)
         argv[argc] = NULL;
     }
     else
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     r = OS_CREATE_PROCESS(
         cmd, argc, argv,
@@ -1378,10 +1379,10 @@ REBNATIVE(access_os)
                                 fail (Error_Permission_Denied_Raw());
 
                             case OS_EINVAL:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
 
                             default:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
                         }
                     } else {
                         SET_INTEGER(D_OUT, ret);
@@ -1389,7 +1390,7 @@ REBNATIVE(access_os)
                     }
                 }
                 else
-                    fail (Error_Invalid_Arg(val));
+                    fail (val);
             }
             else {
                 REBINT ret = OS_GET_UID();
@@ -1414,10 +1415,10 @@ REBNATIVE(access_os)
                                 fail (Error_Permission_Denied_Raw());
 
                             case OS_EINVAL:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
 
                             default:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
                         }
                     } else {
                         SET_INTEGER(D_OUT, ret);
@@ -1425,7 +1426,7 @@ REBNATIVE(access_os)
                     }
                 }
                 else
-                    fail (Error_Invalid_Arg(val));
+                    fail (val);
             }
             else {
                 REBINT ret = OS_GET_GID();
@@ -1450,10 +1451,10 @@ REBNATIVE(access_os)
                                 fail (Error_Permission_Denied_Raw());
 
                             case OS_EINVAL:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
 
                             default:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
                         }
                     } else {
                         SET_INTEGER(D_OUT, ret);
@@ -1461,7 +1462,7 @@ REBNATIVE(access_os)
                     }
                 }
                 else
-                    fail (Error_Invalid_Arg(val));
+                    fail (val);
             }
             else {
                 REBINT ret = OS_GET_EUID();
@@ -1486,10 +1487,10 @@ REBNATIVE(access_os)
                                 fail (Error_Permission_Denied_Raw());
 
                             case OS_EINVAL:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
 
                             default:
-                                fail (Error_Invalid_Arg(val));
+                                fail (val);
                         }
                     } else {
                         SET_INTEGER(D_OUT, ret);
@@ -1497,7 +1498,7 @@ REBNATIVE(access_os)
                     }
                 }
                 else
-                    fail (Error_Invalid_Arg(val));
+                    fail (val);
             }
             else {
                 REBINT ret = OS_GET_EGID();
@@ -1520,7 +1521,8 @@ REBNATIVE(access_os)
                 else if (IS_BLOCK(val)) {
                     RELVAL *sig = NULL;
 
-                    if (VAL_LEN_AT(val) != 2) fail (Error_Invalid_Arg(val));
+                    if (VAL_LEN_AT(val) != 2)
+                        fail (val);
 
                     pid = VAL_ARRAY_AT_HEAD(val, 0);
                     if (!IS_INTEGER(pid))
@@ -1534,7 +1536,7 @@ REBNATIVE(access_os)
                     arg = sig;
                 }
                 else
-                    fail (Error_Invalid_Arg(val));
+                    fail (val);
 
                 if (ret < 0) {
                     switch (ret) {
@@ -1545,13 +1547,13 @@ REBNATIVE(access_os)
                             fail (Error_Permission_Denied_Raw());
 
                         case OS_EINVAL:
-                            fail (Error_Invalid_Arg(KNOWN(arg)));
+                            fail (KNOWN(arg));
 
                         case OS_ESRCH:
                             fail (Error_Process_Not_Found_Raw(pid));
 
                         default:
-                            fail (Error_Invalid_Arg(val));
+                            fail (val);
                     }
                 } else {
                     SET_INTEGER(D_OUT, ret);
@@ -1567,8 +1569,9 @@ REBNATIVE(access_os)
                 }
             }
             break;
+
         default:
-            fail (Error_Invalid_Arg(field));
+            fail (field);
     }
 }
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -173,7 +173,7 @@ static REBARR *Copy_Body_Deep_Bound_To_New_Context(
 
     REBINT num_vars = IS_BLOCK(spec) ? VAL_LEN_AT(spec) : 1;
     if (num_vars == 0)
-        fail (Error_Invalid_Arg(spec));
+        fail (spec);
 
     REBCTX *context = Alloc_Context(REB_OBJECT, num_vars);
     TERM_ARRAY_LEN(CTX_VARLIST(context), num_vars + 1);
@@ -329,7 +329,7 @@ static REB_R Loop_Number_Common(
     else if (IS_DECIMAL(start) || IS_PERCENT(start))
         s = VAL_DECIMAL(start);
     else
-        fail (Error_Invalid_Arg(start));
+        fail (start);
 
     REBDEC e;
     if (IS_INTEGER(end))
@@ -337,7 +337,7 @@ static REB_R Loop_Number_Common(
     else if (IS_DECIMAL(end) || IS_PERCENT(end))
         e = VAL_DECIMAL(end);
     else
-        fail (Error_Invalid_Arg(end));
+        fail (end);
 
     REBDEC i;
     if (IS_INTEGER(incr))
@@ -345,7 +345,7 @@ static REB_R Loop_Number_Common(
     else if (IS_DECIMAL(incr) || IS_PERCENT(incr))
         i = VAL_DECIMAL(incr);
     else
-        fail (Error_Invalid_Arg(incr));
+        fail (incr);
 
     VAL_RESET_HEADER(var, REB_DECIMAL);
 
@@ -440,7 +440,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
             break;
 
         default:
-            fail (Error_Misc_Raw());
+            fail ("FUNCTION! is the only datatype with global enumeration");
         }
     }
     else {
@@ -532,7 +532,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
                     DECLARE_LOCAL (key_name);
                     Init_Word(key_name, VAL_KEY_SPELLING(key));
 
-                    fail (Error_Invalid_Arg(key_name));
+                    fail (key_name);
                 }
                 j++;
             }
@@ -566,7 +566,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
                         DECLARE_LOCAL (key_name);
                         Init_Word(key_name, VAL_KEY_SPELLING(key));
 
-                        fail (Error_Invalid_Arg(key_name));
+                        fail (key_name);
                     }
                     j++;
                 }
@@ -851,8 +851,8 @@ REBNATIVE(for_skip)
 
     REBVAL *var = Get_Mutable_Var_May_Fail(word, SPECIFIED);
 
-    if (!ANY_SERIES(var))
-        fail (Error_Invalid_Arg(var));
+    if (NOT(ANY_SERIES(var)))
+        fail (var);
 
     REBINT skip = Int32(ARG(skip));
 
@@ -899,8 +899,8 @@ REBNATIVE(for_skip)
         if (IS_BLANK(var))
             return R_OUT;
 
-        if (!ANY_SERIES(var))
-            fail (Error_Invalid_Arg(var));
+        if (NOT(ANY_SERIES(var)))
+            fail (var);
 
         VAL_INDEX(var) += skip;
     }

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -421,7 +421,7 @@ REBINT CT_Fail(const RELVAL *a, const RELVAL *b, REBINT mode)
     UNUSED(b);
     UNUSED(mode);
 
-    fail (Error_Misc_Raw());
+    fail ("Datatype does not have type comparison handler registered");
 }
 
 

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -428,7 +428,7 @@ REBNATIVE(compile)
     }
 
     if (debug)
-        fail (Error_Misc_Raw()); // !!! not implemented yet
+        fail ("Debug builds of user natives are not yet implemented.");
 
     // Using the "hot" mold buffer allows us to build the combined source in
     // memory that is generally preallocated.  This makes it not necessary

--- a/src/core/n-protect.c
+++ b/src/core/n-protect.c
@@ -343,7 +343,7 @@ REBNATIVE(unprotect)
     UNUSED(PAR(values));
 
     if (REF(hide))
-        fail (Error_Misc_Raw());
+        fail ("Cannot un-hide an object field once hidden");
 
     return Protect_Unprotect_Core(frame_, FLAGIT(PROT_WORD));
 }

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -209,7 +209,7 @@ REBNATIVE(checksum)
     if (REF(method)) {
         sym = VAL_WORD_SYM(ARG(word));
         if (sym == SYM_0) // not in %words.r, no SYM_XXX constant
-            fail (Error_Invalid_Arg(ARG(word)));
+            fail (ARG(word));
     }
     else
         sym = SYM_SHA1;
@@ -302,7 +302,7 @@ REBNATIVE(checksum)
             return R_OUT;
         }
 
-        fail (Error_Invalid_Arg(ARG(word)));
+        fail (ARG(word));
     }
     else if (REF(tcp)) {
         REBINT ipc = Compute_IPC(data, len);
@@ -500,7 +500,7 @@ REBNATIVE(enbase)
         break;
 
     default:
-        fail (Error_Invalid_Arg(ARG(base_value)));
+        fail (ARG(base_value));
     }
 
     Init_String(D_OUT, ser);
@@ -798,7 +798,7 @@ REBNATIVE(to_hex)
     if (REF(size)) {
         len = cast(REBINT, VAL_INT64(ARG(len)));
         if (len < 0)
-            fail (Error_Invalid_Arg(ARG(len)));
+            fail (ARG(len));
     }
     else
         len = -1;
@@ -825,10 +825,10 @@ REBNATIVE(to_hex)
         *buf = 0;
     }
     else
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     if (NULL == Scan_Issue(D_OUT, &buffer[0], len))
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     return R_OUT;
 }

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -377,7 +377,7 @@ REBNATIVE(limit_usage)
             PG_Mem_Limit = Int64(ARG(limit));
     }
     else
-        fail (Error_Invalid_Arg(ARG(field)));
+        fail (ARG(field));
 
     return R_VOID;
 }

--- a/src/core/n-textcodecs.c
+++ b/src/core/n-textcodecs.c
@@ -106,7 +106,7 @@ REBNATIVE(encode_text)
         // (Other support was unimplemented in R3-Alpha, and would just wind
         // up writing garbage.)
         //
-        fail (Error_Misc_Raw());
+        fail ("Can only write out strings to .txt if they are Latin1.");
     }
 
     Init_Binary(D_OUT, Copy_Sequence_At_Position(ARG(string)));
@@ -169,8 +169,8 @@ static void Encode_Utf16_Core(
         #error "Unsupported CPU endian"
     #endif
     }
-    else { // RESERVED for future unicode expansion
-        fail (Error_Misc_Raw());
+    else {
+        fail ("Unicode width > 2 reserved for future expansion.");
     }
 
     TERM_BIN_LEN(bin, len * sizeof(u16));

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -163,13 +163,15 @@ static REB_R Event_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     // Normal block actions done on events:
     case SYM_POKE:
-        if (!IS_EVENT(D_ARG(3))) fail (Error_Invalid_Arg(D_ARG(3)));
+        if (!IS_EVENT(D_ARG(3)))
+            fail (D_ARG(3));
         goto act_blk;
     case SYM_INSERT:
     case SYM_APPEND:
     //case A_PATH:      // not allowed: port/foo is port object field access
     //case A_PATH_SET:  // not allowed: above
-        if (!IS_EVENT(arg)) fail (Error_Invalid_Arg(arg));
+        if (!IS_EVENT(arg))
+            fail (arg);
     case SYM_PICK_P:
 act_blk:
         Move_Value(save_port, D_ARG(1)); // save for return

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -349,7 +349,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     case SYM_APPEND: {
         if (!(IS_BINARY(D_ARG(2)) || IS_STRING(D_ARG(2)) || IS_BLOCK(D_ARG(2))))
-            fail (Error_Invalid_Arg(D_ARG(2)));
+            fail (D_ARG(2));
         file->index = file->size;
         SET_FLAG(req->modes, RFM_RESEEK); }
         //

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -278,7 +278,7 @@ static REB_R Transport_Actor(
 
         if (REF(seek)) {
             UNUSED(ARG(index));
-            fail (Error_Misc_Raw());
+            fail (Error_Bad_Refines_Raw());
         }
         if (REF(append))
             fail (Error_Bad_Refines_Raw());
@@ -503,7 +503,7 @@ REBNATIVE(set_udp_multicast)
 
     REBINT result = OS_DO_DEVICE(sock, RDC_MODIFY);
     if (result < 0)
-        fail (Error_Misc_Raw()); // should device layer just fail()?
+        fail ("SET-UDP-MULTICAST failure"); // can device layer just fail()?
 
     return R_VOID;
 }
@@ -540,7 +540,7 @@ REBNATIVE(set_udp_ttl)
 
     REBINT result = OS_DO_DEVICE(sock, RDC_MODIFY);
     if (result < 0)
-        fail (Error_Misc_Raw()); // should device layer just fail()?
+        fail ("SET-UDP-TTL failure"); // can device layer just fail()?
 
     return R_VOID;
 }

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -299,6 +299,6 @@ REBNATIVE(get_signal_actor_handle)
     return R_OUT;
 #else
     UNUSED(frame_);
-    fail (Error_Misc_Raw());
+    fail ("GET-SIGNAL-ACTOR-HANDLE only works in builds with POSIX signals");
 #endif
 }

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -75,13 +75,15 @@ static REB_R Timer_Actor(REBFRM *frame_, REBCTX *port, REBCNT action)
 
     // Normal block actions done on events:
     case SYM_POKE:
-        if (!IS_EVENT(D_ARG(3))) fail (Error_Invalid_Arg(D_ARG(3)));
+        if (NOT(IS_EVENT(D_ARG(3))))
+            fail (D_ARG(3));
         goto act_blk;
     case SYM_INSERT:
     case SYM_APPEND:
     //case SYM_PATH:      // not allowed: port/foo is port object field access
     //case SYM_PATH_SET:  // not allowed: above
-        if (!IS_EVENT(arg)) fail (Error_Invalid_Arg(arg));
+        if (NOT(IS_EVENT(arg)))
+            fail (arg);
     case SYM_PICK_P:
 act_blk:
         Move_Value(&save_port, D_ARG(1)); // save for return

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -980,7 +980,7 @@ REBOOL Decode_UTF8_Maybe_Astral_Throws(
                     break;
 
                 default:
-                    fail (Error_Invalid_Arg(item));
+                    fail (item);
                 }
 
                 continue;

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -108,7 +108,7 @@ void MAKE_Bitset(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     // path used 0x0FFFFFFF.  Assume A_MAKE was more likely right.
     //
     if (len < 0 || len > 0x0FFFFFFF)
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     REBSER *ser = Make_Bitset(len);
     Init_Bitset(out, ser);
@@ -616,12 +616,12 @@ REBTYPE(Bitset)
 
     case SYM_POKE:
         if (!IS_LOGIC(D_ARG(3)))
-            fail (Error_Invalid_Arg(D_ARG(3)));
+            fail (D_ARG(3));
         diff = VAL_LOGIC(D_ARG(3));
 set_bits:
         if (BITS_NOT(VAL_SERIES(value))) diff = NOT(diff);
         if (Set_Bits(VAL_SERIES(value), arg, diff)) break;
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     case SYM_REMOVE: {
         INCLUDE_PARAMS_OF_REMOVE;
@@ -638,7 +638,7 @@ set_bits:
         if (Set_Bits(VAL_SERIES(value), ARG(limit), FALSE))
             break;
 
-        fail (Error_Invalid_Arg(ARG(limit))); }
+        fail (ARG(limit)); }
 
     case SYM_COPY: {
         INCLUDE_PARAMS_OF_COPY;

--- a/src/core/t-blank.c
+++ b/src/core/t-blank.c
@@ -103,7 +103,7 @@ REBINT CT_Handle(const RELVAL *a, const RELVAL *b, REBINT mode)
     UNUSED(b);
     UNUSED(mode);
 
-    fail (Error_Misc_Raw());
+    fail ("Currently comparing HANDLE! types is not allowed.");
 }
 
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -907,8 +907,8 @@ REBTYPE(Array)
     }
 
     case SYM_SWAP: {
-        if (!ANY_ARRAY(arg))
-            fail (Error_Invalid_Arg(arg));
+        if (NOT(ANY_ARRAY(arg)))
+            fail (arg);
 
         FAIL_IF_READ_ONLY_ARRAY(array);
         FAIL_IF_READ_ONLY_ARRAY(VAL_ARRAY(arg));

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -493,7 +493,7 @@ static REBINT Int_From_Date_Arg(const REBVAL *opt_poke) {
     else if (IS_BLANK(opt_poke))
         return 0;
     else
-        fail (Error_Invalid_Arg(opt_poke));
+        fail (opt_poke);
 }
 
 
@@ -533,10 +533,11 @@ void Pick_Or_Poke_Date(
         case 11: sym = SYM_MINUTE; break;
         case 12: sym = SYM_SECOND; break;
         default:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
         }
     }
-    else fail (Error_Invalid_Arg(picker));
+    else
+        fail (picker);
 
     REB_TIMEF time; // only pay for split into this if needed...
 
@@ -648,7 +649,7 @@ void Pick_Or_Poke_Date(
             else if (IS_DECIMAL(opt_poke))
                 secs = DEC_TO_SECS(VAL_DECIMAL(opt_poke));
             else
-                fail (Error_Invalid_Arg(opt_poke));
+                fail (opt_poke);
             break;
 
         case SYM_ZONE:
@@ -664,11 +665,11 @@ void Pick_Or_Poke_Date(
         case SYM_JULIAN:
         case SYM_WEEKDAY:
         case SYM_UTC:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
 
         case SYM_DATE:
             if (!IS_DATE(opt_poke))
-                fail (Error_Invalid_Arg(opt_poke));
+                fail (opt_poke);
             date = VAL_DATE(opt_poke);
             goto set_without_normalize;
 
@@ -700,7 +701,7 @@ void Pick_Or_Poke_Date(
             break;
 
         default:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
         }
 
         Normalize_Time(&secs, &day);

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -186,7 +186,7 @@ void MAKE_Decimal(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 
     case REB_BINARY:
         if (VAL_LEN_AT(arg) < 8)
-            fail (Error(RE_MISC));
+            fail (arg);
 
         Init_Decimal_Bits(out, VAL_BIN_AT(arg));
         VAL_RESET_HEADER(out, kind);
@@ -204,7 +204,7 @@ void MAKE_Decimal(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
                 DECLARE_LOCAL (specific);
                 Derelativize(specific, item, VAL_SPECIFIER(arg));
 
-                fail (Error_Invalid_Arg(specific));
+                fail (specific);
             }
 
             ++item;
@@ -217,7 +217,7 @@ void MAKE_Decimal(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
             else {
                 DECLARE_LOCAL (specific);
                 Derelativize(specific, item, VAL_SPECIFIER(arg));
-                fail (Error_Invalid_Arg(specific));
+                fail (specific);
             }
 
             while (exp >= 1) {
@@ -473,7 +473,8 @@ REBTYPE(Decimal)
                     ));
                     return R_OUT;
                 }
-                if (IS_TIME(arg)) fail (Error_Invalid_Arg(arg));
+                if (IS_TIME(arg))
+                    fail (arg);
 
                 d1 = Round_Dec(d1, flags, Dec64(arg));
                 if (IS_INTEGER(arg)) {

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -86,7 +86,7 @@ static REBOOL Set_Event_Var(REBVAL *event, const REBVAL *word, const REBVAL *val
                     return TRUE;
                 }
             }
-            fail (Error_Invalid_Arg(val));
+            fail (val);
         }
         return FALSE;
 
@@ -394,14 +394,11 @@ void MAKE_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 //
 void TO_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 {
-#ifdef NDEBUG
-    UNUSED(kind);
-#else
     assert(kind == REB_EVENT);
-#endif
+    UNUSED(kind);
 
     UNUSED(out);
-    fail (Error_Invalid_Arg(arg));
+    fail (arg);
 }
 
 

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -125,7 +125,7 @@ void TO_Function(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 
     UNUSED(out);
 
-    fail (Error_Invalid_Arg(arg));
+    fail (arg);
 }
 
 
@@ -217,8 +217,13 @@ REBTYPE(Function)
             return R_OUT;
 
         case SYM_BODY:
-            if (IS_FUNCTION_HIJACKER(value))
-                fail (Error_Misc_Raw()); // body corrupt, need to recurse
+            //
+            // A Hijacker may or may not need to splice itself in with a
+            // dispatcher.  So if it does, bypass it to get to the real
+            // function implementation.
+            //
+            while (IS_FUNCTION_HIJACKER(value))
+                value = KNOWN(VAL_FUNC_BODY(value));
 
             if (IS_FUNCTION_INTERPRETED(value)) {
                 //

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -244,8 +244,8 @@ static void Insert_Gobs(
             val = Get_Opt_Var_May_Fail(val, SPECIFIED);
         }
         if (IS_GOB(val)) {
-            // !!! Temporary error of some kind (supposed to trap, not panic?)
-            if (GOB_PARENT(VAL_GOB(val))) fail (Error_Misc_Raw());
+            if (GOB_PARENT(VAL_GOB(val)) != NULL)
+                fail ("GOB! not expected to have parent");
             *ptr++ = VAL_GOB(val);
             GOB_PARENT(VAL_GOB(val)) = gob;
             SET_GOB_STATE(VAL_GOB(val), GOBS_NEW);
@@ -691,7 +691,7 @@ REBARR *Gob_To_Array(REBGOB *gob)
             sym = SYM_EFFECT;
             break;
         default:
-            fail (Error_Misc_Raw());
+            fail ("Unknown GOB! type");
         }
         Init_Set_Word(val1, Canon(sym));
         Get_GOB_Var(gob, val1, val);
@@ -902,7 +902,7 @@ void TO_Gob(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 
     UNUSED(out);
 
-    fail (Error_Invalid_Arg(arg));
+    fail (arg);
 }
 
 
@@ -1004,7 +1004,9 @@ REBTYPE(Gob)
     // unary actions
     switch(action) {
     case SYM_PICK_P:
-        if (!ANY_NUMBER(arg) && !IS_BLANK(arg)) fail (Error_Invalid_Arg(arg));
+        if (NOT(ANY_NUMBER(arg) || IS_BLANK(arg)))
+            fail (arg);
+
         if (!GOB_PANE(gob)) goto is_blank;
         index += Get_Num_From_Arg(arg) - 1;
         if (index >= tail) goto is_blank;

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -686,7 +686,7 @@ REBVAL *Modify_Image(REBFRM *frame_, REBCNT action)
             } else if (IS_BINARY(len)) {
                 part = (VAL_INDEX(len) - VAL_INDEX(arg)) / 4;
             } else
-                fail (Error_Invalid_Arg(len));
+                fail (len);
             part = MAX(part, 0);
         }
         else if (IS_IMAGE(arg)) {
@@ -695,7 +695,9 @@ REBVAL *Modify_Image(REBFRM *frame_, REBCNT action)
                 part = MAX(part, 0);
             }
             else if (IS_IMAGE(len)) {
-                if (!VAL_IMAGE_WIDE(len)) fail (Error_Invalid_Arg(len));
+                if (VAL_IMAGE_WIDE(len) == 0)
+                    fail (len);
+
                 partx = VAL_INDEX(len) - VAL_INDEX(arg);
                 party = partx / VAL_IMAGE_WIDE(len);
                 party = MAX(party, 1);
@@ -719,7 +721,7 @@ REBVAL *Modify_Image(REBFRM *frame_, REBCNT action)
                 fail (Error_Invalid_Type(VAL_TYPE(len)));
         }
         else
-            fail (Error_Invalid_Arg(arg)); // /part not allowed
+            fail (arg); // /part not allowed
     }
     else {
         if (IS_IMAGE(arg)) { // Use image for /part sizes
@@ -1078,7 +1080,7 @@ REBTYPE(Image)
             else if (IS_CHAR(arg))
                 n = VAL_CHAR(arg);
             else
-                fail (Error_Invalid_Arg(arg));
+                fail (arg);
 
             *dp = (*dp & 0xffffff) | (n << 24);
             Move_Value(D_OUT, arg);
@@ -1115,7 +1117,7 @@ REBTYPE(Image)
             }
             else if (IS_IMAGE(val)) {
                 if (!VAL_IMAGE_WIDE(val))
-                    fail (Error_Invalid_Arg(val));
+                    fail (val);
                 len = VAL_INDEX(val) - VAL_INDEX(value); // not same is ok
             }
             else
@@ -1160,7 +1162,7 @@ REBTYPE(Image)
         arg = ARG(limit); // can be image, integer, pair.
         if (IS_IMAGE(arg)) {
             if (VAL_SERIES(arg) != VAL_SERIES(value))
-                fail (Error_Invalid_Arg(arg));
+                fail (arg);
             len = VAL_INDEX(arg) - VAL_INDEX(value);
             arg = value;
             goto makeCopy2;
@@ -1227,7 +1229,7 @@ inline static REBOOL Adjust_Image_Pick_Index_Is_Valid(
     else if (IS_LOGIC(picker))
         n = VAL_LOGIC(picker) ? 1 : 2;
     else
-        fail (Error_Invalid_Arg(picker));
+        fail (picker);
 
     *index += n;
     if (n > 0)
@@ -1278,7 +1280,7 @@ void Pick_Image(REBVAL *out, const REBVAL *value, const REBVAL *picker)
             break; }
 
         default:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
         }
         return;
     }
@@ -1311,7 +1313,7 @@ void Poke_Image_Fail_If_Read_Only(
         switch (VAL_WORD_SYM(picker)) {
         case SYM_SIZE:
             if (!IS_PAIR(poke) || !VAL_PAIR_X(poke))
-                fail (Error_Invalid_Arg(poke));
+                fail (poke);
 
             VAL_IMAGE_WIDE(value) = VAL_PAIR_X_INT(poke);
             VAL_IMAGE_HIGH(value) = MIN(
@@ -1346,7 +1348,7 @@ void Poke_Image_Fail_If_Read_Only(
                 );
             }
             else
-                fail (Error_Invalid_Arg(poke));
+                fail (poke);
             break;
 
         case SYM_ALPHA:
@@ -1366,11 +1368,11 @@ void Poke_Image_Fail_If_Read_Only(
                 );
             }
             else
-                fail (Error_Invalid_Arg(poke));
+                fail (poke);
             break;
 
         default:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
         }
         return;
     }

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -545,7 +545,7 @@ REBTYPE(Integer)
                 return R_OUT;
             }
             if (IS_TIME(val2))
-                fail (Error_Invalid_Arg(val2));
+                fail (val2);
             arg = VAL_INT64(val2);
         }
         else

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -462,7 +462,7 @@ void TO_Map(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         specifier = SPECIFIED; // there should be no relative values in a MAP!
     }
     else
-        fail (Error_Invalid_Arg(arg));
+        fail (arg);
 
     REBMAP *map = Make_Map(len / 2); // [key value key value...] + END
     Append_Map(map, array, index, specifier, len);
@@ -665,7 +665,7 @@ REBTYPE(Map)
             fail (Error_Bad_Refines_Raw());
 
         if (!IS_BLOCK(arg))
-            fail (Error_Invalid_Arg(val));
+            fail (val);
         Move_Value(D_OUT, val);
         if (REF(dup)) {
             if (Int32(ARG(count)) <= 0) break;

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -140,7 +140,7 @@ void Bin_To_Money_May_Fail(REBVAL *result, const REBVAL *val)
         memcpy(buf, VAL_BIN_AT(val), len);
     }
     else
-        fail (Error_Invalid_Arg(val));
+        fail (val);
 
     memcpy(buf + 12 - len, buf, len); // shift to right side
     memset(buf, 0, 12 - len);
@@ -247,7 +247,7 @@ REBTYPE(Money)
             else if (IS_MONEY(scale))
                 Move_Value(temp, scale);
             else
-                fail (Error_Invalid_Arg(scale));
+                fail (scale);
         }
         else
             SET_MONEY(temp, int_to_deci(0));

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -133,7 +133,8 @@ static void Append_To_Context(REBCTX *context, REBVAL *arg)
         return;
     }
 
-    if (!IS_BLOCK(arg)) fail (Error_Invalid_Arg(arg));
+    if (NOT(IS_BLOCK(arg)))
+        fail (arg);
 
     // Process word/value argument block:
 
@@ -436,7 +437,7 @@ void TO_Context(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     if (kind == REB_OBJECT) {
         if (IS_ERROR(arg)) {
             if (VAL_ERR_NUM(arg) < 100)
-                fail (Error_Invalid_Arg(arg)); // !!! ???
+                fail (arg);
         }
 
         // !!! Contexts hold canon values now that are typed, this init
@@ -846,7 +847,7 @@ REBNATIVE(construct)
         // instance), and making an ERROR! from scratch is currently dangerous
         // as well though you can derive them.
         //
-        fail (Error_Misc_Raw());
+        fail ("DATATYPE! not supported for SPEC of CONSTRUCT");
     }
     else {
         assert(IS_BLOCK(spec));
@@ -930,5 +931,5 @@ REBNATIVE(construct)
         return R_OUT;
     }
 
-    fail (Error_Misc_Raw());
+    fail ("Unsupported CONSTRUCT arguments");
 }

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -160,7 +160,7 @@ void Min_Max_Pair(REBVAL *out, const REBVAL *a, const REBVAL *b, REBOOL maxed)
     else if (IS_INTEGER(a))
         ax = ay = cast(REBDEC, VAL_INT64(a));
     else
-        fail (Error_Invalid_Arg(a));
+        fail (a);
 
     float bx;
     float by;
@@ -171,7 +171,7 @@ void Min_Max_Pair(REBVAL *out, const REBVAL *a, const REBVAL *b, REBOOL maxed)
     else if (IS_INTEGER(b))
         bx = by = cast(REBDEC, VAL_INT64(b));
     else
-        fail (Error_Invalid_Arg(b));
+        fail (b);
 
     if (maxed)
         SET_PAIR(out, MAX(ax, bx), MAX(ay, by));
@@ -372,7 +372,7 @@ REBTYPE(Pair)
             else if (VAL_WORD_SYM(arg) == SYM_Y)
                 n = 1;
             else
-                fail (Error_Invalid_Arg(arg));
+                fail (arg);
         }
         else {
             n = Get_Num_From_Arg(arg);
@@ -390,7 +390,7 @@ REBTYPE(Pair)
 ///                 if (index == 0) x1 = (REBINT)VAL_DECIMAL(arg);
 ///                 else y1 = (REBINT)VAL_DECIMAL(arg);
 ///             } else
-///                 fail (Error_Invalid_Arg(arg));
+///                 fail (arg);
 ///             goto setPair;
 ///         }
         SET_DECIMAL(D_OUT, n == 0 ? x1 : y1);

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -427,8 +427,8 @@ void TO_String(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     else
         ser = MAKE_TO_String_Common(arg);
 
-    if (!ser)
-        fail (Error_Invalid_Arg(arg));
+    if (ser == NULL)
+        fail (arg);
 
     Init_Any_Series(out, kind, ser);
 }
@@ -567,7 +567,7 @@ static void Sort_String(
     if (!IS_VOID(skipv)) {
         skip = Get_Num_From_Arg(skipv);
         if (skip <= 0 || len % skip != 0 || skip > len)
-            fail (Error_Invalid_Arg(skipv));
+            fail (skipv);
     }
 
     // Use fast quicksort library function:
@@ -935,7 +935,7 @@ REBTYPE(String)
                 c = VAL_INT32(arg);
             }
             else
-                fail (Error_Invalid_Arg(arg));
+                fail (arg);
 
             ser = VAL_SERIES(value);
             if (IS_BINARY(value)) {
@@ -1035,7 +1035,8 @@ REBTYPE(String)
     case SYM_AND_T:
     case SYM_OR_T:
     case SYM_XOR_T: {
-        if (!IS_BINARY(arg)) fail (Error_Invalid_Arg(arg));
+        if (NOT(IS_BINARY(arg)))
+            fail (arg);
 
         if (VAL_INDEX(value) > VAL_LEN_HEAD(value))
             VAL_INDEX(value) = VAL_LEN_HEAD(value);
@@ -1047,7 +1048,9 @@ REBTYPE(String)
         goto return_ser; }
 
     case SYM_COMPLEMENT: {
-        if (!IS_BINARY(value)) fail (Error_Invalid_Arg(value));
+        if (NOT(IS_BINARY(value)))
+            fail (value);
+
         ser = Complement_Binary(value);
         goto return_ser; }
 
@@ -1075,8 +1078,8 @@ REBTYPE(String)
 
     case SYM_SUBTRACT:
     case SYM_ADD: {
-        if (!IS_BINARY(value))
-            fail (Error_Invalid_Arg(value));
+        if (NOT(IS_BINARY(value)))
+            fail (value);
 
         FAIL_IF_READ_ONLY_SERIES(VAL_SERIES(value));
 
@@ -1084,9 +1087,9 @@ REBTYPE(String)
         if (IS_INTEGER(arg))
             amount = VAL_INT32(arg);
         else if (IS_BINARY(arg))
-            fail (Error_Invalid_Arg(arg)); // should work
+            fail (arg); // should work
         else
-            fail (Error_Invalid_Arg(arg)); // what about other types?
+            fail (arg); // what about other types?
 
         if (action == SYM_SUBTRACT)
             amount = -amount;

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -346,13 +346,13 @@ void Pick_Time(REBVAL *out, const REBVAL *value, const REBVAL *picker)
         case SYM_MINUTE: i = 1; break;
         case SYM_SECOND: i = 2; break;
         default:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
         }
     }
     else if (IS_INTEGER(picker))
         i = VAL_INT32(picker) - 1;
     else
-        fail (Error_Invalid_Arg(picker));
+        fail (picker);
 
     REB_TIMEF tf;
     Split_Time(VAL_TIME(value), &tf); // loses sign
@@ -391,13 +391,13 @@ void Poke_Time_Immediate(
         case SYM_MINUTE: i = 1; break;
         case SYM_SECOND: i = 2; break;
         default:
-            fail (Error_Invalid_Arg(picker));
+            fail (picker);
         }
     }
     else if (IS_INTEGER(picker))
         i = VAL_INT32(picker) - 1;
     else
-        fail (Error_Invalid_Arg(picker));
+        fail (picker);
 
     REB_TIMEF tf;
     Split_Time(VAL_TIME(value), &tf); // loses sign
@@ -408,7 +408,7 @@ void Poke_Time_Immediate(
     else if (IS_BLANK(poke))
         n = 0;
     else
-        fail (Error_Invalid_Arg(poke));
+        fail (poke);
 
     switch(i) {
     case 0:
@@ -432,7 +432,7 @@ void Poke_Time_Immediate(
         }
         break;
     default:
-        fail (Error_Invalid_Arg(picker));
+        fail (picker);
     }
 
     VAL_TIME(value) = Join_Time(&tf, FALSE);
@@ -646,7 +646,8 @@ REBTYPE(Time)
                     Move_Value(D_OUT, ARG(scale));
                     return R_OUT;
                 }
-                else fail (Error_Invalid_Arg(arg));
+                else
+                    fail (arg);
             }
             else {
                 secs = Round_Int(secs, flags | RF_TO, SEC_SEC);

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -76,7 +76,7 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         REBYTE *ap = Temp_Byte_Chars_May_Fail(arg, MAX_SCAN_TUPLE, &len, FALSE);
         if (Scan_Tuple(out, ap, len) != NULL)
             return;
-        goto bad_arg;
+        fail (arg);
     }
 
     if (ANY_ARRAY(arg)) {
@@ -86,7 +86,8 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         RELVAL *item = VAL_ARRAY_AT(arg);
 
         for (; NOT_END(item); ++item, ++vp, ++len) {
-            if (len >= MAX_TUPLE) goto bad_make;
+            if (len >= MAX_TUPLE)
+                goto bad_make;
             if (IS_INTEGER(item)) {
                 n = Int32(item);
             }
@@ -96,7 +97,8 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
             else
                 goto bad_make;
 
-            if (n > 255 || n < 0) goto bad_make;
+            if (n > 255 || n < 0)
+                goto bad_make;
             *vp = n;
         }
 
@@ -112,13 +114,16 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         REBUNI c;
         const REBYTE *ap = VAL_WORD_HEAD(arg);
         REBCNT len = LEN_BYTES(ap);  // UTF-8 len
-        if (len & 1) goto bad_arg; // must have even # of chars
+        if (len & 1)
+            fail (arg); // must have even # of chars
         len /= 2;
-        if (len > MAX_TUPLE) goto bad_arg; // valid even for UTF-8
+        if (len > MAX_TUPLE)
+            fail (arg); // valid even for UTF-8
         VAL_TUPLE_LEN(out) = len;
         for (alen = 0; alen < len; alen++) {
             const REBOOL unicode = FALSE;
-            if (!Scan_Hex2(ap, &c, unicode)) goto bad_arg;
+            if (!Scan_Hex2(ap, &c, unicode))
+                fail (arg);
             *vp++ = cast(REBYTE, c);
             ap += 2;
         }
@@ -130,13 +135,11 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         VAL_TUPLE_LEN(out) = len;
         for (alen = 0; alen < len; alen++) *vp++ = *ap++;
     }
-    else goto bad_arg;
+    else
+        fail (arg);
 
     for (; alen < MAX_TUPLE; alen++) *vp++ = 0;
     return;
-
-bad_arg:
-    fail (Error_Invalid_Arg(arg));
 
 bad_make:
     fail (Error_Bad_Make(REB_TUPLE, arg));
@@ -226,7 +229,7 @@ void Poke_Tuple_Immediate(
         return;
     }
     else
-        fail (Error_Invalid_Arg(poke));
+        fail (poke);
 
     if (i < 0)
         i = 0;
@@ -479,7 +482,8 @@ REBTYPE(Tuple)
             return R_OUT;
         }
         // Poke:
-        if (!IS_INTEGER(D_ARG(3))) fail (Error_Invalid_Arg(D_ARG(3)));
+        if (NOT(IS_INTEGER(D_ARG(3))))
+            fail (D_ARG(3));
         v = VAL_INT32(D_ARG(3));
         if (v < 0)
             v = 0;

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -141,10 +141,9 @@ REBOOL Update_Typeset_Bits_Core(
     VAL_TYPESET_BITS(typeset) = 0;
 
     const RELVAL *item = head;
-    if (NOT_END(item) && IS_BLOCK(item)) {
-        // Double blocks are a variadic signal.
+    if (NOT_END(item) && IS_BLOCK(item)) { // Double blocks signal variadic
         if (NOT_END(item + 1))
-            fail (Error_Misc_Raw());
+            fail ("Invalid double-block in typeset");
 
         item = VAL_ARRAY_AT(item);
         SET_VAL_FLAG(typeset, TYPESET_FLAG_VARIADIC);
@@ -306,10 +305,10 @@ REBTYPE(Typeset)
     switch (action) {
 
     case SYM_FIND:
-        if (IS_DATATYPE(arg)) {
-            return (TYPE_CHECK(val, VAL_TYPE_KIND(arg))) ? R_TRUE : R_FALSE;
-        }
-        fail (Error_Invalid_Arg(arg));
+        if (IS_DATATYPE(arg))
+            return R_FROM_BOOL(TYPE_CHECK(val, VAL_TYPE_KIND(arg)));
+
+        fail (arg);
 
     case SYM_AND_T:
     case SYM_OR_T:
@@ -317,8 +316,8 @@ REBTYPE(Typeset)
         if (IS_DATATYPE(arg)) {
             VAL_TYPESET_BITS(arg) = FLAGIT_KIND(VAL_TYPE(arg));
         }
-        else if (!IS_TYPESET(arg))
-            fail (Error_Invalid_Arg(arg));
+        else if (NOT(IS_TYPESET(arg)))
+            fail (arg);
 
         if (action == SYM_OR_T)
             VAL_TYPESET_BITS(val) |= VAL_TYPESET_BITS(arg);

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -363,7 +363,7 @@ void TO_Varargs(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 
     UNUSED(out);
 
-    fail (Error_Invalid_Arg(arg));
+    fail (arg);
 }
 
 
@@ -382,8 +382,8 @@ REBTYPE(Varargs)
 
     switch (action) {
     case SYM_PICK_P: {
-        if (!IS_INTEGER(arg))
-            fail (Error_Invalid_Arg(arg));
+        if (NOT(IS_INTEGER(arg)))
+            fail (arg);
 
         if (VAL_INT32(arg) != 1)
             fail (Error_Varargs_No_Look_Raw());
@@ -434,7 +434,7 @@ REBTYPE(Varargs)
             limit = 0; // not used, but avoid maybe uninitalized warning
         }
         else
-            fail (Error_Invalid_Arg(ARG(limit)));
+            fail (ARG(limit));
 
         while (IS_BAR(ARG(limit)) || limit-- > 0) {
             indexor = Do_Vararg_Op_May_Throw(D_OUT, value, VARARG_OP_TAKE);

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -202,17 +202,16 @@ void Set_Vector_Row(REBSER *ser, REBVAL *blk)
 REBARR *Vector_To_Array(const REBVAL *vect)
 {
     REBCNT len = VAL_LEN_AT(vect);
+    if (len <= 0)
+        fail (vect);
+
+    REBARR *array = Make_Array(len);
+
     REBYTE *data = SER_DATA_RAW(VAL_SERIES(vect));
     REBCNT type = VECT_TYPE(VAL_SERIES(vect));
-    REBARR *array = NULL;
+
+    RELVAL *val = ARR_HEAD(array);
     REBCNT n;
-    RELVAL *val;
-
-    if (len <= 0)
-        fail (Error_Invalid_Arg(vect));
-
-    array = Make_Array(len);
-    val = ARR_HEAD(array);
     for (n = VAL_INDEX(vect); n < VAL_LEN_HEAD(vect); n++, val++) {
         VAL_RESET_HEADER(val, (type >= VTSF08) ? REB_DECIMAL : REB_INTEGER);
         VAL_INT64(val) = get_vect(type, data, n); // can be int or decimal
@@ -506,7 +505,7 @@ void Pick_Vector(REBVAL *out, const REBVAL *value, const REBVAL *picker) {
     if (IS_INTEGER(picker) || IS_DECIMAL(picker))
         n = Int32(picker);
     else
-        fail (Error_Invalid_Arg(picker));
+        fail (picker);
 
     n += VAL_INDEX(value);
 
@@ -543,7 +542,7 @@ void Poke_Vector_Fail_If_Read_Only(
     if (IS_INTEGER(picker) || IS_DECIMAL(picker))
         n = Int32(picker);
     else
-        fail (Error_Invalid_Arg(picker));
+        fail (picker);
 
     n += VAL_INDEX(value);
 
@@ -573,7 +572,8 @@ void Poke_Vector_Fail_If_Read_Only(
         else
             i = 0xDECAFBAD; // not used, but avoid maybe uninitalized warning
     }
-    else fail (Error_Invalid_Arg(poke));
+    else
+        fail (poke);
 
     set_vect(bits, vp, n - 1, i, f);
 }

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1380,18 +1380,12 @@ REBNATIVE(subparse)
 
         assert(Eval_Count >= 0);
         if (--Eval_Count == 0) {
-            //
-            // !!! See notes on other invocations about the questions raised by
-            // calls to Do_Signals_Throws() by places that do not have a clear
-            // path up to return results from an interactive breakpoint.
-            //
-            DECLARE_LOCAL (result);
+            SET_END(P_CELL);
 
-            if (Do_Signals_Throws(result))
-                fail (Error_No_Catch_For_Throw(result));
+            if (Do_Signals_Throws(P_CELL))
+                fail (Error_No_Catch_For_Throw(P_CELL));
 
-            if (IS_ANY_VALUE(result))
-                fail (Error_Misc_Raw());
+            assert(IS_END(P_CELL));
         }
 
     //==////////////////////////////////////////////////////////////////==//
@@ -1902,7 +1896,7 @@ REBNATIVE(subparse)
                         // since the Do_Eval_Rule routine expects to be
                         // able to arbitrarily update P_NEXT_RULE
                         //
-                        fail (Error_Misc_Raw());
+                        fail ("DO rules currently cannot be iterated");
                     }
 
                     subrule = BLANK_VALUE; // cause an error if iterating
@@ -2318,7 +2312,7 @@ REBNATIVE(parse_accept)
 // internal throw used to indicate "accept".
 {
     UNUSED(frame_);
-    fail (Error_Misc_Raw());
+    fail ("PARSE-ACCEPT is for internal PARSE use only");
 }
 
 
@@ -2335,5 +2329,5 @@ REBNATIVE(parse_reject)
 // internal throw used to indicate "reject".
 {
     UNUSED(frame_);
-    fail (Error_Misc_Raw());
+    fail ("PARSE-REJECT is for internal PARSE use only");
 }

--- a/src/extensions/mod-crypt.c
+++ b/src/extensions/mod-crypt.c
@@ -412,12 +412,12 @@ static REBNATIVE(dh_generate_key)
 
     REBCNT priv_index = Find_Canon_In_Context(obj, CRYPT_WORD_PRIV_KEY, FALSE);
     if (priv_index == 0)
-        fail (Error_Misc_Raw());
+        fail ("Cannot find PRIV-KEY in crypto object");
     Init_Binary(CTX_VAR(obj, priv_index), priv_bin);
 
     REBCNT pub_index = Find_Canon_In_Context(obj, CRYPT_WORD_PUB_KEY, FALSE);
     if (pub_index == 0)
-        fail (Error_Misc_Raw());
+        fail ("Cannot find PUB-KEY in crypto object");
     Init_Binary(CTX_VAR(obj, pub_index), pub_bin);
 
     return R_VOID;
@@ -783,15 +783,15 @@ static REBNATIVE(decloak)
 {
     INCLUDE_PARAMS_OF_DECLOAK;
 
-    if (!Cloak(
+    if (NOT(Cloak(
         TRUE,
         VAL_BIN_AT(ARG(data)),
         VAL_LEN_AT(ARG(data)),
         cast(REBYTE*, ARG(key)),
         0,
         REF(with)
-    )){
-        fail (Error_Invalid_Arg(ARG(key)));
+    ))){
+        fail (ARG(key));
     }
 
     Move_Value(D_OUT, ARG(data));
@@ -816,15 +816,15 @@ static REBNATIVE(encloak)
 {
     INCLUDE_PARAMS_OF_ENCLOAK;
 
-    if (!Cloak(
+    if (NOT(Cloak(
         FALSE,
         VAL_BIN_AT(ARG(data)),
         VAL_LEN_AT(ARG(data)),
         cast(REBYTE*, ARG(key)),
         0,
         REF(with))
-    ){
-        fail (Error_Invalid_Arg(ARG(key)));
+    )){
+        fail (ARG(key));
     }
 
     Move_Value(D_OUT, ARG(data));

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -576,7 +576,7 @@ inline static REBIXO Do_Array_At_Core(
     const REBVAL values[],
     REBCNT index
 ) {
-    fail (Error_Misc_Raw());
+    fail (Error_Not_Done_Raw());
 }*/
 
 

--- a/src/os/dev-net.c
+++ b/src/os/dev-net.c
@@ -608,7 +608,9 @@ DEVICE_CMD Modify_Socket(REBREQ *sock)
         break; }
 
     default:
-        fail (Error_Misc_Raw()); // not return DR_ERROR?  Is failing here ok?
+        // not return DR_ERROR?  Is failing here ok?
+        //
+        fail ("Unknown socket MODIFY operation");
     }
 
     if (result < 0) {

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -206,7 +206,7 @@ REB_R N_debug(REBFRM *frame_) {
         // added by DEBUG itself, which presumably should not count.
         //
         if (!(frame = Frame_For_Stack_Level(&HG_Stack_Level, value, TRUE)))
-            fail (Error_Invalid_Arg(value));
+            fail (value);
 
         Init_Block(D_OUT, Make_Where_For_Frame(frame));
         return R_OUT;


### PR DESCRIPTION
The concept in Rebol is that errors are structural entities, which
hold the relevant parameters for the error, that the user can then
TRAP and extract and react to.  This means that they are defined as
templates in %errors.r, and historically it has required special
syntax from the C code to trigger them.  This also would theoretically
help make it easier to provide internationalization of the strings.

Because the process of adding an error to that table was somewhat of
an effort, especially for an error in transitional code, a "catch-all"
error called RE_MISC was used.  While completely un-informative, it
would serve as a placeholder to come back and replace with a better
error later.

Yet the uninformativeness of an RE_MISC error usually necessitated a
comment anyway.  Much more useful would be to just allow fail() to
accept a C character string and write the comment in that space.  It
can still serve as a sign to come back and fix later with a real
message just as well--just look for `fail ("`.

So this commit eliminates RE_MISC, and takes advantage of the ability
to distinguish UTF-8 strings from REBSER* to allow character strings to
be passed to fail.  As an additional convenience, it takes the #1
most meaningless error about a value (Error_Invalid_Arg) and lets that
lazy option be said even more lazily by passing a REBVAL* to fail():

    fail (Error_Invalid_Arg(ARG(foo)) => fail (ARG(foo))

While perhaps encouraging more laziness, it also makes it easier to
spot that no "real error" is being given in these cases.  A C++
template trick is used to check at compile-time that the void *
parameter isn't actually a RELVAL* or other type Fail_Core() can't
actually handle.