### PR TITLE
Added REPL object to allow skinning

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -576,18 +576,21 @@ view: construct [] [
 ;           _
 ;   ]
 
-;user: construct [] [
-;   name:           ; User's name
-;   email:          ; User's default email address
-;   home:           ; The HOME environment variable
-;   words: _
-;]
+user: construct [] [
+   name:           ; User's name
+   email:          ; User's default email address
+   home:           ; The HOME environment variable
+   rebol:          ; Users rebol customisations dir.  eg. $HOME/.rebol on *nix
+   words: _
+]
 
 ;network: construct [] [
 ;   host: ""        ; Host name of the user's computer
 ;   host-address: 0.0.0.0 ; Host computer's TCP-IP address
 ;   trace: _
 ;]
+
+repl: _         ;; repl object created in host-start (os/host-start.r)
 
 ;console: construct [] [
 ;   hide-types: _    ; types not to print

--- a/src/os/host-repl.r
+++ b/src/os/host-repl.r
@@ -171,6 +171,13 @@ host-repl: function [
     focus-frame [blank! frame!]
         {If at a breakpoint, the function frame where the breakpoint was hit}
 ][
+    ; REPL is an external object for skinning the behaviour & appearance
+    ;
+    ; /cycle - updates internal counter and loads repl-skin on first rotation (ie. once)
+    ;
+    repl: system/repl
+    repl/cycle
+
     source: copy "" ;-- source code potentially built of multiple lines
 
     ; The LOADed and bound code.  It's initialized to empty block so that if
@@ -198,10 +205,11 @@ host-repl: function [
             system/state/last-error: last-result
         ]
     ] else [
-        print ["==" mold :last-result]
+        repl/last-result: mold :last-result 
+        repl/print-result
     ]
 
-    print-newline
+    repl/print-gap
 
     ; If a debug frame is in focus then show it in the prompt, e.g.
     ; as `if:|4|>>` to indicate stack frame 4 is being examined, and
@@ -216,11 +224,11 @@ host-repl: function [
         print/only ["|" focus-level "|"]
     ]
 
-    print/only [">>" space]
+    repl/print-prompt
 
     forever [ ;-- gather potentially multi-line input
 
-        line: input
+        line: repl/input-hook input     ;--  pre-processor hook
         if empty? line [
             ;
             ; if empty line, result is whatever's in `code`, even ERROR!
@@ -263,7 +271,7 @@ host-repl: function [
                 ; could be tailored specifically, e.g. to report
                 ; a depth)
                 ;
-                print/only ["{" space space space]
+                print/only ["^{" space space space]
 
                 append source newline
                 continue ]
@@ -305,25 +313,27 @@ host-repl: function [
         assert [error? code]
     ]
 
-    if code = [q] [
+    if all [1 = length code | shortcut: select repl/shortcuts code/1] [
         ;
-        ; It's possible (and not entirely unlikely) that the user might have
-        ; a variable called Q, and it's bad to have a function defined as "Q"
-        ; which could accidentally trigger a silent exit from scripted code,
-        ; e.g. `append [w x y] q`.  But people have grown used to exiting
-        ; Rebol consoles with it, so detect it specifically in the console.
+        ; One word shortcuts.
+        ; builtin: 
+        ;               q   => quit   
         ;
         if all [bound? code/1 | set? code/1] [
             ;
             ; Help the confused user who might not know about the shortcut not
             ; panic by giving them a message.  Reduce noise for the casual
-            ; quitter by only doing so when there's a bound Q variable.
+            ; shortcut by only doing so when there's a bound SHORTCUT variable.
             ;
-            print "Q interpreted by console as QUIT, use :Q to get variable."
+            repl/print-warning [
+                (uppercase to-string code/1) "interpreted by console as:" form shortcut
+            ]
+            repl/print-warning ["use" form to-get-word code/1 "to get variable."]
         ]
-        code: [quit]
+        code: shortcut
     ]
 
+    code: repl/dialect-hook code
     return code
 ]
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -219,7 +219,6 @@ host-script-pre-load: procedure [
     ]
 ]
 
-
 host-start: function [
     "Loads extras, handles args, security, scripts."
     return: [integer! function!]
@@ -269,6 +268,22 @@ host-start: function [
         :encode-utf16be)
 
     system/product: 'core
+
+    ; Set system/user home & rebol dirs if present
+    ;
+    ; User rebol directory (for local customisations)
+    ;   * default (Linux, MacOS, Unix) - $HOME/.rebol
+    ;   * Windows                      - $HOME/REBOL
+    ;
+    ; TBD - check perms are correct (SECURITY)
+    ;
+    if exists? home: dirize to-file get-env 'HOME [
+        system/user/home: home
+        rebol-dir: join-of home switch/default system/platform/1 [
+            'Windows [%REBOL/]
+        ][%.rebol/]              ;; default *nix (Linux, MacOS & UNIX)
+        if exists? rebol-dir [system/user/rebol: rebol-dir]
+    ]
 
     sys/script-pre-load-hook: :host-script-pre-load
 
@@ -511,7 +526,6 @@ comment [
             return 1
         ]
     ]
