### PR TITLE
Finer-grained errors from scanner, detect mismatched delimiters

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -61,8 +61,11 @@ Internal: [
 Syntax: [
     code: 2000
     type: "syntax error"
-    invalid:            [{invalid} :arg1 {--} :arg2]
-    missing:            [{missing} :arg2 {at} :arg1]
+    scan-invalid:       [{invalid} :arg1 {--} :arg2]
+    scan-missing:       [{missing} :arg1]
+    scan-extra:         [{extra} :arg1]
+    scan-mismatch:      [{expected} :arg1 {but got} :arg2]
+
     no-header:          [{script is missing a REBOL header:} :arg1]
     bad-header:         [{script header is not valid:} :arg1]
     bad-checksum:       [{script checksum failed:} :arg1]

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1828,9 +1828,10 @@ void Drop_Mold_Core(REB_MOLD *mold, REBOOL not_pushed_ok)
     // to "drop" a mold that hasn't ever been pushed is the easiest way to
     // avoid intervening.  Drop_Mold_If_Pushed(&mo) macro makes this clearer.
     //
-    if (not_pushed_ok && !mold->series) return;
+    if (not_pushed_ok && mold->series == NULL)
+        return;
 
-    assert(mold->series); // if NULL there was no Push_Mold
+    assert(mold->series != NULL); // if NULL there was no Push_Mold
 
     // When pushed data are to be discarded, mold->series may be unterminated.
     // (Indeed that happens when Scan_Item_Push_Mold returns NULL/0.)

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -27,9 +27,9 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 
-/*
-**  Tokens returned by the scanner.  Keep in sync with boot.r strings area.
-*/
+//
+//  Tokens returned by the scanner.  Keep in sync with Token_Names[].
+//
 enum Reb_Token {
     TOKEN_END = 0,
     TOKEN_NEWLINE,
@@ -210,12 +210,16 @@ typedef struct rebol_scan_state {
     const REBYTE *begin;
     const REBYTE *end;
     const REBYTE *limit;    /* no chars after this point */
-    REBCNT line_count;
+    
+    REBCNT line;
+    const REBYTE *line_head; // head of current line (used for errors)
+    REBCNT start_line;
+    const REBYTE *start_line_head;
+
     REBSTR *filename;
-    const REBYTE *head_line;        // head of current line (used for errors)
+
     REBFLGS opts;
-    REBOOL has_error;
-    REBCNT errors;
+    enum Reb_Token token;
 } SCAN_STATE;
 
 #define ANY_CR_LF_END(c) (!(c) || (c) == CR || (c) == LF)


### PR DESCRIPTION
The scanner had a uniform means of delivery, so that particular kinds
of scan errors were not getting distinct identities or arguments.
This is a first cut at changing the approach so that any particular
error could be given a unique identity if needed.

The main motivation was to get better discernment of cases like:

    load "[ abc"
    load "[ abc )"
    load "abc ]"

Only cases like the first can be resolved by more input, so the
usermode REPL will keep allowing more typing when errors of that form
occur, but not the others.  This resolves bugs that were related to
not being able to distinguish cases, in particular of open strings.

This is only a first step, with the intention to allow the scan state
to be processed in a stack to provide a complete list of the tokens
which are outstanding.