### PR TITLE
IMPORT 'FOO falls back to IMPORT <FOO>

### DIFF
--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -963,6 +963,21 @@ import: function [
         ]
     ]
 
+    if all [word? module | not mod] [
+    	; IMPORT 'FOO fails, try IMPORT <FOO> 
+        module: first select load rebol/locale/library to tag! module
+	set [name: mod:] apply 'load-module [
+	    source: module
+	    version: version
+	    ver: :ver
+	    check: check
+	    sum: :sum
+	    no-share: no-share
+	    no-lib: no-lib
+	    import: true
+	]
+    ]
+
     unless mod [
         cause-error 'access 'cannot-open reduce [module "module not found"]
     ]


### PR DESCRIPTION
* `import 'foo` searches first in local modules,
then falls back to rebol/locale/library

* `import <foo>` searches only in rebol/locale/library