### PR TITLE
R source tests

### DIFF
--- a/tests/lib/text-lines.reb
+++ b/tests/lib/text-lines.reb
@@ -11,7 +11,7 @@ REBOL [
         See: http://www.apache.org/licenses/LICENSE-2.0
     }
     Author: "Brett Handley"
-    Purpose: {Transition load/next from Rebol 2 to Rebol 3.}
+    Purpose: {Functions operating on lines of text.}
 ]
 
 decode-lines: function [
@@ -82,7 +82,7 @@ for-each-line: func [
 ]
 
 lines-exceeding: function [
-    {Return the line numbers of lines exceeding line-length}
+    {Return the line numbers of lines exceeding line-length.}
     line-length [integer!]
     text [string!]
 ] [

--- a/tests/source/analysis.test.reb
+++ b/tests/source/analysis.test.reb
@@ -21,6 +21,7 @@
 [not find source-analysis 'eof-eol-missing]
 [not find source-analysis 'tabbed]
 [not find source-analysis 'id-mismatch]
+[not find source-analysis 'inconsistent-eol]
 ;; Currently failing. Uncomment, to work on cleaning this up.
 ;[not find source-analysis [line-exceeds 127]]
 ;; Currently failing. Uncomment, to work on cleaning this up.


### PR DESCRIPTION
Adds source analysis checking for Rebol source files and adds detection of inconsistent line termination.

At the time of this PR, running run-recover.r with these changes caused the assetion documented here: https://github.com/metaeducation/ren-c/issues/468