### PR TITLE
Some naming and casing changes to think about

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -276,7 +276,7 @@ RL_API int RL_Event(REBEVT *evt)
     REBVAL *event = Append_Event();     // sets signal
 
     if (event) {                        // null if no room left in series
-        VAL_RESET_HEADER(event, REB_EVENT); // has more space, if needed
+        Reset_Val_Header(event, REB_EVENT); // has more space, if needed
         event->extra.eventee = evt->eventee;
         event->payload.event.type = evt->type;
         event->payload.event.flags = evt->flags;
@@ -490,9 +490,9 @@ RL_API REBRXT RL_Val_Type(const REBVAL *v) {
 //
 RL_API void RL_Val_Update_Header(REBVAL *v, REBRXT rxt) {
     if (rxt == 0)
-        SET_VOID(v);
+        Init_Void(v);
     else
-        VAL_RESET_HEADER(v, RXT_To_Reb[rxt]);
+        Reset_Val_Header(v, RXT_To_Reb[rxt]);
 }
 
 
@@ -642,7 +642,7 @@ RL_API void RL_Init_Date(
     int nano,
     int zone
 ) {
-    VAL_RESET_HEADER(out, REB_DATE);
+    Reset_Val_Header(out, REB_DATE);
     VAL_YEAR(out)  = year;
     VAL_MONTH(out) = month;
     VAL_DAY(out) = day;

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -62,9 +62,9 @@ static void Bind_Values_Inner_Loop(
                 // We're overwriting any previous binding, which may have
                 // been relative.
                 //
-                CLEAR_VAL_FLAG(value, VALUE_FLAG_RELATIVE);
+                Clear_Val_Flag(value, VALUE_FLAG_RELATIVE);
 
-                SET_VAL_FLAG(value, WORD_FLAG_BOUND);
+                Set_Val_Flag(value, WORD_FLAG_BOUND);
                 INIT_WORD_CONTEXT(value, context);
                 INIT_WORD_INDEX(value, n);
             }
@@ -135,7 +135,7 @@ void Bind_Values_Core(
     REBCNT index = 1;
     REBVAL *key = CTX_KEYS_HEAD(context);
     for (; index <= CTX_LEN(context); key++, index++)
-        if (NOT_VAL_FLAG(key, TYPESET_FLAG_UNBINDABLE))
+        if (Not_Val_Flag(key, TYPESET_FLAG_UNBINDABLE))
             Add_Binder_Index(&binder, VAL_KEY_CANON(key), index);
 
     Bind_Values_Inner_Loop(
@@ -194,9 +194,9 @@ REBCNT Try_Bind_Word(REBCTX *context, REBVAL *word)
         //
         // Previously may have been bound relative, remove flag.
         //
-        CLEAR_VAL_FLAG(word, VALUE_FLAG_RELATIVE);
+        Clear_Val_Flag(word, VALUE_FLAG_RELATIVE);
 
-        SET_VAL_FLAG(word, WORD_FLAG_BOUND);
+        Set_Val_Flag(word, WORD_FLAG_BOUND);
         INIT_WORD_CONTEXT(word, context);
         INIT_WORD_INDEX(word, n);
     }
@@ -238,7 +238,7 @@ static void Bind_Relative_Inner_Loop(
                 // (clear out existing binding flags first).
                 //
                 Unbind_Any_Word(value);
-                SET_VAL_FLAGS(value, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
+                Set_Val_Flags(value, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
                 INIT_WORD_FUNC(value, AS_FUNC(paramlist)); // incomplete func
                 INIT_WORD_INDEX(value, n);
             }
@@ -257,7 +257,7 @@ static void Bind_Relative_Inner_Loop(
             // easiest to debug if there is a clear mark on arrays that are
             // part of a deep copy of a function body either way.
             //
-            SET_VAL_FLAG(value, VALUE_FLAG_RELATIVE);
+            Set_Val_Flag(value, VALUE_FLAG_RELATIVE);
             INIT_RELATIVE(value, AS_FUNC(paramlist)); // incomplete func
         }
     }
@@ -329,8 +329,8 @@ void Rebind_Values_Deep(
         }
         else if (
             ANY_WORD(value)
-            && GET_VAL_FLAG(value, WORD_FLAG_BOUND)
-            && NOT_VAL_FLAG(value, VALUE_FLAG_RELATIVE)
+            && Get_Val_Flag(value, WORD_FLAG_BOUND)
+            && Not_Val_Flag(value, VALUE_FLAG_RELATIVE)
             && VAL_WORD_CONTEXT(KNOWN(value)) == src
         ) {
             INIT_WORD_CONTEXT(value, dst);

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -257,7 +257,7 @@ ATTRIBUTE_NO_RETURN void Fail_Core(const void *p)
 
     case DETECTED_AS_SERIES: {
         REBSER *s = m_cast(REBSER*, cast(const REBSER*, p)); // don't mutate
-        if (NOT_SER_FLAG(s, ARRAY_FLAG_VARLIST))
+        if (Not_Ser_Flag(s, ARRAY_FLAG_VARLIST))
             panic (s);
         error = AS_CONTEXT(s);
         break; }
@@ -342,7 +342,7 @@ ATTRIBUTE_NO_RETURN void Fail_Core(const void *p)
         // trash was in the cell.
         //
         if ((f->out->header.bits & NODE_FLAG_VALID) && NOT_END(f->out))
-            SET_END(f->out); // Note: out cells can't be in arrays
+            Init_End(f->out); // Note: out cells can't be in arrays
 
         REBFRM *prior = f->prior;
         Drop_Frame_Core(f);
@@ -357,7 +357,7 @@ ATTRIBUTE_NO_RETURN void Fail_Core(const void *p)
     // raised, then it had the thrown argument set.  Trash it in debug
     // builds.  (The value will not be kept alive, it is not seen by GC)
     //
-    SET_UNREADABLE_BLANK(&TG_Thrown_Arg);
+    Init_Unreadable_Blank(&TG_Thrown_Arg);
 
     LONG_JUMP(Saved_State->cpu_state, 1);
 }
@@ -654,7 +654,7 @@ REBOOL Make_Error_Object_Throws(
 
         // !!! fix in Startup_Errors()?
         //
-        VAL_RESET_HEADER(CTX_VALUE(error), REB_ERROR);
+        Reset_Val_Header(CTX_VALUE(error), REB_ERROR);
 
         vars = ERR_VARS(error);
         assert(IS_BLANK(&vars->code));
@@ -765,7 +765,7 @@ REBOOL Make_Error_Object_Throws(
 
                 Move_Value(&vars->message, message);
 
-                SET_INTEGER(&vars->code,
+                Init_Integer(&vars->code,
                     code
                     + Find_Canon_In_Context(
                         error, VAL_WORD_CANON(&vars->id), FALSE
@@ -793,7 +793,7 @@ REBOOL Make_Error_Object_Throws(
         else {
             // The type and category picked did not overlap any existing one
             // so let it be a user error.
-            SET_INTEGER(&vars->code, RE_USER);
+            Init_Integer(&vars->code, RE_USER);
         }
     }
     else {
@@ -806,7 +806,7 @@ REBOOL Make_Error_Object_Throws(
         // not already there.
 
         if (IS_BLANK(&vars->code))
-            SET_INTEGER(&vars->code, RE_USER);
+            Init_Integer(&vars->code, RE_USER);
         else if (IS_INTEGER(&vars->code)) {
             if (VAL_INT32(&vars->code) != RE_USER)
                 fail (Error_Invalid_Error_Raw(arg));
@@ -888,7 +888,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
     #endif
 
         DECLARE_LOCAL (code_value);
-        SET_INTEGER(code_value, code);
+        Init_Integer(code_value, code);
 
         panic (code_value);
     }
@@ -954,7 +954,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
         // !!! Should tweak root error during boot so it actually is an ERROR!
         // (or use literal error construction syntax, if it worked?)
         //
-        VAL_RESET_HEADER(CTX_VALUE(error), REB_ERROR);
+        Reset_Val_Header(CTX_VALUE(error), REB_ERROR);
     }
     else {
         REBCNT root_len = CTX_LEN(root_error);
@@ -967,7 +967,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
         // !!! Should tweak root error during boot so it actually is an ERROR!
         // (or use literal error construction syntax, if it worked?)
         //
-        VAL_RESET_HEADER(CTX_VALUE(error), REB_ERROR);
+        Reset_Val_Header(CTX_VALUE(error), REB_ERROR);
 
         // Fix up the tail first so CTX_KEY and CTX_VAR don't complain
         // in the debug build that they're accessing beyond the error length
@@ -1032,7 +1032,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
                 }
 
             #if !defined(NDEBUG)
-                if (GET_VAL_FLAG(arg, VALUE_FLAG_RELATIVE)) {
+                if (Get_Val_Flag(arg, VALUE_FLAG_RELATIVE)) {
                     //
                     // Make_Error doesn't have any way to pass in a specifier,
                     // so only specific values should be used.
@@ -1072,7 +1072,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
                 Init_Typeset(key, ALL_64, Canon(*arg1_arg2_arg3));
                 arg1_arg2_arg3++;
                 key++;
-                SET_BLANK(value);
+                Init_Blank(value);
                 value++;
             }
         }
@@ -1092,7 +1092,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
             // error/__LINE__ (an INTEGER! value)
             Init_Typeset(key, ALL_64, Canon(SYM___LINE__));
             key++;
-            SET_INTEGER(value, TG_Erroring_C_Line);
+            Init_Integer(value, TG_Erroring_C_Line);
             value++;
         }
     #endif
@@ -1106,7 +1106,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
     ERROR_VARS *vars = ERR_VARS(error);
 
     // Set error number:
-    SET_INTEGER(&vars->code, code);
+    Init_Integer(&vars->code, code);
 
     Move_Value(&vars->message, message);
     Move_Value(&vars->id, id);
@@ -1241,7 +1241,7 @@ REBCTX *Error_Invalid_Datatype(REBCNT id)
 {
     DECLARE_LOCAL (id_value);
 
-    SET_INTEGER(id_value, id);
+    Init_Integer(id_value, id);
     return Error_Invalid_Datatype_Raw(id_value);
 }
 
@@ -1253,7 +1253,7 @@ REBCTX *Error_No_Memory(REBCNT bytes)
 {
     DECLARE_LOCAL (bytes_value);
 
-    SET_INTEGER(bytes_value, bytes);
+    Init_Integer(bytes_value, bytes);
     return Error_No_Memory_Raw(bytes_value);
 }
 
@@ -1534,7 +1534,7 @@ REBCTX *Error_On_Port(REBCNT errnum, REBCTX *port, REBINT err_code)
         val = VAL_CONTEXT_VAR(spec, STD_PORT_SPEC_HEAD_TITLE); // less info
 
     DECLARE_LOCAL (err_code_value);
-    SET_INTEGER(err_code_value, err_code);
+    Init_Integer(err_code_value, err_code);
 
     return Error(errnum, val, err_code_value, END);
 }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -109,7 +109,7 @@ REBARR *List_Func_Typesets(REBVAL *func)
         // bits.  This may not be desirable over the long run (what if
         // a typeset wishes to encode hiddenness, protectedness, etc?)
         //
-        VAL_RESET_HEADER(value, REB_TYPESET);
+        Reset_Val_Header(value, REB_TYPESET);
     }
 
     return array;
@@ -195,7 +195,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
     // it is turned into a rootkey for param_notes.
     //
     DS_PUSH_TRASH; // paramlist[0] (will become FUNCTION! canon value)
-    SET_UNREADABLE_BLANK(DS_TOP);
+    Init_Unreadable_Blank(DS_TOP);
     DS_PUSH(EMPTY_BLOCK); // param_types[0] (to be OBJECT! canon value, if any)
     DS_PUSH(EMPTY_STRING); // param_notes[0] (holds description, then canon)
 
@@ -536,7 +536,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         // FUNCTION!/CLOSURE! distinction.
         //
         if (durable)
-            SET_VAL_FLAG(typeset, TYPESET_FLAG_DURABLE);
+            Set_Val_Flag(typeset, TYPESET_FLAG_DURABLE);
     }
 
     Drop_Frame(&f);
@@ -665,8 +665,8 @@ REBARR *Make_Paramlist_Managed_May_Fail(
 
     if (TRUE) {
         RELVAL *dest = ARR_HEAD(paramlist); // canon function value
-        VAL_RESET_HEADER(dest, REB_FUNCTION);
-        SET_VAL_FLAGS(dest, header_bits);
+        Reset_Val_Header(dest, REB_FUNCTION);
+        Set_Val_Flags(dest, header_bits);
         dest->payload.function.paramlist = paramlist;
         dest->extra.binding = NULL;
         ++dest;
@@ -764,14 +764,14 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         );
     }
     else if (meta)
-        SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_DESCRIPTION));
+        Init_Void(CTX_VAR(meta, STD_FUNCTION_META_DESCRIPTION));
 
     // Only make `parameter-types` if there were blocks in the spec
     //
     if (NOT(has_types)) {
         if (meta) {
-            SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_PARAMETER_TYPES));
-            SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_RETURN_TYPE));
+            Init_Void(CTX_VAR(meta, STD_FUNCTION_META_PARAMETER_TYPES));
+            Init_Void(CTX_VAR(meta, STD_FUNCTION_META_RETURN_TYPE));
         }
     }
     else {
@@ -781,7 +781,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         INIT_CTX_KEYLIST_SHARED(AS_CONTEXT(types_varlist), paramlist);
 
         REBVAL *dest = SINK(ARR_HEAD(types_varlist)); // "rootvar"
-        VAL_RESET_HEADER(dest, REB_FRAME);
+        Reset_Val_Header(dest, REB_FRAME);
         dest->payload.any_context.varlist = types_varlist; // canon FRAME!
         dest->payload.any_context.phase = AS_FUNC(paramlist);
         dest->extra.binding = NULL;
@@ -795,7 +795,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                 continue;
 
             if (VAL_ARRAY_LEN_AT(src) == 0)
-                SET_VOID(dest);
+                Init_Void(dest);
             else
                 Move_Value(dest, src);
             ++dest;
@@ -811,7 +811,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             // the function.)
             //
             if (VAL_ARRAY_LEN_AT(definitional_return + 1) == 0)
-                SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_RETURN_TYPE));
+                Init_Void(CTX_VAR(meta, STD_FUNCTION_META_RETURN_TYPE));
             else {
                 Move_Value(
                     CTX_VAR(meta, STD_FUNCTION_META_RETURN_TYPE),
@@ -820,7 +820,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             }
 
             if (NOT(flags & MKF_FAKE_RETURN)) {
-                SET_VOID(dest); // clear the local RETURN: var's description
+                Init_Void(dest); // clear the local RETURN: var's description
                 ++dest;
             }
         }