-
     host-start: 'done
 
     ; Evaluate the DO string, e.g. `r3 --do "print {Hello}"`
@@ -538,6 +552,84 @@ comment [
 
     boot-print boot-help
 
+    ; set-up repl object
+    system/repl: make object! [
+        ; This object is used in skinning the REPL
+        ; see /os/host-repl.r where this object is called from
+        ; %repl-skin.reb if found in system/user/rebol is loaded on REPL start
+
+        counter: 0
+        last-result: _    ;-- stores last evaluated result (sent by host-repl func)
+
+        ;-- Allowing for multiple skins in future.  For now just user/rebol skin
+        skins: does [reduce [join-of system/user/rebol %repl-skin.reb]]
+
+        cycle: does [
+            ;; this is called on every line of input (by host-repl function in os/host-repl.r)
+            if zero? ++ counter [load-skin]     ;-- only load skin on first cycle
+            counter
+        ]
+
+        load-skin: does [
+            if empty? skins [return false]
+
+            print [newline "REPL skinning:" newline]
+            foreach skin-file skins [
+                trap/with [
+                    print [
+                        space space
+                        either exists? skin-file [
+                            do load skin-file
+                            "Loaded skin"
+                        ]["Skin does not exist"]
+                        "-" skin-file
+                    ]
+                ] func [error] [
+                    print [
+                        "  Error loading skin" "-" skin-file newline newline 
+                        error newline newline
+                        "  Fix error and enter repl/load-skin to reload"
+                    ]
+                ]
+            ]
+
+            print-greeting
+        ]
+
+        ; Below are methods we can override (ie. "skin")
+        ;
+        
+        ;; appearance
+        prompt:   {>> }
+        result:   {== }
+        warning:  {!! }
+        print-greeting: _
+        print-prompt:   proc []  [print/only prompt]
+        print-result:   proc []  [print unspaced [result last-result]]
+        print-warning:  proc [s] [print unspaced [warning reduce s]]
+        print-gap:      proc []  [print-newline]
+
+        ;; behaviour 
+        input-hook:   func [s] [s]  ;-- receives line input, parse/transform, send back to repl eval
+        dialect-hook: func [s] [s]  ;-- receives code block, parse/transform, send back to repl eval
+        shortcuts: make object! [
+            ;; default REPL shortcuts
+            q: [quit]
+            list-shortcuts: [print system/repl/shortcuts]
+        ]
+
+        ;; helpers
+        add-shortcut: proc [
+            {Add/Change REPL shortcut}
+            name  [any-word!]   {shortcut name}
+            block [block!]      {command(s) expanded to}
+        ][
+            extend shortcuts name block
+        ]
+    ]
+
+
+
     ; Rather than have the host C code look up the REPL function by name, it
     ; is returned as a function value from calling the start.  It's a bit of
     ; a hack, and might be better with something like the SYS_FUNC table that
@@ -545,3 +637,4 @@ comment [
     ;
     return :host-repl
 ]
+


### PR DESCRIPTION
Synopsis...

* `system/user` object resurrected!   
* `system/user/home` is now set to the contents of HOME env variable on Rebol startup.
* New `system/user/rebol` field which is set to local user rebol directory (if found under `system/user/home`).
* New `system/repl` object containing properties & code for skinning repl.
* On REPL start-up it will load `%repl-skin.reb` if found in `system/user/rebol` directory.

Here is an extreme example of customising REPL using `%repl-skin.reb` :)  https://gist.github.com/draegtun/83ae0cd3307eb20ee010d8949121c4ba

Currently there are 3 types of *hooks* which can be changed in the REPL...

* shortcuts - Lookup word entered in `system/repl/shortcuts` object and transforms it to what it maps to.  
 
```
    >> ;;  Q and LIST-SHORTCUTS are two predefined shortcuts
    
    >> list-shortcuts
    q: [quit]
    list-shortcuts: [print system/repl/shortcuts]
    
    >> list-shortcuts: 1
    
    >> list-shortcuts    
    !! LIST-SHORTCUTS interpreted by console as: print system/repl/shortcuts
    !! use :list-shortcuts to get variable.
    q: [quit]
    list-shortcuts: [print system/repl/shortcuts]
    
    >> :list-shortcuts
    == 1
```

* input-hook - Can be used to parse/modify every input line (string).
* dialect-hook - Can be used to parse/modify whole code block provided (multi-line).

Having all 3 hooks maybe an overkill but it will interesting to see how we can make use of them.  NB.  Hooks concatenate: input-hook -> shortcut -> dialect-hook.

This is a proof-of-concept and I have more ideas on how we can extend this further.  I have been using it a little for a few weeks.   If this PR is OK then I'll write up some more detailed documentation.

**IMPORTANT**  - The HOME environment variable needs to be set to pick-up location of Rebol user area.  The directory on Windows/DOS would be...

    %HOME%\REBOL

and on Linux/OSX...

    $HOME/.rebol          