@@ -839,8 +839,8 @@ REBARR *Make_Paramlist_Managed_May_Fail(
     //
     if (NOT(has_notes)) {
         if (meta) {
-            SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_PARAMETER_NOTES));
-            SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_RETURN_NOTE));
+            Init_Void(CTX_VAR(meta, STD_FUNCTION_META_PARAMETER_NOTES));
+            Init_Void(CTX_VAR(meta, STD_FUNCTION_META_RETURN_NOTE));
         }
     }
     else {
@@ -850,7 +850,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         INIT_CTX_KEYLIST_SHARED(AS_CONTEXT(notes_varlist), paramlist);
 
         REBVAL *dest = SINK(ARR_HEAD(notes_varlist)); // "rootvar"
-        VAL_RESET_HEADER(dest, REB_FRAME);
+        Reset_Val_Header(dest, REB_FRAME);
         dest->payload.any_context.varlist = notes_varlist; // canon FRAME!
         dest->payload.any_context.phase = AS_FUNC(paramlist);
         dest->extra.binding = NULL;
@@ -864,7 +864,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                 continue;
 
             if (SER_LEN(VAL_SERIES(src)) == 0)
-                SET_VOID(dest);
+                Init_Void(dest);
             else
                 Move_Value(dest, src);
             ++dest;
@@ -877,7 +877,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             // parameter in the list
             //
             if (SER_LEN(VAL_SERIES(definitional_return + 2)) == 0)
-                SET_VOID(CTX_VAR(meta, STD_FUNCTION_META_RETURN_NOTE));
+                Init_Void(CTX_VAR(meta, STD_FUNCTION_META_RETURN_NOTE));
             else {
                 Move_Value(
                     CTX_VAR(meta, STD_FUNCTION_META_RETURN_NOTE),
@@ -886,7 +886,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             }
 
             if (NOT(flags & MKF_FAKE_RETURN)) {
-                SET_VOID(dest);
+                Init_Void(dest);
                 ++dest;
             }
         }
@@ -999,7 +999,7 @@ REBFUN *Make_Function(
             //
             // First argument is not tight, cache flag to report it.
             //
-            SET_VAL_FLAG(rootparam, FUNC_FLAG_DEFERS_LOOKBACK_ARG);
+            Set_Val_Flag(rootparam, FUNC_FLAG_DEFERS_LOOKBACK_ARG);
             goto done_caching;
 
         // Otherwise, at least one argument but not one that requires the
@@ -1013,7 +1013,7 @@ REBFUN *Make_Function(
 
         case PARAM_CLASS_HARD_QUOTE:
         case PARAM_CLASS_SOFT_QUOTE:
-            SET_VAL_FLAG(rootparam, FUNC_FLAG_QUOTES_FIRST_ARG);
+            Set_Val_Flag(rootparam, FUNC_FLAG_QUOTES_FIRST_ARG);
             goto done_caching;
 
         default:
@@ -1027,7 +1027,7 @@ done_caching:;
     // a block--it's anything that the dispatcher might wish to interpret.
 
     REBARR *body_holder = Alloc_Singular_Array();
-    SET_BLANK(ARR_HEAD(body_holder));
+    Init_Blank(ARR_HEAD(body_holder));
     MANAGE_ARRAY(body_holder);
 
     rootparam->payload.function.body_holder = body_holder;
@@ -1082,7 +1082,7 @@ done_caching:;
     //
     assert(
         AS_SERIES(paramlist)->link.meta == NULL
-        || GET_SER_FLAG(
+        || Get_Ser_Flag(
             CTX_VARLIST(AS_SERIES(paramlist)->link.meta), ARRAY_FLAG_VARLIST
         )
     );
@@ -1093,8 +1093,8 @@ done_caching:;
     // error).  That protection is now done to the frame series on reification
     // in order to be able to MAKE FRAME! and reuse the native's paramlist.
 
-    assert(NOT_SER_FLAG(paramlist, SERIES_FLAG_FILE_LINE));
-    assert(NOT_SER_FLAG(body_holder, SERIES_FLAG_FILE_LINE));
+    assert(Not_Ser_Flag(paramlist, SERIES_FLAG_FILE_LINE));
+    assert(Not_Ser_Flag(body_holder, SERIES_FLAG_FILE_LINE));
 
     return AS_FUNC(paramlist);
 }
@@ -1124,10 +1124,10 @@ REBCTX *Make_Expired_Frame_Ctx_Managed(REBFUN *func)
     REBARR *varlist = Alloc_Singular_Array_Core(
         ARRAY_FLAG_VARLIST | CONTEXT_FLAG_STACK
     );
-    SET_BLANK(ARR_HEAD(varlist));
+    Init_Blank(ARR_HEAD(varlist));
     MANAGE_ARRAY(varlist);
 
-    SET_SER_INFO(varlist, SERIES_INFO_INACCESSIBLE);
+    Set_Ser_Info(varlist, SERIES_INFO_INACCESSIBLE);
 
     REBCTX *expired = AS_CONTEXT(varlist);
 
@@ -1165,8 +1165,8 @@ REBARR *Get_Maybe_Fake_Func_Body(REBOOL *is_fake, const REBVAL *func)
     assert(IS_FUNCTION(func) && IS_FUNCTION_INTERPRETED(func));
 
     REBCNT body_index;
-    if (GET_VAL_FLAG(func, FUNC_FLAG_RETURN)) {
-        if (GET_VAL_FLAG(func, FUNC_FLAG_LEAVE)) {
+    if (Get_Val_Flag(func, FUNC_FLAG_RETURN)) {
+        if (Get_Val_Flag(func, FUNC_FLAG_LEAVE)) {
             example = Get_System(SYS_STANDARD, STD_FUNC_BODY);
             body_index = 8;
         }
@@ -1176,7 +1176,7 @@ REBARR *Get_Maybe_Fake_Func_Body(REBOOL *is_fake, const REBVAL *func)
         }
         *is_fake = TRUE;
     }
-    else if (GET_VAL_FLAG(func, FUNC_FLAG_LEAVE)) {
+    else if (Get_Val_Flag(func, FUNC_FLAG_LEAVE)) {
         example = Get_System(SYS_STANDARD, STD_PROC_BODY);
         body_index = 4;
         *is_fake = TRUE;
@@ -1198,8 +1198,8 @@ REBARR *Get_Maybe_Fake_Func_Body(REBOOL *is_fake, const REBVAL *func)
         RELVAL *slot = ARR_AT(fake_body, body_index); // #BODY
         assert(IS_ISSUE(slot));
 
-        VAL_RESET_HEADER(slot, REB_GROUP);
-        SET_VAL_FLAGS(slot, VALUE_FLAG_RELATIVE | VALUE_FLAG_LINE);
+        Reset_Val_Header(slot, REB_GROUP);
+        Set_Val_Flags(slot, VALUE_FLAG_RELATIVE | VALUE_FLAG_LINE);
         INIT_VAL_ARRAY(slot, VAL_ARRAY(VAL_FUNC_BODY(func)));
         VAL_INDEX(slot) = 0;
         INIT_RELATIVE(slot, VAL_FUNC(func));
@@ -1273,7 +1273,7 @@ REBFUN *Make_Interpreted_Function_May_Fail(
 
     REBARR *body_array;
     if (VAL_ARRAY_LEN_AT(code) == 0) {
-        if (GET_VAL_FLAG(value, FUNC_FLAG_RETURN)) {
+        if (Get_Val_Flag(value, FUNC_FLAG_RETURN)) {
             //
             // Since we're bypassing type checking in the dispatcher for
             // speed, we need to make sure that the return type allows void
@@ -1293,9 +1293,9 @@ REBFUN *Make_Interpreted_Function_May_Fail(
         // Body is not empty, so we need to pick the right dispatcher based
         // on how the output value is to be handled.
         //
-        if (GET_VAL_FLAG(value, FUNC_FLAG_RETURN))
+        if (Get_Val_Flag(value, FUNC_FLAG_RETURN))
             FUNC_DISPATCHER(fun) = &Returner_Dispatcher; // type checks f->out
-        else if (GET_VAL_FLAG(value, FUNC_FLAG_LEAVE))
+        else if (Get_Val_Flag(value, FUNC_FLAG_LEAVE))
             FUNC_DISPATCHER(fun) = &Voider_Dispatcher; // forces f->out void
         else
             FUNC_DISPATCHER(fun) = &Unchecked_Dispatcher; // leaves f->out
@@ -1316,7 +1316,7 @@ REBFUN *Make_Interpreted_Function_May_Fail(
     // relative to a function.  (Init_Block assumes all specific values)
     //
     RELVAL *body = FUNC_BODY(fun);
-    VAL_RESET_HEADER_EXTRA(body, REB_BLOCK, VALUE_FLAG_RELATIVE);
+    Reset_Val_Header_Core(body, REB_BLOCK, VALUE_FLAG_RELATIVE);
     INIT_VAL_ARRAY(body, body_array);
     VAL_INDEX(body) = 0;
     INIT_RELATIVE(body, fun);
@@ -1331,10 +1331,10 @@ REBFUN *Make_Interpreted_Function_May_Fail(
     //
     if (
         LEGACY_RUNNING(OPTIONS_REFINEMENTS_BLANK)
-        || GET_SER_INFO(VAL_ARRAY(spec), SERIES_INFO_LEGACY_DEBUG)
-        || GET_SER_INFO(VAL_ARRAY(code), SERIES_INFO_LEGACY_DEBUG)
+        || Get_Ser_Info(VAL_ARRAY(spec), SERIES_INFO_LEGACY_DEBUG)
+        || Get_Ser_Info(VAL_ARRAY(code), SERIES_INFO_LEGACY_DEBUG)
     ) {
-        SET_VAL_FLAG(FUNC_VALUE(fun), FUNC_FLAG_LEGACY_DEBUG);
+        Set_Val_Flag(FUNC_VALUE(fun), FUNC_FLAG_LEGACY_DEBUG);
     }
 #endif
 
@@ -1382,7 +1382,7 @@ REBCTX *Make_Frame_For_Function(const REBVAL *value) {
     // Fill in the rootvar information for the context canon REBVAL
     //
     REBVAL *var = SINK(ARR_HEAD(varlist));
-    VAL_RESET_HEADER(var, REB_FRAME);
+    Reset_Val_Header(var, REB_FRAME);
     var->payload.any_context.varlist = varlist;
     var->extra.binding = value->extra.binding;
     var->payload.any_context.phase = func;
@@ -1411,7 +1411,7 @@ REBCTX *Make_Frame_For_Function(const REBVAL *value) {
     //
     REBCNT n;
     for (n = 1; n <= FUNC_NUM_PARAMS(func); ++n, ++var)
-        SET_VOID(var);
+        Init_Void(var);
 
     TERM_ARRAY_LEN(varlist, ARR_LEN(FUNC_PARAMLIST(func)));
 
@@ -1456,7 +1456,7 @@ REBOOL Specialize_Function_Throws(
         REBARR *varlist = Copy_Array_Deep_Managed(
             CTX_VARLIST(exemplar), SPECIFIED
         );
-        SET_SER_FLAG(varlist, ARRAY_FLAG_VARLIST);
+        Set_Ser_Flag(varlist, ARRAY_FLAG_VARLIST);
         INIT_CTX_KEYLIST_SHARED(AS_CONTEXT(varlist), CTX_KEYLIST(exemplar));
 
         exemplar = AS_CONTEXT(varlist); // okay, now make exemplar our copy
@@ -1527,13 +1527,13 @@ REBOOL Specialize_Function_Throws(
 
     REBCTX *meta = Copy_Context_Shallow(VAL_CONTEXT(example));
 
-    SET_VOID(CTX_VAR(meta, STD_SPECIALIZED_META_DESCRIPTION)); // default
+    Init_Void(CTX_VAR(meta, STD_SPECIALIZED_META_DESCRIPTION)); // default
     Move_Value(
         CTX_VAR(meta, STD_SPECIALIZED_META_SPECIALIZEE),
         specializee
     );
     if (opt_specializee_name == NULL)
-        SET_VOID(CTX_VAR(meta, STD_SPECIALIZED_META_SPECIALIZEE_NAME));
+        Init_Void(CTX_VAR(meta, STD_SPECIALIZED_META_SPECIALIZEE_NAME));
     else
         Init_Word(
             CTX_VAR(meta, STD_SPECIALIZED_META_SPECIALIZEE_NAME),
@@ -1622,7 +1622,7 @@ void Clonify_Function(REBVAL *value)
         FUNC_PARAMLIST(original_fun),
         SPECIFIED
     );
-    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    Set_Ser_Flag(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
 
@@ -1643,7 +1643,7 @@ void Clonify_Function(REBVAL *value)
     // that it's o.k. to tell the frame lookup that it can find variables
     // under the "new paramlist".
     //
-    VAL_RESET_HEADER_EXTRA(body, REB_BLOCK, VALUE_FLAG_RELATIVE);
+    Reset_Val_Header_Core(body, REB_BLOCK, VALUE_FLAG_RELATIVE);
     INIT_VAL_ARRAY(
         body,
         Copy_Rerelativized_Array_Deep_Managed(
@@ -1972,7 +1972,7 @@ void Get_If_Word_Or_Path_Arg(
 
     if (ANY_WORD(value)) {
         *opt_name_out = VAL_WORD_SPELLING(value);
-        VAL_SET_TYPE_BITS(adjusted, REB_GET_WORD);
+        Reset_Val_Kind(adjusted, REB_GET_WORD);
     }
     else if (ANY_PATH(value)) {
         //
@@ -1980,7 +1980,7 @@ void Get_If_Word_Or_Path_Arg(
         // evaluated GETs.  Not implemented at the moment.
         //
         *opt_name_out = NULL;
-        VAL_SET_TYPE_BITS(adjusted, REB_GET_PATH);
+        Reset_Val_Kind(adjusted, REB_GET_PATH);
     }
     else {
         *opt_name_out = NULL;
@@ -2073,7 +2073,7 @@ REB_R Apply_Frame_Core(REBFRM *f, REBSTR *label, REBVAL *opt_def)
         else
             f->special = m_cast(REBVAL*, END); // literal pointer tested
 
-        SET_END(&f->cell); // needed for GC safety
+        Init_End(&f->cell); // needed for GC safety
     }
 
     // Ordinary function dispatch does not pre-fill the arguments; they
@@ -2103,7 +2103,7 @@ REB_R Apply_Frame_Core(REBFRM *f, REBSTR *label, REBVAL *opt_def)
             ++f->special;
         }
         else if (opt_def)
-            SET_VOID(f->arg);
+            Init_Void(f->arg);
         else {
             // just leave it alone
         }
@@ -2149,7 +2149,7 @@ REB_R Apply_Frame_Core(REBFRM *f, REBSTR *label, REBVAL *opt_def)
 
     f->special = f->args_head; // do type/refinement checks on existing data
 
-    SET_END(f->out);
+    Init_End(f->out);
 
     Do_Core(f);
 

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -118,7 +118,7 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
         break;
 
     case PE_NONE:
-        SET_BLANK(pvs->store);
+        Init_Blank(pvs->store);
     case PE_USE_STORE:
         pvs->value = pvs->store;
         pvs->value_specifier = SPECIFIED;
@@ -175,7 +175,7 @@ REBOOL Do_Path_Throws_Core(
     //
     REBPVS pvs;
     Prep_Global_Cell(&pvs.selector_cell);
-    SET_END(&pvs.selector_cell);
+    Init_End(&pvs.selector_cell);
     PUSH_GUARD_VALUE(&pvs.selector_cell);
     pvs.selector = &pvs.selector_cell;
 
@@ -196,7 +196,7 @@ REBOOL Do_Path_Throws_Core(
     // will do, which is unset in release builds.
     //
     if (opt_setval)
-        SET_UNREADABLE_BLANK(out);
+        Init_Unreadable_Blank(out);
 
     // None of the values passed in can live on the data stack, because
     // they might be relocated during the path evaluation process.

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -159,7 +159,7 @@ REBINT Awake_System(REBARR *ports, REBOOL only)
     if (ports)
         Init_Block(tmp, ports);
     else
-        SET_BLANK(tmp);
+        Init_Blank(tmp);
 
     DECLARE_LOCAL (awake_only);
     if (only) {

--- a/src/core/c-signal.c
+++ b/src/core/c-signal.c
@@ -159,7 +159,7 @@ REBOOL Do_Signals_Throws(REBVAL *out)
         if (NOT(IS_VOID(out)))
             fail ("Interrupt-based debug session used RESUME/WITH");
 
-        SET_END(out);
+        Init_End(out);
         return FALSE;
     }
 

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -112,15 +112,15 @@ void Assert_Cell_Writable(const RELVAL *v, const char *file, int line)
 
 
 //
-//  SET_END_Debug: C
+//  Init_End_Debug: C
 //
 // Uses REB_0 for the type, to help cue debugging.
 //
-// When SET_END is used, it uses the whole cell.  Implicit termination is
+// When Init_End is used, it uses the whole cell.  Implicit termination is
 // done by the raw creation of a Reb_Header in the containing structure,
 // see Init_Endlike_Header().
 //
-void SET_END_Debug(RELVAL *v, const char *file, int line) {
+void Init_End_Debug(RELVAL *v, const char *file, int line) {
     ASSERT_CELL_WRITABLE(v, file, line);
     v->header.bits &= CELL_MASK_RESET;
     v->header.bits |= NODE_FLAG_VALID | FLAGBYTE_FIRST(255);
@@ -151,7 +151,7 @@ REBOOL IS_END_Debug(const RELVAL *v, const char *file, int line) {
 //
 REBCTX *VAL_SPECIFIC_Debug(const REBVAL *v)
 {
-    assert(NOT_VAL_FLAG(v, VALUE_FLAG_RELATIVE));
+    assert(Not_Val_Flag(v, VALUE_FLAG_RELATIVE));
     assert(
         ANY_WORD(v)
         || ANY_ARRAY(v)
@@ -166,7 +166,7 @@ REBCTX *VAL_SPECIFIC_Debug(const REBVAL *v)
         //
         // Basic sanity check: make sure it's a context at all
         //
-        if (NOT_SER_FLAG(CTX_VARLIST(specific), ARRAY_FLAG_VARLIST)) {
+        if (Not_Ser_Flag(CTX_VARLIST(specific), ARRAY_FLAG_VARLIST)) {
             printf("Non-CONTEXT found as specifier in specific value\n");
             panic (specific); // may not be a series, either
         }
@@ -239,14 +239,14 @@ void Probe_Core_Debug(
         //
         ASSERT_SERIES(s);
 
-        if (GET_SER_FLAG(s, ARRAY_FLAG_VARLIST)) {
+        if (Get_Ser_Flag(s, ARRAY_FLAG_VARLIST)) {
             REBCTX *c = AS_CONTEXT(s);
 
             // Don't use Init_Any_Context, because that can implicitly manage
             // the context...which we don't want a debug dump routine to do.
             //
             DECLARE_LOCAL (temp);
-            VAL_RESET_HEADER(temp, CTX_TYPE(c));
+            Reset_Val_Header(temp, CTX_TYPE(c));
             temp->extra.binding = NULL;
             temp->payload.any_context.varlist = CTX_VARLIST(c);
             temp->payload.any_context.phase = NULL;
@@ -261,7 +261,7 @@ void Probe_Core_Debug(
 
             if (BYTE_SIZE(s))
                 Debug_Str(s_cast(BIN_HEAD(s)));
-            else if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY)) {
+            else if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY)) {
                 //
                 // May not actually be a REB_BLOCK, but we put it in a value
                 // container for now saying it is so we can output it.  May
@@ -269,7 +269,7 @@ void Probe_Core_Debug(
                 // initialization instead of Init_Block.
                 //
                 DECLARE_LOCAL (value);
-                VAL_RESET_HEADER(value, REB_BLOCK);
+                Reset_Val_Header(value, REB_BLOCK);
                 INIT_VAL_ARRAY(value, AS_ARRAY(s));
                 VAL_INDEX(value) = 0;
 

--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -127,7 +127,7 @@ static void Expand_Word_Table(void)
     REBCNT new_size = Get_Hash_Prime(old_size + 1);
     if (new_size == 0) {
         DECLARE_LOCAL (temp);
-        SET_INTEGER(temp, old_size + 1);
+        Init_Integer(temp, old_size + 1);
         fail (Error_Size_Limit_Raw(temp));
     }
 
@@ -239,7 +239,7 @@ REBSTR *Intern_UTF8_Managed(const REBYTE *utf8, REBCNT len)
             continue;
         }
 
-        assert(GET_SER_INFO(canon, STRING_INFO_CANON));
+        assert(Get_Ser_Info(canon, STRING_INFO_CANON));
 
         // Compare_UTF8 returns 0 when the spelling is a case-sensitive match,
         // and is the exact interning to return.
@@ -266,7 +266,7 @@ REBSTR *Intern_UTF8_Managed(const REBYTE *utf8, REBCNT len)
         REBSTR *synonym = canon->link.synonym;
         while (synonym != canon) {
             assert(synonym->misc.canon == canon);
-            assert(NOT_SER_INFO(synonym, STRING_INFO_CANON));
+            assert(Not_Ser_Info(synonym, STRING_INFO_CANON));
 
             // Exact match for a synonym also means no new allocation needed.
             //
@@ -304,9 +304,9 @@ new_interning: ; // semicolon needed for statement
 
 #if !defined(NDEBUG)
     if (len + 1 > sizeof(intern->content))
-        assert(GET_SER_INFO(intern, SERIES_INFO_HAS_DYNAMIC));
+        assert(Get_Ser_Info(intern, SERIES_INFO_HAS_DYNAMIC));
     else
-        assert(NOT_SER_INFO(intern, SERIES_INFO_HAS_DYNAMIC));
+        assert(Not_Ser_Info(intern, SERIES_INFO_HAS_DYNAMIC));
 #endif
 
     // The incoming string isn't always null terminated, e.g. if you are
@@ -332,7 +332,7 @@ new_interning: ; // semicolon needed for statement
             ++PG_Num_Canon_Slots_In_Use;
         }
 
-        SET_SER_INFO(intern, STRING_INFO_CANON);
+        Set_Ser_Info(intern, STRING_INFO_CANON);
 
         intern->link.synonym = intern; // circularly linked list, empty state
 
@@ -397,13 +397,13 @@ void GC_Kill_Interning(REBSTR *intern)
     //
     REBSER *temp = synonym;
     while (temp->link.synonym != intern) {
-        if (GET_SER_INFO(intern, STRING_INFO_CANON))
+        if (Get_Ser_Info(intern, STRING_INFO_CANON))
             temp->misc.canon = synonym;
         temp = temp->link.synonym;
     }
     temp->link.synonym = synonym; // cut intern out of chain (or no-op)
 
-    if (NOT_SER_INFO(intern, STRING_INFO_CANON))
+    if (Not_Ser_Info(intern, STRING_INFO_CANON))
         return; // for non-canon forms, removing from chain is all you need
 
     assert(intern->misc.bind_index.high == 0); // shouldn't GC during binds?
@@ -436,7 +436,7 @@ void GC_Kill_Interning(REBSTR *intern)
         //
         /*assert(hash == Hash_Word(STR_HEAD(synonym)));*/
         canons_by_hash[hash] = synonym;
-        SET_SER_INFO(synonym, STRING_INFO_CANON);
+        Set_Ser_Info(synonym, STRING_INFO_CANON);
         synonym->misc.bind_index.low = 0;
         synonym->misc.bind_index.high = 0;
     }
@@ -526,7 +526,7 @@ void Startup_Symbols(REBARR *words)
     RELVAL *word = ARR_HEAD(words);
     for (; NOT_END(word); ++word) {
         REBSTR *canon = VAL_WORD_CANON(word);
-        assert(GET_SER_INFO(canon, STRING_INFO_CANON));
+        assert(Get_Ser_Info(canon, STRING_INFO_CANON));
 
         sym = cast(REBSYM, cast(REBCNT, sym) + 1);
         *SER_AT(REBSTR*, PG_Symbol_Canons, cast(REBCNT, sym)) = canon;

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -406,19 +406,19 @@ REBNATIVE(resume)
     REBARR *instruction = Make_Array(RESUME_INST_MAX);
 
     if (REF(with)) {
-        SET_FALSE(ARR_AT(instruction, RESUME_INST_MODE)); // don't DO value
+        Init_False(ARR_AT(instruction, RESUME_INST_MODE)); // don't DO value
         Move_Value(
             SINK(ARR_AT(instruction, RESUME_INST_PAYLOAD)), ARG(value)
         );
     }
     else if (REF(do)) {
-        SET_TRUE(ARR_AT(instruction, RESUME_INST_MODE)); // DO the value
+        Init_True(ARR_AT(instruction, RESUME_INST_MODE)); // DO the value
         Move_Value(
             SINK(ARR_AT(instruction, RESUME_INST_PAYLOAD)), ARG(code)
         );
     }
     else {
-        SET_BLANK(ARR_AT(instruction, RESUME_INST_MODE)); // use default
+        Init_Blank(ARR_AT(instruction, RESUME_INST_MODE)); // use default
 
         // Even though this slot should be ignored, use BAR! to try and make
         // any attempts to use it more conspicuous (an unset wouldn't be)

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -144,7 +144,7 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
             PROBE(s);
         #endif
 
-        if (GET_SER_FLAG(s, ARRAY_FLAG_VARLIST)) {
+        if (Get_Ser_Flag(s, ARRAY_FLAG_VARLIST)) {
             printf("Series VARLIST detected.\n");
             REBCTX *context = AS_CONTEXT(s);
             if (CTX_TYPE(context) == REB_ERROR) {

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -130,7 +130,7 @@ void Dump_Series(REBSER *s, const char *memo)
 
     printf(" wide: %d\n", SER_WIDE(s));
     printf(" size: %ld\n", cast(unsigned long, SER_TOTAL_IF_DYNAMIC(s)));
-    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
+    if (Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC))
         printf(" bias: %d\n", cast(int, SER_BIAS(s)));
     printf(" tail: %d\n", cast(int, SER_LEN(s)));
     printf(" rest: %d\n", cast(int, SER_REST(s)));
@@ -143,7 +143,7 @@ void Dump_Series(REBSER *s, const char *memo)
 
     fflush(stdout);
 
-    if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+    if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY))
         Dump_Values(ARR_HEAD(AS_ARRAY(s)), SER_LEN(s));
     else
         Dump_Bytes(SER_DATA_RAW(s), (SER_LEN(s) + 1) * SER_WIDE(s));

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -121,7 +121,7 @@ void Do_Core_Entry_Checks_Debug(REBFRM *f)
     REBSER *containing = Try_Find_Containing_Series_Debug(f->out);
 
     if (containing) {
-        if (GET_SER_FLAG(containing, SERIES_FLAG_FIXED_SIZE)) {
+        if (Get_Ser_Flag(containing, SERIES_FLAG_FIXED_SIZE)) {
             //
             // Currently it's considered OK to be writing into a fixed size
             // series, for instance the durable portion of a function's

--- a/src/core/d-legacy.c
+++ b/src/core/d-legacy.c
@@ -68,7 +68,7 @@ REBOOL In_Legacy_Function_Debug(void)
 
     // Check the flag on the source series
     //
-    if (GET_SER_INFO(frame->source.array, SERIES_INFO_LEGACY_DEBUG))
+    if (Get_Ser_Info(frame->source.array, SERIES_INFO_LEGACY_DEBUG))
         return TRUE;
 
     return FALSE;
@@ -103,7 +103,7 @@ void Legacy_Convert_Function_Args(REBFRM *f)
                 if (VAL_LOGIC(arg))
                     set_blank = FALSE;
                 else {
-                    SET_BLANK(arg);
+                    Init_Blank(arg);
                     set_blank = TRUE;
                 }
             }
@@ -124,7 +124,7 @@ void Legacy_Convert_Function_Args(REBFRM *f)
         case PARAM_CLASS_SOFT_QUOTE:
             if (set_blank) {
                 assert(IS_VOID(arg));
-                SET_BLANK(arg);
+                Init_Blank(arg);
             }
             break;
 
@@ -181,7 +181,7 @@ REBCTX *Make_Guarded_Arg123_Error(void)
             ALL_64,
             Canon(cast(REBSYM, cast(REBCNT, SYM_ARG1) + n))
         );
-        SET_BLANK(var);
+        Init_Blank(var);
     }
 
     MANAGE_ARRAY(CTX_VARLIST(error));

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -128,7 +128,7 @@ void Prin_OS_String(const void *p, REBCNT len, REBFLGS opts)
     buffer[0] = 0; // for debug tracing
 
     DECLARE_LOCAL (result);
-    SET_END(result);
+    Init_End(result);
 
     if (opts & OPT_ENC_RAW) {
         if (Do_Signals_Throws(result))
@@ -731,12 +731,12 @@ pick:
             // !!! Better approach?  Can the series be passed directly?
             //
             REBSER* temp = va_arg(*vaptr, REBSER*);
-            if (GET_SER_FLAG(temp, SERIES_FLAG_ARRAY)) {
-                VAL_RESET_HEADER(value, REB_BLOCK);
+            if (Get_Ser_Flag(temp, SERIES_FLAG_ARRAY)) {
+                Reset_Val_Header(value, REB_BLOCK);
                 INIT_VAL_ARRAY(value, AS_ARRAY(temp)); // careful, macro!
             }
             else {
-                VAL_RESET_HEADER(value, REB_STRING);
+                Reset_Val_Header(value, REB_STRING);
                 INIT_VAL_SERIES(value, temp); // careful, macro!
             }
             VAL_INDEX(value) = 0;

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -69,7 +69,7 @@ void Collapsify_Array(REBARR *array, REBSPC *specifier, REBCNT limit)
             enum Reb_Kind kind = VAL_TYPE(item);
             Init_Any_Array_At(item, kind, copy, 0); // at 0 now
             assert(IS_SPECIFIC(item));
-            assert(NOT_VAL_FLAG(item, VALUE_FLAG_LINE)); // should be cleared
+            assert(Not_Val_Flag(item, VALUE_FLAG_LINE)); // should be cleared
         }
     }
 }
@@ -147,7 +147,7 @@ REBARR *Make_Where_For_Frame(REBFRM *f)
             // Get rid of any newline marker on the first element,
             // that would visually disrupt the backtrace for no reason.
             //
-            CLEAR_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+            Clear_Val_Flag(DS_TOP, VALUE_FLAG_LINE);
         }
     }
 
@@ -245,7 +245,7 @@ REBNATIVE(file_of)
 
     REBSER *s = VAL_SERIES(ARG(series));
 
-    if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
+    if (Not_Ser_Flag(s, SERIES_FLAG_FILE_LINE))
         return R_BLANK;
 
     // !!! How to tell whether it's a URL! or a FILE! ?
@@ -270,10 +270,10 @@ REBNATIVE(line_of)
 
     REBSER *s = VAL_SERIES(ARG(series));
 
-    if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
+    if (Not_Ser_Flag(s, SERIES_FLAG_FILE_LINE))
         return R_BLANK;
 
-    SET_INTEGER(D_OUT, s->misc.line);
+    Init_Integer(D_OUT, s->misc.line);
     return R_OUT;
 }
 
@@ -330,7 +330,7 @@ REBNATIVE(backtrace_index)
     REBCNT number;
 
     if (NULL != Frame_For_Stack_Level(&number, ARG(level), TRUE)) {
-        SET_INTEGER(D_OUT, number);
+        Init_Integer(D_OUT, number);
         return R_OUT;
     }
 
@@ -448,7 +448,7 @@ REBNATIVE(backtrace)
         //
         if (!pending) {
             DECLARE_LOCAL (temp_val);
-            SET_INTEGER(temp_val, number);
+            Init_Integer(temp_val, number);
 
             REBCNT temp_num;
             if (
@@ -497,7 +497,7 @@ REBNATIVE(backtrace)
                     //
                     DS_PUSH_TRASH;
                     Init_Word(DS_TOP, Canon(SYM_ASTERISK));
-                    SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE); // put on own line
+                    Set_Val_Flag(DS_TOP, VALUE_FLAG_LINE); // put on own line
                 }
                 break;
             }
@@ -555,9 +555,9 @@ REBNATIVE(backtrace)
             Init_Word(DS_TOP, Canon(SYM_ASTERISK));
         }
         else
-            SET_INTEGER(DS_TOP, number);
+            Init_Integer(DS_TOP, number);
 
-        SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+        Set_Val_Flag(DS_TOP, VALUE_FLAG_LINE);
     }
 
     // If we ran out of stack levels before finding the single one requested

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -225,7 +225,7 @@ void Clonify_Values_Len_Managed(
             REBSER *series;
             if (ANY_CONTEXT(value)) {
             #if !defined(NDEBUG)
-                legacy = GET_SER_INFO(
+                legacy = Get_Ser_Info(
                     CTX_VARLIST(VAL_CONTEXT(value)),
                     SERIES_INFO_LEGACY_DEBUG
                 );
@@ -237,9 +237,9 @@ void Clonify_Values_Len_Managed(
                 series = AS_SERIES(CTX_VARLIST(VAL_CONTEXT(value)));
             }
             else {
-                if (GET_SER_FLAG(VAL_SERIES(value), SERIES_FLAG_ARRAY)) {
+                if (Get_Ser_Flag(VAL_SERIES(value), SERIES_FLAG_ARRAY)) {
                 #if !defined(NDEBUG)
-                    legacy = GET_SER_INFO(
+                    legacy = Get_Ser_Info(
                         VAL_ARRAY(value), SERIES_INFO_LEGACY_DEBUG
                     );
                 #endif
@@ -267,7 +267,7 @@ void Clonify_Values_Len_Managed(
 
         #if !defined(NDEBUG)
             if (legacy) // propagate legacy
-                SET_SER_INFO(series, SERIES_INFO_LEGACY_DEBUG);
+                Set_Ser_Info(series, SERIES_INFO_LEGACY_DEBUG);
         #endif
 
             MANAGE_SERIES(series);
@@ -355,8 +355,8 @@ REBARR *Copy_Array_Core_Managed(
     // be marked legacy.  Then if it runs, the SWITCH can dispatch to return
     // blank instead of the Ren-C behavior of returning `2`.
     //
-    if (GET_SER_INFO(original, SERIES_INFO_LEGACY_DEBUG))
-        SET_SER_INFO(copy, SERIES_INFO_LEGACY_DEBUG);
+    if (Get_Ser_Info(original, SERIES_INFO_LEGACY_DEBUG))
+        Set_Ser_Info(copy, SERIES_INFO_LEGACY_DEBUG);
 #endif
 
     ASSERT_NO_RELATIVE(copy, deep);

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -251,7 +251,7 @@ REBNATIVE(unload_extension_helper)
 
     if (ret < 0) {
         DECLARE_LOCAL (i);
-        SET_INTEGER(i, ret);
+        Init_Integer(i, ret);
         fail (Error_Fail_To_Quit_Extension_Raw(i));
     }
 
@@ -293,9 +293,9 @@ REBARR *Make_Extension_Module_Array(
     );
 
     if (error_base == 0)
-        SET_BLANK(ARR_AT(arr, 2));
+        Init_Blank(ARR_AT(arr, 2));
     else
-        SET_INTEGER(ARR_AT(arr, 2), error_base);
+        Init_Integer(ARR_AT(arr, 2), error_base);
 
     TERM_ARRAY_LEN(arr, 3);
     return arr;
@@ -393,7 +393,7 @@ REBNATIVE(load_native)
     );
 
     if (REF(unloadable))
-        SET_VAL_FLAG(FUNC_VALUE(fun), FUNC_FLAG_UNLOADABLE_NATIVE);
+        Set_Val_Flag(FUNC_VALUE(fun), FUNC_FLAG_UNLOADABLE_NATIVE);
 
     if (REF(body)) {
         *FUNC_BODY(fun) = *ARG(code);
@@ -431,7 +431,7 @@ REBNATIVE(unload_native)
     INCLUDE_PARAMS_OF_UNLOAD_NATIVE;
 
     REBFUN *fun = VAL_FUNC(ARG(nat));
-    if (NOT_VAL_FLAG(FUNC_VALUE(fun), FUNC_FLAG_UNLOADABLE_NATIVE))
+    if (Not_Val_Flag(FUNC_VALUE(fun), FUNC_FLAG_UNLOADABLE_NATIVE))
         fail (Error_Non_Unloadable_Native_Raw(ARG(nat)));
 
     FUNC_DISPATCHER(VAL_FUNC(ARG(nat))) = Unloaded_Dispatcher;

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -89,11 +89,11 @@ REB_R Series_Common_Action_Maybe_Unhandled(
         break;
 
     case SYM_INDEX_OF:
-        SET_INTEGER(D_OUT, cast(REBI64, index) + 1);
+        Init_Integer(D_OUT, cast(REBI64, index) + 1);
         return R_OUT; // handled
 
     case SYM_LENGTH:
-        SET_INTEGER(D_OUT, tail > index ? tail - index : 0);
+        Init_Integer(D_OUT, tail > index ? tail - index : 0);
         return R_OUT; // handled
 
     case SYM_REMOVE: {

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -69,7 +69,7 @@ REBINT Float_Int16(REBD32 f)
 {
     if (fabs(f) > cast(REBD32, 0x7FFF)) {
         DECLARE_LOCAL (temp);
-        SET_DECIMAL(temp, f);
+        Init_Decimal(temp, f);
 
         fail (Error_Out_Of_Range(temp));
     }
@@ -348,7 +348,7 @@ void Init_Any_Series_At_Core(
         ASSERT_SERIES_TERM(series); // doesn't apply to image/vector
     }
 
-    VAL_RESET_HEADER(out, type);
+    Reset_Val_Header(out, type);
     out->payload.any_series.series = series;
     VAL_INDEX(out) = index;
     if (specifier == SPECIFIED)
@@ -357,7 +357,7 @@ void Init_Any_Series_At_Core(
         INIT_SPECIFIC(out, AS_CONTEXT(specifier));
 
 #if !defined(NDEBUG)
-    if (GET_SER_FLAG(series, SERIES_FLAG_ARRAY) && specifier == SPECIFIED) {
+    if (Get_Ser_Flag(series, SERIES_FLAG_ARRAY) && specifier == SPECIFIED) {
         //
         // If a SPECIFIED is used for an array, then that top level of the
         // array cannot have any relative values in it.  Catch it here vs.
@@ -378,7 +378,7 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 {
     REBYTE *bp;
 
-    VAL_RESET_HEADER(value, REB_TUPLE);
+    Reset_Val_Header(value, REB_TUPLE);
     VAL_TUPLE_LEN(value) = (REBYTE)len;
     for (bp = VAL_TUPLE(value); len > 0; len--)
         *bp++ = *bytes++;
@@ -412,10 +412,10 @@ void Init_Any_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *c) {
     if (CTX_KEYLIST(c) == NULL)
         panic (c);
 
-    assert(GET_SER_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
+    assert(Get_Ser_Flag(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
 
-    assert(NOT_SER_FLAG(CTX_VARLIST(c), SERIES_FLAG_FILE_LINE));
-    assert(NOT_SER_FLAG(CTX_KEYLIST(c), SERIES_FLAG_FILE_LINE));
+    assert(Not_Ser_Flag(CTX_VARLIST(c), SERIES_FLAG_FILE_LINE));
+    assert(Not_Ser_Flag(CTX_KEYLIST(c), SERIES_FLAG_FILE_LINE));
 
     if (IS_FRAME(CTX_VALUE(c)))
         assert(IS_FUNCTION(CTX_FRAME_FUNC_VALUE(c)));

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1502,7 +1502,7 @@ static REBARR *Scan_Array(
         // If in a path, handle start of path /word or word//word cases:
         if (mode_char == '/' && *bp == '/') {
             DS_PUSH_TRASH;
-            SET_BLANK(DS_TOP);
+            Init_Blank(DS_TOP);
             scan_state->begin = bp + 1;
             continue;
         }
@@ -1527,24 +1527,24 @@ static REBARR *Scan_Array(
             DS_PUSH_TRASH;
 
             if (token == TOKEN_LIT) {
-                VAL_RESET_HEADER(DS_TOP, REB_LIT_PATH);
-                VAL_RESET_HEADER(ARR_HEAD(array), REB_WORD);
+                Reset_Val_Header(DS_TOP, REB_LIT_PATH);
+                Reset_Val_Header(ARR_HEAD(array), REB_WORD);
                 assert(IS_WORD_UNBOUND(ARR_HEAD(array)));
             }
             else if (IS_GET_WORD(ARR_HEAD(array))) {
                 if (*scan_state->end == ':')
                     goto syntax_error;
-                VAL_RESET_HEADER(DS_TOP, REB_GET_PATH);
-                VAL_RESET_HEADER(ARR_HEAD(array), REB_WORD);
+                Reset_Val_Header(DS_TOP, REB_GET_PATH);
+                Reset_Val_Header(ARR_HEAD(array), REB_WORD);
                 assert(IS_WORD_UNBOUND(ARR_HEAD(array)));
             }
             else {
                 if (*scan_state->end == ':') {
-                    VAL_RESET_HEADER(DS_TOP, REB_SET_PATH);
+                    Reset_Val_Header(DS_TOP, REB_SET_PATH);
                     scan_state->begin = ++(scan_state->end);
                 }
                 else
-                    VAL_RESET_HEADER(DS_TOP, REB_PATH);
+                    Reset_Val_Header(DS_TOP, REB_PATH);
             }
             INIT_VAL_ARRAY(DS_TOP, array); // copies args
             VAL_INDEX(DS_TOP) = 0;
@@ -1578,7 +1578,7 @@ static REBARR *Scan_Array(
 
         case TOKEN_BLANK:
             DS_PUSH_TRASH;
-            SET_BLANK(DS_TOP);
+            Init_Blank(DS_TOP);
             ++bp;
             break;
 
@@ -1616,7 +1616,7 @@ static REBARR *Scan_Array(
                     goto syntax_error;
                 }
                 DS_PUSH_TRASH;
-                SET_BLANK(DS_TOP);  // A single # means NONE
+                Init_Blank(DS_TOP);  // A single # means NONE
             }
             else {
                 DS_PUSH_TRASH;
@@ -1685,7 +1685,7 @@ static REBARR *Scan_Array(
                 goto syntax_error;
 
             if (bp[len - 1] == '%') {
-                VAL_RESET_HEADER(DS_TOP, REB_PERCENT);
+                Reset_Val_Header(DS_TOP, REB_PERCENT);
                 VAL_DECIMAL(DS_TOP) /= 100.0;
             }
             break;
@@ -1736,7 +1736,7 @@ static REBARR *Scan_Array(
             bp += 2; // skip #", and subtract 1 from ep for "
             if (ep - 1 != Scan_UTF8_Char_Escapable(&VAL_CHAR(DS_TOP), bp))
                 goto syntax_error;
-            VAL_RESET_HEADER(DS_TOP, REB_CHAR);
+            Reset_Val_Header(DS_TOP, REB_CHAR);
             break;
 
         case TOKEN_STRING: {
@@ -1830,7 +1830,7 @@ static REBARR *Scan_Array(
                 //
                 DECLARE_LOCAL (cell);
                 PUSH_GUARD_ARRAY(array);
-                SET_UNREADABLE_BLANK(cell);
+                Init_Unreadable_Blank(cell);
                 PUSH_GUARD_VALUE(cell);
 
                 dispatcher(cell, kind, KNOWN(ARR_AT(array, 1))); // may fail()
@@ -1857,18 +1857,18 @@ static REBARR *Scan_Array(
                 case SYM_NONE:
                     // Should be under a LEGACY flag...
                     DS_PUSH_TRASH;
-                    SET_BLANK(DS_TOP);
+                    Init_Blank(DS_TOP);
                     break;
             #endif
 
                 case SYM_FALSE:
                     DS_PUSH_TRASH;
-                    SET_FALSE(DS_TOP);
+                    Init_False(DS_TOP);
                     break;
 
                 case SYM_TRUE:
                     DS_PUSH_TRASH;
-                    SET_TRUE(DS_TOP);
+                    Init_True(DS_TOP);
                     break;
 
                 default: {
@@ -1911,12 +1911,12 @@ static REBARR *Scan_Array(
             REBSER *s = VAL_SERIES(DS_TOP);
             s->misc.line = scan_state->line_count;
             s->link.filename = scan_state->filename;
-            SET_SER_FLAG(s, SERIES_FLAG_FILE_LINE);
+            Set_Ser_Flag(s, SERIES_FLAG_FILE_LINE);
         }
 
         if (line) {
             line = FALSE;
-            SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+            Set_Val_Flag(DS_TOP, VALUE_FLAG_LINE);
         }
 
         // Check for end of path:
@@ -1970,7 +1970,7 @@ exit_block:
     //
 #if !defined(NDEBUG)
     if (LEGACY(OPTIONS_REFINEMENTS_BLANK))
-        SET_SER_INFO(result, SERIES_INFO_LEGACY_DEBUG);
+        Set_Ser_Info(result, SERIES_INFO_LEGACY_DEBUG);
 #endif
 
     return result;

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -42,7 +42,7 @@
 //
 
 #define return_NULL \
-    do { SET_UNREADABLE_BLANK(out); return NULL; } while (TRUE)
+    do { Init_Unreadable_Blank(out); return NULL; } while (TRUE)
 
 
 //
@@ -264,7 +264,7 @@ const REBYTE *Scan_Hex(
     if (cnt < minlen)
         return_NULL;
 
-    SET_INTEGER(out, i);
+    Init_Integer(out, i);
     return cp;
 }
 
@@ -509,7 +509,7 @@ const REBYTE *Scan_Decimal(
     if (cast(REBCNT, cp - bp) != len)
         return_NULL;
 
-    VAL_RESET_HEADER(out, REB_DECIMAL);
+    Reset_Val_Header(out, REB_DECIMAL);
 
     const char *se;
     VAL_DECIMAL(out) = STRTOD(s_cast(buf), &se);
@@ -539,11 +539,11 @@ const REBYTE *Scan_Integer(
     // Super-fast conversion of zero and one (most common cases):
     if (len == 1) {
         if (*cp == '0') {
-            SET_INTEGER(out, 0);
+            Init_Integer(out, 0);
             return cp + 1;
         }
         if (*cp == '1') {
-            SET_INTEGER(out, 1);
+            Init_Integer(out, 1);
             return cp + 1;
          }
     }
@@ -579,7 +579,7 @@ const REBYTE *Scan_Integer(
 
     if (num == 0) { // all zeros or '
         // return early to avoid platform dependant error handling in CHR_TO_INT
-        SET_INTEGER(out, 0);
+        Init_Integer(out, 0);
         return cp;
     }
 
@@ -606,7 +606,7 @@ const REBYTE *Scan_Integer(
     // Convert, check, and return:
     errno = 0;
 
-    VAL_RESET_HEADER(out, REB_INTEGER);
+    Reset_Val_Header(out, REB_INTEGER);
 
     VAL_INT64(out) = CHR_TO_INT(buf);
     if (errno != 0)
@@ -640,7 +640,7 @@ const REBYTE *Scan_Money(
     if (len == 0)
         return_NULL;
 
-    SET_MONEY(out, string_to_deci(cp, &end));
+    Init_Money(out, string_to_deci(cp, &end));
     if (end != cp + len)
         return_NULL;
 
@@ -1024,10 +1024,10 @@ const REBYTE *Scan_Pair(
     if (*ep != 'x' && *ep != 'X')
         return_NULL;
 
-    VAL_RESET_HEADER(out, REB_PAIR);
+    Reset_Val_Header(out, REB_PAIR);
     out->payload.pair = Alloc_Pairing(NULL);
-    VAL_RESET_HEADER(out->payload.pair, REB_DECIMAL);
-    VAL_RESET_HEADER(PAIRING_KEY(out->payload.pair), REB_DECIMAL);
+    Reset_Val_Header(out->payload.pair, REB_DECIMAL);
+    Reset_Val_Header(PAIRING_KEY(out->payload.pair), REB_DECIMAL);
 
     VAL_PAIR_X(out) = cast(float, atof(cast(char*, &buf[0]))); //n;
     ep++;
@@ -1079,7 +1079,7 @@ const REBYTE *Scan_Tuple(
     if (size < 3)
         size = 3;
 
-    VAL_RESET_HEADER(out, REB_TUPLE);
+    Reset_Val_Header(out, REB_TUPLE);
     VAL_TUPLE_LEN(out) = cast(REBYTE, size);
 
     REBYTE *tp = VAL_TUPLE(out);
@@ -1257,7 +1257,7 @@ REBNATIVE(scan_net_header)
                         SPECIFIED // no relative values added
                     );
                     val = Alloc_Tail_Array(array);
-                    SET_UNREADABLE_BLANK(val); // for Init_Block
+                    Init_Unreadable_Blank(val); // for Init_Block
                     Init_Block(item + 1, array);
                 }
                 break;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -130,7 +130,7 @@ static inline void Mark_Rebser_Only(REBSER *s)
         panic (s);
     }
 #endif
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY));
 
     if (s->header.bits & SERIES_FLAG_FILE_LINE)
         s->link.filename->header.bits |= NODE_FLAG_MARKED;
@@ -175,7 +175,7 @@ static void Queue_Mark_Array_Subclass_Deep(REBARR *a)
     if (IS_FREE_NODE(a))
         panic (a);
 
-    if (NOT_SER_FLAG(a, SERIES_FLAG_ARRAY))
+    if (Not_Ser_Flag(a, SERIES_FLAG_ARRAY))
         panic (a);
 
     if (!IS_ARRAY_MANAGED(a))
@@ -204,11 +204,11 @@ static void Queue_Mark_Array_Subclass_Deep(REBARR *a)
 }
 
 inline static void Queue_Mark_Array_Deep(REBARR *a) {
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_VARLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PARAMLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PAIRLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_VARLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PARAMLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PAIRLIST));
 
-    if (GET_SER_FLAG(a, SERIES_FLAG_FILE_LINE))
+    if (Get_Ser_Flag(a, SERIES_FLAG_FILE_LINE))
         AS_SERIES(a)->link.filename->header.bits |= NODE_FLAG_MARKED;
 
     Queue_Mark_Array_Subclass_Deep(a);
@@ -216,10 +216,10 @@ inline static void Queue_Mark_Array_Deep(REBARR *a) {
 
 inline static void Queue_Mark_Context_Deep(REBCTX *c) {
     REBARR *a = CTX_VARLIST(c);
-    assert(GET_SER_FLAG(a, ARRAY_FLAG_VARLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PARAMLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PAIRLIST));
-    assert(NOT_SER_FLAG(a, SERIES_FLAG_FILE_LINE));
+    assert(Get_Ser_Flag(a, ARRAY_FLAG_VARLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PARAMLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PAIRLIST));
+    assert(Not_Ser_Flag(a, SERIES_FLAG_FILE_LINE));
 
     Queue_Mark_Array_Subclass_Deep(a);
 
@@ -230,10 +230,10 @@ inline static void Queue_Mark_Context_Deep(REBCTX *c) {
 
 inline static void Queue_Mark_Function_Deep(REBFUN *f) {
     REBARR *a = FUNC_PARAMLIST(f);
-    assert(GET_SER_FLAG(a, ARRAY_FLAG_PARAMLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_VARLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PAIRLIST));
-    assert(NOT_SER_FLAG(a, SERIES_FLAG_FILE_LINE));
+    assert(Get_Ser_Flag(a, ARRAY_FLAG_PARAMLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_VARLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PAIRLIST));
+    assert(Not_Ser_Flag(a, SERIES_FLAG_FILE_LINE));
 
     Queue_Mark_Array_Subclass_Deep(a);
 
@@ -244,10 +244,10 @@ inline static void Queue_Mark_Function_Deep(REBFUN *f) {
 
 inline static void Queue_Mark_Map_Deep(REBMAP *m) {
     REBARR *a = MAP_PAIRLIST(m);
-    assert(GET_SER_FLAG(a, ARRAY_FLAG_PAIRLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PARAMLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_VARLIST));
-    assert(NOT_SER_FLAG(a, SERIES_FLAG_FILE_LINE));
+    assert(Get_Ser_Flag(a, ARRAY_FLAG_PAIRLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PARAMLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_VARLIST));
+    assert(Not_Ser_Flag(a, SERIES_FLAG_FILE_LINE));
 
 
     Queue_Mark_Array_Subclass_Deep(a);
@@ -264,12 +264,12 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v);
 // faster by avoiding a queue step for the array node or walk.
 //
 inline static void Queue_Mark_Singular_Array(REBARR *a) {
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PAIRLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_PARAMLIST));
-    assert(NOT_SER_FLAG(a, ARRAY_FLAG_VARLIST));
-    assert(NOT_SER_FLAG(a, SERIES_FLAG_FILE_LINE));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PAIRLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_PARAMLIST));
+    assert(Not_Ser_Flag(a, ARRAY_FLAG_VARLIST));
+    assert(Not_Ser_Flag(a, SERIES_FLAG_FILE_LINE));
 
-    assert(NOT_SER_INFO(a, SERIES_INFO_HAS_DYNAMIC));
+    assert(Not_Ser_Info(a, SERIES_INFO_HAS_DYNAMIC));
 
     AS_SERIES(a)->header.bits |= NODE_FLAG_MARKED;
     Queue_Mark_Opt_Value_Deep(ARR_HEAD(a));
@@ -351,17 +351,17 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         // time a canon word's "index" field is allowed to be nonzero.
         //
         assert(
-            NOT_SER_INFO(spelling, STRING_INFO_CANON)
+            Not_Ser_Info(spelling, STRING_INFO_CANON)
             || (
                 spelling->misc.bind_index.high == 0
                 && spelling->misc.bind_index.low == 0
             )
         );
 
-        if (GET_VAL_FLAG(v, WORD_FLAG_BOUND)) {
+        if (Get_Val_Flag(v, WORD_FLAG_BOUND)) {
             assert(v->payload.any_word.index != 0);
 
-            if (GET_VAL_FLAG(v, VALUE_FLAG_RELATIVE)) {
+            if (Get_Val_Flag(v, VALUE_FLAG_RELATIVE)) {
                 // Bound relative to a function, keep that function alive.
                 //
                 // (To turn a relative binding into a specific one, a
@@ -384,7 +384,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
             // The word is unbound...make sure index is 0 in debug build.
             // (it can be left uninitialized in release builds, for now)
             //
-            assert(!GET_VAL_FLAG(v, VALUE_FLAG_RELATIVE));
+            assert(!Get_Val_Flag(v, VALUE_FLAG_RELATIVE));
         #if !defined(NDEBUG)
             assert(v->payload.any_word.index == 0);
         #endif
@@ -453,7 +453,7 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
                 // references at once), the data pointers in all but the
                 // shared singular value are NULL.
                 //
-                if (GET_VAL_FLAG(v, HANDLE_FLAG_CFUNC))
+                if (Get_Val_Flag(v, HANDLE_FLAG_CFUNC))
                     assert(
                         IS_CFUNC_TRASH_DEBUG(v->payload.handle.data.cfunc)
                     );
@@ -542,14 +542,14 @@ static void Queue_Mark_Opt_Value_Deep(const RELVAL *v)
         // holds the shared index among all same varargs into that array.
         //
         REBARR *feed = v->payload.varargs.feed;
-        assert(GET_SER_FLAG(feed, ARRAY_FLAG_VARLIST) || ARR_LEN(feed) == 1);
+        assert(Get_Ser_Flag(feed, ARRAY_FLAG_VARLIST) || ARR_LEN(feed) == 1);
         if (IS_ARRAY_MANAGED(feed))
             Queue_Mark_Array_Subclass_Deep(feed);
         else {
             // !!! Should also assert that this is a frame in mid-fulfillment
             // on the stack.
             // 
-            assert(GET_SER_FLAG(feed, ARRAY_FLAG_VARLIST));
+            assert(Get_Ser_Flag(feed, ARRAY_FLAG_VARLIST));
         }
         break; }
 
@@ -732,13 +732,13 @@ static void Propagate_All_GC_Marks(void)
         // For a lighter check, make sure it's marked as a value-bearing array
         // and that it hasn't been freed.
         //
-        assert(GET_SER_FLAG(a, SERIES_FLAG_ARRAY));
+        assert(Get_Ser_Flag(a, SERIES_FLAG_ARRAY));
         assert(!IS_FREE_NODE(AS_SERIES(a)));
     #endif
 
         RELVAL *v = ARR_HEAD(a);
 
-        if (GET_SER_FLAG(a, ARRAY_FLAG_PARAMLIST)) {
+        if (Get_Ser_Flag(a, ARRAY_FLAG_PARAMLIST)) {
             //
             // These queueings cannot be done in Queue_Mark_Function_Deep
             // because of the potential for overflowing the C stack with calls
@@ -762,7 +762,7 @@ static void Propagate_All_GC_Marks(void)
             assert(v->extra.binding == NULL); // archetypes have no binding
             ++v; // function archetype completely marked by this process
         }
-        else if (GET_SER_FLAG(a, ARRAY_FLAG_VARLIST)) {
+        else if (Get_Ser_Flag(a, ARRAY_FLAG_VARLIST)) {
             //
             // These queueings cannot be done in Queue_Mark_Context_Deep
             // because of the potential for overflowing the C stack with calls
@@ -780,7 +780,7 @@ static void Propagate_All_GC_Marks(void)
             assert(v->extra.binding == NULL); // archetypes have no binding
             ++v; // context archtype completely marked by this process
         }
-        else if (GET_SER_FLAG(a, ARRAY_FLAG_PAIRLIST)) {
+        else if (Get_Ser_Flag(a, ARRAY_FLAG_PAIRLIST)) {
             //
             // There was once a "small map" optimization that wouldn't
             // produce a hashlist for small maps and just did linear search.
@@ -794,15 +794,15 @@ static void Propagate_All_GC_Marks(void)
             Mark_Rebser_Only(hashlist);
         }
 
-        if (GET_SER_INFO(a, SERIES_INFO_INACCESSIBLE)) {
+        if (Get_Ser_Info(a, SERIES_INFO_INACCESSIBLE)) {
             //
             // At present the only inaccessible arrays are expired frames of
             // functions with stack-bound arg and local lifetimes.  They are
             // just singular REBARRs with the FRAME! archetype value.
             //
-            assert(GET_SER_FLAG(a, ARRAY_FLAG_VARLIST));
+            assert(Get_Ser_Flag(a, ARRAY_FLAG_VARLIST));
             assert(IS_FRAME(ARR_HEAD(a)));
-            assert(GET_SER_FLAG(a, CONTEXT_FLAG_STACK));
+            assert(Get_Ser_Flag(a, CONTEXT_FLAG_STACK));
             continue;
         }
 
@@ -817,8 +817,8 @@ static void Propagate_All_GC_Marks(void)
             //
             if (NOT(IS_BLANK_RAW(v)) && IS_VOID(v)) {
                 if(
-                    !GET_SER_FLAG(a, ARRAY_FLAG_VARLIST)
-                    && !GET_SER_FLAG(a, ARRAY_FLAG_VOIDS_LEGAL)
+                    !Get_Ser_Flag(a, ARRAY_FLAG_VARLIST)
+                    && !Get_Ser_Flag(a, ARRAY_FLAG_VOIDS_LEGAL)
                 )
                     panic(a);
             }
@@ -917,7 +917,7 @@ static void Mark_Root_Series(void)
                 REBVAL *paired = key + 1;
                 if (
                     IS_FRAME(key)
-                    && GET_VAL_FLAG(key, ANY_CONTEXT_FLAG_OWNS_PAIRED)
+                    && Get_Val_Flag(key, ANY_CONTEXT_FLAG_OWNS_PAIRED)
                     && !Is_Context_Running_Or_Pending(VAL_CONTEXT(key))
                 ){
                     Free_Pairing(paired); // don't consider a root
@@ -939,7 +939,7 @@ static void Mark_Root_Series(void)
                 // this is.  So if it's a context, we have to get the
                 // keylist...etc.
                 //
-                if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+                if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY))
                     Queue_Mark_Array_Subclass_Deep(AS_ARRAY(s));
                 else
                     Mark_Rebser_Only(s);
@@ -1050,7 +1050,7 @@ static void Mark_Guarded_Nodes(void)
         }
         else { // a series
             REBSER *s = cast(REBSER*, node);
-            if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+            if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY))
                 Queue_Mark_Array_Subclass_Deep(AS_ARRAY(s));
             else
                 Mark_Rebser_Only(s);
@@ -1308,7 +1308,7 @@ static REBCNT Sweep_Series(void)
                 // sounds like what could plausibly be an ordinary END marker
                 // in a cell (as opposed to an implicit END).  However, there
                 // would be no way to distinguish this from legal leading
-                // bytes of multi-byte UTF-8 sequences.  Hence SET_END()
+                // bytes of multi-byte UTF-8 sequences.  Hence Init_End()
                 // uses a different bit pattern (below).
                 //
                 assert(FALSE);
@@ -1319,7 +1319,7 @@ static REBCNT Sweep_Series(void)
                 // While this indicates a "managed" cell that's an END marker,
                 // there is actually only one legal possibility...and the
                 // managed bit is not relevant.  What is relevant is that
-                // SET_END() on a valid cell spot uses the special illegal
+                // Init_End() on a valid cell spot uses the special illegal
                 // UTF-8 pattern of `11111111` (255) to allow distinguishing
                 // it from a valid multi-byte UTF-8 sequence.
                 //
@@ -1463,7 +1463,7 @@ REBCNT Recycle_Core(REBOOL shutdown, REBSER *sweeplist)
 
         // Mark potential error object from callback!
         if (!IS_BLANK_RAW(&Callback_Error)) {
-            assert(NOT_VAL_FLAG(&Callback_Error, VALUE_FLAG_RELATIVE));
+            assert(Not_Val_Flag(&Callback_Error, VALUE_FLAG_RELATIVE));
             Queue_Mark_Value_Deep(&Callback_Error);
         }
         Propagate_All_GC_Marks();
@@ -1653,7 +1653,7 @@ REBARR *Snapshot_All_Functions(void)
                 // of other bits, see Sweep_Series.)
                 //
                 assert(IS_SERIES_MANAGED(s));
-                if (GET_SER_FLAG(s, ARRAY_FLAG_PARAMLIST)) {
+                if (Get_Ser_Flag(s, ARRAY_FLAG_PARAMLIST)) {
                     REBVAL *v = KNOWN(ARR_HEAD(AS_ARRAY(s)));
                     assert(IS_FUNCTION(v));
                     DS_PUSH(v);

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -89,7 +89,7 @@ void Append_Series(REBSER *s, const REBYTE *data, REBCNT len)
     REBCNT len_old = SER_LEN(s);
     REBYTE wide = SER_WIDE(s);
 
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY));
 
     EXPAND_SERIES_TAIL(s, len);
     memcpy(SER_DATA_RAW(s) + (wide * len_old), data, wide * len);
@@ -138,7 +138,7 @@ void Append_Values_Len(REBARR *a, const REBVAL *head, REBCNT len)
 //
 REBSER *Copy_Sequence(REBSER *original)
 {
-    assert(NOT_SER_FLAG(original, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(original, SERIES_FLAG_ARRAY));
 
     REBCNT len = SER_LEN(original);
     REBSER *copy = Make_Series(len + 1, SER_WIDE(original));
@@ -164,7 +164,7 @@ REBSER *Copy_Sequence(REBSER *original)
 //
 REBSER *Copy_Sequence_At_Len(REBSER *original, REBCNT index, REBCNT len)
 {
-    assert(NOT_SER_FLAG(original, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(original, SERIES_FLAG_ARRAY));
 
     REBSER *copy = Make_Series(len + 1, SER_WIDE(original));
     memcpy(
@@ -201,7 +201,7 @@ void Remove_Series(REBSER *s, REBCNT index, REBINT len)
 {
     if (len <= 0) return;
 
-    REBOOL is_dynamic = GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC);
+    REBOOL is_dynamic = Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC);
     REBCNT len_old = SER_LEN(s);
 
     REBCNT start = index * SER_WIDE(s);
@@ -314,8 +314,8 @@ void Unbias_Series(REBSER *s, REBOOL keep)
 //
 void Reset_Sequence(REBSER *s)
 {
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY));
-    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY));
+    if (Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)) {
         Unbias_Series(s, FALSE);
         s->content.dynamic.len = 0;
         TERM_SEQUENCE(s);
@@ -333,7 +333,7 @@ void Reset_Sequence(REBSER *s)
 //
 void Reset_Array(REBARR *a)
 {
-    if (GET_SER_INFO(a, SERIES_INFO_HAS_DYNAMIC))
+    if (Get_Ser_Info(a, SERIES_INFO_HAS_DYNAMIC))
         Unbias_Series(AS_SERIES(a), FALSE);
     TERM_ARRAY_LEN(a, 0);
 }
@@ -349,7 +349,7 @@ void Clear_Series(REBSER *s)
 {
     assert(!Is_Series_Read_Only(s));
 
-    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
+    if (Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)) {
         Unbias_Series(s, FALSE);
         CLEAR(s->content.dynamic.data, SER_REST(s) * SER_WIDE(s));
     }
@@ -368,7 +368,7 @@ void Clear_Series(REBSER *s)
 //
 void Resize_Series(REBSER *s, REBCNT size)
 {
-    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
+    if (Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)) {
         s->content.dynamic.len = 0;
         Unbias_Series(s, TRUE);
     }
@@ -409,7 +409,7 @@ REBYTE *Reset_Buffer(REBSER *buf, REBCNT len)
 //
 REBSER *Copy_Buffer(REBSER *buf, REBCNT index, void *end)
 {
-    assert(NOT_SER_FLAG(buf, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(buf, SERIES_FLAG_ARRAY));
 
     REBCNT len = BYTE_SIZE(buf)
         ? cast(REBYTE*, end) - BIN_HEAD(buf)
@@ -437,7 +437,7 @@ REBSER *Copy_Buffer(REBSER *buf, REBCNT index, void *end)
 //
 void Assert_Series_Term_Core(REBSER *s)
 {
-    if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY)) {
+    if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY)) {
         //
         // END values aren't canonized to zero bytes, check IS_END explicitly
         //
@@ -469,10 +469,10 @@ void Assert_Series_Core(REBSER *s)
         panic (s);
 
     assert(
-        GET_SER_INFO(s, SERIES_INFO_0_IS_TRUE)
-        && GET_SER_INFO(s, SERIES_INFO_1_IS_TRUE)
-        && NOT_SER_INFO(s, SERIES_INFO_2_IS_FALSE)
-        && NOT_SER_INFO(s, SERIES_INFO_8_IS_FALSE)
+        Get_Ser_Info(s, SERIES_INFO_0_IS_TRUE)
+        && Get_Ser_Info(s, SERIES_INFO_1_IS_TRUE)
+        && Not_Ser_Info(s, SERIES_INFO_2_IS_FALSE)
+        && Not_Ser_Info(s, SERIES_INFO_8_IS_FALSE)
     );
 
     assert(SER_LEN(s) < SER_REST(s));

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -81,7 +81,7 @@ void Startup_Stacks(REBCNT size)
     // are building a context varlist or similar.
     //
     DS_Array = Make_Array_Core(1, ARRAY_FLAG_VOIDS_LEGAL);
-    SET_UNREADABLE_BLANK(ARR_HEAD(DS_Array));
+    Init_Unreadable_Blank(ARR_HEAD(DS_Array));
 
     // The END marker will signal DS_PUSH that it has run out of space,
     // and it will perform the allocation at that time.
@@ -185,7 +185,7 @@ void Expand_Data_Stack_May_Fail(REBCNT amount)
     REBCNT len_new = len_old + amount;
     REBCNT n;
     for (n = len_old; n < len_new; ++n) {
-        SET_UNREADABLE_BLANK(value);
+        Init_Unreadable_Blank(value);
         ++value;
     }
 
@@ -281,11 +281,11 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
         // a context.  !!! Really this cannot reify if we're in arg gathering
         // mode, calling MANAGE_ARRAY is illegal -- need test for that !!!
         //
-        assert(NOT_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST));
-        SET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST);
+        assert(Not_Ser_Flag(f->varlist, ARRAY_FLAG_VARLIST));
+        Set_Ser_Flag(f->varlist, ARRAY_FLAG_VARLIST);
 
         assert(IS_TRASH_DEBUG(ARR_AT(f->varlist, 0))); // we fill this in
-        assert(GET_SER_INFO(f->varlist, SERIES_INFO_HAS_DYNAMIC));
+        assert(Get_Ser_Info(f->varlist, SERIES_INFO_HAS_DYNAMIC));
     }
     else {
         f->varlist = Alloc_Singular_Array_Core(
@@ -312,7 +312,7 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
     // might be stopped.
     //
     REBVAL *rootvar = SINK(ARR_HEAD(f->varlist));
-    VAL_RESET_HEADER(rootvar, REB_FRAME);
+    Reset_Val_Header(rootvar, REB_FRAME);
     rootvar->payload.any_context.varlist = f->varlist;
     rootvar->payload.any_context.phase = f->phase;
     rootvar->extra.binding = f->binding;
@@ -327,7 +327,7 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
     // itself, but should stop modifications from user code.
     //
     if (f->flags.bits & DO_FLAG_NATIVE_HOLD)
-        SET_SER_INFO(f->varlist, SERIES_INFO_RUNNING);
+        Set_Ser_Info(f->varlist, SERIES_INFO_RUNNING);
 
     MANAGE_ARRAY(f->varlist);
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -461,14 +461,14 @@ REBNATIVE(switch)
     // For safety, notice if someone wrote `switch [x] [...]` with a literal
     // block in source, as that is likely a mistake.
     //
-    if (IS_BLOCK(value) && GET_VAL_FLAG(value, VALUE_FLAG_UNEVALUATED))
+    if (IS_BLOCK(value) && Get_Val_Flag(value, VALUE_FLAG_UNEVALUATED))
         fail (Error_Block_Switch_Raw(value));
 
     // Frame's extra D_CELL is free since the function has > 1 arg.  Reuse it
     // as a temporary GC-safe location for holding evaluations.  This
     // holds the last test so that `switch 9 [1 ["a"] 2 ["b"] "c"]` is "c".
 
-    SET_VOID(D_CELL); // used for "fallout"
+    Init_Void(D_CELL); // used for "fallout"
 
     while (NOT_END(f.value)) {
 
@@ -477,7 +477,7 @@ REBNATIVE(switch)
         // feature of the last value "falling out" the bottom of the switch
 
         if (IS_BLOCK(f.value)) {
-            SET_VOID(D_CELL);
+            Init_Void(D_CELL);
             goto continue_loop;
         }
 
@@ -782,7 +782,7 @@ REBNATIVE(throw)
     else {
         // Blank values serve as representative of THROWN() means "no name"
         //
-        SET_BLANK(D_OUT);
+        Init_Blank(D_OUT);
     }
 
     CONVERT_NAME_TO_THROWN(D_OUT, value);

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -312,7 +312,7 @@ REBNATIVE(do_all)
     // Holds either an error value that is raised, or the thrown value.
     //
     DECLARE_LOCAL (arg_or_error);
-    SET_END(arg_or_error);
+    Init_End(arg_or_error);
     PUSH_GUARD_VALUE(arg_or_error);
 
     // If arg_or_error is not end, but thrown_name is an end, a throw tried
@@ -320,7 +320,7 @@ REBNATIVE(do_all)
     // arg_or_error is also not, it is an error which tried to propagate.
     //
     DECLARE_LOCAL (thrown_name);
-    SET_END(thrown_name);
+    Init_End(thrown_name);
     PUSH_GUARD_VALUE(thrown_name);
 
     REBFRM f;
@@ -367,7 +367,7 @@ repush:
         goto repush;
     }
 
-    SET_VOID(D_OUT); // default return result of DO-ALL []
+    Init_Void(D_OUT); // default return result of DO-ALL []
 
     while (NOT_END(f.value)) {
         if (IS_BAR(f.value)) {
@@ -385,7 +385,7 @@ repush:
             // frame--as that's not generically possible unless you skip to
             // the next BAR!, as this routine does.
             //
-            SET_VOID(D_OUT);
+            Init_Void(D_OUT);
             Fetch_Next_In_Frame(&f);
             continue;
         }

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -188,7 +188,7 @@ REBNATIVE(exit)
     UNUSED(REF(with)); // implied by non-void value
 
     if (NOT(REF(from)))
-        SET_INTEGER(ARG(level), 1); // default--exit one function stack level
+        Init_Integer(ARG(level), 1); // default--exit one function stack level
 
     Make_Thrown_Exit_Value(D_OUT, ARG(level), ARG(value), frame_);
 
@@ -285,7 +285,7 @@ REBNATIVE(typechecker)
     REBARR *paramlist = Make_Array_Core(2, ARRAY_FLAG_PARAMLIST);
 
     REBVAL *archetype = Alloc_Tail_Array(paramlist);
-    VAL_RESET_HEADER(archetype, REB_FUNCTION);
+    Reset_Val_Header(archetype, REB_FUNCTION);
     archetype->payload.function.paramlist = paramlist;
     archetype->extra.binding = NULL;
 
@@ -404,7 +404,7 @@ REBNATIVE(chain)
         VAL_FUNC_PARAMLIST(ARR_HEAD(chainees)), SPECIFIED
     );
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
-    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    Set_Ser_Flag(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     // See %sysobj.r for `chained-meta:` object template
@@ -412,14 +412,14 @@ REBNATIVE(chain)
     REBVAL *std_meta = Get_System(SYS_STANDARD, STD_CHAINED_META);
     REBCTX *meta = Copy_Context_Shallow(VAL_CONTEXT(std_meta));
 
-    SET_VOID(CTX_VAR(meta, STD_CHAINED_META_DESCRIPTION)); // default
+    Init_Void(CTX_VAR(meta, STD_CHAINED_META_DESCRIPTION)); // default
     Init_Block(CTX_VAR(meta, STD_CHAINED_META_CHAINEES), chainees);
     //
     // !!! There could be a system for preserving names in the chain, by
     // accepting lit-words instead of functions--or even by reading the
     // GET-WORD!s in the block.  Consider for the future.
     //
-    SET_VOID(CTX_VAR(meta, STD_CHAINED_META_CHAINEE_NAMES));
+    Init_Void(CTX_VAR(meta, STD_CHAINED_META_CHAINEE_NAMES));
 
     MANAGE_ARRAY(CTX_VARLIST(meta));
     AS_SERIES(paramlist)->link.meta = meta;
@@ -496,7 +496,7 @@ REBNATIVE(adapt)
         VAL_FUNC_PARAMLIST(adaptee), SPECIFIED
     );
     ARR_HEAD(paramlist)->payload.function.paramlist = paramlist;
-    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    Set_Ser_Flag(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
 
     // See %sysobj.r for `adapted-meta:` object template
@@ -504,10 +504,10 @@ REBNATIVE(adapt)
     REBVAL *example = Get_System(SYS_STANDARD, STD_ADAPTED_META);
 
     REBCTX *meta = Copy_Context_Shallow(VAL_CONTEXT(example));
-    SET_VOID(CTX_VAR(meta, STD_ADAPTED_META_DESCRIPTION)); // default
+    Init_Void(CTX_VAR(meta, STD_ADAPTED_META_DESCRIPTION)); // default
     Move_Value(CTX_VAR(meta, STD_ADAPTED_META_ADAPTEE), adaptee);
     if (opt_adaptee_name == NULL)
-        SET_VOID(CTX_VAR(meta, STD_ADAPTED_META_ADAPTEE_NAME));
+        Init_Void(CTX_VAR(meta, STD_ADAPTED_META_ADAPTEE_NAME));
     else
         Init_Word(
             CTX_VAR(meta, STD_ADAPTED_META_ADAPTEE_NAME),
@@ -532,7 +532,7 @@ REBNATIVE(adapt)
     REBARR *adaptation = Make_Array(2);
 
     REBVAL *block = Alloc_Tail_Array(adaptation);
-    VAL_RESET_HEADER_EXTRA(block, REB_BLOCK, VALUE_FLAG_RELATIVE);
+    Reset_Val_Header_Core(block, REB_BLOCK, VALUE_FLAG_RELATIVE);
     INIT_VAL_ARRAY(block, prelude);
     VAL_INDEX(block) = 0;
     INIT_RELATIVE(block, underlying);
@@ -540,7 +540,7 @@ REBNATIVE(adapt)
     Append_Value(adaptation, adaptee);
 
     RELVAL *body = FUNC_BODY(fun);
-    VAL_RESET_HEADER_EXTRA(body, REB_BLOCK, VALUE_FLAG_RELATIVE);
+    Reset_Val_Header_Core(body, REB_BLOCK, VALUE_FLAG_RELATIVE);
     INIT_VAL_ARRAY(body, adaptation);
     VAL_INDEX(body) = 0;
     INIT_RELATIVE(body, underlying);
@@ -669,7 +669,7 @@ REBNATIVE(variadic_q)
 
     REBVAL *param = VAL_FUNC_PARAMS_HEAD(ARG(func));
     for (; NOT_END(param); ++param) {
-        if (GET_VAL_FLAG(param, TYPESET_FLAG_VARIADIC))
+        if (Get_Val_Flag(param, TYPESET_FLAG_VARIADIC))
             return R_TRUE;
     }
 
@@ -710,7 +710,7 @@ REBNATIVE(tighten)
         FUNC_PARAMLIST(original),
         SPECIFIED // no relative values in parameter lists
     );
-    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST); // flags not auto-copied
+    Set_Ser_Flag(paramlist, ARRAY_FLAG_PARAMLIST); // flags not auto-copied
 
     RELVAL *param = ARR_AT(paramlist, 1); // first parameter (0 is FUNCTION!)
     for (; NOT_END(param); ++param) {
@@ -720,7 +720,7 @@ REBNATIVE(tighten)
     }
 
     RELVAL *rootparam = ARR_HEAD(paramlist);
-    CLEAR_VAL_FLAGS(rootparam, FUNC_FLAG_CACHED_MASK);
+    Clear_Val_Flags(rootparam, FUNC_FLAG_CACHED_MASK);
     rootparam->payload.function.paramlist = paramlist;
     rootparam->extra.binding = NULL;
 

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -165,9 +165,9 @@ REBNATIVE(new_line)
         if ((skip != 0) && (n % skip != 0)) continue;
 
         if (mark)
-            SET_VAL_FLAG(value, VALUE_FLAG_LINE);
+            Set_Val_Flag(value, VALUE_FLAG_LINE);
         else
-            CLEAR_VAL_FLAG(value, VALUE_FLAG_LINE);
+            Clear_Val_Flag(value, VALUE_FLAG_LINE);
 
         if (skip == 0) break;
     }
@@ -189,7 +189,7 @@ REBNATIVE(new_line_q)
 {
     INCLUDE_PARAMS_OF_NEW_LINE_Q;
 
-    if (GET_VAL_FLAG(VAL_ARRAY_AT(ARG(position)), VALUE_FLAG_LINE))
+    if (Get_Val_Flag(VAL_ARRAY_AT(ARG(position)), VALUE_FLAG_LINE))
         return R_TRUE;
 
     return R_FALSE;
@@ -264,10 +264,10 @@ REBNATIVE(now)
         VAL_ZONE(ret) = 0;
     }
     else if (REF(time)) {
-        VAL_RESET_HEADER(ret, REB_TIME);
+        Reset_Val_Header(ret, REB_TIME);
     }
     else if (REF(zone)) {
-        VAL_RESET_HEADER(ret, REB_TIME);
+        Reset_Val_Header(ret, REB_TIME);
         VAL_TIME(ret) = VAL_ZONE(ret) * ZONE_MINS * MIN_SEC;
     }
     else if (REF(weekday))
@@ -282,7 +282,7 @@ REBNATIVE(now)
         n = VAL_DAY(ret);
 
     if (n > 0)
-        SET_INTEGER(ret, n);
+        Init_Integer(ret, n);
 
     return R_OUT;
 }
@@ -336,7 +336,7 @@ REBNATIVE(wait)
     REBARR *ports = NULL;
     REBINT n = 0;
 
-    SET_BLANK(D_OUT);
+    Init_Blank(D_OUT);
 
     RELVAL *val;
     if (IS_BLOCK(ARG(value))) {
@@ -361,7 +361,7 @@ REBNATIVE(wait)
         if (IS_END(val)) {
             if (n == 0) return R_BLANK; // has no pending ports!
             else timeout = ALL_BITS; // no timeout provided
-            // SET_BLANK(val); // no timeout -- BUG: unterminated block in GC
+            // Init_Blank(val); // no timeout -- BUG: unterminated block in GC
         }
     }
     else
@@ -409,7 +409,7 @@ REBNATIVE(wait)
         if (IS_PORT(val))
             Move_Value(D_OUT, KNOWN(val));
         else
-            SET_BLANK(D_OUT);
+            Init_Blank(D_OUT);
     }
 
     return R_OUT;
@@ -999,9 +999,9 @@ REBNATIVE(call)
     if (REF(info)) {
         REBCTX *info = Alloc_Context(REB_OBJECT, 2);
 
-        SET_INTEGER(Append_Context(info, NULL, Canon(SYM_ID)), pid);
+        Init_Integer(Append_Context(info, NULL, Canon(SYM_ID)), pid);
         if (REF(wait))
-            SET_INTEGER(
+            Init_Integer(
                 Append_Context(info, NULL, Canon(SYM_EXIT_CODE)),
                 exit_code
             );
@@ -1019,9 +1019,9 @@ REBNATIVE(call)
     // we only return a process ID if /WAIT was not explicitly used
     //
     if (REF(wait))
-        SET_INTEGER(D_OUT, exit_code);
+        Init_Integer(D_OUT, exit_code);
     else
-        SET_INTEGER(D_OUT, pid);
+        Init_Integer(D_OUT, pid);
 
     return R_OUT;
 }
@@ -1227,7 +1227,7 @@ REBNATIVE(request_file)
             Init_File(D_OUT, ser);
         }
     } else
-        SET_BLANK(D_OUT);
+        Init_Blank(D_OUT);
 
     OS_FREE(fr.files);
 
@@ -1385,7 +1385,7 @@ REBNATIVE(access_os)
                                 fail (val);
                         }
                     } else {
-                        SET_INTEGER(D_OUT, ret);
+                        Init_Integer(D_OUT, ret);
                         return R_OUT;
                     }
                 }
@@ -1397,7 +1397,7 @@ REBNATIVE(access_os)
                 if (ret < 0) {
                     return R_BLANK;
                 } else {
-                    SET_INTEGER(D_OUT, ret);
+                    Init_Integer(D_OUT, ret);
                     return R_OUT;
                 }
             }
@@ -1421,7 +1421,7 @@ REBNATIVE(access_os)
                                 fail (val);
                         }
                     } else {
-                        SET_INTEGER(D_OUT, ret);
+                        Init_Integer(D_OUT, ret);
                         return R_OUT;
                     }
                 }
@@ -1433,7 +1433,7 @@ REBNATIVE(access_os)
                 if (ret < 0) {
                     return R_BLANK;
                 } else {
-                    SET_INTEGER(D_OUT, ret);
+                    Init_Integer(D_OUT, ret);
                     return R_OUT;
                 }
             }
@@ -1457,7 +1457,7 @@ REBNATIVE(access_os)
                                 fail (val);
                         }
                     } else {
-                        SET_INTEGER(D_OUT, ret);
+                        Init_Integer(D_OUT, ret);
                         return R_OUT;
                     }
                 }
@@ -1469,7 +1469,7 @@ REBNATIVE(access_os)
                 if (ret < 0) {
                     return R_BLANK;
                 } else {
-                    SET_INTEGER(D_OUT, ret);
+                    Init_Integer(D_OUT, ret);
                     return R_OUT;
                 }
             }
@@ -1493,7 +1493,7 @@ REBNATIVE(access_os)
                                 fail (val);
                         }
                     } else {
-                        SET_INTEGER(D_OUT, ret);
+                        Init_Integer(D_OUT, ret);
                         return R_OUT;
                     }
                 }
@@ -1505,7 +1505,7 @@ REBNATIVE(access_os)
                 if (ret < 0) {
                     return R_BLANK;
                 } else {
-                    SET_INTEGER(D_OUT, ret);
+                    Init_Integer(D_OUT, ret);
                     return R_OUT;
                 }
             }
@@ -1556,7 +1556,7 @@ REBNATIVE(access_os)
                             fail (val);
                     }
                 } else {
-                    SET_INTEGER(D_OUT, ret);
+                    Init_Integer(D_OUT, ret);
                     return R_OUT;
                 }
             } else {
@@ -1564,7 +1564,7 @@ REBNATIVE(access_os)
                 if (ret < 0) {
                     return R_BLANK;
                 } else {
-                    SET_INTEGER(D_OUT, ret);
+                    Init_Integer(D_OUT, ret);
                     return R_OUT;
                 }
             }

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -200,7 +200,7 @@ static REBARR *Copy_Body_Deep_Bound_To_New_Context(
         Init_Typeset(key, ALL_64, VAL_WORD_SPELLING(item));
         key++;
 
-        SET_VOID(var);
+        Init_Void(var);
         var++;
 
         ++item;
@@ -281,7 +281,7 @@ static REB_R Loop_Integer_Common(
 ) {
     assert(IS_END(out));
 
-    VAL_RESET_HEADER(var, REB_INTEGER);
+    Reset_Val_Header(var, REB_INTEGER);
 
     while ((incr > 0) ? start <= end : start >= end) {
         VAL_INT64(var) = start;
@@ -347,7 +347,7 @@ static REB_R Loop_Number_Common(
     else
         fail (incr);
 
-    VAL_RESET_HEADER(var, REB_DECIMAL);
+    Reset_Val_Header(var, REB_DECIMAL);
 
     for (; (i > 0.0) ? s <= e : s >= e; s += i) {
         VAL_DECIMAL(var) = s;
@@ -397,7 +397,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
 
     assert(IS_END(D_OUT));
     if (mode == LOOP_EVERY)
-        SET_END(D_CELL); // Final result is in D_CELL (last TRUE? or a BLANK!)
+        Init_End(D_CELL); // Final result is in D_CELL (last TRUE? or a BLANK!)
 
     REBCTX *context;
     REBARR *body_copy = Copy_Body_Deep_Bound_To_New_Context(
@@ -448,7 +448,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
         index = VAL_INDEX(data);
         if (index >= SER_LEN(series)) {
             if (mode == LOOP_REMOVE_EACH) {
-                SET_INTEGER(D_OUT, 0);
+                Init_Integer(D_OUT, 0);
                 return R_OUT;
             }
             else if (mode == LOOP_MAP_EACH) {
@@ -479,7 +479,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
         for (i = 1; NOT_END(key); i++, key++, var++) {
 
             if (index >= tail) {
-                SET_BLANK(var);
+                Init_Blank(var);
                 continue;
             }
 
@@ -498,7 +498,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
                 );
             }
             else if (ANY_CONTEXT(data)) {
-                if (GET_VAL_FLAG(
+                if (Get_Val_Flag(
                     VAL_CONTEXT_KEY(data, index), TYPESET_FLAG_HIDDEN
                 )) {
                     // Do not evaluate this iteration
@@ -576,14 +576,14 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
                 }
             }
             else if (IS_BINARY(data)) {
-                SET_INTEGER(var, (REBI64)(BIN_HEAD(series)[index]));
+                Init_Integer(var, (REBI64)(BIN_HEAD(series)[index]));
             }
             else if (IS_IMAGE(data)) {
                 Set_Tuple_Pixel(BIN_AT(series, index), var);
             }
             else {
                 assert(IS_STRING(data));
-                VAL_RESET_HEADER(var, REB_CHAR);
+                Reset_Val_Header(var, REB_CHAR);
                 VAL_CHAR(var) = GET_ANY_CHAR(series, index);
             }
             index++;
@@ -647,7 +647,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
                 // Unsets "opt out" of the vote, as with ANY and ALL
             }
             else if (IS_CONDITIONAL_FALSE(D_OUT))
-                SET_BLANK(D_CELL); // at least one false means blank result
+                Init_Blank(D_CELL); // at least one false means blank result
             else if (IS_END(D_CELL) || !IS_BLANK(D_CELL))
                 Move_Value(D_CELL, D_OUT);
             break;
@@ -656,7 +656,7 @@ static REB_R Loop_Each(REBFRM *frame_, LOOP_MODE mode)
         }
 
         if (stop) {
-            SET_BLANK(D_OUT);
+            Init_Blank(D_OUT);
             break;
         }
 
@@ -714,7 +714,7 @@ skip_hidden: ;
         // Remove hole (updates tail):
         if (write_index < index)
             Remove_Series(series, write_index, index - write_index);
-        SET_INTEGER(D_OUT, index - write_index);
+        Init_Integer(D_OUT, index - write_index);
         return R_OUT;
 
     case LOOP_MAP_EACH:
@@ -1112,7 +1112,7 @@ REBNATIVE(repeat)
         return R_VOID;
 
     if (IS_DECIMAL(value) || IS_PERCENT(value))
-        SET_INTEGER(value, Int64(value));
+        Init_Integer(value, Int64(value));
 
     REBCTX *context;
     REBARR *copy = Copy_Body_Deep_Bound_To_New_Context(

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -97,7 +97,7 @@ static void Arc_Trans(REBVAL *out, const REBVAL *value, REBOOL degrees, REBCNT k
     if (degrees)
         dval = dval * 180.0 / PI; // to degrees
 
-    SET_DECIMAL(out, dval);
+    Init_Decimal(out, dval);
 }
 
 
@@ -118,7 +118,7 @@ REBNATIVE(cosine)
 
     REBDEC dval = cos(Trig_Value(ARG(value), NOT(REF(radians)), COSINE));
     if (fabs(dval) < DBL_EPSILON) dval = 0.0;
-    SET_DECIMAL(D_OUT, dval);
+    Init_Decimal(D_OUT, dval);
     return R_OUT;
 }
 
@@ -140,7 +140,7 @@ REBNATIVE(sine)
 
     REBDEC dval = sin(Trig_Value(ARG(value), NOT(REF(radians)), SINE));
     if (fabs(dval) < DBL_EPSILON) dval = 0.0;
-    SET_DECIMAL(D_OUT, dval);
+    Init_Decimal(D_OUT, dval);
     return R_OUT;
 }
 
@@ -164,7 +164,7 @@ REBNATIVE(tangent)
     if (Eq_Decimal(fabs(dval), PI / 2.0))
         fail (Error_Overflow_Raw());
 
-    SET_DECIMAL(D_OUT, tan(dval));
+    Init_Decimal(D_OUT, tan(dval));
     return R_OUT;
 }
 
@@ -243,7 +243,7 @@ REBNATIVE(exp)
 
     dval = pow(eps, dval);
 //!!!!  Check_Overflow(dval);
-    SET_DECIMAL(D_OUT, dval);
+    Init_Decimal(D_OUT, dval);
     return R_OUT;
 }
 
@@ -262,7 +262,7 @@ REBNATIVE(log_10)
 
     REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval <= 0) fail (Error_Positive_Raw());
-    SET_DECIMAL(D_OUT, log10(dval));
+    Init_Decimal(D_OUT, log10(dval));
     return R_OUT;
 }
 
@@ -281,7 +281,7 @@ REBNATIVE(log_2)
 
     REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval <= 0) fail (Error_Positive_Raw());
-    SET_DECIMAL(D_OUT, log(dval) / LOG2);
+    Init_Decimal(D_OUT, log(dval) / LOG2);
     return R_OUT;
 }
 
@@ -300,7 +300,7 @@ REBNATIVE(log_e)
 
     REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval <= 0) fail (Error_Positive_Raw());
-    SET_DECIMAL(D_OUT, log(dval));
+    Init_Decimal(D_OUT, log(dval));
     return R_OUT;
 }
 
@@ -319,7 +319,7 @@ REBNATIVE(square_root)
 
     REBDEC dval = AS_DECIMAL(ARG(value));
     if (dval < 0) fail (Error_Positive_Raw());
-    SET_DECIMAL(D_OUT, sqrt(dval));
+    Init_Decimal(D_OUT, sqrt(dval));
     return R_OUT;
 }
 
@@ -463,12 +463,12 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
         case REB_INTEGER:
             if (tb == REB_DECIMAL || tb == REB_PERCENT) {
                 REBDEC dec_a = cast(REBDEC, VAL_INT64(a));
-                SET_DECIMAL(a, dec_a);
+                Init_Decimal(a, dec_a);
                 goto compare;
             }
             else if (tb == REB_MONEY) {
                 deci amount = int_to_deci(VAL_INT64(a));
-                SET_MONEY(a, amount);
+                Init_Money(a, amount);
                 goto compare;
             }
             break;
@@ -477,11 +477,11 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
         case REB_PERCENT:
             if (tb == REB_INTEGER) {
                 REBDEC dec_b = cast(REBDEC, VAL_INT64(b));
-                SET_DECIMAL(b, dec_b);
+                Init_Decimal(b, dec_b);
                 goto compare;
             }
             else if (tb == REB_MONEY) {
-                SET_MONEY(a, decimal_to_deci(VAL_DECIMAL(a)));
+                Init_Money(a, decimal_to_deci(VAL_DECIMAL(a)));
                 goto compare;
             }
             else if (tb == REB_DECIMAL || tb == REB_PERCENT) // equivalent types
@@ -490,11 +490,11 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
 
         case REB_MONEY:
             if (tb == REB_INTEGER) {
-                SET_MONEY(b, int_to_deci(VAL_INT64(b)));
+                Init_Money(b, int_to_deci(VAL_INT64(b)));
                 goto compare;
             }
             if (tb == REB_DECIMAL || tb == REB_PERCENT) {
-                SET_MONEY(b, decimal_to_deci(VAL_DECIMAL(b)));
+                Init_Money(b, decimal_to_deci(VAL_DECIMAL(b)));
                 goto compare;
             }
             break;

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -313,7 +313,7 @@ REBNATIVE(make_native)
         Init_String(Alloc_Tail_Array(info), bin);
     }
 
-    SET_BLANK(Alloc_Tail_Array(info)); // no TCC_State, yet...
+    Init_Blank(Alloc_Tail_Array(info)); // no TCC_State, yet...
 
     Init_Block(FUNC_BODY(fun), info);
 
@@ -321,7 +321,7 @@ REBNATIVE(make_native)
     // long run be able to tell it is when the dispatcher is replaced with an
     // arbitrary compiled function pointer!
     //
-    SET_VAL_FLAG(FUNC_VALUE(fun), FUNC_FLAG_USER_NATIVE);
+    Set_Val_Flag(FUNC_VALUE(fun), FUNC_FLAG_USER_NATIVE);
 
     Move_Value(D_OUT, FUNC_VALUE(fun));
     return R_OUT;
@@ -468,7 +468,7 @@ REBNATIVE(compile)
         }
 
         if (IS_FUNCTION(var)) {
-            assert(GET_VAL_FLAG(var, FUNC_FLAG_USER_NATIVE));
+            assert(Get_Val_Flag(var, FUNC_FLAG_USER_NATIVE));
 
             // Remember this function, because we're going to need to come
             // back and fill in its dispatcher and TCC_State after the
@@ -627,7 +627,7 @@ REBNATIVE(compile)
         REBVAL *var = DS_TOP;
 
         assert(IS_FUNCTION(var));
-        assert(GET_VAL_FLAG(var, FUNC_FLAG_USER_NATIVE));
+        assert(Get_Val_Flag(var, FUNC_FLAG_USER_NATIVE));
 
         RELVAL *info = VAL_FUNC_BODY(var);
         RELVAL *name = VAL_ARRAY_AT_HEAD(info, 1);

--- a/src/core/n-protect.c
+++ b/src/core/n-protect.c
@@ -46,9 +46,9 @@ static void Protect_Key(REBCTX *context, REBCNT index, REBFLGS flags)
     //
     if (GET_FLAG(flags, PROT_WORD)) {
         if (GET_FLAG(flags, PROT_SET))
-            SET_VAL_FLAG(var, VALUE_FLAG_PROTECTED);
+            Set_Val_Flag(var, VALUE_FLAG_PROTECTED);
         else
-            CLEAR_VAL_FLAG(var, VALUE_FLAG_PROTECTED);
+            Clear_Val_Flag(var, VALUE_FLAG_PROTECTED);
     }
 
     if (GET_FLAG(flags, PROT_HIDE)) {
@@ -63,9 +63,9 @@ static void Protect_Key(REBCTX *context, REBCNT index, REBFLGS flags)
         REBVAL *key = CTX_KEY(context, index);
 
         if (GET_FLAG(flags, PROT_SET))
-            SET_VAL_FLAGS(key, TYPESET_FLAG_HIDDEN | TYPESET_FLAG_UNBINDABLE);
+            Set_Val_Flags(key, TYPESET_FLAG_HIDDEN | TYPESET_FLAG_UNBINDABLE);
         else
-            CLEAR_VAL_FLAGS(
+            Clear_Val_Flags(
                 key, TYPESET_FLAG_HIDDEN | TYPESET_FLAG_UNBINDABLE
             );
     }
@@ -99,17 +99,17 @@ void Protect_Series(REBSER *s, REBCNT index, REBFLGS flags)
     if (GET_FLAG(flags, PROT_SET)) {
         if (GET_FLAG(flags, PROT_FREEZE)) {
             assert(GET_FLAG(flags, PROT_DEEP));
-            SET_SER_INFO(s, SERIES_INFO_FROZEN);
+            Set_Ser_Info(s, SERIES_INFO_FROZEN);
         }
         else
-            SET_SER_INFO(s, SERIES_INFO_PROTECTED);
+            Set_Ser_Info(s, SERIES_INFO_PROTECTED);
     }
     else {
         assert(!GET_FLAG(flags, PROT_FREEZE));
-        CLEAR_SER_INFO(s, SERIES_INFO_PROTECTED);
+        Clear_Ser_Info(s, SERIES_INFO_PROTECTED);
     }
 
-    if (NOT_SER_FLAG(s, SERIES_FLAG_ARRAY) || !GET_FLAG(flags, PROT_DEEP))
+    if (Not_Ser_Flag(s, SERIES_FLAG_ARRAY) || !GET_FLAG(flags, PROT_DEEP))
         return;
 
     Flip_Series_To_Black(s); // recursion protection
@@ -133,14 +133,14 @@ void Protect_Context(REBCTX *c, REBFLGS flags)
     if (GET_FLAG(flags, PROT_SET)) {
         if (GET_FLAG(flags, PROT_FREEZE)) {
             assert(GET_FLAG(flags, PROT_DEEP));
-            SET_SER_INFO(CTX_VARLIST(c), SERIES_INFO_FROZEN);
+            Set_Ser_Info(CTX_VARLIST(c), SERIES_INFO_FROZEN);
         }
         else
-            SET_SER_INFO(CTX_VARLIST(c), SERIES_INFO_PROTECTED);
+            Set_Ser_Info(CTX_VARLIST(c), SERIES_INFO_PROTECTED);
     }
     else {
         assert(!GET_FLAG(flags, PROT_FREEZE));
-        CLEAR_SER_INFO(CTX_VARLIST(c), SERIES_INFO_PROTECTED);
+        Clear_Ser_Info(CTX_VARLIST(c), SERIES_INFO_PROTECTED);
     }
 
     if (!GET_FLAG(flags, PROT_DEEP)) return;

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -156,7 +156,7 @@ REBNATIVE(spelling_of)
         // during the FORMing process.  Use SET_TYPE and not reset header
         // because the binding bits need to stay consistent
         //
-        VAL_SET_TYPE_BITS(value, REB_WORD);
+        Reset_Val_Kind(value, REB_WORD);
         series = Copy_Mold_Value(value, 0 /* opts... MOPT_0? */);
     }
 
@@ -227,7 +227,7 @@ REBNATIVE(checksum)
             // signed INTEGER! available.
             //
             REBINT crc32 = cast(REBINT, CRC32(data, len));
-            SET_INTEGER(D_OUT, crc32);
+            Init_Integer(D_OUT, crc32);
             return R_OUT;
         }
 
@@ -240,7 +240,7 @@ REBNATIVE(checksum)
             // of the adler calculation to a signed integer.
             //
             uLong adler = z_adler32(0L, data, len);
-            SET_INTEGER(D_OUT, adler);
+            Init_Integer(D_OUT, adler);
             return R_OUT;
         }
 
@@ -304,7 +304,7 @@ REBNATIVE(checksum)
     }
     else if (REF(tcp)) {
         REBINT ipc = Compute_IPC(data, len);
-        SET_INTEGER(D_OUT, ipc);
+        Init_Integer(D_OUT, ipc);
     }
     else if (REF(hash)) {
         REBINT sum = VAL_INT32(ARG(size));
@@ -312,11 +312,11 @@ REBNATIVE(checksum)
             sum = 1;
 
         REBINT hash = Hash_String(data, len, wide) % sum;
-        SET_INTEGER(D_OUT, hash);
+        Init_Integer(D_OUT, hash);
     }
     else {
         REBINT crc = Compute_CRC(data, len);
-        SET_INTEGER(D_OUT, crc);
+        Init_Integer(D_OUT, crc);
     }
 
     return R_OUT;
@@ -878,7 +878,7 @@ REBNATIVE(utf_q)
     INCLUDE_PARAMS_OF_UTF_Q;
 
     REBINT utf = What_UTF(VAL_BIN_AT(ARG(data)), VAL_LEN_AT(ARG(data)));
-    SET_INTEGER(D_OUT, utf);
+    Init_Integer(D_OUT, utf);
     return R_OUT;
 }
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -181,7 +181,7 @@ REBNATIVE(recycle)
         count = Recycle();
     }
 
-    SET_INTEGER(D_OUT, count);
+    Init_Integer(D_OUT, count);
     return R_OUT;
 }
 
@@ -211,13 +211,13 @@ REBNATIVE(stats)
 
     if (REF(timer)) {
         VAL_TIME(D_OUT) = OS_DELTA_TIME(PG_Boot_Time, 0) * 1000;
-        VAL_RESET_HEADER(D_OUT, REB_TIME);
+        Reset_Val_Header(D_OUT, REB_TIME);
         return R_OUT;
     }
 
     if (REF(evals)) {
         REBI64 n = Eval_Cycles + Eval_Dose - Eval_Count;
-        SET_INTEGER(D_OUT, n);
+        Init_Integer(D_OUT, n);
         return R_OUT;
     }
 
@@ -235,32 +235,32 @@ REBNATIVE(stats)
             REBVAL *stats = VAL_CONTEXT_VAR(D_OUT, 1);
 
             VAL_TIME(stats) = OS_DELTA_TIME(PG_Boot_Time, 0) * 1000;
-            VAL_RESET_HEADER(stats, REB_TIME);
+            Reset_Val_Header(stats, REB_TIME);
             stats++;
-            SET_INTEGER(stats, Eval_Cycles + Eval_Dose - Eval_Count);
+            Init_Integer(stats, Eval_Cycles + Eval_Dose - Eval_Count);
             stats++;
-            SET_INTEGER(stats, 0); // no such thing as natives, only functions
+            Init_Integer(stats, 0); // no such thing as natives, only functions
             stats++;
-            SET_INTEGER(stats, Eval_Functions);
+            Init_Integer(stats, Eval_Functions);
 
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Series_Made);
+            Init_Integer(stats, PG_Reb_Stats->Series_Made);
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Series_Freed);
+            Init_Integer(stats, PG_Reb_Stats->Series_Freed);
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Series_Expanded);
+            Init_Integer(stats, PG_Reb_Stats->Series_Expanded);
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Series_Memory);
+            Init_Integer(stats, PG_Reb_Stats->Series_Memory);
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Recycle_Series_Total);
+            Init_Integer(stats, PG_Reb_Stats->Recycle_Series_Total);
 
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Blocks);
+            Init_Integer(stats, PG_Reb_Stats->Blocks);
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Objects);
+            Init_Integer(stats, PG_Reb_Stats->Objects);
 
             stats++;
-            SET_INTEGER(stats, PG_Reb_Stats->Recycle_Counter);
+            Init_Integer(stats, PG_Reb_Stats->Recycle_Counter);
         }
 
         return R_OUT;
@@ -272,7 +272,7 @@ REBNATIVE(stats)
         return R_BLANK;
     }
 
-    SET_INTEGER(D_OUT, Inspect_Series(REF(show)));
+    Init_Integer(D_OUT, Inspect_Series(REF(show)));
 
     if (REF(show))
         Dump_Pools();

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -74,7 +74,7 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
             req->common.data = 0;
         }
         else if (req->command == RDC_WRITE) {
-            SET_BLANK(arg);  // Write is done.
+            Init_Blank(arg);  // Write is done.
         }
         return R_BLANK;
 
@@ -196,10 +196,10 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         req->actual = 0;
 
         result = OS_DO_DEVICE(req, RDC_WRITE);
-        SET_BLANK(CTX_VAR(port, STD_PORT_DATA)); // GC can collect it
+        Init_Blank(CTX_VAR(port, STD_PORT_DATA)); // GC can collect it
 
         if (result < 0) fail (Error_On_Port(RE_WRITE_ERROR, port, req->error));
-        //if (result == DR_DONE) SET_BLANK(CTX_VAR(port, STD_PORT_DATA));
+        //if (result == DR_DONE) Init_Blank(CTX_VAR(port, STD_PORT_DATA));
         break; }
 
     case SYM_OPEN: {

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -222,7 +222,7 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
             if (result < 0)
                 fail (Error_On_Port(RE_CANNOT_OPEN, port, dir.devreq.error));
             Move_Value(D_OUT, state);
-            SET_BLANK(state);
+            Init_Blank(state);
         }
         else {
             // !!! This copies the strings in the block, shallowly.  What is
@@ -256,7 +256,7 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
             Move_Value(D_OUT, D_ARG(1));
             return R_OUT;
         }
-        SET_BLANK(state);
+        Init_Blank(state);
         break;
 
     case SYM_RENAME:
@@ -277,7 +277,7 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     case SYM_DELETE:
         //Trap_Security(flags[POL_WRITE], POL_WRITE, path);
-        SET_BLANK(state);
+        Init_Blank(state);
         Init_Dir_Path(&dir, path, 0, POL_WRITE);
         // !!! add *.r deletion
         // !!! add recursive delete (?)
@@ -323,12 +323,12 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         return R_FALSE;
 
     case SYM_CLOSE:
-        SET_BLANK(state);
+        Init_Blank(state);
         break;
 
     case SYM_QUERY:
         //Trap_Security(flags[POL_READ], POL_READ, path);
-        SET_BLANK(state);
+        Init_Blank(state);
         Init_Dir_Path(&dir, path, -1, REMOVE_TAIL_SLASH | POL_READ);
         if (OS_DO_DEVICE(&dir.devreq, RDC_QUERY) < 0) return R_BLANK;
         Ret_Query_File(port, &dir, D_OUT);
@@ -339,7 +339,7 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
     case SYM_LENGTH:
         len = IS_BLOCK(state) ? VAL_ARRAY_LEN_AT(state) : 0;
-        SET_INTEGER(D_OUT, len);
+        Init_Integer(D_OUT, len);
         break;
 
     default:

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -91,7 +91,7 @@ REBVAL *Append_Event(void)
     TERM_ARRAY_LEN(VAL_ARRAY(state), VAL_LEN_HEAD(state) + 1);
 
     REBVAL *value = SINK(ARR_LAST(VAL_ARRAY(state)));
-    SET_BLANK(value);
+    Init_Blank(value);
 
     return value;
 }
@@ -194,7 +194,7 @@ act_blk:
         break;
 
     case SYM_LENGTH:
-        SET_INTEGER(D_OUT, VAL_LEN_HEAD(state));
+        Init_Integer(D_OUT, VAL_LEN_HEAD(state));
         break;
 
     case SYM_OPEN: {

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -115,7 +115,7 @@ void Ret_Query_File(REBCTX *port, struct devreq_file *file, REBVAL *ret)
         CTX_VAR(context, STD_FILE_INFO_TYPE),
         GET_FLAG(req->modes, RFM_DIR) ? Canon(SYM_DIR) : Canon(SYM_FILE)
     );
-    SET_INTEGER(
+    Init_Integer(
         CTX_VAR(context, STD_FILE_INFO_SIZE), file->size
     );
     OS_FILE_TIME(CTX_VAR(context, STD_FILE_INFO_DATE), file);
@@ -411,7 +411,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
 
         if (req->error) {
             DECLARE_LOCAL(i);
-            SET_INTEGER(i, req->error);
+            Init_Integer(i, req->error);
             fail (Error_Write_Error_Raw(path, i));
         }
 
@@ -558,14 +558,14 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         return R_TRUE; }
 
     case SYM_INDEX_OF:
-        SET_INTEGER(D_OUT, file->index + 1);
+        Init_Integer(D_OUT, file->index + 1);
         return R_OUT;
 
     case SYM_LENGTH:
         //
         // Comment said "clip at zero"
         ///
-        SET_INTEGER(D_OUT, file->size - file->index);
+        Init_Integer(D_OUT, file->size - file->index);
         return R_OUT;
 
     case SYM_HEAD: {
@@ -610,7 +610,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
         req->length = 0;
         if (OS_DO_DEVICE(req, RDC_WRITE) < 0) {
             DECLARE_LOCAL(i);
-            SET_INTEGER(i, req->error);
+            Init_Integer(i, req->error);
             fail (Error_Write_Error_Raw(path, i));
         }
         return R_OUT;

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -58,7 +58,7 @@ static void Ret_Query_Net(REBCTX *port, struct devreq_net *sock, REBVAL *out)
         cast(REBYTE*, &sock->local_ip),
         4
     );
-    SET_INTEGER(
+    Init_Integer(
         CTX_VAR(info, STD_NET_INFO_LOCAL_PORT),
         sock->local_port
     );
@@ -68,7 +68,7 @@ static void Ret_Query_Net(REBCTX *port, struct devreq_net *sock, REBVAL *out)
         cast(REBYTE*, &sock->remote_ip),
         4
     );
-    SET_INTEGER(
+    Init_Integer(
         CTX_VAR(info, STD_NET_INFO_REMOTE_PORT),
         sock->remote_port
     );
@@ -99,8 +99,8 @@ static void Accept_New_Port(REBVAL *out, REBCTX *port, struct devreq_net *sock)
     port = Copy_Context_Shallow(port);
     Init_Port(out, port); // Also for GC protect
 
-    SET_BLANK(CTX_VAR(port, STD_PORT_DATA)); // just to be sure.
-    SET_BLANK(CTX_VAR(port, STD_PORT_STATE)); // just to be sure.
+    Init_Blank(CTX_VAR(port, STD_PORT_DATA)); // just to be sure.
+    Init_Blank(CTX_VAR(port, STD_PORT_STATE)); // just to be sure.
 
     // Copy over the new sock data:
     sock = cast(struct devreq_net*, Ensure_Port_State(port, RDI_NET));
@@ -213,7 +213,7 @@ static REB_R Transport_Actor(
             }
         }
         else if (sock->command == RDC_WRITE) {
-            SET_BLANK(port_data); // Write is done.
+            Init_Blank(port_data); // Write is done.
         }
         return R_BLANK; }
 
@@ -323,7 +323,7 @@ static REB_R Transport_Actor(
             fail (Error_On_Port(RE_WRITE_ERROR, port, sock->error));
 
         if (result == DR_DONE)
-            SET_BLANK(CTX_VAR(port, STD_PORT_DATA));
+            Init_Blank(CTX_VAR(port, STD_PORT_DATA));
 
         Move_Value(D_OUT, CTX_VALUE(port));
         return R_OUT; }
@@ -367,7 +367,7 @@ static REB_R Transport_Actor(
 
     case SYM_LENGTH: {
         REBVAL *port_data = CTX_VAR(port, STD_PORT_DATA);
-        SET_INTEGER(
+        Init_Integer(
             D_OUT,
             ANY_SERIES(port_data) ? VAL_LEN_HEAD(port_data) : 0
         );
@@ -385,7 +385,7 @@ static REB_R Transport_Actor(
         // !!! Comment said "Temporary to TEST error handler!"
         //
         REBVAL *event = Append_Event(); // sets signal
-        VAL_RESET_HEADER(event, REB_EVENT); // has more space, if needed
+        Reset_Val_Header(event, REB_EVENT); // has more space, if needed
         VAL_EVENT_TYPE(event) = EVT_ERROR;
         VAL_EVENT_DATA(event) = 101;
         VAL_EVENT_REQ(event) = sock;

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -257,7 +257,7 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
             }
         }
         else if (req->command == RDC_WRITE) {
-            SET_BLANK(arg);  // Write is done.
+            Init_Blank(arg);  // Write is done.
         }
         return R_BLANK;
 

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -50,20 +50,20 @@ static void update(struct devreq_posix_signal *signal, REBINT len, REBVAL *arg)
         REBVAL *val = Append_Context(
             obj, NULL, Intern_UTF8_Managed(signal_no, LEN_BYTES(signal_no))
         );
-        SET_INTEGER(val, sig[i].si_signo);
+        Init_Integer(val, sig[i].si_signo);
 
         val = Append_Context(
             obj, NULL, Intern_UTF8_Managed(code, LEN_BYTES(code))
         );
-        SET_INTEGER(val, sig[i].si_code);
+        Init_Integer(val, sig[i].si_code);
         val = Append_Context(
             obj, NULL, Intern_UTF8_Managed(source_pid, LEN_BYTES(source_pid))
         );
-        SET_INTEGER(val, sig[i].si_pid);
+        Init_Integer(val, sig[i].si_pid);
         val = Append_Context(
             obj, NULL, Intern_UTF8_Managed(source_uid, LEN_BYTES(source_uid))
         );
-        SET_INTEGER(val, sig[i].si_uid);
+        Init_Integer(val, sig[i].si_uid);
 
         Init_Object(Alloc_Tail_Array(VAL_ARRAY(arg)), obj);
     }

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -106,7 +106,7 @@ act_blk:
         break;
 
     case SYM_LENGTH:
-        SET_INTEGER(D_OUT, VAL_LEN_HEAD(state));
+        Init_Integer(D_OUT, VAL_LEN_HEAD(state));
         break;
 
     case SYM_OPEN: {

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -385,7 +385,7 @@ REBSER *Make_Hash_Sequence(REBCNT len)
     REBCNT n = Get_Hash_Prime(len * 2); // best when 2X # of keys
     if (n == 0) {
         DECLARE_LOCAL (temp);
-        SET_INTEGER(temp, len);
+        Init_Integer(temp, len);
 
         fail (Error_Size_Limit_Raw(temp));
     }
@@ -412,7 +412,7 @@ void Init_Map(REBVAL *out, REBMAP *map)
 
     ENSURE_ARRAY_MANAGED(MAP_PAIRLIST(map));
 
-    VAL_RESET_HEADER(out, REB_MAP);
+    Reset_Val_Header(out, REB_MAP);
     out->extra.binding = (REBARR*)SPECIFIED; // !!! cast() gripes, investigate
     out->payload.any_series.series = AS_SERIES(MAP_PAIRLIST(map));
     out->payload.any_series.index = 0;

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -578,7 +578,7 @@ static void Mold_All_String(const REBVAL *value, REB_MOLD *mold)
     if (IS_BINARY(value))
         Mold_Binary(head, mold);
     else {
-        VAL_RESET_HEADER(head, REB_STRING);
+        Reset_Val_Header(head, REB_STRING);
         Mold_String_Series(head, mold);
     }
 
@@ -626,7 +626,7 @@ void Mold_Array_At(
     // !!! Review how to avoid needing to put the series into a value
     {
         REBVAL *temp = Alloc_Tail_Array(MOLD_STACK);
-        VAL_RESET_HEADER(temp, REB_BLOCK);
+        Reset_Val_Header(temp, REB_BLOCK);
         INIT_VAL_ARRAY(temp, array); // copies args
         VAL_INDEX(temp) = 0;
     }
@@ -639,7 +639,7 @@ void Mold_Array_At(
 
     value = ARR_AT(array, index);
     while (NOT_END(value)) {
-        if (GET_VAL_FLAG(value, VALUE_FLAG_LINE)) {
+        if (Get_Val_Flag(value, VALUE_FLAG_LINE)) {
             if (sep[1] || line_flag) New_Indented_Line(mold);
             had_lines = TRUE;
         }
@@ -964,7 +964,7 @@ static void Form_Object(const REBVAL *value, REB_MOLD *mold)
 
     // Mold all words and their values:
     for (; NOT_END(key); key++, var++) {
-        if (NOT_VAL_FLAG(key, TYPESET_FLAG_HIDDEN)) {
+        if (Not_Val_Flag(key, TYPESET_FLAG_HIDDEN)) {
             had_output = TRUE;
             Emit(mold, "N: V\n", VAL_KEY_SPELLING(key), var);
         }
@@ -1038,7 +1038,7 @@ static void Mold_Object(const REBVAL *value, REB_MOLD *mold)
         DECLARE_LOCAL (any_word);
         Init_Any_Word(
             any_word,
-            GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN) ? REB_SET_WORD : REB_WORD,
+            Get_Val_Flag(key, TYPESET_FLAG_HIDDEN) ? REB_SET_WORD : REB_WORD,
             VAL_KEY_SPELLING(key)
         );
         Mold_Value(mold, any_word, TRUE);
@@ -1054,7 +1054,7 @@ static void Mold_Object(const REBVAL *value, REB_MOLD *mold)
     var = vars_head;
 
     for (; NOT_END(key); var ? (++key, ++var) : ++key) {
-        if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
+        if (Get_Val_Flag(key, TYPESET_FLAG_HIDDEN))
             continue; // !!! Should hidden fields be in molded view?
 
         if (var && IS_VOID(value))

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -362,7 +362,7 @@ void Shuffle_String(REBVAL *value, REBOOL secure)
 //
 void Trim_Tail(REBSER *src, REBYTE chr)
 {
-    assert(NOT_SER_FLAG(src, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(src, SERIES_FLAG_ARRAY));
 
     REBOOL unicode = NOT(BYTE_SIZE(src));
     REBCNT tail;
@@ -775,7 +775,7 @@ REBARR *Split_Lines(REBVAL *str)
                 DS_TOP,
                 Copy_String_Slimming(s, start, i - start)
             );
-            SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+            Set_Val_Flag(DS_TOP, VALUE_FLAG_LINE);
             ++i;
             if (c == CR && GET_ANY_CHAR(s, i) == LF)
                 ++i;
@@ -791,7 +791,7 @@ REBARR *Split_Lines(REBVAL *str)
             DS_TOP,
             Copy_String_Slimming(s, start, i - start)
         );
-        SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+        Set_Val_Flag(DS_TOP, VALUE_FLAG_LINE);
     }
 
     return Pop_Stack_Values(dsp_orig);

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -946,7 +946,7 @@ REBOOL Decode_UTF8_Maybe_Astral_Throws(
 
             if (ch > 0xFFFF) { // too big to fit in today's REBUNI
                 if (IS_FUNCTION(handler)) {
-                    SET_INTEGER(astral, ch); // CHAR! only 16-bit for now
+                    Init_Integer(astral, ch); // CHAR! only 16-bit for now
 
                     // Try passing the handler the codepoint value.  Passing
                     // FALSE for `fully` means it will not raise an error if

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -513,7 +513,7 @@ REBINT PD_Bitset(REBPVS *pvs)
 
     if (!pvs->opt_setval) {
         if (Check_Bits(ser, pvs->selector, FALSE)) {
-            SET_TRUE(pvs->store);
+            Init_True(pvs->store);
             return PE_USE_STORE;
         }
         return PE_NONE;
@@ -666,7 +666,7 @@ set_bits:
 
     case SYM_LENGTH:
         len = VAL_LEN_HEAD(value) * 8;
-        SET_INTEGER(value, len);
+        Init_Integer(value, len);
         break;
 
     case SYM_TAIL_Q:

--- a/src/core/t-blank.c
+++ b/src/core/t-blank.c
@@ -45,7 +45,7 @@ REBINT CT_Unit(const RELVAL *a, const RELVAL *b, REBINT mode)
 //
 void MAKE_Unit(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     UNUSED(arg);
-    VAL_RESET_HEADER(out, kind);
+    Reset_Val_Header(out, kind);
 }
 
 
@@ -54,7 +54,7 @@ void MAKE_Unit(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 //
 void TO_Unit(REBVAL *out, enum Reb_Kind kind, const REBVAL *data) {
     UNUSED(data);
-    VAL_RESET_HEADER(out, kind);
+    Reset_Val_Header(out, kind);
 }
 
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -125,7 +125,7 @@ void MAKE_Array(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
         );
 
         // !!! Previously this code would clear line break options on path
-        // elements, using `CLEAR_VAL_FLAG(..., VALUE_FLAG_LINE)`.  But if
+        // elements, using `Clear_Val_Flag(..., VALUE_FLAG_LINE)`.  But if
         // arrays are allowed to alias each others contents, the aliasing
         // via MAKE shouldn't modify the store.  Line marker filtering out of
         // paths should be part of the MOLDing logic -or- a path with embedded
@@ -593,7 +593,7 @@ RELVAL *Pick_Block(REBVAL *out, const REBVAL *block, const REBVAL *selector)
     n = Get_Num_From_Arg(selector);
     n += VAL_INDEX(block) - 1;
     if (n < 0 || cast(REBCNT, n) >= VAL_LEN_HEAD(block)) {
-        SET_VOID(out);
+        Init_Void(out);
         return NULL;
     }
     else {
@@ -808,7 +808,7 @@ REBTYPE(Array)
         if (index < VAL_LEN_HEAD(value)) {
             if (index == 0) Reset_Array(array);
             else {
-                SET_END(ARR_AT(array, index));
+                Init_End(ARR_AT(array, index));
                 SET_SERIES_LEN(VAL_SERIES(value), cast(REBCNT, index));
             }
         }
@@ -988,7 +988,7 @@ REBTYPE(Array)
             if (index >= VAL_LEN_HEAD(value))
                 return R_BLANK;
 
-            SET_INTEGER(
+            Init_Integer(
                 ARG(seed),
                 1 + (Random_Int(REF(secure)) % (VAL_LEN_HEAD(value) - index))
             );
@@ -1035,7 +1035,7 @@ void Assert_Array_Core(REBARR *a)
     //
     Assert_Series_Core(AS_SERIES(a));
 
-    if (NOT(GET_SER_FLAG(a, SERIES_FLAG_ARRAY)))
+    if (NOT(Get_Ser_Flag(a, SERIES_FLAG_ARRAY)))
         panic (a);
 
     RELVAL *item = ARR_HEAD(a);
@@ -1050,7 +1050,7 @@ void Assert_Array_Core(REBARR *a)
     if (NOT_END(item))
         panic (item);
 
-    if (GET_SER_INFO(a, SERIES_INFO_HAS_DYNAMIC)) {
+    if (Get_Ser_Info(a, SERIES_INFO_HAS_DYNAMIC)) {
         REBCNT rest = SER_REST(AS_SERIES(a));
 
         assert(rest > 0 && rest > i);

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -118,7 +118,7 @@ void MAKE_Char(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         fail (Error_Bad_Make(REB_CHAR, arg));
     }
 
-    SET_CHAR(out, uni);
+    Init_Char(out, uni);
 }
 
 
@@ -168,7 +168,7 @@ REBTYPE(Char)
         arg = Math_Arg_For_Char(D_ARG(2), action);
         chr -= cast(REBUNI, arg);
         if (IS_CHAR(D_ARG(2))) {
-            SET_INTEGER(D_OUT, chr);
+            Init_Integer(D_OUT, chr);
             return R_OUT;
         }
         break;
@@ -236,7 +236,7 @@ REBTYPE(Char)
 
     if ((chr >> 16) != 0 && (chr >> 16) != 0xffff)
         fail (Error_Type_Limit_Raw(Get_Type(REB_CHAR)));
-    SET_CHAR(D_OUT, chr);
+    Init_Char(D_OUT, chr);
     return R_OUT;
 }
 

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -52,7 +52,7 @@ void MAKE_Datatype(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     if (sym == SYM_0 || sym > SYM_FROM_KIND(REB_MAX))
         fail (Error_Bad_Make(kind, arg));
 
-    VAL_RESET_HEADER(out, REB_DATATYPE);
+    Reset_Val_Header(out, REB_DATATYPE);
     VAL_TYPE_KIND(out) = KIND_FROM_SYM(sym);
     VAL_TYPE_SPEC(out) = 0;
 }
@@ -106,7 +106,7 @@ REBTYPE(Datatype)
             );
 
             for (; NOT_END(var); ++var, ++key) {
-                if (IS_END(value)) SET_BLANK(var);
+                if (IS_END(value)) Init_Blank(var);
                 else {
                     // typespec array does not contain relative values
                     //

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -47,7 +47,7 @@ void Set_Date_UTC(REBVAL *val, REBINT y, REBINT m, REBINT d, REBI64 t, REBINT z)
     VAL_DAY(val)   = d;
     VAL_TIME(val)  = t;
     VAL_ZONE(val)  = z;
-    VAL_RESET_HEADER(val, REB_DATE);
+    Reset_Val_Header(val, REB_DATE);
     if (z) Adjust_Date_Zone(val, TRUE);
 }
 
@@ -365,7 +365,7 @@ void Subtract_Date(REBVAL *d1, REBVAL *d2, REBVAL *result)
     t2 = VAL_TIME(d2);
     if (t2 == NO_TIME) t2 = 0L;
 
-    VAL_RESET_HEADER(result, REB_TIME);
+    Reset_Val_Header(result, REB_TIME);
     VAL_TIME(result) = (t1 - t2) + ((REBI64)diff * TIME_IN_DAY);
 }
 
@@ -467,7 +467,7 @@ void MAKE_Date(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
         Normalize_Time(&secs, &day);
         date = Normalize_Date(day, month, year, tz);
 
-        VAL_RESET_HEADER(out, REB_DATE);
+        Reset_Val_Header(out, REB_DATE);
         VAL_DATE(out) = date;
         VAL_TIME(out) = secs;
         Adjust_Date_Zone(out, TRUE);
@@ -549,30 +549,30 @@ void Pick_Or_Poke_Date(
 
         switch (sym) {
         case SYM_YEAR:
-            SET_INTEGER(opt_out, year);
+            Init_Integer(opt_out, year);
             break;
 
         case SYM_MONTH:
-            SET_INTEGER(opt_out, month + 1);
+            Init_Integer(opt_out, month + 1);
             break;
 
         case SYM_DAY:
-            SET_INTEGER(opt_out, day + 1);
+            Init_Integer(opt_out, day + 1);
             break;
 
         case SYM_TIME:
             if (secs == NO_TIME)
-                SET_VOID(opt_out);
+                Init_Void(opt_out);
             else
-                VAL_RESET_HEADER(opt_out, REB_TIME);
+                Reset_Val_Header(opt_out, REB_TIME);
             break;
 
         case SYM_ZONE:
             if (secs == NO_TIME)
-                SET_VOID(opt_out);
+                Init_Void(opt_out);
             else {
                 VAL_TIME(opt_out) = cast(i64, tz) * ZONE_MINS * MIN_SEC;
-                VAL_RESET_HEADER(opt_out, REB_TIME);
+                Reset_Val_Header(opt_out, REB_TIME);
             }
             break;
 
@@ -582,12 +582,12 @@ void Pick_Or_Poke_Date(
             break;
 
         case SYM_WEEKDAY:
-            SET_INTEGER(opt_out, Week_Day(date));
+            Init_Integer(opt_out, Week_Day(date));
             break;
 
         case SYM_JULIAN:
         case SYM_YEARDAY:
-            SET_INTEGER(opt_out, cast(REBINT, Julian_Date(date)));
+            Init_Integer(opt_out, cast(REBINT, Julian_Date(date)));
             break;
 
         case SYM_UTC:
@@ -596,24 +596,24 @@ void Pick_Or_Poke_Date(
 
         case SYM_HOUR:
             Split_Time(secs, &time);
-            SET_INTEGER(opt_out, time.h);
+            Init_Integer(opt_out, time.h);
             break;
 
         case SYM_MINUTE:
             Split_Time(secs, &time);
-            SET_INTEGER(opt_out, time.m);
+            Init_Integer(opt_out, time.m);
             break;
 
         case SYM_SECOND:
             Split_Time(secs, &time);
             if (time.n == 0)
-                SET_INTEGER(opt_out, time.s);
+                Init_Integer(opt_out, time.s);
             else
-                SET_DECIMAL(opt_out, cast(REBDEC, time.s) + (time.n * NANO));
+                Init_Decimal(opt_out, cast(REBDEC, time.s) + (time.n * NANO));
             break;
 
         default:
-            SET_VOID(opt_out); // "out of range" PICK semantics
+            Init_Void(opt_out); // "out of range" PICK semantics
         }
     }
     else {
@@ -708,7 +708,7 @@ void Pick_Or_Poke_Date(
         date = Normalize_Date(day, month, year, tz);
 
     set_without_normalize:
-        VAL_RESET_HEADER(value, REB_DATE);
+        Reset_Val_Header(value, REB_DATE);
         VAL_DATE(value) = date;
         VAL_TIME(value) = secs;
         Adjust_Date_Zone(value, TRUE);
@@ -895,12 +895,12 @@ fixDate:
     date = Normalize_Date(day, month, year, tz);
 
 setDate:
-    VAL_RESET_HEADER(D_OUT, REB_DATE);
+    Reset_Val_Header(D_OUT, REB_DATE);
     VAL_DATE(D_OUT) = date;
     VAL_TIME(D_OUT) = secs;
     return R_OUT;
 
 ret_int:
-    SET_INTEGER(D_OUT, num);
+    Init_Integer(D_OUT, num);
     return R_OUT;
 }

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -117,7 +117,7 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 //
 void Init_Decimal_Bits(REBVAL *out, const REBYTE *bp)
 {
-    VAL_RESET_HEADER(out, REB_DECIMAL);
+    Reset_Val_Header(out, REB_DECIMAL);
 
     REBYTE *dp = cast(REBYTE*, &VAL_DECIMAL(out));
 
@@ -189,7 +189,7 @@ void MAKE_Decimal(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
             fail (arg);
 
         Init_Decimal_Bits(out, VAL_BIN_AT(arg));
-        VAL_RESET_HEADER(out, kind);
+        Reset_Val_Header(out, kind);
         d = VAL_DECIMAL(out);
         break;
 
@@ -246,7 +246,7 @@ dont_divide_if_percent:
     if (!FINITE(d))
         fail (Error_Overflow_Raw());
 
-    VAL_RESET_HEADER(out, kind);
+    Reset_Val_Header(out, kind);
     VAL_DECIMAL(out) = d;
     return;
 
@@ -372,7 +372,7 @@ REBTYPE(Decimal)
                 if (action == SYM_DIVIDE) type = REB_DECIMAL;
                 else if (!IS_PERCENT(val)) type = VAL_TYPE(val);
             } else if (type == REB_MONEY) {
-                SET_MONEY(val, decimal_to_deci(VAL_DECIMAL(val)));
+                Init_Money(val, decimal_to_deci(VAL_DECIMAL(val)));
                 return T_Money(frame_, action);
             } else if (type == REB_CHAR) {
                 d2 = (REBDEC)VAL_CHAR(arg);
@@ -468,7 +468,7 @@ REBTYPE(Decimal)
             arg = ARG(scale);
             if (REF(to)) {
                 if (IS_MONEY(arg)) {
-                    SET_MONEY(D_OUT, Round_Deci(
+                    Init_Money(D_OUT, Round_Deci(
                         decimal_to_deci(d1), flags, VAL_MONEY_AMOUNT(arg)
                     ));
                     return R_OUT;
@@ -478,7 +478,7 @@ REBTYPE(Decimal)
 
                 d1 = Round_Dec(d1, flags, Dec64(arg));
                 if (IS_INTEGER(arg)) {
-                    VAL_RESET_HEADER(D_OUT, REB_INTEGER);
+                    Reset_Val_Header(D_OUT, REB_INTEGER);
                     VAL_INT64(D_OUT) = cast(REBI64, d1);
                     return R_OUT;
                 }
@@ -509,7 +509,7 @@ REBTYPE(Decimal)
             goto setDec; }
 
         case SYM_COMPLEMENT:
-            SET_INTEGER(D_OUT, ~(REBINT)d1);
+            Init_Integer(D_OUT, ~(REBINT)d1);
             return R_OUT;
 
         default:
@@ -522,7 +522,7 @@ REBTYPE(Decimal)
 setDec:
     if (!FINITE(d1)) fail (Error_Overflow_Raw());
 
-    VAL_RESET_HEADER(D_OUT, type);
+    Reset_Val_Header(D_OUT, type);
     VAL_DECIMAL(D_OUT) = d1;
 
     return R_OUT;

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -207,7 +207,7 @@ void Set_Event_Vars(REBVAL *evt, RELVAL *blk, REBSPC *specifier)
         ++blk;
 
         if (IS_END(blk))
-            SET_BLANK(val);
+            Init_Blank(val);
         else
             Get_Simple_Value_Into(val, blk, specifier);
 
@@ -300,7 +300,7 @@ static REBOOL Get_Event_Var(const REBVAL *value, REBSTR *name, REBVAL *val)
             }
             return FALSE;
         }
-        SET_CHAR(val, n);
+        Init_Char(val, n);
         break;
 
     case SYM_FLAGS:
@@ -322,14 +322,14 @@ static REBOOL Get_Event_Var(const REBVAL *value, REBSTR *name, REBVAL *val)
             Init_Block(val, array);
         }
         else
-            SET_BLANK(val);
+            Init_Blank(val);
         break;
 
     case SYM_CODE:
         if (VAL_EVENT_TYPE(value) != EVT_KEY && VAL_EVENT_TYPE(value) != EVT_KEY_UP)
             goto is_blank;
         n = VAL_EVENT_DATA(value); // key-words in top 16, chars in lower 16
-        SET_INTEGER(val, n);
+        Init_Integer(val, n);
         break;
 
     case SYM_DATA:
@@ -362,7 +362,7 @@ static REBOOL Get_Event_Var(const REBVAL *value, REBSTR *name, REBVAL *val)
     return TRUE;
 
 is_blank:
-    SET_BLANK(val);
+    Init_Blank(val);
     return TRUE;
 }
 
@@ -377,7 +377,7 @@ void MAKE_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     if (IS_BLOCK(arg)) {
         CLEARS(out);
         INIT_CELL(out);
-        VAL_RESET_HEADER(out, REB_EVENT);
+        Reset_Val_Header(out, REB_EVENT);
         Set_Event_Vars(
             out,
             VAL_ARRAY_AT(arg),

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -172,7 +172,7 @@ REBTYPE(Function)
         ARR_HEAD(proxy_paramlist)->payload.function.paramlist
             = proxy_paramlist;
         AS_SERIES(proxy_paramlist)->link.meta = VAL_FUNC_META(value);
-        SET_SER_FLAG(proxy_paramlist, ARRAY_FLAG_PARAMLIST);
+        Set_Ser_Flag(proxy_paramlist, ARRAY_FLAG_PARAMLIST);
 
         // If the function had code, then that code will be bound relative
         // to the original paramlist that's getting hijacked.  So when the
@@ -205,7 +205,7 @@ REBTYPE(Function)
                 // The CFUNC is fabricated by the FFI if it's a callback, or
                 // just the wrapped DLL function if it's an ordinary routine
                 //
-                SET_INTEGER(
+                Init_Integer(
                     D_OUT, cast(REBUPT, RIN_CFUNC(VAL_FUNC_ROUTINE(value)))
                 );
                 return R_OUT;
@@ -270,7 +270,7 @@ REBTYPE(Function)
                 );
             }
             else {
-                SET_BLANK(D_OUT);
+                Init_Blank(D_OUT);
             }
             return R_OUT;
 
@@ -351,7 +351,7 @@ REBNATIVE(func_class_of)
         n = 1;
     }
 
-    SET_INTEGER(D_OUT, n);
+    Init_Integer(D_OUT, n);
     return R_OUT;
 }
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -560,7 +560,7 @@ static REBOOL Get_GOB_Var(REBGOB *gob, const REBVAL *word, REBVAL *val)
         break;
 
     case SYM_ALPHA:
-        SET_INTEGER(val, GOB_ALPHA(gob));
+        Init_Integer(val, GOB_ALPHA(gob));
         break;
 
     case SYM_PANE:
@@ -576,7 +576,7 @@ static REBOOL Get_GOB_Var(REBGOB *gob, const REBVAL *word, REBVAL *val)
         }
         else
 is_blank:
-            SET_BLANK(val);
+            Init_Blank(val);
         break;
 
     case SYM_DATA:
@@ -593,7 +593,7 @@ is_blank:
             Init_Binary(val, GOB_DATA(gob));
         }
         else if (GOB_DTYPE(gob) == GOBD_INTEGER) {
-            SET_INTEGER(val, (REBIPT)GOB_DATA(gob));
+            Init_Integer(val, (REBIPT)GOB_DATA(gob));
         }
         else goto is_blank;
         break;
@@ -659,12 +659,12 @@ REBARR *Gob_To_Array(REBGOB *gob)
         val = Alloc_Tail_Array(array);
         Init_Set_Word(val, Canon(words[n]));
         vals[n] = Alloc_Tail_Array(array);
-        SET_BLANK(vals[n]);
+        Init_Blank(vals[n]);
     }
 
     SET_PAIR(vals[0], GOB_X(gob), GOB_Y(gob));
     SET_PAIR(vals[1], GOB_W(gob), GOB_H(gob));
-    SET_INTEGER(vals[2], GOB_ALPHA(gob));
+    Init_Integer(vals[2], GOB_ALPHA(gob));
 
     if (!GOB_TYPE(gob)) return array;
 
@@ -712,7 +712,7 @@ static void Return_Gob_Pair(REBVAL *out, REBGOB *gob, REBD32 x, REBD32 y)
     SET_GOB(Alloc_Tail_Array(blk), gob);
 
     REBVAL *val = Alloc_Tail_Array(blk);
-    VAL_RESET_HEADER(val, REB_PAIR);
+    Reset_Val_Header(val, REB_PAIR);
     VAL_PAIR_X(val) = x;
     VAL_PAIR_Y(val) = y;
 }
@@ -971,7 +971,7 @@ REBINT PD_Gob(REBPVS *pvs)
         if (index >= tail) return PE_NONE;
 
         gob = *GOB_AT(gob, index);
-        VAL_RESET_HEADER(pvs->store, REB_GOB);
+        Reset_Val_Header(pvs->store, REB_GOB);
         VAL_GOB(pvs->store) = gob;
         VAL_GOB_INDEX(pvs->store) = 0;
         return PE_USE_STORE;
@@ -1105,7 +1105,7 @@ REBTYPE(Gob)
         if (index + len > tail) len = tail - index;
         if (index >= tail) goto is_blank;
         if (NOT(REF(part))) { // just one value
-            VAL_RESET_HEADER(D_OUT, REB_GOB);
+            Reset_Val_Header(D_OUT, REB_GOB);
             VAL_GOB(D_OUT) = *GOB_AT(gob, index);
             VAL_GOB_INDEX(D_OUT) = 0;
             Remove_Gobs(gob, index, 1);
@@ -1144,12 +1144,12 @@ REBTYPE(Gob)
         goto is_false;
 
     case SYM_INDEX_OF:
-        SET_INTEGER(D_OUT, index + 1);
+        Init_Integer(D_OUT, index + 1);
         break;
 
     case SYM_LENGTH:
         index = (tail > index) ? tail - index : 0;
-        SET_INTEGER(D_OUT, index);
+        Init_Integer(D_OUT, index);
         break;
 
     case SYM_FIND:
@@ -1175,7 +1175,7 @@ REBTYPE(Gob)
     return R_OUT;
 
 set_index:
-    VAL_RESET_HEADER(D_OUT, REB_GOB);
+    Reset_Val_Header(D_OUT, REB_GOB);
     VAL_GOB(D_OUT) = gob;
     VAL_GOB_INDEX(D_OUT) = index;
     return R_OUT;

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -287,7 +287,7 @@ void Set_Tuple_Pixel(REBYTE *dp, REBVAL *tuple)
     // Pixel to tuple.
     REBYTE *tup = VAL_TUPLE(tuple);
 
-    VAL_RESET_HEADER(tuple, REB_TUPLE);
+    Reset_Val_Header(tuple, REB_TUPLE);
     VAL_TUPLE_LEN(tuple) = 4;
     tup[0] = dp[C_R];
     tup[1] = dp[C_G];
@@ -821,7 +821,7 @@ void Find_Image(REBFRM *frame_)
 
     REBCNT len = tail - index;
     if (len == 0) {
-        SET_VOID(D_OUT);
+        Init_Void(D_OUT);
         return;
     }
 
@@ -864,7 +864,7 @@ void Find_Image(REBFRM *frame_)
         fail (Error_Invalid_Type(VAL_TYPE(arg)));
 
     if (p == 0) {
-        SET_VOID(D_OUT);
+        Init_Void(D_OUT);
         return;
     }
 
@@ -874,7 +874,7 @@ void Find_Image(REBFRM *frame_)
     n = (REBCNT)(p - (REBCNT *)VAL_IMAGE_HEAD(value));
     if (REF(match)) {
         if (n != cast(REBINT, index)) {
-            SET_VOID(D_OUT);
+            Init_Void(D_OUT);
             return;
         }
         n++;
@@ -1008,12 +1008,12 @@ REBTYPE(Image)
             return R_OUT;
         }
         else {
-            SET_INTEGER(D_OUT, index + 1);
+            Init_Integer(D_OUT, index + 1);
             return R_OUT;
         }}
         // fallthrough
     case SYM_LENGTH:
-        SET_INTEGER(D_OUT, tail > index ? tail - index : 0);
+        Init_Integer(D_OUT, tail > index ? tail - index : 0);
         return R_OUT;
 
     case SYM_PICK_P:
@@ -1286,7 +1286,7 @@ void Pick_Image(REBVAL *out, const REBVAL *value, const REBVAL *picker)
     if (Adjust_Image_Pick_Index_Is_Valid(&index, value, picker))
         Set_Tuple_Pixel(QUAD_SKIP(series, index), out);
     else
-        SET_VOID(out);
+        Init_Void(out);
 }
 
 

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -63,9 +63,9 @@ void MAKE_Integer(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         // fewer seeming "rules" than TO would.
 
         if (VAL_LOGIC(arg))
-            SET_INTEGER(out, 1);
+            Init_Integer(out, 1);
         else
-            SET_INTEGER(out, 0);
+            Init_Integer(out, 0);
 
         // !!! The same principle could suggest MAKE is not bound by
         // the "reversibility" requirement and hence could interpret
@@ -126,11 +126,11 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
         if (VAL_DECIMAL(value) < MIN_D64 || VAL_DECIMAL(value) >= MAX_D64)
             fail (Error_Overflow_Raw());
 
-        SET_INTEGER(out, cast(REBI64, VAL_DECIMAL(value)));
+        Init_Integer(out, cast(REBI64, VAL_DECIMAL(value)));
         goto check_sign;
     }
     else if (IS_MONEY(value)) {
-        SET_INTEGER(out, deci_to_int(VAL_MONEY_AMOUNT(value)));
+        Init_Integer(out, deci_to_int(VAL_MONEY_AMOUNT(value)));
         goto check_sign;
     }
     else if (IS_BINARY(value)) { // must be before ANY_STRING() test...
@@ -172,7 +172,7 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
             for (; n; n--, bp++)
                 i = cast(REBI64, (cast(REBU64, i) << 8) | *bp);
 
-            SET_INTEGER(out, i);
+            Init_Integer(out, i);
 
             // There was no TO-INTEGER/UNSIGNED in R3-Alpha, so even if
             // running in compatibility mode we can check the sign if used.
@@ -185,7 +185,7 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
             //
             // !!! Should #{} empty binary be 0 or error?  (Historically, 0)
             //
-            SET_INTEGER(out, 0);
+            Init_Integer(out, 0);
             return;
         }
 
@@ -214,9 +214,9 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
         if (n == 0) {
             if (negative) {
                 assert(!no_sign);
-                SET_INTEGER(out, -1);
+                Init_Integer(out, -1);
             } else
-                SET_INTEGER(out, 0);
+                Init_Integer(out, 0);
             return;
         }
 
@@ -249,7 +249,7 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
             fail (Error_Out_Of_Range_Raw(value));
         }
 
-        SET_INTEGER(out, i);
+        Init_Integer(out, i);
         return;
     }
     else if (IS_ISSUE(value)) {
@@ -292,7 +292,7 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
             DECLARE_LOCAL (d);
             if (Scan_Decimal(d, bp, len, TRUE)) {
                 if (VAL_DECIMAL(d) < MAX_I64 && VAL_DECIMAL(d) >= MIN_I64) {
-                    SET_INTEGER(out, cast(REBI64, VAL_DECIMAL(d)));
+                    Init_Integer(out, cast(REBI64, VAL_DECIMAL(d)));
                     goto check_sign;
                 }
 
@@ -313,11 +313,11 @@ void Value_To_Int64(REBVAL *out, const REBVAL *value, REBOOL no_sign)
         fail (Error_Bad_Make(REB_INTEGER, value));
     }
     else if (IS_CHAR(value)) {
-        SET_INTEGER(out, VAL_CHAR(value)); // always unsigned
+        Init_Integer(out, VAL_CHAR(value)); // always unsigned
         return;
     }
     else if (IS_TIME(value)) {
-        SET_INTEGER(out, SECS_IN(VAL_TIME(value))); // always unsigned
+        Init_Integer(out, SECS_IN(VAL_TIME(value))); // always unsigned
         return;
     }
     else
@@ -403,17 +403,17 @@ REBTYPE(Integer)
             case SYM_REMAINDER:
             case SYM_POWER:
                 if (IS_DECIMAL(val2) || IS_PERCENT(val2)) {
-                    SET_DECIMAL(val, (REBDEC)num); // convert main arg
+                    Init_Decimal(val, (REBDEC)num); // convert main arg
                     return T_Decimal(frame_, action);
                 }
                 if (IS_MONEY(val2)) {
-                    SET_MONEY(val, int_to_deci(VAL_INT64(val)));
+                    Init_Money(val, int_to_deci(VAL_INT64(val)));
                     return T_Money(frame_, action);
                 }
                 if (n > 0) {
                     if (IS_TIME(val2)) {
                         VAL_TIME(val) = SEC_TIME(VAL_INT64(val));
-                        VAL_SET_TYPE_BITS(val, REB_TIME);
+                        Reset_Val_Kind(val, REB_TIME);
                         return T_Time(frame_, action);
                     }
                     if (IS_DATE(val2))
@@ -467,8 +467,8 @@ REBTYPE(Integer)
         }
         // Fall thru
     case SYM_POWER:
-        SET_DECIMAL(val, (REBDEC)num);
-        SET_DECIMAL(val2, (REBDEC)arg);
+        Init_Decimal(val, (REBDEC)num);
+        Init_Decimal(val2, (REBDEC)arg);
         return T_Decimal(frame_, action);
 
     case SYM_REMAINDER:
@@ -531,7 +531,7 @@ REBTYPE(Integer)
         val2 = ARG(scale);
         if (REF(to)) {
             if (IS_MONEY(val2)) {
-                SET_MONEY(D_OUT, Round_Deci(
+                Init_Money(D_OUT, Round_Deci(
                     int_to_deci(num), flags, VAL_MONEY_AMOUNT(val2)
                 ));
                 return R_OUT;
@@ -540,7 +540,7 @@ REBTYPE(Integer)
                 REBDEC dec = Round_Dec(
                     cast(REBDEC, num), flags, VAL_DECIMAL(val2)
                 );
-                VAL_RESET_HEADER(D_OUT, VAL_TYPE(val2));
+                Reset_Val_Header(D_OUT, VAL_TYPE(val2));
                 VAL_DECIMAL(D_OUT) = dec;
                 return R_OUT;
             }
@@ -574,6 +574,6 @@ REBTYPE(Integer)
         fail (Error_Illegal_Action(REB_INTEGER, action));
     }
 
-    SET_INTEGER(D_OUT, num);
+    Init_Integer(D_OUT, num);
     return R_OUT;
 }

--- a/src/core/t-library.c
+++ b/src/core/t-library.c
@@ -64,7 +64,7 @@ void MAKE_Library(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         fail (Error_Bad_Make(REB_LIBRARY, arg));
 
     REBARR *singular = Alloc_Singular_Array();
-    VAL_RESET_HEADER(ARR_HEAD(singular), REB_LIBRARY);
+    Reset_Val_Header(ARR_HEAD(singular), REB_LIBRARY);
     ARR_HEAD(singular)->payload.library.singular = singular;
 
     AS_SERIES(singular)->misc.fd = fd;

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -180,10 +180,10 @@ void MAKE_Logic(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
         )
         || (IS_MONEY(arg) && deci_is_zero(VAL_MONEY_AMOUNT(arg)))
     ) {
-        SET_FALSE(out);
+        Init_False(out);
     }
     else
-        SET_TRUE(out);
+        Init_True(out);
 }
 
 
@@ -199,9 +199,9 @@ void TO_Logic(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     // considered effectively "truth".
     //
     if (IS_CONDITIONAL_TRUE(arg))
-        SET_TRUE(out);
+        Init_True(out);
     else
-        SET_FALSE(out);
+        Init_False(out);
 }
 
 

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -253,11 +253,11 @@ void Expand_Hash(REBSER *ser)
     REBINT pnum = Get_Hash_Prime(SER_LEN(ser) + 1);
     if (pnum == 0) {
         DECLARE_LOCAL (temp);
-        SET_INTEGER(temp, SER_LEN(ser) + 1);
+        Init_Integer(temp, SER_LEN(ser) + 1);
         fail (Error_Size_Limit_Raw(temp));
     }
 
-    assert(NOT_SER_FLAG(ser, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(ser, SERIES_FLAG_ARRAY));
     Remake_Series(ser, pnum + 1, SER_WIDE(ser), SERIES_FLAG_POWER_OF_2);
 
     Clear_Series(ser);
@@ -358,7 +358,7 @@ REBINT PD_Map(REBPVS *pvs)
     );
 
     if (n == 0) {
-        SET_VOID(pvs->store);
+        Init_Void(pvs->store);
         return PE_USE_STORE;
     }
 
@@ -366,7 +366,7 @@ REBINT PD_Map(REBPVS *pvs)
         ARR_AT(MAP_PAIRLIST(VAL_MAP(pvs->value)), ((n - 1) * 2) + 1)
     );
     if (IS_VOID(val)) {
-        SET_VOID(pvs->store);
+        Init_Void(pvs->store);
         return PE_USE_STORE;
     }
 
@@ -519,7 +519,7 @@ REBMAP *Mutate_Array_Into_Map(REBARR *a)
     //
     assert(NOT(IS_ARRAY_MANAGED(a)));
 
-    SET_SER_FLAG(a, ARRAY_FLAG_PAIRLIST);
+    Set_Ser_Flag(a, ARRAY_FLAG_PAIRLIST);
 
     REBMAP *map = AS_MAP(a);
     MAP_HASHLIST(map) = Make_Hash_Sequence(size);
@@ -721,7 +721,7 @@ REBTYPE(Map)
         return R_OUT; }
 
     case SYM_LENGTH:
-        SET_INTEGER(D_OUT, Length_Map(map));
+        Init_Integer(D_OUT, Length_Map(map));
         return R_OUT;
 
     case SYM_COPY: {

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -61,12 +61,12 @@ void MAKE_Money(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 
     switch (VAL_TYPE(arg)) {
     case REB_INTEGER:
-        SET_MONEY(out, int_to_deci(VAL_INT64(arg)));
+        Init_Money(out, int_to_deci(VAL_INT64(arg)));
         break;
 
     case REB_DECIMAL:
     case REB_PERCENT:
-        SET_MONEY(out, decimal_to_deci(VAL_DECIMAL(arg)));
+        Init_Money(out, decimal_to_deci(VAL_DECIMAL(arg)));
         break;
 
     case REB_MONEY:
@@ -77,7 +77,7 @@ void MAKE_Money(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     {
         const REBYTE *end;
         REBYTE *str = Temp_Byte_Chars_May_Fail(arg, MAX_SCAN_MONEY, 0, FALSE);
-        SET_MONEY(out, string_to_deci(str, &end));
+        Init_Money(out, string_to_deci(str, &end));
         if (end == str || *end != 0)
             goto bad_make;
         break;
@@ -89,7 +89,7 @@ void MAKE_Money(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         break;
 
     case REB_LOGIC:
-        SET_MONEY(out, int_to_deci(VAL_LOGIC(arg) ? 1 : 0));
+        Init_Money(out, int_to_deci(VAL_LOGIC(arg) ? 1 : 0));
         break;
 
     default:
@@ -97,7 +97,7 @@ void MAKE_Money(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         fail (Error_Bad_Make(REB_MONEY, arg));
     }
 
-    VAL_RESET_HEADER(out, REB_MONEY);
+    Reset_Val_Header(out, REB_MONEY);
 }
 
 
@@ -144,7 +144,7 @@ void Bin_To_Money_May_Fail(REBVAL *result, const REBVAL *val)
 
     memcpy(buf + 12 - len, buf, len); // shift to right side
     memset(buf, 0, 12 - len);
-    SET_MONEY(result, binary_to_deci(buf));
+    Init_Money(result, binary_to_deci(buf));
 }
 
 
@@ -154,12 +154,12 @@ static REBVAL *Math_Arg_For_Money(REBVAL *store, REBVAL *arg, REBSYM action)
         return arg;
 
     if (IS_INTEGER(arg)) {
-        SET_MONEY(store, int_to_deci(VAL_INT64(arg)));
+        Init_Money(store, int_to_deci(VAL_INT64(arg)));
         return store;
     }
 
     if (IS_DECIMAL(arg) || IS_PERCENT(arg)) {
-        SET_MONEY(store, decimal_to_deci(VAL_DECIMAL(arg)));
+        Init_Money(store, decimal_to_deci(VAL_DECIMAL(arg)));
         return store;
     }
 
@@ -178,35 +178,35 @@ REBTYPE(Money)
     switch (action) {
     case SYM_ADD:
         arg = Math_Arg_For_Money(D_OUT, D_ARG(2), action);
-        SET_MONEY(D_OUT, deci_add(
+        Init_Money(D_OUT, deci_add(
             VAL_MONEY_AMOUNT(val), VAL_MONEY_AMOUNT(arg)
         ));
         break;
 
     case SYM_SUBTRACT:
         arg = Math_Arg_For_Money(D_OUT, D_ARG(2), action);
-        SET_MONEY(D_OUT, deci_subtract(
+        Init_Money(D_OUT, deci_subtract(
             VAL_MONEY_AMOUNT(val), VAL_MONEY_AMOUNT(arg)
         ));
         break;
 
     case SYM_MULTIPLY:
         arg = Math_Arg_For_Money(D_OUT, D_ARG(2), action);
-        SET_MONEY(D_OUT, deci_multiply(
+        Init_Money(D_OUT, deci_multiply(
             VAL_MONEY_AMOUNT(val), VAL_MONEY_AMOUNT(arg)
         ));
         break;
 
     case SYM_DIVIDE:
         arg = Math_Arg_For_Money(D_OUT, D_ARG(2), action);
-        SET_MONEY(D_OUT, deci_divide(
+        Init_Money(D_OUT, deci_divide(
             VAL_MONEY_AMOUNT(val), VAL_MONEY_AMOUNT(arg)
         ));
         break;
 
     case SYM_REMAINDER:
         arg = Math_Arg_For_Money(D_OUT, D_ARG(2), action);
-        SET_MONEY(D_OUT, deci_mod(
+        Init_Money(D_OUT, deci_mod(
             VAL_MONEY_AMOUNT(val), VAL_MONEY_AMOUNT(arg)
         ));
         break;
@@ -241,18 +241,18 @@ REBTYPE(Money)
         DECLARE_LOCAL (temp);
         if (REF(to)) {
             if (IS_INTEGER(scale))
-                SET_MONEY(temp, int_to_deci(VAL_INT64(scale)));
+                Init_Money(temp, int_to_deci(VAL_INT64(scale)));
             else if (IS_DECIMAL(scale) || IS_PERCENT(scale))
-                SET_MONEY(temp, decimal_to_deci(VAL_DECIMAL(scale)));
+                Init_Money(temp, decimal_to_deci(VAL_DECIMAL(scale)));
             else if (IS_MONEY(scale))
                 Move_Value(temp, scale);
             else
                 fail (scale);
         }
         else
-            SET_MONEY(temp, int_to_deci(0));
+            Init_Money(temp, int_to_deci(0));
 
-        SET_MONEY(D_OUT, Round_Deci(
+        Init_Money(D_OUT, Round_Deci(
             VAL_MONEY_AMOUNT(val),
             flags,
             VAL_MONEY_AMOUNT(temp)
@@ -261,13 +261,13 @@ REBTYPE(Money)
         if (REF(to)) {
             if (IS_DECIMAL(scale) || IS_PERCENT(scale)) {
                 REBDEC dec = deci_to_decimal(VAL_MONEY_AMOUNT(D_OUT));
-                VAL_RESET_HEADER(D_OUT, VAL_TYPE(scale));
+                Reset_Val_Header(D_OUT, VAL_TYPE(scale));
                 VAL_DECIMAL(D_OUT) = dec;
                 return R_OUT;
             }
             if (IS_INTEGER(scale)) {
                 REBI64 i64 = deci_to_int(VAL_MONEY_AMOUNT(D_OUT));
-                VAL_RESET_HEADER(D_OUT, REB_INTEGER);
+                Reset_Val_Header(D_OUT, REB_INTEGER);
                 VAL_INT64(D_OUT) = i64;
                 return R_OUT;
             }
@@ -284,7 +284,7 @@ REBTYPE(Money)
         fail (Error_Illegal_Action(REB_MONEY, action));
     }
 
-    VAL_RESET_HEADER(D_OUT, REB_MONEY);
+    Reset_Val_Header(D_OUT, REB_MONEY);
     return R_OUT;
 }
 

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -74,12 +74,12 @@ static REBOOL Equal_Context(const RELVAL *val, const RELVAL *arg)
         //
         // Hidden vars shouldn't affect the comparison.
         //
-        if (GET_VAL_FLAG(key1, TYPESET_FLAG_HIDDEN)) {
+        if (Get_Val_Flag(key1, TYPESET_FLAG_HIDDEN)) {
             key1++; var1++;
             if (IS_END(key1)) break;
             goto no_advance;
         }
-        if (GET_VAL_FLAG(key2, TYPESET_FLAG_HIDDEN)) {
+        if (Get_Val_Flag(key2, TYPESET_FLAG_HIDDEN)) {
             key2++; var2++;
             if (IS_END(key2)) break;
             goto no_advance;
@@ -109,11 +109,11 @@ static REBOOL Equal_Context(const RELVAL *val, const RELVAL *arg)
     // they don't line up.
     //
     for (; NOT_END(key1); key1++, var1++) {
-        if (NOT_VAL_FLAG(key1, TYPESET_FLAG_HIDDEN))
+        if (Not_Val_Flag(key1, TYPESET_FLAG_HIDDEN))
             return FALSE;
     }
     for (; NOT_END(key2); key2++, var2++) {
-        if (NOT_VAL_FLAG(key2, TYPESET_FLAG_HIDDEN))
+        if (Not_Val_Flag(key2, TYPESET_FLAG_HIDDEN))
             return FALSE;
     }
 
@@ -192,14 +192,14 @@ static void Append_To_Context(REBCTX *context, REBVAL *arg)
         REBVAL *key = CTX_KEY(context, i);
         REBVAL *var = CTX_VAR(context, i);
 
-        if (GET_VAL_FLAG(var, VALUE_FLAG_PROTECTED))
+        if (Get_Val_Flag(var, VALUE_FLAG_PROTECTED))
             fail (Error_Protected_Key(key));
 
-        if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
+        if (Get_Val_Flag(key, TYPESET_FLAG_HIDDEN))
             fail (Error_Hidden_Raw());
 
         if (IS_END(word + 1)) {
-            SET_BLANK(var);
+            Init_Blank(var);
             break; // fix bug#708
         }
         else {
@@ -207,8 +207,8 @@ static void Append_To_Context(REBCTX *context, REBVAL *arg)
 
             // Should the VALUE_FLAG_ENFIXED be preserved here?
             //
-            if (GET_VAL_FLAG(&word[1], VALUE_FLAG_ENFIXED))
-                SET_VAL_FLAG(var, VALUE_FLAG_ENFIXED);
+            if (Get_Val_Flag(&word[1], VALUE_FLAG_ENFIXED))
+                Set_Val_Flag(var, VALUE_FLAG_ENFIXED);
 
         }
     }
@@ -235,7 +235,7 @@ static REBCTX *Trim_Context(REBCTX *context)
     for (; NOT_END(var); var++, key++) {
         if (VAL_TYPE(var) == REB_BLANK)
             continue;
-        if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
+        if (Get_Val_Flag(key, TYPESET_FLAG_HIDDEN))
             continue;
 
         ++copy_count;
@@ -256,7 +256,7 @@ static REBCTX *Trim_Context(REBCTX *context)
     for (; NOT_END(var); var++, key++) {
         if (VAL_TYPE(var) == REB_BLANK)
             continue;
-        if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
+        if (Get_Val_Flag(key, TYPESET_FLAG_HIDDEN))
             continue;
 
         Move_Value(var_new, var);
@@ -400,7 +400,7 @@ void MAKE_Context(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         /*
         REBINT n = Int32s(arg, 0); 
         context = Alloc_Context(kind, n);
-        VAL_RESET_HEADER(CTX_VALUE(context), target);
+        Reset_Val_Header(CTX_VALUE(context), target);
         CTX_SPEC(context) = NULL;
         CTX_BODY(context) = NULL; */
         Init_Any_Context(out, kind, context);
@@ -472,7 +472,7 @@ REBINT PD_Context(REBPVS *pvs)
         // with the behavior of GET-WORD!
         //
         if (IS_GET_PATH(pvs->orig) && IS_END(pvs->item + 1)) {
-            SET_VOID(pvs->store);
+            Init_Void(pvs->store);
             return PE_USE_STORE;
         }
         fail (Error_Bad_Path_Select(pvs));
@@ -484,7 +484,7 @@ REBINT PD_Context(REBPVS *pvs)
     if (pvs->opt_setval && IS_END(pvs->item + 1)) {
         FAIL_IF_READ_ONLY_CONTEXT(c);
 
-        if (GET_VAL_FLAG(CTX_VAR(c, n), VALUE_FLAG_PROTECTED))
+        if (Get_Val_Flag(CTX_VAR(c, n), VALUE_FLAG_PROTECTED))
             fail (Error_Protected_Word_Raw(pvs->selector));
     }
 
@@ -589,7 +589,7 @@ REBNATIVE(set_meta)
 REBCTX *Copy_Context_Core(REBCTX *original, REBOOL deep, REBU64 types)
 {
     REBARR *varlist = Copy_Array_Shallow(CTX_VARLIST(original), SPECIFIED);
-    SET_SER_FLAG(varlist, ARRAY_FLAG_VARLIST);
+    Set_Ser_Flag(varlist, ARRAY_FLAG_VARLIST);
 
     // The type information and fields in the rootvar (at head of the varlist)
     // are filled in because it's a copy, but the varlist needs to be updated
@@ -640,7 +640,7 @@ REBTYPE(Context)
     case SYM_LENGTH:
         if (!IS_OBJECT(value))
             fail (Error_Illegal_Action(VAL_TYPE(value), action));
-        SET_INTEGER(D_OUT, CTX_LEN(VAL_CONTEXT(value)));
+        Init_Integer(D_OUT, CTX_LEN(VAL_CONTEXT(value)));
         return R_OUT;
 
     case SYM_COPY: { // Note: words are not copied and bindings not changed!
@@ -734,7 +734,7 @@ REBTYPE(Context)
 
     case SYM_TAIL_Q:
         if (IS_OBJECT(value)) {
-            SET_LOGIC(D_OUT, LOGICAL(CTX_LEN(VAL_CONTEXT(value)) == 0));
+            Init_Logic(D_OUT, LOGICAL(CTX_LEN(VAL_CONTEXT(value)) == 0));
             return R_OUT;
         }
         fail (Error_Illegal_Action(VAL_TYPE(value), action));

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -221,7 +221,7 @@ REBINT PD_Pair(REBPVS *pvs)
     }
     else {
         dec = (n == 1 ? VAL_PAIR_X(pvs->value) : VAL_PAIR_Y(pvs->value));
-        SET_DECIMAL(pvs->store, dec);
+        Init_Decimal(pvs->store, dec);
         return PE_USE_STORE;
     }
 
@@ -393,7 +393,7 @@ REBTYPE(Pair)
 ///                 fail (arg);
 ///             goto setPair;
 ///         }
-        SET_DECIMAL(D_OUT, n == 0 ? x1 : y1);
+        Init_Decimal(D_OUT, n == 0 ? x1 : y1);
         return R_OUT; }
 
     default:

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -84,7 +84,7 @@ void TO_Port(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     // system/standard/port is made with CONTEXT and not with MAKE PORT!
     //
     REBCTX *context = Copy_Context_Shallow(VAL_CONTEXT(arg));
-    VAL_RESET_HEADER(CTX_VALUE(context), REB_PORT);
+    Reset_Val_Header(CTX_VALUE(context), REB_PORT);
     Init_Port(out, context);
 }
 

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -270,7 +270,7 @@ static void Schema_From_Block_May_Fail(
 
         switch (VAL_WORD_SYM(item)) {
         case SYM_VOID:
-            SET_BLANK(schema_out); // only valid for return types
+            Init_Blank(schema_out); // only valid for return types
             Init_Typeset(param_out, FLAGIT_KIND(REB_MAX_VOID), NULL);
             break;
 
@@ -675,7 +675,7 @@ static void ffi_to_rebol(
         memcpy(SER_HEAD(REBYTE, data), ffi_rvalue, FLD_WIDE(top));
         MANAGE_SERIES(data);
 
-        VAL_RESET_HEADER(out, REB_STRUCT);
+        Reset_Val_Header(out, REB_STRUCT);
         out->payload.structure.stu = stu;
         out->payload.structure.data = data;
         out->extra.struct_offset = 0;
@@ -692,47 +692,47 @@ static void ffi_to_rebol(
 
     switch (VAL_WORD_SYM(schema)) {
     case SYM_UINT8:
-        SET_INTEGER(out, *cast(u8*, ffi_rvalue));
+        Init_Integer(out, *cast(u8*, ffi_rvalue));
         break;
 
     case SYM_INT8:
-        SET_INTEGER(out, *cast(i8*, ffi_rvalue));
+        Init_Integer(out, *cast(i8*, ffi_rvalue));
         break;
 
     case SYM_UINT16:
-        SET_INTEGER(out, *cast(u16*, ffi_rvalue));
+        Init_Integer(out, *cast(u16*, ffi_rvalue));
         break;
 
     case SYM_INT16:
-        SET_INTEGER(out, *cast(i16*, ffi_rvalue));
+        Init_Integer(out, *cast(i16*, ffi_rvalue));
         break;
 
     case SYM_UINT32:
-        SET_INTEGER(out, *cast(u32*, ffi_rvalue));
+        Init_Integer(out, *cast(u32*, ffi_rvalue));
         break;
 
     case SYM_INT32:
-        SET_INTEGER(out, *cast(i32*, ffi_rvalue));
+        Init_Integer(out, *cast(i32*, ffi_rvalue));
         break;
 
     case SYM_UINT64:
-        SET_INTEGER(out, *cast(u64*, ffi_rvalue));
+        Init_Integer(out, *cast(u64*, ffi_rvalue));
         break;
 
     case SYM_INT64:
-        SET_INTEGER(out, *cast(i64*, ffi_rvalue));
+        Init_Integer(out, *cast(i64*, ffi_rvalue));
         break;
 
     case SYM_POINTER:
-        SET_INTEGER(out, cast(REBUPT, *cast(void**, ffi_rvalue)));
+        Init_Integer(out, cast(REBUPT, *cast(void**, ffi_rvalue)));
         break;
 
     case SYM_FLOAT:
-        SET_DECIMAL(out, *cast(float*, ffi_rvalue));
+        Init_Decimal(out, *cast(float*, ffi_rvalue));
         break;
 
     case SYM_DOUBLE:
-        SET_DECIMAL(out, *cast(double*, ffi_rvalue));
+        Init_Decimal(out, *cast(double*, ffi_rvalue));
         break;
 
     case SYM_REBVAL:
@@ -985,7 +985,7 @@ REB_R Routine_Dispatcher(REBFRM *f)
     //
     // Note that the "offsets" are now actually pointers.
     {
-        SET_UNREADABLE_BLANK(&Callback_Error); // !!! is it already?
+        Init_Unreadable_Blank(&Callback_Error); // !!! is it already?
 
         ffi_call(
             cif,
@@ -1001,7 +1001,7 @@ REB_R Routine_Dispatcher(REBFRM *f)
     }
 
     if (IS_BLANK(RIN_RET_SCHEMA(rin)))
-        SET_VOID(f->out);
+        Init_Void(f->out);
     else
         ffi_to_rebol(f->out, RIN_RET_SCHEMA(rin), ret_offset);
 
@@ -1148,15 +1148,15 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
 
     REBRIN *r = Make_Array(IDX_ROUTINE_MAX);
 
-    SET_INTEGER(RIN_AT(r, IDX_ROUTINE_ABI), abi);
+    Init_Integer(RIN_AT(r, IDX_ROUTINE_ABI), abi);
 
     // Caller will update these in the returned function.
     //
-    SET_UNREADABLE_BLANK(RIN_AT(r, IDX_ROUTINE_CFUNC));
-    SET_UNREADABLE_BLANK(RIN_AT(r, IDX_ROUTINE_CLOSURE));
-    SET_UNREADABLE_BLANK(RIN_AT(r, IDX_ROUTINE_ORIGIN)); // LIBRARY!/FUNCTION!
+    Init_Unreadable_Blank(RIN_AT(r, IDX_ROUTINE_CFUNC));
+    Init_Unreadable_Blank(RIN_AT(r, IDX_ROUTINE_CLOSURE));
+    Init_Unreadable_Blank(RIN_AT(r, IDX_ROUTINE_ORIGIN)); // LIBRARY!/FUNCTION!
 
-    SET_BLANK(RIN_AT(r, IDX_ROUTINE_RET_SCHEMA)); // returns void as default
+    Init_Blank(RIN_AT(r, IDX_ROUTINE_RET_SCHEMA)); // returns void as default
 
     const REBCNT capacity_guess = 8; // !!! Magic number...why 8? (can grow)
 
@@ -1212,7 +1212,7 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
                     ALL_64 & ~FLAGIT_KIND(REB_VARARGS),
                     Canon(SYM_VARARGS)
                 );
-                SET_VAL_FLAG(param, TYPESET_FLAG_VARIADIC);
+                Set_Val_Flag(param, TYPESET_FLAG_VARIADIC);
                 INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_NORMAL);
             }
             else { // ordinary argument
@@ -1267,7 +1267,7 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
         }
     }
 
-    SET_LOGIC(RIN_AT(r, IDX_ROUTINE_IS_VARIADIC), is_variadic);
+    Init_Logic(RIN_AT(r, IDX_ROUTINE_IS_VARIADIC), is_variadic);
 
     TERM_ARRAY_LEN(r, IDX_ROUTINE_MAX);
     ASSERT_ARRAY(args_schemas);
@@ -1278,8 +1278,8 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
         // Each individual call needs to use `ffi_prep_cif_var` to make the
         // proper variadic CIF for that call.
         //
-        SET_BLANK(RIN_AT(r, IDX_ROUTINE_CIF));
-        SET_BLANK(RIN_AT(r, IDX_ROUTINE_ARG_FFTYPES));
+        Init_Blank(RIN_AT(r, IDX_ROUTINE_CIF));
+        Init_Blank(RIN_AT(r, IDX_ROUTINE_ARG_FFTYPES));
     }
     else {
         // The same CIF can be used for every call of the routine if it is
@@ -1320,7 +1320,7 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
         );
 
         if (args_fftypes == NULL)
-            SET_BLANK(RIN_AT(r, IDX_ROUTINE_ARG_FFTYPES));
+            Init_Blank(RIN_AT(r, IDX_ROUTINE_ARG_FFTYPES));
         else
             Init_Handle_Managed(
                 RIN_AT(r, IDX_ROUTINE_ARG_FFTYPES),
@@ -1334,11 +1334,11 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
 
     // Now fill in the canon value of the paramlist so it is an actual "REBFUN"
     //
-    VAL_RESET_HEADER(rootparam, REB_FUNCTION);
+    Reset_Val_Header(rootparam, REB_FUNCTION);
     rootparam->payload.function.paramlist = paramlist;
     rootparam->extra.binding = NULL;
 
-    SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    Set_Ser_Flag(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);
     AS_SERIES(paramlist)->link.meta = NULL;
 
@@ -1466,7 +1466,7 @@ REBNATIVE(make_routine_raw)
     REBRIN *r = FUNC_ROUTINE(fun);
 
     Init_Handle_Cfunc(RIN_AT(r, IDX_ROUTINE_CFUNC), cfunc, 0);
-    SET_BLANK(RIN_AT(r, IDX_ROUTINE_ORIGIN)); // no LIBRARY! in this case.
+    Init_Blank(RIN_AT(r, IDX_ROUTINE_ORIGIN)); // no LIBRARY! in this case.
 
     Move_Value(D_OUT, FUNC_VALUE(fun));
     return R_OUT;

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -59,7 +59,7 @@ static void str_to_char(REBVAL *out, REBVAL *val, REBCNT idx)
 {
     // Note: out may equal val, do assignment in two steps
     REBUNI codepoint = GET_ANY_CHAR(VAL_SERIES(val), idx);
-    SET_CHAR(out, codepoint);
+    Init_Char(out, codepoint);
 }
 
 
@@ -606,9 +606,9 @@ REBINT PD_String(REBPVS *pvs)
     if (!pvs->opt_setval) {
         if (n < 0 || (REBCNT)n >= SER_LEN(ser)) return PE_NONE;
         if (IS_BINARY(pvs->value)) {
-            SET_INTEGER(pvs->store, *BIN_AT(ser, n));
+            Init_Integer(pvs->store, *BIN_AT(ser, n));
         } else {
-            SET_CHAR(pvs->store, GET_ANY_CHAR(ser, n));
+            Init_Char(pvs->store, GET_ANY_CHAR(ser, n));
         }
         return PE_USE_STORE;
     }
@@ -895,7 +895,7 @@ REBTYPE(String)
             ret++;
             if (ret >= (REBCNT)tail) return R_BLANK;
             if (IS_BINARY(value)) {
-                SET_INTEGER(value, *BIN_AT(VAL_SERIES(value), ret));
+                Init_Integer(value, *BIN_AT(VAL_SERIES(value), ret));
             }
             else
                 str_to_char(value, value, ret);
@@ -916,7 +916,7 @@ REBTYPE(String)
         }
         if (action == SYM_PICK_P) {
             if (IS_BINARY(value)) {
-                SET_INTEGER(D_OUT, *VAL_BIN_AT_HEAD(value, index));
+                Init_Integer(D_OUT, *VAL_BIN_AT_HEAD(value, index));
             }
             else
                 str_to_char(D_OUT, value, index);
@@ -987,7 +987,7 @@ REBTYPE(String)
         //
         if (NOT(REF(part))) {
             if (IS_BINARY(value)) {
-                SET_INTEGER(value, *VAL_BIN_AT_HEAD(value, index));
+                Init_Integer(value, *VAL_BIN_AT_HEAD(value, index));
             } else
                 str_to_char(value, value, index);
         }
@@ -1248,7 +1248,7 @@ REBTYPE(String)
                 return R_BLANK;
             index += (REBCNT)Random_Int(REF(secure)) % (tail - index);
             if (IS_BINARY(value)) { // same as PICK
-                SET_INTEGER(D_OUT, *VAL_BIN_AT_HEAD(value, index));
+                Init_Integer(D_OUT, *VAL_BIN_AT_HEAD(value, index));
             }
             else
                 str_to_char(D_OUT, value, index);

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -48,7 +48,7 @@ static void fail_if_non_accessible(const REBVAL *val)
 {
     if (VAL_STRUCT_INACCESSIBLE(val)) {
         DECLARE_LOCAL (i);
-        SET_INTEGER(i, cast(REBUPT, VAL_STRUCT_DATA_HEAD(val)));
+        Init_Integer(i, cast(REBUPT, VAL_STRUCT_DATA_HEAD(val)));
         fail (Error_Bad_Memory_Raw(i, val));
     }
 }
@@ -81,7 +81,7 @@ static void get_scalar(
         //
         // Note: The original code allowed this for STU_INACCESSIBLE(stu).
         //
-        VAL_RESET_HEADER(single, REB_STRUCT);
+        Reset_Val_Header(single, REB_STRUCT);
         MANAGE_ARRAY(sub_stu);
         single->payload.structure.stu = sub_stu;
 
@@ -105,7 +105,7 @@ static void get_scalar(
         // !!! This just gets void with no error...that seems like a bad idea,
         // if the data is truly inaccessible.
         //
-        SET_VOID(out);
+        Init_Void(out);
         return;
     }
 
@@ -113,47 +113,47 @@ static void get_scalar(
 
     switch (FLD_TYPE_SYM(field)) {
     case SYM_UINT8:
-        SET_INTEGER(out, *cast(u8*, p));
+        Init_Integer(out, *cast(u8*, p));
         break;
 
     case SYM_INT8:
-        SET_INTEGER(out, *cast(i8*, p));
+        Init_Integer(out, *cast(i8*, p));
         break;
 
     case SYM_UINT16:
-        SET_INTEGER(out, *cast(u16*, p));
+        Init_Integer(out, *cast(u16*, p));
         break;
 
     case SYM_INT16:
-        SET_INTEGER(out, *cast(i8*, p));
+        Init_Integer(out, *cast(i8*, p));
         break;
 
     case SYM_UINT32:
-        SET_INTEGER(out, *cast(u32*, p));
+        Init_Integer(out, *cast(u32*, p));
         break;
 
     case SYM_INT32:
-        SET_INTEGER(out, *cast(i32*, p));
+        Init_Integer(out, *cast(i32*, p));
         break;
 
     case SYM_UINT64:
-        SET_INTEGER(out, *cast(u64*, p));
+        Init_Integer(out, *cast(u64*, p));
         break;
 
     case SYM_INT64:
-        SET_INTEGER(out, *cast(i64*, p));
+        Init_Integer(out, *cast(i64*, p));
         break;
 
     case SYM_FLOAT:
-        SET_DECIMAL(out, *cast(float*, p));
+        Init_Decimal(out, *cast(float*, p));
         break;
 
     case SYM_DOUBLE:
-        SET_DECIMAL(out, *cast(double*, p));
+        Init_Decimal(out, *cast(double*, p));
         break;
 
     case SYM_POINTER:
-        SET_INTEGER(out, cast(REBUPT, *cast(void**, p)));
+        Init_Integer(out, cast(REBUPT, *cast(void**, p)));
         break;
 
     case SYM_REBVAL:
@@ -265,7 +265,7 @@ REBARR *Struct_To_Array(REBSTU *stu)
             //
             REBCNT dimension = FLD_DIMENSION(field);
             REBARR *one_int = Alloc_Singular_Array();
-            SET_INTEGER(ARR_HEAD(one_int), dimension);
+            Init_Integer(ARR_HEAD(one_int), dimension);
             Init_Block(Alloc_Tail_Array(typespec), one_int);
 
             // Initialization seems to be just another block after that (?)
@@ -649,7 +649,7 @@ static REBSER *make_ext_storage(
 ) {
     if (raw_size >= 0 && raw_size != cast(REBINT, len)) {
         DECLARE_LOCAL (i);
-        SET_INTEGER(i, raw_size);
+        Init_Integer(i, raw_size);
         fail (Error_Invalid_Data_Raw(i));
     }
 
@@ -784,57 +784,57 @@ static void Parse_Field_Type_May_Fail(
 
         switch (sym) {
         case SYM_UINT8:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 1);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 1);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_INT8:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 1);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 1);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_UINT16:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 2);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 2);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_INT16:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 2);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 2);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_UINT32:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 4);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 4);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_INT32:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 4);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 4);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_UINT64:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 8);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 8);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_INT64:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 8);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 8);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_FLOAT:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 4);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 4);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_DOUBLE:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), 8);
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), 8);
             Prepare_Field_For_FFI(field);
             break;
 
         case SYM_POINTER:
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), sizeof(void*));
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), sizeof(void*));
             Prepare_Field_For_FFI(field);
             break;
 
@@ -847,7 +847,7 @@ static void Parse_Field_Type_May_Fail(
             Derelativize(specified, val, VAL_SPECIFIER(spec));
             MAKE_Struct(inner, REB_STRUCT, specified); // may fail()
 
-            SET_INTEGER(
+            Init_Integer(
                 FLD_AT(field, IDX_FIELD_WIDE),
                 VAL_STRUCT_DATA_LEN(inner)
             );
@@ -882,7 +882,7 @@ static void Parse_Field_Type_May_Fail(
             // to a callback's frame, the lifetime of the REBVAL* should last
             // for the entirety of the routine it was passed to.
             //
-            SET_INTEGER(FLD_AT(field, IDX_FIELD_WIDE), sizeof(REBVAL*));
+            Init_Integer(FLD_AT(field, IDX_FIELD_WIDE), sizeof(REBVAL*));
             Prepare_Field_For_FFI(field);
             break; }
 
@@ -894,7 +894,7 @@ static void Parse_Field_Type_May_Fail(
         //
         // [b: [struct-a] val-a]
         //
-        SET_INTEGER(
+        Init_Integer(
             FLD_AT(field, IDX_FIELD_WIDE),
             VAL_STRUCT_DATA_LEN(val)
         );
@@ -920,7 +920,7 @@ static void Parse_Field_Type_May_Fail(
     // Find out the array dimension (if there is one)
     //
     if (IS_END(val)) {
-        SET_BLANK(FLD_AT(field, IDX_FIELD_DIMENSION)); // scalar
+        Init_Blank(FLD_AT(field, IDX_FIELD_DIMENSION)); // scalar
     }
     else if (IS_BLOCK(val)) {
         //
@@ -941,7 +941,7 @@ static void Parse_Field_Type_May_Fail(
         if (!IS_INTEGER(ret))
             fail (Error_Unexpected_Type(REB_INTEGER, VAL_TYPE(val)));
 
-        SET_INTEGER(FLD_AT(field, IDX_FIELD_DIMENSION), VAL_INT64(ret));
+        Init_Integer(FLD_AT(field, IDX_FIELD_DIMENSION), VAL_INT64(ret));
         ++ val;
     }
     else
@@ -1067,13 +1067,13 @@ void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     // schema should be shared between common instances of the same struct.
     //
     REBFLD *schema = Make_Array(IDX_FIELD_MAX);
-    SET_BLANK(FLD_AT(schema, IDX_FIELD_NAME)); // no symbol for struct itself
+    Init_Blank(FLD_AT(schema, IDX_FIELD_NAME)); // no symbol for struct itself
     // we'll be filling in the IDX_FIELD_TYPE slot with an array of fields
-    SET_BLANK(FLD_AT(schema, IDX_FIELD_DIMENSION)); // not an array
+    Init_Blank(FLD_AT(schema, IDX_FIELD_DIMENSION)); // not an array
 
-    SET_UNREADABLE_BLANK(FLD_AT(schema, IDX_FIELD_FFTYPE));
+    Init_Unreadable_Blank(FLD_AT(schema, IDX_FIELD_FFTYPE));
 
-    SET_BLANK(FLD_AT(schema, IDX_FIELD_OFFSET)); // the offset is not used
+    Init_Blank(FLD_AT(schema, IDX_FIELD_OFFSET)); // the offset is not used
     // we'll be filling in the IDX_FIELD_WIDE at the end.
 
 
@@ -1123,8 +1123,8 @@ void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 
         REBFLD *field = Make_Array(IDX_FIELD_MAX);
 
-        SET_UNREADABLE_BLANK(FLD_AT(field, IDX_FIELD_FFTYPE));
-        SET_INTEGER(FLD_AT(field, IDX_FIELD_OFFSET), offset);
+        Init_Unreadable_Blank(FLD_AT(field, IDX_FIELD_FFTYPE));
+        Init_Integer(FLD_AT(field, IDX_FIELD_OFFSET), offset);
 
         // Must be a word or a set-word, with set-words initializing
 
@@ -1291,7 +1291,7 @@ void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     Init_Block(FLD_AT(schema, IDX_FIELD_TYPE), fieldlist);
     Prepare_Field_For_FFI(schema);
 
-    SET_INTEGER(FLD_AT(schema, IDX_FIELD_WIDE), offset); // total size known
+    Init_Integer(FLD_AT(schema, IDX_FIELD_WIDE), offset); // total size known
 
     TERM_ARRAY_LEN(schema, IDX_FIELD_MAX);
     ASSERT_ARRAY(schema);
@@ -1305,12 +1305,12 @@ void MAKE_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
     // Set it to blank so the Kill_Series can be called upon in case of error
     // thrown before it is fully constructed.
     //
-    SET_BLANK(ARR_HEAD(stu));
+    Init_Blank(ARR_HEAD(stu));
 
     MANAGE_ARRAY(schema);
     AS_SERIES(stu)->link.schema = schema;
 
-    VAL_RESET_HEADER(out, REB_STRUCT);
+    Reset_Val_Header(out, REB_STRUCT);
     out->payload.structure.stu = stu;
     if (raw_addr) {
         out->payload.structure.data
@@ -1509,7 +1509,7 @@ REBTYPE(Struct)
 
     val = D_ARG(1);
 
-    SET_VOID(D_OUT);
+    Init_Void(D_OUT);
     // unary actions
     switch(action) {
 
@@ -1549,7 +1549,7 @@ REBTYPE(Struct)
             break;
 
         case SYM_ADDR:
-            SET_INTEGER(D_OUT, cast(REBUPT, VAL_STRUCT_DATA_AT(val)));
+            Init_Integer(D_OUT, cast(REBUPT, VAL_STRUCT_DATA_AT(val)));
             break;
 
         default:
@@ -1558,7 +1558,7 @@ REBTYPE(Struct)
         break; }
 
     case SYM_LENGTH:
-        SET_INTEGER(D_OUT, VAL_STRUCT_DATA_LEN(val));
+        Init_Integer(D_OUT, VAL_STRUCT_DATA_LEN(val));
         break;
 
     default:
@@ -1584,13 +1584,13 @@ REBNATIVE(destroy_struct_storage)
     INCLUDE_PARAMS_OF_DESTROY_STRUCT_STORAGE;
 
     REBSER *data = ARG(struct)->payload.structure.data;
-    if (NOT_SER_FLAG(data, SERIES_FLAG_ARRAY))
+    if (Not_Ser_Flag(data, SERIES_FLAG_ARRAY))
         fail (Error_No_External_Storage_Raw());
 
     RELVAL *handle = ARR_HEAD(AS_ARRAY(data));
 
     DECLARE_LOCAL (pointer);
-    SET_INTEGER(pointer, cast(REBUPT, VAL_HANDLE_POINTER(void, handle)));
+    Init_Integer(pointer, cast(REBUPT, VAL_HANDLE_POINTER(void, handle)));
 
     if (VAL_HANDLE_LEN(handle) == 0)
         fail (Error_Already_Destroyed_Raw(pointer));

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -145,7 +145,7 @@ const REBYTE *Scan_Time(REBVAL *out, const REBYTE *cp, REBCNT len)
     else
         merid = '\0';
 
-    VAL_RESET_HEADER(out, REB_TIME);
+    Reset_Val_Header(out, REB_TIME);
 
     if (part3 >= 0 || part4 < 0) { // HH:MM mode
         if (merid != '\0') {
@@ -301,7 +301,7 @@ void MAKE_Time(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     if (secs == NO_TIME)
         fail (Error_Bad_Make(REB_TIME, arg));
 
-    VAL_RESET_HEADER(out, REB_TIME);
+    Reset_Val_Header(out, REB_TIME);
     VAL_TIME(out) = secs;
     VAL_DATE(out).bits = 0;
 }
@@ -359,19 +359,19 @@ void Pick_Time(REBVAL *out, const REBVAL *value, const REBVAL *picker)
 
     switch(i) {
     case 0: // hours
-        SET_INTEGER(out, tf.h);
+        Init_Integer(out, tf.h);
         break;
     case 1: // minutes
-        SET_INTEGER(out, tf.m);
+        Init_Integer(out, tf.m);
         break;
     case 2: // seconds
         if (tf.n == 0)
-            SET_INTEGER(out, tf.s);
+            Init_Integer(out, tf.s);
         else
-            SET_DECIMAL(out, cast(REBDEC, tf.s) + (tf.n * NANO));
+            Init_Decimal(out, cast(REBDEC, tf.s) + (tf.n * NANO));
         break;
     default:
-        SET_VOID(out); // "out of range" behavior for pick
+        Init_Void(out); // "out of range" behavior for pick
     }
 }
 
@@ -506,7 +506,7 @@ REBTYPE(Time)
             case SYM_DIVIDE:
                 if (secs2 == 0) fail (Error_Zero_Divide_Raw());
                 //secs /= secs2;
-                VAL_RESET_HEADER(D_OUT, REB_DECIMAL);
+                Reset_Val_Header(D_OUT, REB_DECIMAL);
                 VAL_DECIMAL(D_OUT) = (REBDEC)secs / (REBDEC)secs2;
                 return R_OUT;
 
@@ -541,7 +541,7 @@ REBTYPE(Time)
             case SYM_DIVIDE:
                 if (num == 0) fail (Error_Zero_Divide_Raw());
                 secs /= num;
-                SET_INTEGER(D_OUT, secs);
+                Init_Integer(D_OUT, secs);
                 goto setTime;
 
             case SYM_REMAINDER:
@@ -636,13 +636,13 @@ REBTYPE(Time)
                         Dec64(arg) * SEC_SEC
                     );
                     VAL_DECIMAL(arg) /= SEC_SEC;
-                    VAL_RESET_HEADER(arg, REB_DECIMAL);
+                    Reset_Val_Header(arg, REB_DECIMAL);
                     Move_Value(D_OUT, ARG(scale));
                     return R_OUT;
                 }
                 else if (IS_INTEGER(arg)) {
                     VAL_INT64(arg) = Round_Int(secs, 1, Int32(arg) * SEC_SEC) / SEC_SEC;
-                    VAL_RESET_HEADER(arg, REB_INTEGER);
+                    Reset_Val_Header(arg, REB_INTEGER);
                     Move_Value(D_OUT, ARG(scale));
                     return R_OUT;
                 }
@@ -691,6 +691,6 @@ REBTYPE(Time)
 fixTime:
 setTime:
     VAL_TIME(D_OUT) = secs;
-    VAL_RESET_HEADER(D_OUT, REB_TIME);
+    Reset_Val_Header(D_OUT, REB_TIME);
     return R_OUT;
 }

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -58,7 +58,7 @@ void MAKE_Tuple(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         return;
     }
 
-    VAL_RESET_HEADER(out, REB_TUPLE);
+    Reset_Val_Header(out, REB_TUPLE);
     REBYTE *vp = VAL_TUPLE(out);
 
     // !!! Net lookup parses IP addresses out of `tcp://93.184.216.34` or
@@ -192,9 +192,9 @@ void Pick_Tuple(REBVAL *out, const REBVAL *value, const REBVAL *picker)
 
     REBINT n = Get_Num_From_Arg(picker);
     if (n > 0 && n <= len)
-        SET_INTEGER(out, dat[n - 1]);
+        Init_Integer(out, dat[n - 1]);
     else
-        SET_VOID(out);
+        Init_Void(out);
 }
 
 
@@ -436,7 +436,7 @@ REBTYPE(Tuple)
     switch (action) {
     case SYM_LENGTH:
         len = MAX(len, 3);
-        SET_INTEGER(D_OUT, len);
+        Init_Integer(D_OUT, len);
         return R_OUT;
 
     case SYM_PICK_P:
@@ -478,7 +478,7 @@ REBTYPE(Tuple)
             fail (Error_Out_Of_Range(arg));
         }
         if (action == A_PICK) {
-            SET_INTEGER(D_OUT, vp[a-1]);
+            Init_Integer(D_OUT, vp[a-1]);
             return R_OUT;
         }
         // Poke:

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -113,7 +113,7 @@ void Startup_Typesets(void)
 //
 void Init_Typeset(RELVAL *value, REBU64 bits, REBSTR *opt_name)
 {
-    VAL_RESET_HEADER(value, REB_TYPESET);
+    Reset_Val_Header(value, REB_TYPESET);
     INIT_TYPESET_NAME(value, opt_name);
     VAL_TYPESET_BITS(value) = bits;
 }
@@ -146,7 +146,7 @@ REBOOL Update_Typeset_Bits_Core(
             fail ("Invalid double-block in typeset");
 
         item = VAL_ARRAY_AT(item);
-        SET_VAL_FLAG(typeset, TYPESET_FLAG_VARIADIC);
+        Set_Val_Flag(typeset, TYPESET_FLAG_VARIADIC);
     }
 
     for (; NOT_END(item); item++) {
@@ -173,7 +173,7 @@ REBOOL Update_Typeset_Bits_Core(
             // Notational convenience for variadic.
             // func [x [<...> integer!]] => func [x [[integer!]]]
             //
-            SET_VAL_FLAG(typeset, TYPESET_FLAG_VARIADIC);
+            Set_Val_Flag(typeset, TYPESET_FLAG_VARIADIC);
         }
         else if (
             IS_BAR(item) || (keywords && IS_TAG(item) && (
@@ -185,7 +185,7 @@ REBOOL Update_Typeset_Bits_Core(
             //
             // func [x [<end> integer!]] => func [x [| integer!]]
             //
-            SET_VAL_FLAG(typeset, TYPESET_FLAG_ENDABLE);
+            Set_Val_Flag(typeset, TYPESET_FLAG_ENDABLE);
         }
         else if (
             IS_BLANK(item) || (keywords && IS_TAG(item) && (
@@ -284,7 +284,7 @@ REBARR *Typeset_To_Array(const REBVAL *tset)
                 // indicate that they take optional values.  This may wind up
                 // as a feature of MAKE FUNCTION! only.
                 //
-                SET_BLANK(value);
+                Init_Blank(value);
             }
             else
                 Val_Init_Datatype(value, cast(enum Reb_Kind, n));

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -69,7 +69,7 @@ REBIXO Do_Vararg_Op_May_Throw(
     if (op == VARARG_OP_TAIL_Q)
         assert(out == NULL); // not expecting return result
     else
-        SET_END(out); // don't want trash in frame output on FAIL
+        Init_End(out); // don't want trash in frame output on FAIL
 #endif
 
     const RELVAL *param; // for type checking
@@ -118,7 +118,7 @@ REBIXO Do_Vararg_Op_May_Throw(
 
     REBFRM *f;
 
-    if (NOT_SER_FLAG(vararg->payload.varargs.feed, ARRAY_FLAG_VARLIST)) {
+    if (Not_Ser_Flag(vararg->payload.varargs.feed, ARRAY_FLAG_VARLIST)) {
         REBARR *array1 = vararg->payload.varargs.feed;
 
         // We are processing an ANY-ARRAY!-based varargs, which came from
@@ -137,7 +137,7 @@ REBIXO Do_Vararg_Op_May_Throw(
         // its index will be updated (or set to END when exhausted)
 
         if (VAL_INDEX(shared) >= ARR_LEN(VAL_ARRAY(shared))) {
-            SET_END(shared); // input now exhausted, mark for shared instances
+            Init_End(shared); // input now exhausted, mark for shared instances
             return END_FLAG;
         }
 
@@ -217,10 +217,10 @@ REBIXO Do_Vararg_Op_May_Throw(
         );
 
         if (IS_FUNCTION(child_gotten)) {
-            if (GET_VAL_FLAG(child_gotten, VALUE_FLAG_ENFIXED)) {
+            if (Get_Val_Flag(child_gotten, VALUE_FLAG_ENFIXED)) {
                 if (pclass == PARAM_CLASS_TIGHT)
                     return END_FLAG;
-                if (GET_VAL_FLAG(child_gotten, FUNC_FLAG_DEFERS_LOOKBACK_ARG))
+                if (Get_Val_Flag(child_gotten, FUNC_FLAG_DEFERS_LOOKBACK_ARG))
                     return END_FLAG;
             }
         }
@@ -282,10 +282,10 @@ REBIXO Do_Vararg_Op_May_Throw(
     }
 
     if (arg) {
-        if (GET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED))
-            SET_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
+        if (Get_Val_Flag(out, VALUE_FLAG_UNEVALUATED))
+            Set_Val_Flag(arg, VALUE_FLAG_UNEVALUATED);
         else
-            CLEAR_VAL_FLAG(arg, VALUE_FLAG_UNEVALUATED);
+            Clear_Val_Flag(arg, VALUE_FLAG_UNEVALUATED);
     }
 
     assert(NOT(THROWN(out))); // should have returned above
@@ -297,7 +297,7 @@ REBIXO Do_Vararg_Op_May_Throw(
     if (f == &temp_frame) {
         assert(ANY_ARRAY(shared));
         if (IS_END(f->value))
-            SET_END(shared); // signal no more to all varargs sharing value
+            Init_End(shared); // signal no more to all varargs sharing value
         else {
             // The indexor is "prefetched", so although the temp_frame would
             // be ready to use again we're throwing it away, and need to
@@ -337,7 +337,7 @@ void MAKE_Varargs(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         Move_Value(ARR_HEAD(array1), arg);
         MANAGE_ARRAY(array1);
 
-        VAL_RESET_HEADER(out, REB_VARARGS);
+        Reset_Val_Header(out, REB_VARARGS);
         out->extra.binding = NULL;
     #if !defined(NDEBUG)
         out->payload.varargs.param_offset = -1020;
@@ -391,7 +391,7 @@ REBTYPE(Varargs)
         indexor = Do_Vararg_Op_May_Throw(D_OUT, value, VARARG_OP_FIRST);
         assert(indexor == VA_LIST_FLAG || indexor == END_FLAG); // no throw
         if (indexor == END_FLAG)
-            SET_BLANK(D_OUT); // want to be consistent with TAKE
+            Init_Blank(D_OUT); // want to be consistent with TAKE
 
         return R_OUT;
     }
@@ -419,7 +419,7 @@ REBTYPE(Varargs)
                 return R_OUT_IS_THROWN;
 
             if (indexor == END_FLAG)
-                SET_VOID(D_OUT); // currently allowed even without an /OPT
+                Init_Void(D_OUT); // currently allowed even without an /OPT
 
             return R_OUT;
         }
@@ -550,7 +550,7 @@ void Mold_Varargs(const REBVAL *v, REB_MOLD *mold) {
 
     REBARR *feed = v->payload.varargs.feed;
 
-    if (NOT_SER_FLAG(feed, ARRAY_FLAG_VARLIST)) {
+    if (Not_Ser_Flag(feed, ARRAY_FLAG_VARLIST)) {
         REBARR *array1 = feed;
 
         { // Just [...] for now

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -213,7 +213,7 @@ REBARR *Vector_To_Array(const REBVAL *vect)
     RELVAL *val = ARR_HEAD(array);
     REBCNT n;
     for (n = VAL_INDEX(vect); n < VAL_LEN_HEAD(vect); n++, val++) {
-        VAL_RESET_HEADER(val, (type >= VTSF08) ? REB_DECIMAL : REB_INTEGER);
+        Reset_Val_Header(val, (type >= VTSF08) ? REB_DECIMAL : REB_INTEGER);
         VAL_INT64(val) = get_vect(type, data, n); // can be int or decimal
     }
 
@@ -293,12 +293,12 @@ void Set_Vector_Value(REBVAL *var, REBSER *series, REBCNT index)
     REBCNT bits = VECT_TYPE(series);
 
     if (bits >= VTSF08) {
-        VAL_RESET_HEADER(var, REB_DECIMAL);
+        Reset_Val_Header(var, REB_DECIMAL);
         REBU64 u =  get_vect(bits, data, index);
         Init_Decimal_Bits(var, cast(REBYTE*, &u));
     }
     else {
-        VAL_RESET_HEADER(var, REB_INTEGER);
+        Reset_Val_Header(var, REB_INTEGER);
         VAL_INT64(var) = get_vect(bits, data, index);
     }
 }
@@ -419,7 +419,7 @@ REBVAL *Make_Vector_Spec(RELVAL *bp, REBSPC *specifier, REBVAL *value)
         bp++;
     }
 
-    VAL_RESET_HEADER(value, REB_VECTOR);
+    Reset_Val_Header(value, REB_VECTOR);
 
     // Index offset:
     if (NOT_END(bp) && IS_INTEGER(bp)) {
@@ -508,7 +508,7 @@ void Pick_Vector(REBVAL *out, const REBVAL *value, const REBVAL *picker) {
     n += VAL_INDEX(value);
 
     if (n <= 0 || cast(REBCNT, n) > SER_LEN(vect)) {
-        SET_VOID(out); // out of range of vector data
+        Init_Void(out); // out of range of vector data
         return;
     }
 
@@ -516,9 +516,9 @@ void Pick_Vector(REBVAL *out, const REBVAL *value, const REBVAL *picker) {
     REBINT bits = VECT_TYPE(vect);
 
     if (bits < VTSF08)
-        SET_INTEGER(out, get_vect(bits, vp, n - 1)); // 64-bit
+        Init_Integer(out, get_vect(bits, vp, n - 1)); // 64-bit
     else {
-        VAL_RESET_HEADER(out, REB_DECIMAL);
+        Reset_Val_Header(out, REB_DECIMAL);
         REBI64 i = get_vect(bits, vp, n - 1);
         Init_Decimal_Bits(out, cast(REBYTE*, &i));
     }
@@ -627,7 +627,7 @@ REBTYPE(Vector)
 
     case SYM_LENGTH:
         //bits = 1 << (vect->size & 3);
-        SET_INTEGER(D_OUT, SER_LEN(vect));
+        Init_Integer(D_OUT, SER_LEN(vect));
         return R_OUT;
 
     case SYM_COPY: {

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -79,7 +79,7 @@ void MAKE_Word(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
         // stay in sync with the binding state)
         //
         Move_Value(out, arg);
-        VAL_SET_TYPE_BITS(out, kind);
+        Reset_Val_Kind(out, kind);
         return;
     }
 
@@ -157,7 +157,7 @@ REBTYPE(Word)
             if (ch == 0)
                 break;
         }
-        SET_INTEGER(D_OUT, len);
+        Init_Integer(D_OUT, len);
         return R_OUT; }
 
     default:

--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -125,7 +125,7 @@ static REBCTX *Error_Compression(const z_stream *strm, int ret)
     if (strm->msg != NULL)
         Init_String(arg, Make_UTF8_May_Fail(strm->msg));
     else
-        SET_INTEGER(arg, ret);
+        Init_Integer(arg, ret);
 
     return Error_Bad_Compression_Raw(arg);
 }
@@ -275,7 +275,7 @@ REBSER *Decompress(
         //
         if (max >= 0 && buf_size > cast(REBCNT, max)) {
             DECLARE_LOCAL (temp);
-            SET_INTEGER(temp, max);
+            Init_Integer(temp, max);
 
             // NOTE: You can hit this if you 'make prep' without doing a full
             // rebuild.  'make clean' and build again, it should go away.
@@ -379,7 +379,7 @@ REBSER *Decompress(
 
         if (max >= 0 && buf_size >= cast(REBCNT, max)) {
             DECLARE_LOCAL (temp);
-            SET_INTEGER(temp, max);
+            Init_Integer(temp, max);
 
             // NOTE: You can hit this on 'make prep' without doing a full
             // rebuild.  'make clean' and build again, it should go away.

--- a/src/extensions/mod-crypt.c
+++ b/src/extensions/mod-crypt.c
@@ -605,7 +605,7 @@ static REBNATIVE(aes)
         REBINT len = VAL_LEN_AT(ARG(crypt_key)) << 3;
         if (len != 128 && len != 256) {
             DECLARE_LOCAL (i);
-            SET_INTEGER(i, len);
+            Init_Integer(i, len);
             fail (Error(RE_EXT_CRYPT_INVALID_AES_KEY_LENGTH, i));
         }
 

--- a/src/include/mem-series.h
+++ b/src/include/mem-series.h
@@ -50,14 +50,14 @@ inline static void SER_SET_WIDE(REBSER *s, REBYTE w) {
 //
 
 inline static REBCNT SER_BIAS(REBSER *s) {
-    assert(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC));
+    assert(Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC));
     return cast(REBCNT, ((s)->content.dynamic.bias >> 16) & 0xffff);
 }
 
 #define MAX_SERIES_BIAS 0x1000
 
 inline static void SER_SET_BIAS(REBSER *s, REBCNT bias) {
-    assert(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC));
+    assert(Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC));
     s->content.dynamic.bias =
         (s->content.dynamic.bias & 0xffff) | (bias << 16);
 }
@@ -73,7 +73,7 @@ inline static size_t SER_TOTAL(REBSER *s) {
 }
 
 inline static size_t SER_TOTAL_IF_DYNAMIC(REBSER *s) {
-    if (NOT_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
+    if (Not_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC))
         return 0;
     return SER_TOTAL(s);
 }

--- a/src/include/reb-struct.h
+++ b/src/include/reb-struct.h
@@ -399,7 +399,7 @@ inline static REBCNT STU_OFFSET(REBSTU *stu) {
 
 inline static REBYTE *VAL_STRUCT_DATA_HEAD(const RELVAL *v) {
     REBSER *data = v->payload.structure.data;
-    if (NOT_SER_FLAG(data, SERIES_FLAG_ARRAY))
+    if (Not_Ser_Flag(data, SERIES_FLAG_ARRAY))
         return BIN_HEAD(data);
 
     RELVAL *handle = ARR_HEAD(AS_ARRAY(data));
@@ -420,7 +420,7 @@ inline static REBYTE *VAL_STRUCT_DATA_AT(const RELVAL *v) {
 
 inline static REBCNT VAL_STRUCT_DATA_LEN(const RELVAL *v) {
     REBSER *data = v->payload.structure.data;
-    if (NOT_SER_FLAG(data, SERIES_FLAG_ARRAY))
+    if (Not_Ser_Flag(data, SERIES_FLAG_ARRAY))
         return BIN_LEN(data);
 
     RELVAL *handle = ARR_HEAD(AS_ARRAY(data));
@@ -434,7 +434,7 @@ inline static REBCNT STU_DATA_LEN(REBSTU *stu) {
 
 inline static REBOOL VAL_STRUCT_INACCESSIBLE(const RELVAL *v) {
     REBSER *data = v->payload.structure.data;
-    if (NOT_SER_FLAG(data, SERIES_FLAG_ARRAY))
+    if (Not_Ser_Flag(data, SERIES_FLAG_ARRAY))
         return FALSE; // it's not "external", so never inaccessible
 
     RELVAL *handle = ARR_HEAD(AS_ARRAY(data));

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -46,13 +46,13 @@ enum Reb_Result {
     //
     // http://stackoverflow.com/questions/2725044/
     //
-    R_FALSE = 0, // => SET_FALSE(D_OUT); return R_OUT;
-    R_TRUE = 1, // => SET_TRUE(D_OUT); return R_OUT;
+    R_FALSE = 0, // => Init_False(D_OUT); return R_OUT;
+    R_TRUE = 1, // => Init_True(D_OUT); return R_OUT;
 
     // Void and blank are also common results.
     //
-    R_VOID, // => SET_VOID(D_OUT); return R_OUT;
-    R_BLANK, // => SET_BLANK(D_OUT); return R_OUT;
+    R_VOID, // => Init_Void(D_OUT); return R_OUT;
+    R_BLANK, // => Init_Blank(D_OUT); return R_OUT;
     R_BAR, // SET_BAR(D_OUT); return R_OUT;
 
     // This means that the value in D_OUT is to be used as the return result.

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -32,7 +32,7 @@
 // when Make_Array() was called.  But this always had to be an END.
 //
 // In Ren-C, there is an implicit END marker just past the last cell in the
-// capacity.  Allowing a SET_END() on this position could corrupt the END
+// capacity.  Allowing a Init_End() on this position could corrupt the END
 // signaling slot, which only uses a bit out of a Reb_Header sized item to
 // signal.  Use TERM_ARRAY_LEN() to safely terminate arrays and respect not
 // writing if it's past capacity.
@@ -71,7 +71,7 @@ struct Reb_Array {
             "AS_ARRAY works on: void*, REBNOD*, REBSER*"
         );
         REBSER *s = cast(REBSER*, p);
-        assert(GET_SER_FLAG(s, SERIES_FLAG_ARRAY));
+        assert(Get_Ser_Flag(s, SERIES_FLAG_ARRAY));
         return cast(REBARR*, s);
     }
 #else
@@ -104,7 +104,7 @@ inline static RELVAL *ARR_LAST(REBARR *a)
 // performance reasons (for better or worse).
 //
 inline static REBCNT ARR_LEN(REBARR *a) {
-    assert(GET_SER_FLAG(a, SERIES_FLAG_ARRAY));
+    assert(Get_Ser_Flag(a, SERIES_FLAG_ARRAY));
     return SER_LEN(AS_SERIES(a));
 }
 
@@ -122,7 +122,7 @@ inline static void TERM_ARRAY_LEN(REBARR *a, REBCNT len) {
     if (len + 1 == rest)
         assert(IS_END(ARR_TAIL(a)));
     else
-        SET_END(ARR_TAIL(a));
+        Init_End(ARR_TAIL(a));
 }
 
 inline static void SET_ARRAY_LEN_NOTERM(REBARR *a, REBCNT len) {
@@ -134,7 +134,7 @@ inline static void RESET_ARRAY(REBARR *a) {
 }
 
 inline static void TERM_SERIES(REBSER *s) {
-    if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+    if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY))
         TERM_ARRAY_LEN(AS_ARRAY(s), SER_LEN(s));
     else
         memset(SER_AT_RAW(SER_WIDE(s), s, SER_LEN(s)), 0, SER_WIDE(s));
@@ -183,7 +183,7 @@ inline static void DROP_GUARD_ARRAY_CONTENTS(REBARR *a) {
 //
 
 inline static REBOOL Is_Array_Deeply_Frozen(REBARR *a) {
-    return GET_SER_INFO(a, SERIES_INFO_FROZEN);
+    return Get_Ser_Info(a, SERIES_INFO_FROZEN);
 
     // should be frozen all the way down (can only freeze arrays deeply)
 }
@@ -218,8 +218,8 @@ inline static REBARR *Make_Array_Core(REBCNT capacity, REBUPT flags)
 
     assert(
         capacity <= 1
-            ? NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
-            : GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
+            ? NOT(Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC))
+            : Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)
     );
 
     REBARR *a = AS_ARRAY(s);
@@ -244,7 +244,7 @@ inline static REBARR *Alloc_Singular_Array_Core(REBUPT flags) {
         sizeof(REBVAL),
         SERIES_FLAG_ARRAY | SERIES_FLAG_FIXED_SIZE | flags
     );
-    assert(NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)));
+    assert(NOT(Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)));
 
     // The length still needs to be set in the header, as it defaults
     // to 0 and we want it to be 1.
@@ -413,7 +413,7 @@ inline static RELVAL *VAL_ARRAY_TAIL(const RELVAL *v) {
         ASSERT_SERIES_MANAGED(AS_SERIES(array))
 
     static inline void ASSERT_SERIES(REBSER *s) {
-        if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+        if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY))
             Assert_Array_Core(AS_ARRAY(s));
         else
             Assert_Series_Core(s);

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -91,7 +91,7 @@ inline static REBOOL Try_Add_Binder_Index(
     REBINT index
 ){
     assert(index != 0);
-    assert(GET_SER_INFO(canon, STRING_INFO_CANON));
+    assert(Get_Ser_Info(canon, STRING_INFO_CANON));
     if (binder->high) {
         if (canon->misc.bind_index.high != 0)
             return FALSE;
@@ -129,7 +129,7 @@ inline static REBINT Try_Get_Binder_Index( // 0 if not present
     struct Reb_Binder *binder,
     REBSTR *canon
 ){
-    assert(GET_SER_INFO(canon, STRING_INFO_CANON));
+    assert(Get_Ser_Info(canon, STRING_INFO_CANON));
 
     if (binder->high)
         return canon->misc.bind_index.high;
@@ -142,7 +142,7 @@ inline static REBINT Try_Remove_Binder_Index( // 0 if failure, else old index
     struct Reb_Binder *binder,
     REBSTR *canon
 ){
-    assert(GET_SER_INFO(canon, STRING_INFO_CANON));
+    assert(Get_Ser_Info(canon, STRING_INFO_CANON));
 
     REBINT old_index;
     if (binder->high) {
@@ -245,7 +245,7 @@ inline static REBVAL *Get_Var_Core(
 
     assert(ANY_WORD(any_word));
 
-    if (GET_VAL_FLAG(any_word, VALUE_FLAG_RELATIVE)) {
+    if (Get_Val_Flag(any_word, VALUE_FLAG_RELATIVE)) {
         //
         // RELATIVE BINDING: The word was made during a deep copy of the block
         // that was given as a function's body, and stored a reference to that
@@ -253,7 +253,7 @@ inline static REBVAL *Get_Var_Core(
         // find the right function call on the stack (if any) for the word to
         // refer to (the FRAME!)
         //
-        assert(GET_VAL_FLAG(any_word, WORD_FLAG_BOUND)); // should be set too
+        assert(Get_Val_Flag(any_word, WORD_FLAG_BOUND)); // should be set too
 
     #if !defined(NDEBUG)
         if (specifier == SPECIFIED) {
@@ -268,7 +268,7 @@ inline static REBVAL *Get_Var_Core(
             VAL_WORD_FUNC(any_word) == VAL_FUNC(CTX_FRAME_FUNC_VALUE(context))
         );
     }
-    else if (GET_VAL_FLAG(any_word, WORD_FLAG_BOUND)) {
+    else if (Get_Val_Flag(any_word, WORD_FLAG_BOUND)) {
         //
         // SPECIFIC BINDING: The context the word is bound to is explicitly
         // contained in the `any_word` REBVAL payload.  Just extract it.
@@ -337,7 +337,7 @@ inline static REBVAL *Get_Var_Core(
         // The PROTECT command has a finer-grained granularity for marking
         // not just contexts, but individual fields as protected.
         //
-        if (GET_VAL_FLAG(var, VALUE_FLAG_PROTECTED))
+        if (Get_Val_Flag(var, VALUE_FLAG_PROTECTED))
             fail (Error_Protected_Word_Raw(any_word));
 
     }

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -73,7 +73,7 @@ struct Reb_Context {
 //
 inline static REBCTX *AS_CONTEXT(void *p) {
     REBARR *a = AS_ARRAY(p);
-    assert(GET_SER_FLAG(a, ARRAY_FLAG_VARLIST));
+    assert(Get_Ser_Flag(a, ARRAY_FLAG_VARLIST));
     return cast(REBCTX*, a);
 }
 
@@ -98,12 +98,12 @@ inline static REBARR *CTX_KEYLIST(REBCTX *c) {
 }
 
 static inline void INIT_CTX_KEYLIST_SHARED(REBCTX *c, REBARR *keylist) {
-    SET_SER_INFO(keylist, SERIES_INFO_SHARED_KEYLIST);
+    Set_Ser_Info(keylist, SERIES_INFO_SHARED_KEYLIST);
     AS_SERIES(CTX_VARLIST(c))->link.keylist = keylist;
 }
 
 static inline void INIT_CTX_KEYLIST_UNIQUE(REBCTX *c, REBARR *keylist) {
-    assert(NOT_SER_INFO(keylist, SERIES_INFO_SHARED_KEYLIST));
+    assert(Not_Ser_Info(keylist, SERIES_INFO_SHARED_KEYLIST));
     AS_SERIES(CTX_VARLIST(c))->link.keylist = keylist;
 }
 
@@ -143,7 +143,7 @@ inline static REBVAL *CTX_KEYS_HEAD(REBCTX *c) {
 // REBSER node data itself.
 //
 inline static REBVAL *CTX_VALUE(REBCTX *c) {
-    return GET_SER_FLAG(CTX_VARLIST(c), CONTEXT_FLAG_STACK)
+    return Get_Ser_Flag(CTX_VARLIST(c), CONTEXT_FLAG_STACK)
         ? KNOWN(&AS_SERIES(CTX_VARLIST(c))->content.values[0])
         : KNOWN(ARR_HEAD(CTX_VARLIST(c))); // not a RELVAL
 }
@@ -162,7 +162,7 @@ inline static REBFRM *CTX_FRAME_IF_ON_STACK(REBCTX *c) {
 }
 
 inline static REBVAL *CTX_VARS_HEAD(REBCTX *c) {
-    if (NOT(GET_SER_FLAG(CTX_VARLIST(c), CONTEXT_FLAG_STACK)))
+    if (NOT(Get_Ser_Flag(CTX_VARLIST(c), CONTEXT_FLAG_STACK)))
         return KNOWN(ARR_AT(CTX_VARLIST(c), 1));
 
     REBFRM *f = CTX_FRAME_IF_ON_STACK(c);
@@ -180,7 +180,7 @@ inline static REBVAL *CTX_KEY(REBCTX *c, REBCNT n) {
 inline static REBVAL *CTX_VAR(REBCTX *c, REBCNT n) {
     REBVAL *var;
     assert(n != 0 && n <= CTX_LEN(c));
-    assert(GET_SER_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
+    assert(Get_Ser_Flag(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
 
     var = CTX_VARS_HEAD(c) + (n) - 1;
 
@@ -225,8 +225,8 @@ inline static REBOOL CTX_VARS_UNAVAILABLE(REBCTX *c) {
     // Mechanically any array can become inaccessible, but really the varlist
     // of a stack context is the only case that should happen today.
     //
-    if (GET_SER_INFO(CTX_VARLIST(c), SERIES_INFO_INACCESSIBLE)) {
-        assert(GET_SER_FLAG(CTX_VARLIST(c), CONTEXT_FLAG_STACK));
+    if (Get_Ser_Info(CTX_VARLIST(c), SERIES_INFO_INACCESSIBLE)) {
+        assert(Get_Ser_Flag(CTX_VARLIST(c), CONTEXT_FLAG_STACK));
         return TRUE;
     }
     return FALSE;
@@ -361,7 +361,7 @@ inline static void Deep_Freeze_Context(REBCTX *c) {
 }
 
 inline static REBOOL Is_Context_Deeply_Frozen(REBCTX *c) {
-    return GET_SER_INFO(CTX_VARLIST(c), SERIES_INFO_FROZEN);
+    return Get_Ser_Info(CTX_VARLIST(c), SERIES_INFO_FROZEN);
 }
 
 
@@ -409,7 +409,7 @@ inline static REBOOL Is_Context_Deeply_Frozen(REBCTX *c) {
 // repeating the code.
 //
 inline static void FAIL_IF_BAD_PORT(REBCTX *port) {
-    assert(GET_SER_FLAG(CTX_VARLIST(port), ARRAY_FLAG_VARLIST));
+    assert(Get_Ser_Flag(CTX_VARLIST(port), ARRAY_FLAG_VARLIST));
 
     if (
         (CTX_LEN(port) < STD_PORT_MAX - 1) ||

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -697,8 +697,8 @@ inline static void SET_SIGNAL(REBFLGS f) {
 ***********************************************************************/
 
 #ifdef NDEBUG
-    #define SET_VOID_UNLESS_LEGACY_NONE(v) \
-        SET_VOID(v) // LEGACY() only available in Debug builds
+    #define Init_Void_UNLESS_LEGACY_NONE(v) \
+        Init_Void(v) // LEGACY() only available in Debug builds
 #else
     #define LEGACY(option) ( \
         (PG_Boot_Phase >= BOOT_ERRORS) \
@@ -713,11 +713,11 @@ inline static void SET_SIGNAL(REBFLGS f) {
     // return a BLANK! value instead of no value.  See implementation notes.
     //
     #ifdef NDEBUG
-        #define SET_VOID_UNLESS_LEGACY_NONE(v) \
-            SET_VOID(v) // LEGACY() only available in Debug builds
+        #define Init_Void_UNLESS_LEGACY_NONE(v) \
+            Init_Void(v) // LEGACY() only available in Debug builds
     #else
-        #define SET_VOID_UNLESS_LEGACY_NONE(v) \
-            SET_VOID_UNLESS_LEGACY_NONE_Debug(v, __FILE__, __LINE__);
+        #define Init_Void_UNLESS_LEGACY_NONE(v) \
+            Init_Void_UNLESS_LEGACY_NONE_Debug(v, __FILE__, __LINE__);
     #endif
 
 #endif

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -153,10 +153,10 @@ inline static void Push_Frame_Core(REBFRM *f)
     f->prior = TG_Frame_Stack;
     TG_Frame_Stack = f;
     if (NOT(f->flags.bits & DO_FLAG_VA_LIST)) {
-        if (GET_SER_INFO(f->source.array, SERIES_INFO_RUNNING))
+        if (Get_Ser_Info(f->source.array, SERIES_INFO_RUNNING))
             NOOP; // already temp-locked
         else {
-            SET_SER_INFO(f->source.array, SERIES_INFO_RUNNING);
+            Set_Ser_Info(f->source.array, SERIES_INFO_RUNNING);
             f->flags.bits |= DO_FLAG_TOOK_FRAME_LOCK;
         }
     }
@@ -168,8 +168,8 @@ inline static void UPDATE_EXPRESSION_START(REBFRM *f) {
 
 inline static void Drop_Frame_Core(REBFRM *f) {
     if (f->flags.bits & DO_FLAG_TOOK_FRAME_LOCK) {
-        assert(GET_SER_INFO(f->source.array, SERIES_INFO_RUNNING));
-        CLEAR_SER_INFO(f->source.array, SERIES_INFO_RUNNING);
+        assert(Get_Ser_Info(f->source.array, SERIES_INFO_RUNNING));
+        Clear_Ser_Info(f->source.array, SERIES_INFO_RUNNING);
     }
     assert(TG_Frame_Stack == f);
     TG_Frame_Stack = f->prior;
@@ -286,7 +286,7 @@ inline static REBOOL Do_Next_In_Frame_Throws(
     assert(f->eval_type == REB_0); // see notes in Push_Frame_At()
     assert(NOT(f->flags.bits & DO_FLAG_TO_END));
 
-    SET_END(out);
+    Init_End(out);
     f->out = out;
     Do_Core(f); // should already be pushed
 
@@ -322,7 +322,7 @@ inline static REBOOL Do_Next_Mid_Frame_Throws(REBFRM *f) {
     assert(f->state.dsp == f->dsp_orig);
 #endif
 
-    SET_END(f->out);
+    Init_End(f->out);
     Do_Core(f); // should already be pushed
 
     // The & on the following line is purposeful.  See Init_Endlike_Header.
@@ -387,7 +387,7 @@ inline static REBOOL Do_Next_In_Subframe_Throws(
 
     child->gotten = parent->gotten;
 
-    SET_END(out);
+    Init_End(out);
     child->out = out;
 
     child->source = parent->source;
@@ -420,7 +420,7 @@ inline static REBOOL Do_Next_In_Subframe_Throws(
 
 inline static void Quote_Next_In_Frame(REBVAL *dest, REBFRM *f) {
     Derelativize(dest, f->value, f->specifier);
-    SET_VAL_FLAG(dest, VALUE_FLAG_UNEVALUATED);
+    Set_Val_Flag(dest, VALUE_FLAG_UNEVALUATED);
     f->gotten = END;
     Fetch_Next_In_Frame(f);
 }
@@ -466,7 +466,7 @@ inline static REBIXO DO_NEXT_MAY_THROW(
 
     SET_FRAME_VALUE(f, ARR_AT(array, index));
     if (IS_END(f->value)) {
-        SET_VOID(out);
+        Init_Void(out);
         return END_FLAG;
     }
 
@@ -479,7 +479,7 @@ inline static REBIXO DO_NEXT_MAY_THROW(
     f->pending = NULL;
     f->gotten = END;
 
-    SET_END(out);
+    Init_End(out);
     f->out = out;
 
     Push_Frame_Core(f);    
@@ -525,11 +525,11 @@ inline static REBIXO Do_Array_At_Core(
     }
 
     if (IS_END(f.value)) {
-        SET_VOID(out);
+        Init_Void(out);
         return END_FLAG;
     }
 
-    SET_END(out);
+    Init_End(out);
     f.out = out;
 
     f.source.array = array;
@@ -646,14 +646,14 @@ inline static void Reify_Va_To_Array_In_Frame(
 
     f->source.array = Pop_Stack_Values(dsp_orig); // may contain voids
     MANAGE_ARRAY(f->source.array); // held alive while frame running
-    SET_SER_FLAG(f->source.array, ARRAY_FLAG_VOIDS_LEGAL);
+    Set_Ser_Flag(f->source.array, ARRAY_FLAG_VOIDS_LEGAL);
 
     // The array just popped into existence, and it's tied to a running
     // frame...so safe to say we locked it.  (This would be more complex if
     // we reused the empty array if dsp_orig == DSP, since someone else
     // might have it locked...not worth the complexity.) 
     //
-    SET_SER_INFO(f->source.array, SERIES_INFO_RUNNING);
+    Set_Ser_Info(f->source.array, SERIES_INFO_RUNNING);
     f->flags.bits |= DO_FLAG_TOOK_FRAME_LOCK;
 
     if (truncated)
@@ -724,11 +724,11 @@ inline static REBIXO Do_Va_Core(
     }
 
     if (IS_END(f.value)) {
-        SET_VOID(out);
+        Init_Void(out);
         return END_FLAG;
     }
 
-    SET_END(out);
+    Init_End(out);
     f.out = out;
 
 #if !defined(NDEBUG)

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -44,12 +44,12 @@ inline static REBARR *VAL_BINDING(const RELVAL *v) {
 }
 
 inline static void INIT_RELATIVE(RELVAL *v, REBFUN *func) {
-    assert(GET_VAL_FLAG(v, VALUE_FLAG_RELATIVE));
+    assert(Get_Val_Flag(v, VALUE_FLAG_RELATIVE));
     v->extra.binding = FUNC_PARAMLIST(func);
 }
 
 inline static void INIT_SPECIFIC(RELVAL *v, REBCTX *context) {
-    assert(NOT_VAL_FLAG(v, VALUE_FLAG_RELATIVE));
+    assert(Not_Val_Flag(v, VALUE_FLAG_RELATIVE));
     v->extra.binding = CTX_VARLIST(context);
 }
 
@@ -77,13 +77,13 @@ inline static void INIT_SPECIFIC(RELVAL *v, REBCTX *context) {
 //
 
 #define THROWN(v) \
-    GET_VAL_FLAG((v), VALUE_FLAG_THROWN)
+    Get_Val_Flag((v), VALUE_FLAG_THROWN)
 
 static inline void CONVERT_NAME_TO_THROWN(
     REBVAL *name, const REBVAL *arg
 ){
     assert(!THROWN(name));
-    SET_VAL_FLAG(name, VALUE_FLAG_THROWN);
+    Set_Val_Flag(name, VALUE_FLAG_THROWN);
 
     assert(IS_UNREADABLE_IF_DEBUG(&TG_Thrown_Arg));
     Move_Value(&TG_Thrown_Arg, arg);
@@ -95,11 +95,11 @@ static inline void CATCH_THROWN(REBVAL *arg_out, REBVAL *thrown) {
     //
     assert(NOT_END(thrown));
     assert(THROWN(thrown));
-    CLEAR_VAL_FLAG(thrown, VALUE_FLAG_THROWN);
+    Clear_Val_Flag(thrown, VALUE_FLAG_THROWN);
 
     assert(!IS_UNREADABLE_IF_DEBUG(&TG_Thrown_Arg));
     Move_Value(arg_out, &TG_Thrown_Arg);
-    SET_UNREADABLE_BLANK(&TG_Thrown_Arg);
+    Init_Unreadable_Blank(&TG_Thrown_Arg);
 }
 
 
@@ -203,7 +203,7 @@ inline static REBFUN *FRM_UNDERLYING(REBFRM *f) {
         REBVAL *var = &f->args_head[n - 1];
 
         assert(!THROWN(var));
-        assert(NOT_VAL_FLAG(var, VALUE_FLAG_RELATIVE));
+        assert(Not_Val_Flag(var, VALUE_FLAG_RELATIVE));
         return var;
     }
 #endif
@@ -395,7 +395,7 @@ inline static void SET_FRAME_VALUE(REBFRM *f, const RELVAL *value) {
 inline static void Enter_Native(REBFRM *f) {
     f->flags.bits |= DO_FLAG_NATIVE_HOLD;
     if (f->varlist != NULL)
-        SET_SER_INFO(f->varlist, SERIES_INFO_RUNNING);
+        Set_Ser_Info(f->varlist, SERIES_INFO_RUNNING);
 }
 
 
@@ -504,7 +504,7 @@ inline static void Push_Or_Alloc_Args_For_Underlying_Func(
     // to check.  Note that this can only be done after extracting the function
     // properties, as f->gotten may be f->cell.
     //
-    SET_END(&f->cell);
+    Init_End(&f->cell);
 }
 
 
@@ -549,7 +549,7 @@ inline static void Drop_Function_Args_For_Frame_Core(
             goto finished;
     }
 
-    assert(GET_SER_FLAG(f->varlist, SERIES_FLAG_ARRAY));
+    assert(Get_Ser_Flag(f->varlist, SERIES_FLAG_ARRAY));
 
     if (NOT(IS_ARRAY_MANAGED(f->varlist))) {
         //
@@ -574,24 +574,24 @@ inline static void Drop_Function_Args_For_Frame_Core(
 
     ASSERT_ARRAY_MANAGED(f->varlist);
 
-    if (NOT(GET_SER_FLAG(f->varlist, CONTEXT_FLAG_STACK))) {
+    if (NOT(Get_Ser_Flag(f->varlist, CONTEXT_FLAG_STACK))) {
         //
         // If there's no stack memory being tracked by this context, it
         // has dynamic memory and is being managed by the garbage collector
         // so there's nothing to do.
         //
-        assert(GET_SER_INFO(f->varlist, SERIES_INFO_HAS_DYNAMIC));
+        assert(Get_Ser_Info(f->varlist, SERIES_INFO_HAS_DYNAMIC));
         goto finished;
     }
 
     // It's reified but has its data pointer into the chunk stack, which
     // means we have to free it and mark the array inaccessible.
 
-    assert(GET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST));
-    assert(NOT_SER_INFO(f->varlist, SERIES_INFO_HAS_DYNAMIC));
+    assert(Get_Ser_Flag(f->varlist, ARRAY_FLAG_VARLIST));
+    assert(Not_Ser_Info(f->varlist, SERIES_INFO_HAS_DYNAMIC));
 
-    assert(NOT_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE));
-    SET_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE);
+    assert(Not_Ser_Info(f->varlist, SERIES_INFO_INACCESSIBLE));
+    Set_Ser_Info(f->varlist, SERIES_INFO_INACCESSIBLE);
 
 finished:
 
@@ -609,7 +609,7 @@ inline static REBCTX *Context_For_Frame_May_Reify_Managed(REBFRM *f)
 {
     assert(NOT(Is_Function_Frame_Fulfilling(f)));
 
-    if (f->varlist == NULL || NOT_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST))
+    if (f->varlist == NULL || Not_Ser_Flag(f->varlist, ARRAY_FLAG_VARLIST))
         Reify_Frame_Context_Maybe_Fulfilling(f); // it's not fulfilling, here
 
     return AS_CONTEXT(f->varlist);

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -50,7 +50,7 @@ struct Reb_Func {
             "AS_FUNC works on: void*, REBNOD*, REBSER*, REBARR*"
         );
         REBARR *paramlist = cast(REBARR*, p);
-        assert(GET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST));
+        assert(Get_Ser_Flag(paramlist, ARRAY_FLAG_PARAMLIST));
         return cast(REBFUN*, paramlist);
     }
 #else
@@ -60,7 +60,7 @@ struct Reb_Func {
 
 
 inline static REBARR *FUNC_PARAMLIST(REBFUN *f) {
-    assert(GET_SER_FLAG(&f->paramlist, ARRAY_FLAG_PARAMLIST));
+    assert(Get_Ser_Flag(&f->paramlist, ARRAY_FLAG_PARAMLIST));
     return &f->paramlist;
 }
 
@@ -104,8 +104,8 @@ inline static REBARR *FUNC_FACADE(REBFUN *f) {
     assert(IS_FUNCTION(ARR_HEAD(facade)));
     REBARR *underlying = ARR_HEAD(facade)->payload.function.paramlist;
     if (underlying != facade) {
-        assert(NOT_SER_FLAG(facade, ARRAY_FLAG_PARAMLIST));
-        assert(GET_SER_FLAG(underlying, ARRAY_FLAG_PARAMLIST));
+        assert(Not_Ser_Flag(facade, ARRAY_FLAG_PARAMLIST));
+        assert(Get_Ser_Flag(underlying, ARRAY_FLAG_PARAMLIST));
         assert(ARR_LEN(facade) == ARR_LEN(underlying));
     }
 #endif
@@ -314,7 +314,7 @@ inline static REBRIN *VAL_FUNC_ROUTINE(const RELVAL *v) {
 inline static REBOOL IS_FUNC_DURABLE(REBFUN *f) {
     return LOGICAL(
         FUNC_NUM_PARAMS(f) != 0
-        && GET_VAL_FLAG(FUNC_PARAM(f, 1), TYPESET_FLAG_DURABLE)
+        && Get_Val_Flag(FUNC_PARAM(f, 1), TYPESET_FLAG_DURABLE)
     );
 }
 

--- a/src/include/sys-handle.h
+++ b/src/include/sys-handle.h
@@ -72,7 +72,7 @@ inline static REBUPT VAL_HANDLE_LEN(const RELVAL *v) {
 
 inline static void *VAL_HANDLE_VOID_POINTER(const RELVAL *v) {
     assert(IS_HANDLE(v));
-    assert(NOT_VAL_FLAG(v, HANDLE_FLAG_CFUNC));
+    assert(Not_Val_Flag(v, HANDLE_FLAG_CFUNC));
     if (v->extra.singular)
         return ARR_HEAD(v->extra.singular)->payload.handle.data.pointer;
     else
@@ -84,7 +84,7 @@ inline static void *VAL_HANDLE_VOID_POINTER(const RELVAL *v) {
 
 inline static CFUNC *VAL_HANDLE_CFUNC(const RELVAL *v) {
     assert(IS_HANDLE(v));
-    assert(GET_VAL_FLAG(v, HANDLE_FLAG_CFUNC));
+    assert(Get_Val_Flag(v, HANDLE_FLAG_CFUNC));
     if (v->extra.singular)
         return ARR_HEAD(v->extra.singular)->payload.handle.data.cfunc;
     else
@@ -107,7 +107,7 @@ inline static void SET_HANDLE_LEN(RELVAL *v, REBUPT length) {
 
 inline static void SET_HANDLE_POINTER(RELVAL *v, void *pointer) {
     assert(IS_HANDLE(v));
-    assert(NOT_VAL_FLAG(v, HANDLE_FLAG_CFUNC));
+    assert(Not_Val_Flag(v, HANDLE_FLAG_CFUNC));
     if (v->extra.singular)
         ARR_HEAD(v->extra.singular)->payload.handle.data.pointer = pointer;
     else
@@ -116,7 +116,7 @@ inline static void SET_HANDLE_POINTER(RELVAL *v, void *pointer) {
 
 inline static void SET_HANDLE_CFUNC(RELVAL *v, CFUNC *cfunc) {
     assert(IS_HANDLE(v));
-    assert(GET_VAL_FLAG(v, HANDLE_FLAG_CFUNC));
+    assert(Get_Val_Flag(v, HANDLE_FLAG_CFUNC));
     if (v->extra.singular)
         ARR_HEAD(v->extra.singular)->payload.handle.data.cfunc = cfunc;
     else
@@ -128,7 +128,7 @@ inline static void Init_Handle_Simple(
     void *pointer,
     REBUPT length
 ){
-    VAL_RESET_HEADER(out, REB_HANDLE);
+    Reset_Val_Header(out, REB_HANDLE);
     out->extra.singular = NULL;
     out->payload.handle.data.pointer = pointer;
     out->payload.handle.length = length;
@@ -139,7 +139,7 @@ inline static void Init_Handle_Cfunc(
     CFUNC *cfunc,
     REBUPT length
 ){
-    VAL_RESET_HEADER_EXTRA(out, REB_HANDLE, HANDLE_FLAG_CFUNC);
+    Reset_Val_Header_Core(out, REB_HANDLE, HANDLE_FLAG_CFUNC);
     out->extra.singular = NULL;
     out->payload.handle.data.cfunc = cfunc;
     out->payload.handle.length = length;
@@ -172,7 +172,7 @@ inline static void Init_Handle_Managed_Common(
     // series component.
     //
     SET_TRASH_IF_DEBUG(out);
-    VAL_RESET_HEADER(out, REB_HANDLE);
+    Reset_Val_Header(out, REB_HANDLE);
     out->extra.singular = singular;
     TRASH_POINTER_IF_DEBUG(out->payload.handle.data.pointer);
 }
@@ -187,9 +187,9 @@ inline static void Init_Handle_Managed(
 
     // Leave the non-singular cfunc as trash; clients should not be using
     //
-    VAL_RESET_HEADER(out, REB_HANDLE);
+    Reset_Val_Header(out, REB_HANDLE);
 
-    VAL_RESET_HEADER(ARR_HEAD(out->extra.singular), REB_HANDLE);
+    Reset_Val_Header(ARR_HEAD(out->extra.singular), REB_HANDLE);
     ARR_HEAD(out->extra.singular)->payload.handle.data.pointer = pointer;
 }
 
@@ -203,9 +203,9 @@ inline static void Init_Handle_Managed_Cfunc(
 
     // Leave the non-singular cfunc as trash; clients should not be using
     //
-    VAL_RESET_HEADER_EXTRA(out, REB_HANDLE, HANDLE_FLAG_CFUNC);
+    Reset_Val_Header_Core(out, REB_HANDLE, HANDLE_FLAG_CFUNC);
     
-    VAL_RESET_HEADER_EXTRA(
+    Reset_Val_Header_Core(
         ARR_HEAD(out->extra.singular),
         REB_HANDLE,
         HANDLE_FLAG_CFUNC

--- a/src/include/sys-map.h
+++ b/src/include/sys-map.h
@@ -48,7 +48,7 @@ struct Reb_Map {
 };
 
 inline static REBARR *MAP_PAIRLIST(REBMAP *m) {
-    assert(GET_SER_FLAG(&(m)->pairlist, ARRAY_FLAG_PAIRLIST));
+    assert(Get_Ser_Flag(&(m)->pairlist, ARRAY_FLAG_PAIRLIST));
     return (&(m)->pairlist);
 }
 

--- a/src/include/sys-pair.h
+++ b/src/include/sys-pair.h
@@ -64,10 +64,10 @@ inline static REBVAL *PAIRING_KEY(REBVAL *pairing) {
     ROUND_TO_INT(VAL_PAIR_Y(v))
 
 inline static void SET_PAIR(RELVAL *v, float x, float y) {
-    VAL_RESET_HEADER(v, REB_PAIR);
+    Reset_Val_Header(v, REB_PAIR);
     v->payload.pair = Alloc_Pairing(NULL);
-    SET_DECIMAL(PAIRING_KEY((v)->payload.pair), x);
-    SET_DECIMAL((v)->payload.pair, y);
+    Init_Decimal(PAIRING_KEY((v)->payload.pair), x);
+    Init_Decimal((v)->payload.pair, y);
     Manage_Pairing((v)->payload.pair);
 }
 
@@ -81,7 +81,7 @@ inline static void SET_ZEROED(RELVAL *v, enum Reb_Kind kind) {
         SET_PAIR(v, 0, 0); // !!! inefficient, performs allocation, review
     }
     else {
-        VAL_RESET_HEADER(v, kind);
+        Reset_Val_Header(v, kind);
         CLEAR(&v->extra, sizeof(union Reb_Value_Extra));
         CLEAR(&v->payload, sizeof(union Reb_Value_Payload));
     }

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -182,7 +182,7 @@
 // it from Do_Core().
 //
 // It is in the negative sense because the act of requesting it is uncommon,
-// e.g. from the QUOTE operator.  So most SET_BLANK() or other assignment
+// e.g. from the QUOTE operator.  So most Init_Blank() or other assignment
 // should default to being "evaluative".
 //
 // !!! This concept is somewhat dodgy and experimental, but it shows promise
@@ -817,7 +817,7 @@ struct Reb_Value
     #define IS_END(v) \
         IS_END_MACRO(v)
 
-    inline static void SET_END(RELVAL *v) {
+    inline static void Init_End(RELVAL *v) {
         //
         // Invalid UTF-8 byte, but also NODE_FLAG_END and NODE_FLAG_CELL set.
         // Other flags are set (e.g. NODE_FLAG_MANAGED) which should not
@@ -828,7 +828,7 @@ struct Reb_Value
     }
 #else
     // Note: These must be macros (that don't need IS_END_Debug or
-    // SET_END_Debug defined until used at a callsite) because %tmp-funcs.h
+    // Init_End_Debug defined until used at a callsite) because %tmp-funcs.h
     // cannot be included until after REBSER and other definitions that
     // depend on %sys-rebval.h have been defined.  (Or they could be manually
     // forward-declared here.)
@@ -836,8 +836,8 @@ struct Reb_Value
     #define IS_END(v) \
         IS_END_Debug((v), __FILE__, __LINE__)
 
-    #define SET_END(v) \
-        SET_END_Debug((v), __FILE__, __LINE__)
+    #define Init_End(v) \
+        Init_End_Debug((v), __FILE__, __LINE__)
 #endif
 
 #define NOT_END(v) \
@@ -1006,7 +1006,7 @@ inline static REBOOL IS_RELATIVE(const RELVAL *v) {
 
 inline static REBFUN *VAL_RELATIVE(const RELVAL *v) {
     assert(IS_RELATIVE(v));
-    //assert(NOT(GET_SER_FLAG(v->extra.binding, ARRAY_FLAG_VARLIST)));
+    //assert(NOT(Get_Ser_Flag(v->extra.binding, ARRAY_FLAG_VARLIST)));
     return cast(REBFUN*, v->extra.binding);
 }
 
@@ -1014,7 +1014,7 @@ inline static REBCTX *VAL_SPECIFIC_COMMON(const RELVAL *v) {
     assert(IS_SPECIFIC(v));
     //assert(
     //    v->extra.binding == SPECIFIED
-    //    || GET_SER_FLAG(v->extra.binding, ARRAY_FLAG_VARLIST)
+    //    || Get_Ser_Flag(v->extra.binding, ARRAY_FLAG_VARLIST)
     //);
     return cast(REBCTX*, v->extra.binding);
 }

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -287,7 +287,7 @@ inline static const REBYTE *Back_Scan_UTF8_Char(
     const REBYTE *bp_new = Back_Scan_UTF8_Char_Core(&ch, bp, len);
     if (bp_new != NULL && ch > 0xFFFF) {
         DECLARE_LOCAL (num);
-        SET_INTEGER(num, cast(REBI64, ch));
+        Init_Integer(num, cast(REBI64, ch));
         fail (Error_Codepoint_Too_High_Raw(num));
     }
     *out = cast(REBUNI, ch);

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -117,7 +117,7 @@
     inline REBSER *AS_SERIES(void *p) {
         REBNOD *n = cast(REBNOD*, p);
         assert(
-            n->header.bits & NODE_FLAG_VALID // GET_SER_FLAG would recurse!
+            n->header.bits & NODE_FLAG_VALID // Get_Ser_Flag would recurse!
             && NOT(n->header.bits & NODE_FLAG_CELL)
             && NOT(n->header.bits & NODE_FLAG_END)
         );
@@ -127,7 +127,7 @@
     template <>
     inline REBSER *AS_SERIES(REBNOD *n) {
         assert(
-            n->header.bits & NODE_FLAG_VALID // GET_SER_FLAG would recurse!
+            n->header.bits & NODE_FLAG_VALID // Get_Ser_Flag would recurse!
             && NOT(n->header.bits & NODE_FLAG_CELL)
             && NOT(n->header.bits & NODE_FLAG_END)
         );
@@ -155,46 +155,46 @@
 // Series header FLAGs (distinct from INFO bits)
 //
 
-#define SET_SER_FLAG(s,f) \
+#define Set_Ser_Flag(s,f) \
     cast(void, (AS_SERIES(s)->header.bits |= cast(REBUPT, (f))))
 
-#define CLEAR_SER_FLAG(s,f) \
+#define Clear_Ser_Flag(s,f) \
     cast(void, (AS_SERIES(s)->header.bits &= ~cast(REBUPT, (f))))
 
-#define GET_SER_FLAG(s,f) \
+#define Get_Ser_Flag(s,f) \
     LOGICAL(AS_SERIES(s)->header.bits & (f))
 
-#define NOT_SER_FLAG(s,f) \
+#define Not_Ser_Flag(s,f) \
     NOT(AS_SERIES(s)->header.bits & (f))
 
-#define SET_SER_FLAGS(s,f) \
-    SET_SER_FLAG((s), (f))
+#define Set_Ser_Flags(s,f) \
+    Set_Ser_Flag((s), (f))
 
-#define CLEAR_SER_FLAGS(s,f) \
-    CLEAR_SER_FLAG((s), (f))
+#define Clear_Ser_Flags(s,f) \
+    Clear_Ser_Flag((s), (f))
 
 
 //
 // Series INFO bits (distinct from header FLAGs)
 //
 
-#define SET_SER_INFO(s,f) \
+#define Set_Ser_Info(s,f) \
     cast(void, (AS_SERIES(s)->info.bits |= cast(REBUPT, f)))
 
-#define CLEAR_SER_INFO(s,f) \
+#define Clear_Ser_Info(s,f) \
     cast(void, (AS_SERIES(s)->info.bits &= ~cast(REBUPT, f)))
 
-#define GET_SER_INFO(s,f) \
+#define Get_Ser_Info(s,f) \
     LOGICAL(AS_SERIES(s)->info.bits & (f))
 
-#define NOT_SER_INFO(s,f) \
+#define Not_Ser_Info(s,f) \
     NOT(AS_SERIES(s)->info.bits & (f))
 
-#define SET_SER_INFOS(s,f) \
-    SET_SER_INFO((s), (f))
+#define Set_Ser_Infos(s,f) \
+    Set_Ser_Info((s), (f))
 
-#define CLEAR_SER_INFOS(s,f) \
-    CLEAR_SER_INFO((s), (f))
+#define Clear_Ser_Infos(s,f) \
+    Clear_Ser_Info((s), (f))
 
 
 //
@@ -212,15 +212,15 @@
     RIGHT_8_BITS((s)->info.bits) // inlining unnecessary
 
 inline static REBCNT SER_LEN(REBSER *s) {
-    return GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
+    return Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)
         ? s->content.dynamic.len
         : MID_8_BITS(s->info.bits);
 }
 
 inline static void SET_SERIES_LEN(REBSER *s, REBCNT len) {
-    assert(NOT_SER_FLAG(s, CONTEXT_FLAG_STACK));
+    assert(Not_Ser_Flag(s, CONTEXT_FLAG_STACK));
 
-    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
+    if (Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)) {
         s->content.dynamic.len = len;
     }
     else {
@@ -232,10 +232,10 @@ inline static void SET_SERIES_LEN(REBSER *s, REBCNT len) {
 }
 
 inline static REBCNT SER_REST(REBSER *s) {
-    if (GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
+    if (Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC))
         return s->content.dynamic.rest;
 
-    if (GET_SER_FLAG(s, SERIES_FLAG_ARRAY))
+    if (Get_Ser_Flag(s, SERIES_FLAG_ARRAY))
         return 2; // includes info bits acting as trick "terminator"
 
     assert(sizeof(s->content) % SER_WIDE(s) == 0);
@@ -248,7 +248,7 @@ inline static REBCNT SER_REST(REBSER *s) {
 //
 inline static REBYTE *SER_DATA_RAW(REBSER *s) {
     // if updating, also update manual inlining in SER_AT_RAW
-    return GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
+    return Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)
         ? s->content.dynamic.data
         : cast(REBYTE*, &s->content);
 }
@@ -267,7 +267,7 @@ inline static REBYTE *SER_AT_RAW(REBYTE w, REBSER *s, REBCNT i) {
 #endif
 
     return ((w) * (i)) + ( // v-- inlining of SER_DATA_RAW
-        GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
+        Get_Ser_Info(s, SERIES_INFO_HAS_DYNAMIC)
             ? s->content.dynamic.data
             : cast(REBYTE*, &s->content)
         );
@@ -331,7 +331,7 @@ inline static void EXPAND_SERIES_TAIL(REBSER *s, REBCNT delta) {
 //
 
 inline static void TERM_SEQUENCE(REBSER *s) {
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY));
     memset(SER_AT_RAW(SER_WIDE(s), s, SER_LEN(s)), 0, SER_WIDE(s));
 }
 
@@ -437,24 +437,24 @@ inline static void ENSURE_SERIES_MANAGED(REBSER *s) {
 //
 
 static inline REBOOL Is_Series_Black(REBSER *s) {
-    return GET_SER_INFO(s, SERIES_INFO_BLACK);
+    return Get_Ser_Info(s, SERIES_INFO_BLACK);
 }
 
 static inline REBOOL Is_Series_White(REBSER *s) {
-    return NOT(GET_SER_INFO(s, SERIES_INFO_BLACK));
+    return NOT(Get_Ser_Info(s, SERIES_INFO_BLACK));
 }
 
 static inline void Flip_Series_To_Black(REBSER *s) {
-    assert(NOT_SER_INFO(s, SERIES_INFO_BLACK));
-    SET_SER_INFO(s, SERIES_INFO_BLACK);
+    assert(Not_Ser_Info(s, SERIES_INFO_BLACK));
+    Set_Ser_Info(s, SERIES_INFO_BLACK);
 #if !defined(NDEBUG)
     ++TG_Num_Black_Series;
 #endif
 }
 
 static inline void Flip_Series_To_White(REBSER *s) {
-    assert(GET_SER_INFO(s, SERIES_INFO_BLACK));
-    CLEAR_SER_INFO(s, SERIES_INFO_BLACK);
+    assert(Get_Ser_Info(s, SERIES_INFO_BLACK));
+    Clear_Ser_Info(s, SERIES_INFO_BLACK);
 #if !defined(NDEBUG)
     --TG_Num_Black_Series;
 #endif
@@ -466,13 +466,13 @@ static inline void Flip_Series_To_White(REBSER *s) {
 //
 
 inline static void Freeze_Sequence(REBSER *s) { // there is no unfreeze!
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY)); // use Deep_Freeze_Array
-    SET_SER_INFO(s, SERIES_INFO_FROZEN);
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY)); // use Deep_Freeze_Array
+    Set_Ser_Info(s, SERIES_INFO_FROZEN);
 }
 
 inline static REBOOL Is_Series_Frozen(REBSER *s) {
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY)); // use Is_Array_Deeply_Frozen
-    return GET_SER_INFO(s, SERIES_INFO_FROZEN);
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY)); // use Is_Array_Deeply_Frozen
+    return Get_Ser_Info(s, SERIES_INFO_FROZEN);
 }
 
 inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
@@ -494,13 +494,13 @@ inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
 //
 inline static void FAIL_IF_READ_ONLY_SERIES(REBSER *s) {
     if (Is_Series_Read_Only(s)) {
-        if (GET_SER_INFO(s, SERIES_INFO_RUNNING))
+        if (Get_Ser_Info(s, SERIES_INFO_RUNNING))
             fail (Error_Series_Running_Raw());
 
-        if (GET_SER_INFO(s, SERIES_INFO_FROZEN))
+        if (Get_Ser_Info(s, SERIES_INFO_FROZEN))
             fail (Error_Series_Frozen_Raw());
 
-        assert(GET_SER_INFO(s, SERIES_INFO_PROTECTED));
+        assert(Get_Ser_Info(s, SERIES_INFO_PROTECTED));
         fail (Error_Series_Protected_Raw());
     }
 }
@@ -618,7 +618,7 @@ inline static REBSER *VAL_SERIES(const RELVAL *v) {
 }
 
 inline static void INIT_VAL_SERIES(RELVAL *v, REBSER *s) {
-    assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY));
+    assert(Not_Ser_Flag(s, SERIES_FLAG_ARRAY));
     v->payload.any_series.series = s;
 }
 

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -162,7 +162,7 @@ inline static void DS_PUSH(const REBVAL *v) {
 #else
     inline static void DS_DROP_Core() {
         // Note: DS_TOP checks to make sure it's not an END.
-        SET_UNREADABLE_BLANK(DS_TOP); // TRASH would mean ASSERT_ARRAY failing
+        Init_Unreadable_Blank(DS_TOP); // TRASH would mean ASSERT_ARRAY failing
         --DS_Index;
     }
 

--- a/src/include/sys-string.h
+++ b/src/include/sys-string.h
@@ -90,7 +90,7 @@ inline static const REBYTE *STR_HEAD(REBSTR *str) {
 }
 
 inline static REBSTR *STR_CANON(REBSTR *str) {
-    if (GET_SER_INFO(str, STRING_INFO_CANON))
+    if (Get_Ser_Info(str, STRING_INFO_CANON))
         return str;
     return str->misc.canon;
 }

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -163,7 +163,7 @@ enum Reb_Param_Class {
         (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_TYPESET))
 #endif
 
-// Option flags used with GET_VAL_FLAG().  These describe properties of
+// Option flags used with Get_Val_Flag().  These describe properties of
 // a value slot when it's constrained to the types in the typeset
 //
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -161,13 +161,13 @@
         VAL_TYPE_Debug((v), __FILE__, __LINE__)
 #endif
 
-inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
+inline static void Reset_Val_Kind(RELVAL *v, enum Reb_Kind kind) {
     //
     // Note: Only use if you are sure the new type payload is in sync with
     // the type and bits (e.g. changing ANY-WORD! to another ANY-WORD!).
     // Otherwise the value-specific flags might be misinterpreted.
     //
-    // Use VAL_RESET_HEADER() to set the type AND initialize the flags to 0.
+    // Use Reset_Val_Header() to set the type AND initialize the flags to 0.
     //
     assert(
         (v->header.bits & NODE_FLAG_CELL)
@@ -190,31 +190,31 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 //
 
 #ifdef NDEBUG
-    inline static void SET_VAL_FLAGS(RELVAL *v, REBUPT f) {
+    inline static void Set_Val_Flags(RELVAL *v, REBUPT f) {
         v->header.bits |= f;
     }
 
-    #define SET_VAL_FLAG(v,f) \
-        SET_VAL_FLAGS((v), (f))
+    #define Set_Val_Flag(v,f) \
+        Set_Val_Flags((v), (f))
 
-    inline static REBOOL GET_VAL_FLAG(const RELVAL *v, REBUPT f) {
+    inline static REBOOL Get_Val_Flag(const RELVAL *v, REBUPT f) {
         return LOGICAL(v->header.bits & f);
     }
 
-    inline static REBOOL ANY_VAL_FLAGS(const RELVAL *v, REBUPT f) {
+    inline static REBOOL Any_Val_Flags(const RELVAL *v, REBUPT f) {
         return LOGICAL((v->header.bits & f) != 0);
     }
 
-    inline static REBOOL ALL_VAL_FLAGS(const RELVAL *v, REBUPT f) {
+    inline static REBOOL All_Val_Flags(const RELVAL *v, REBUPT f) {
         return LOGICAL((v->header.bits & f) == f);
     }
 
-    inline static void CLEAR_VAL_FLAGS(RELVAL *v, REBUPT f) {
+    inline static void Clear_Val_Flags(RELVAL *v, REBUPT f) {
         v->header.bits &= ~f;
     }
 
-    #define CLEAR_VAL_FLAG(v,f) \
-        CLEAR_VAL_FLAGS((v), (f))
+    #define Clear_Val_Flag(v,f) \
+        Clear_Val_Flags((v), (f))
 #else
     // For safety in the debug build, all the type-specific flags include a
     // type (or type representing a category) as part of the flag.  This type
@@ -239,45 +239,45 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
             CLEAR_8_RIGHT_BITS(flags); \
         } \
 
-    inline static void SET_VAL_FLAGS(RELVAL *v, REBUPT f) {
+    inline static void Set_Val_Flags(RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         v->header.bits |= f;
     }
 
-    inline static void SET_VAL_FLAG(RELVAL *v, REBUPT f) {
+    inline static void Set_Val_Flag(RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         assert(f && (f & (f - 1)) == 0); // checks that only one bit is set
         v->header.bits |= f;
     }
 
-    inline static REBOOL GET_VAL_FLAG(const RELVAL *v, REBUPT f) {
+    inline static REBOOL Get_Val_Flag(const RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         assert(f && (f & (f - 1)) == 0); // checks that only one bit is set
         return LOGICAL(v->header.bits & f);
     }
 
-    inline static REBOOL ANY_VAL_FLAGS(const RELVAL *v, REBUPT f) {
+    inline static REBOOL Any_Val_Flags(const RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         return LOGICAL((v->header.bits & f) != 0);
     }
 
-    inline static REBOOL ALL_VAL_FLAGS(const RELVAL *v, REBUPT f) {
+    inline static REBOOL All_Val_Flags(const RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         return LOGICAL((v->header.bits & f) == f);
     }
 
-    inline static void CLEAR_VAL_FLAGS(RELVAL *v, REBUPT f) {
+    inline static void Clear_Val_Flags(RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         v->header.bits &= ~f;
     }
 
-    inline static void CLEAR_VAL_FLAG(RELVAL *v, REBUPT f) {
+    inline static void Clear_Val_Flag(RELVAL *v, REBUPT f) {
         enum Reb_Kind kind = VAL_TYPE(v);
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(f);
         assert(f && (f & (f - 1)) == 0); // checks that only one bit is set
@@ -285,8 +285,8 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 #endif
 
-#define NOT_VAL_FLAG(v,f) \
-    NOT(GET_VAL_FLAG((v), (f)))
+#define Not_Val_Flag(v,f) \
+    NOT(Get_Val_Flag((v), (f)))
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -332,7 +332,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// VAL_RESET_HEADER clears out the header of *most* bits, setting it to a
+// Reset_Val_Header clears out the header of *most* bits, setting it to a
 // new type.
 //
 // The value is expected to already be "pre-formatted" with the NODE_FLAG_CELL
@@ -341,7 +341,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 // so that is left as-is also.
 //
 
-inline static void VAL_RESET_HEADER_common( // don't call directly
+inline static void Reset_Val_Header_common( // don't call directly
     RELVAL *v,
     enum Reb_Kind kind,
     REBUPT extra_flags
@@ -356,8 +356,8 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 }
 
 #ifdef NDEBUG
-    #define VAL_RESET_HEADER_EXTRA(v,kind,extra) \
-        VAL_RESET_HEADER_common((v), (kind), (extra))
+    #define Reset_Val_Header_Core(v,kind,extra) \
+        Reset_Val_Header_common((v), (kind), (extra))
 
     #define ASSERT_CELL_WRITABLE(v,file,line) \
         NOOP
@@ -368,7 +368,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     #define ASSERT_CELL_WRITABLE(v,file,line) \
         Assert_Cell_Writable((v), (file), (line))
 
-    inline static void VAL_RESET_HEADER_EXTRA_Debug(
+    inline static void Reset_Val_Header_Core_Debug(
         RELVAL *v,
         enum Reb_Kind kind,
         REBUPT extra,
@@ -384,11 +384,11 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         //
         CHECK_VALUE_FLAGS_EVIL_MACRO_DEBUG(extra);
         
-        VAL_RESET_HEADER_common(v, kind, extra);
+        Reset_Val_Header_common(v, kind, extra);
     }
 
-    #define VAL_RESET_HEADER_EXTRA(v,kind,extra) \
-        VAL_RESET_HEADER_EXTRA_Debug((v), (kind), (extra), __FILE__, __LINE__)
+    #define Reset_Val_Header_Core(v,kind,extra) \
+        Reset_Val_Header_Core_Debug((v), (kind), (extra), __FILE__, __LINE__)
 
     inline static void INIT_CELL_Debug(
         RELVAL *v, const char *file, int line
@@ -401,8 +401,8 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         INIT_CELL_Debug((v), __FILE__, __LINE__)
 #endif
 
-#define VAL_RESET_HEADER(v,t) \
-    VAL_RESET_HEADER_EXTRA((v), (t), 0)
+#define Reset_Val_Header(v,t) \
+    Reset_Val_Header_Core((v), (t), 0)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -475,8 +475,8 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 #define IS_VOID(v) \
     LOGICAL(VAL_TYPE(v) == REB_MAX_VOID)
 
-#define SET_VOID(v) \
-    VAL_RESET_HEADER(v, REB_MAX_VOID)
+#define Init_Void(v) \
+    Reset_Val_Header(v, REB_MAX_VOID)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -503,10 +503,10 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     c_cast(const REBVAL*, &PG_Bar_Value[0])
 
 #define SET_BAR(v) \
-    VAL_RESET_HEADER((v), REB_BAR)
+    Reset_Val_Header((v), REB_BAR)
 
 #define SET_LIT_BAR(v) \
-    VAL_RESET_HEADER((v), REB_LIT_BAR)
+    Reset_Val_Header((v), REB_LIT_BAR)
 
 
 //=////////////////////////////////////////////////////////////////////////=//
@@ -543,12 +543,12 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 #define BLANK_VALUE \
     c_cast(const REBVAL*, &PG_Blank_Value[0])
 
-#define SET_BLANK(v) \
-    VAL_RESET_HEADER_EXTRA((v), REB_BLANK, VALUE_FLAG_CONDITIONAL_FALSE)
+#define Init_Blank(v) \
+    Reset_Val_Header_Core((v), REB_BLANK, VALUE_FLAG_CONDITIONAL_FALSE)
 
 #ifdef NDEBUG
-    #define SET_UNREADABLE_BLANK(v) \
-        SET_BLANK(v)
+    #define Init_Unreadable_Blank(v) \
+        Init_Blank(v)
 
     #define IS_BLANK_RAW(v) \
         IS_BLANK(v)
@@ -559,8 +559,8 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     #define SINK(v) \
         cast(REBVAL*, (v))
 #else
-    #define SET_UNREADABLE_BLANK(v) \
-        VAL_RESET_HEADER_EXTRA((v), REB_BLANK, \
+    #define Init_Unreadable_Blank(v) \
+        Reset_Val_Header_Core((v), REB_BLANK, \
             VALUE_FLAG_CONDITIONAL_FALSE | BLANK_FLAG_UNREADABLE_DEBUG)
 
     inline static REBOOL IS_BLANK_RAW(const RELVAL *v) {
@@ -593,7 +593,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         ASSERT_CELL_WRITABLE(v, file, line);
 
         if (v->header.bits & NODE_FLAG_VALID) {
-            VAL_RESET_HEADER_EXTRA_Debug(
+            Reset_Val_Header_Core_Debug(
                 v,
                 REB_BLANK,
                 VALUE_FLAG_CONDITIONAL_FALSE | BLANK_FLAG_UNREADABLE_DEBUG,
@@ -644,19 +644,19 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 #define TRUE_VALUE \
     c_cast(const REBVAL*, &PG_True_Value[0])
 
-#define SET_TRUE(v) \
-    VAL_RESET_HEADER_EXTRA((v), REB_LOGIC, 0)
+#define Init_True(v) \
+    Reset_Val_Header_Core((v), REB_LOGIC, 0)
 
-#define SET_FALSE(v) \
-    VAL_RESET_HEADER_EXTRA((v), REB_LOGIC, VALUE_FLAG_CONDITIONAL_FALSE)
+#define Init_False(v) \
+    Reset_Val_Header_Core((v), REB_LOGIC, VALUE_FLAG_CONDITIONAL_FALSE)
 
-#define SET_LOGIC(v,b) \
-    VAL_RESET_HEADER_EXTRA((v), REB_LOGIC, \
+#define Init_Logic(v,b) \
+    Reset_Val_Header_Core((v), REB_LOGIC, \
         (b) ? 0 : VALUE_FLAG_CONDITIONAL_FALSE)
 
 #ifdef NDEBUG
     #define IS_CONDITIONAL_FALSE(v) \
-        GET_VAL_FLAG((v), VALUE_FLAG_CONDITIONAL_FALSE)
+        Get_Val_Flag((v), VALUE_FLAG_CONDITIONAL_FALSE)
 #else
     inline static REBOOL IS_CONDITIONAL_FALSE_Debug(
         const RELVAL *v, const char *file, int line
@@ -665,7 +665,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
             printf("Conditional true/false test on void\n");
             panic_at (v, file, line);
         }
-        return GET_VAL_FLAG(v, VALUE_FLAG_CONDITIONAL_FALSE);
+        return Get_Val_Flag(v, VALUE_FLAG_CONDITIONAL_FALSE);
     }
 
     #define IS_CONDITIONAL_FALSE(v) \
@@ -682,7 +682,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 //
 inline static REBOOL IS_CONDITIONAL_TRUE_SAFE(const REBVAL *v) {
     if (IS_BLOCK(v)) {
-        if (GET_VAL_FLAG(v, VALUE_FLAG_UNEVALUATED))
+        if (Get_Val_Flag(v, VALUE_FLAG_UNEVALUATED))
             fail (Error_Block_Conditional_Raw(v));
             
         return TRUE;
@@ -692,7 +692,7 @@ inline static REBOOL IS_CONDITIONAL_TRUE_SAFE(const REBVAL *v) {
 
 inline static REBOOL VAL_LOGIC(const RELVAL *v) {
     assert(IS_LOGIC(v));
-    return NOT_VAL_FLAG((v), VALUE_FLAG_CONDITIONAL_FALSE);
+    return Not_Val_Flag((v), VALUE_FLAG_CONDITIONAL_FALSE);
 }
 
 
@@ -750,8 +750,8 @@ inline static enum Reb_Kind KIND_FROM_SYM(REBSYM s) {
 #define VAL_CHAR(v) \
     ((v)->payload.character)
 
-inline static void SET_CHAR(RELVAL *v, REBUNI uni) {
-    VAL_RESET_HEADER(v, REB_CHAR);
+inline static void Init_Char(RELVAL *v, REBUNI uni) {
+    Reset_Val_Header(v, REB_CHAR);
     VAL_CHAR(v) = uni;
 }
 
@@ -795,8 +795,8 @@ inline static void SET_CHAR(RELVAL *v, REBUNI uni) {
     }
 #endif
 
-inline static void SET_INTEGER(RELVAL *v, REBI64 i64) {
-    VAL_RESET_HEADER(v, REB_INTEGER);
+inline static void Init_Integer(RELVAL *v, REBI64 i64) {
+    Reset_Val_Header(v, REB_INTEGER);
     v->payload.integer = i64;
 }
 
@@ -840,13 +840,13 @@ inline static void SET_INTEGER(RELVAL *v, REBI64 i64) {
     }
 #endif
 
-inline static void SET_DECIMAL(RELVAL *v, REBDEC d) {
-    VAL_RESET_HEADER(v, REB_DECIMAL);
+inline static void Init_Decimal(RELVAL *v, REBDEC d) {
+    Reset_Val_Header(v, REB_DECIMAL);
     v->payload.decimal = d;
 }
 
 inline static void SET_PERCENT(RELVAL *v, REBDEC d) {
-    VAL_RESET_HEADER(v, REB_PERCENT);
+    Reset_Val_Header(v, REB_PERCENT);
     v->payload.decimal = d;
 }
 
@@ -895,8 +895,8 @@ inline static deci VAL_MONEY_AMOUNT(const RELVAL *v) {
     return amount;
 }
 
-inline static void SET_MONEY(RELVAL *v, deci amount) {
-    VAL_RESET_HEADER(v, REB_MONEY);
+inline static void Init_Money(RELVAL *v, deci amount) {
+    Reset_Val_Header(v, REB_MONEY);
     v->extra.m0 = amount.m0;
     v->payload.money.m1 = amount.m1;
     v->payload.money.m2 = amount.m2;
@@ -962,8 +962,8 @@ inline static void SET_MONEY(RELVAL *v, deci amount) {
 
 #define NO_TIME MIN_I64
 
-inline static void SET_TIME(RELVAL *v, REBI64 nanoseconds) {
-    VAL_RESET_HEADER(v, REB_TIME);
+inline static void Init_Time(RELVAL *v, REBI64 nanoseconds) {
+    Reset_Val_Header(v, REB_TIME);
     VAL_TIME(v) = nanoseconds;
 }
 
@@ -1032,7 +1032,7 @@ inline static void SET_TIME(RELVAL *v, REBI64 nanoseconds) {
     ((v)->payload.tuple.tuple)
 
 inline static void SET_TUPLE(RELVAL *v, const void *data) {
-    VAL_RESET_HEADER(v, REB_TUPLE);
+    Reset_Val_Header(v, REB_TUPLE);
     memcpy(VAL_TUPLE_DATA(v), data, sizeof(VAL_TUPLE_DATA(v)));
 }
 
@@ -1217,7 +1217,7 @@ inline static void SET_EVENT_KEY(RELVAL *v, REBCNT k, REBCNT c) {
     ((v)->payload.gob.index)
 
 inline static void SET_GOB(RELVAL *v, REBGOB *g) {
-    VAL_RESET_HEADER(v, REB_GOB);
+    Reset_Val_Header(v, REB_GOB);
     VAL_GOB(v) = g;
     VAL_GOB_INDEX(v) = 0;
 }
@@ -1237,8 +1237,8 @@ inline static void SET_GOB(RELVAL *v, REBGOB *g) {
 inline static REBVAL *Move_Value(RELVAL *out, const REBVAL *v)
 {
     assert(
-        GET_VAL_FLAG(v, NODE_FLAG_CELL)
-        && GET_VAL_FLAG(v, NODE_FLAG_VALID)
+        Get_Val_Flag(v, NODE_FLAG_CELL)
+        && Get_Val_Flag(v, NODE_FLAG_VALID)
     );
     assert(NOT_END(v));
     ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -61,7 +61,7 @@
 
 
 #define IS_WORD_BOUND(v) \
-    GET_VAL_FLAG((v), WORD_FLAG_BOUND)
+    Get_Val_Flag((v), WORD_FLAG_BOUND)
 
 #define IS_WORD_UNBOUND(v) \
     NOT(IS_WORD_BOUND(v))
@@ -85,30 +85,30 @@ inline static const REBYTE *VAL_WORD_HEAD(const RELVAL *v) {
 }
 
 inline static void INIT_WORD_CONTEXT(RELVAL *v, REBCTX *context) {
-    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND) && context != SPECIFIED);
+    assert(Get_Val_Flag(v, WORD_FLAG_BOUND) && context != SPECIFIED);
     ENSURE_SERIES_MANAGED(CTX_SERIES(context));
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(context));
     v->extra.binding = CTX_VARLIST(context);
 }
 
 inline static REBCTX *VAL_WORD_CONTEXT(const REBVAL *v) {
-    assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
+    assert(Get_Val_Flag((v), WORD_FLAG_BOUND));
     return VAL_SPECIFIC(v);
 }
 
 inline static void INIT_WORD_FUNC(RELVAL *v, REBFUN *func) {
-    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND));
+    assert(Get_Val_Flag(v, WORD_FLAG_BOUND));
     v->extra.binding = FUNC_PARAMLIST(func);
 }
 
 inline static REBFUN *VAL_WORD_FUNC(const RELVAL *v) {
-    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND));
+    assert(Get_Val_Flag(v, WORD_FLAG_BOUND));
     return VAL_RELATIVE(v);
 }
 
 inline static void INIT_WORD_INDEX(RELVAL *v, REBCNT i) {
     assert(ANY_WORD(v));
-    assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
+    assert(Get_Val_Flag((v), WORD_FLAG_BOUND));
     assert(SAME_STR(
         VAL_WORD_SPELLING(v),
         IS_RELATIVE(v)
@@ -126,7 +126,7 @@ inline static REBCNT VAL_WORD_INDEX(const RELVAL *v) {
 }
 
 inline static void Unbind_Any_Word(RELVAL *v) {
-    CLEAR_VAL_FLAGS(v, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
+    Clear_Val_Flags(v, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
 #if !defined(NDEBUG)
     v->payload.any_word.index = 0;
 #endif
@@ -137,7 +137,7 @@ inline static void Init_Any_Word(
     enum Reb_Kind kind,
     REBSTR *spelling
 ) {
-    VAL_RESET_HEADER(out, kind);
+    Reset_Val_Header(out, kind);
 
     assert(spelling != NULL);
     out->payload.any_word.spelling = spelling;
@@ -179,7 +179,7 @@ inline static void Init_Any_Word_Bound(
 ) {
     assert(CTX_KEY_CANON(context, index) == STR_CANON(spelling));
 
-    VAL_RESET_HEADER_EXTRA(out, type, WORD_FLAG_BOUND);
+    Reset_Val_Header_Core(out, type, WORD_FLAG_BOUND);
 
     assert(spelling != NULL);
     out->payload.any_word.spelling = spelling;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -349,12 +349,12 @@ void Host_Repl(
     REBOOL at_breakpoint
 ) {
     REBOOL last_failed = FALSE;
-    SET_VOID(out);
+    Init_Void(out);
 
     DECLARE_LOCAL (level);
     DECLARE_LOCAL (frame);
-    SET_BLANK(level);
-    SET_BLANK(frame);
+    Init_Blank(level);
+    Init_Blank(frame);
 
     PUSH_GUARD_VALUE(frame);
 
@@ -368,7 +368,7 @@ void Host_Repl(
             // The DEBUG command can change this, so at the moment it
             // has to be refreshed each time an evaluation is performed.
 
-            SET_INTEGER(level, HG_Stack_Level);
+            Init_Integer(level, HG_Stack_Level);
 
             REBFRM *f = Frame_For_Stack_Level(NULL, level, FALSE);
             assert(f);
@@ -445,7 +445,7 @@ void Host_Repl(
             // The output value will be an END marker on halt, to signal the
             // unusability of the interrupted result.
             //
-            SET_VOID(out);
+            Init_Void(out);
         }
         else if (do_result == -2) {
             //
@@ -520,7 +520,7 @@ REBOOL Host_Breakpoint_Quitting_Hook(
     REBCNT old_stack_level = HG_Stack_Level;
 
     DECLARE_LOCAL (level);
-    SET_INTEGER(level, 1);
+    Init_Integer(level, 1);
 
     if (Frame_For_Stack_Level(NULL, level, FALSE) != NULL)
         HG_Stack_Level = 1;
@@ -839,7 +839,7 @@ int main(int argc, char **argv_ansi)
     volatile REBOOL finished; // without volatile, gets "clobbered" warning
 
     Prep_Global_Cell(&HG_Host_Repl);
-    SET_BLANK(&HG_Host_Repl);
+    Init_Blank(&HG_Host_Repl);
 
     if (error != NULL) {
         //
@@ -936,12 +936,12 @@ int main(int argc, char **argv_ansi)
 
         DECLARE_LOCAL (embedded_value);
         if (embedded == NULL)
-            SET_BLANK(embedded_value);
+            Init_Blank(embedded_value);
         else
             Init_Block(embedded_value, embedded);
 
         DECLARE_LOCAL (ext_value);
-        SET_BLANK(ext_value);
+        Init_Blank(ext_value);
         LOAD_BOOT_EXTENSIONS(ext_value);
 
         if (!IS_FUNCTION(host_start))
@@ -1010,7 +1010,7 @@ int main(int argc, char **argv_ansi)
     DECLARE_LOCAL (value);
 
     while (NOT(finished)) {
-        SET_END(value);
+        Init_End(value);
         PUSH_GUARD_VALUE(value); // !!! Out_Value expects value to be GC safe
 
         struct Reb_State state;

--- a/tests/misc/fib.r
+++ b/tests/misc/fib.r
@@ -8,8 +8,8 @@ c-fib: make-native [
 ]{
     int n = VAL_INT64(ARG(n));
 
-    if (n < zero) { SET_INTEGER(D_OUT, -1); return R_OUT; }
-    if (n <= one) { SET_INTEGER(D_OUT, n); return R_OUT; }
+    if (n < zero) { Init_Integer(D_OUT, -1); return R_OUT; }
+    if (n <= one) { Init_Integer(D_OUT, n); return R_OUT; }
 
     int i0 = zero;
     int i1 = one;
@@ -19,7 +19,7 @@ c-fib: make-native [
         i0 = t;
         --n;
     }
-    SET_INTEGER(D_OUT, i1);
+    Init_Integer(D_OUT, i1);
     return R_OUT;
 }
 


### PR DESCRIPTION
Some naming issues from R3-Alpha have been gradually phased out over
time.  For instance, to initialize a value cell with an integer there
was a macro SET_INTEGER(...).  But this gets quite confusing if you
try to expand that pattern to initialize a cell for a WORD!, because
you get SET_WORD(...).  It's an obviously broken pattern that has
given way to things like `Init_Block(...)`, `Init_Set_Word(...)`,
`Init_Word(...)`, etc.  So at some point the writing is on the wall
that SET_INTEGER will join the club and become `Init_Integer(...)`

But there are other less obvious cases, and this is an incomplete bit
of change to spark the thought experiment of considering them.

R3-Alpha had quite a lot of preprocessor macros doing its work.  This
was problematic for all the reasons that preprocessor macros are
usually problematic...they don't have any type signatures, if you
pass them something with side effects (like a function call) and they
use that parameter more than once, you'll get the side effects multiple
times, etc. etc.

Ren-C bit the bullet and was completely re-laid out in a way that had
the dependencies in line to allow for inline functions.  In most all
circumstances, nothing is allowed to be a macro if it would repeat
its arguments...if macro features are absolutely necessary (e.g.
capturing __FILE__ and __LINE__) then it is broken into two parts--a
macro and an inline function that macro calls.

Yet the C convention of warning people something is a macro by using
ALL-CAPS was not abandoned at the moment of that transition.  This
leaves the question on the table of exactly how should the "tool" of
naming, capitalization, casing, etc. be used in the codebase.

It's hard to tell exactly what's good or bad if one is used to looking
at things a certain way...sometimes it takes time.  But if you are
reading something like:

    if (NOT_END(f->value)) { ... }

and it gets changed to:

    if (Not_End(f->value)) { ... }

It might feel like "tests are all caps, variables are lowercase"
had provided an element of contrast and readability.  Regardless of
if NOT_END is a function or a macro, it might be more "operator-like"
and the capitalization might be a good thing.

I'm not sure on the answers, so this is really just a conversation
piece for the moment.  I know I like Init_Word() better than SET_WORD()
and I'm fairly sure I like Init_Word() better than INIT_WORD(), but I
don't know if I like Is_Word() better than IS_WORD() yet.

I also know that I like `Reset_Val_Header` better than `VAL_RESET_HEADER()`,
because I remember how nonsensical the latter sounded to me when I
first saw it.  Actually I think it was initially `VAL_SET_HEADER()`, but I thought
"reset" was more clear because even though you're only passing in a type
you're actually setting *all* the bits.