### PR TITLE
Unify semantics of GET-PATH + PICK*, and SET-PATH! + POKE

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -172,19 +172,6 @@ length-of: action [
     series [any-series! port! map! tuple! bitset! object! gob! struct! any-word! blank!]
 ]
 
-;-- Series Extraction
-
-pick*: action [
-    {Returns the value at the specified position.}
-    return: [<opt> any-value!]
-        {Picked value, or void if index not present}
-    aggregate [
-        any-series! map! gob! pair! date! time! tuple! bitset! port! varargs!
-    ]
-    index
-        {Index offset, symbol, or other value to use as index}
-]
-
 ;-- Series Search
 
 find: action [
@@ -300,13 +287,6 @@ change: action [
     /only {Only change a block as a single value (not the contents of the block)}
     /dup {Duplicates the change a specified number of times}
     count [any-number! pair!]
-]
-
-poke: action [
-    {Replaces an element at a given position.}
-    series [any-series! port! map! gob! bitset!] {(modified)}
-    index {Index offset, symbol, or other value to use as index}
-    value [<opt> any-value!] {The new value (returned)}
 ]
 
 clear: action [

--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -64,9 +64,9 @@ block       array       *       *       [series array]
 ;
 binary      string      *       *       [series]
 string      string      *       *       [series string]
-file        string      file    *       [series string]
+file        string      *       *       [series string]
 email       string      *       *       [series string]
-url         string      url     *       [series string]
+url         string      *       *       [series string]
 tag         string      *       *       [series string]
 
 bitset      bitset      *       *       -
@@ -75,7 +75,7 @@ vector      vector      *       *       [series]
 
 map         map         *       *       -
 
-varargs     varargs     -       *       -
+varargs     varargs     *       *       -
 
 object      context     *       *       context
 frame       context     *       *       context

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -47,6 +47,18 @@ none
 ;
 paren!
 
+; The PICK* action was killed in favor of a native that uses the same logic
+; as path processing.  Code still remains for processing PICK*, and ports or
+; other mechanics may wind up using it...or path dispatch itself may be
+; rewritten to use the PICK* action (but that would require significiant
+; change for setting and getting paths)
+;
+; Similar story for POKE, which uses the same logic as PICK* to find the
+; location to write the value.
+;
+pick*
+poke
+
 native
 action
 self

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -133,20 +133,18 @@ static void Assert_Basics(void)
     // enumerated as an ARRAY.
     //
     if (
-        offsetof(struct Reb_Series, info)
-            - offsetof(struct Reb_Series, content)
-        != sizeof(REBVAL)
+        offsetof(REBSER, info) - offsetof(REBSER, content) != sizeof(REBVAL)
     ){
         panic ("bad structure alignment for internal array termination");
     }
 
-    // The END marker logic currently uses REB_MAX for the type bits.  That's
-    // okay up until the REB_MAX bumps to 256.  If you hit this then some
-    // other value needs to be chosen in the debug build to represent the
-    // type value for END's bits.  (REB_TRASH is just a poor choice, because
-    // you'd like to catch IS_END() tests on trash.)
+    // Void cells currently use REB_MAX for the type bits, and the debug
+    // build uses REB_MAX + 1 for signaling "trash".  At most 64 "Reb_Kind"
+    // types are used at the moment, yet the type is a byte for efficient
+    // reading, so there's little danger of hitting this unless there's
+    // a big change.
     //
-    assert(REB_MAX < 256);
+    assert(REB_MAX + 1 < 256);
 
     // Make sure tricks for "internal END markers" are lined up as expected.
     //

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -71,39 +71,39 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
 
     pvs->item++;
 
-    // Calculate the "selector" into the GC guarded cell.
+    // Calculate the "picker" into the GC guarded cell.
     //
-    assert(pvs->selector == &pvs->selector_cell);
+    assert(pvs->picker == &pvs->picker_cell);
 
     if (IS_GET_WORD(pvs->item)) { // e.g. object/:field
         Copy_Opt_Var_May_Fail(
-            &pvs->selector_cell, pvs->item, pvs->item_specifier
+            &pvs->picker_cell, pvs->item, pvs->item_specifier
         );
 
-        if (IS_VOID(pvs->selector))
+        if (IS_VOID(pvs->picker))
             fail (Error_No_Value_Core(pvs->item, pvs->item_specifier));
     }
     else if (IS_GROUP(pvs->item)) { // object/(expr) case:
         REBSPC *derived = Derive_Specifier(pvs->item_specifier, pvs->item);
         if (Do_At_Throws(
-            &pvs->selector_cell,
+            &pvs->picker_cell,
             VAL_ARRAY(pvs->item),
             VAL_INDEX(pvs->item),
             derived
         )) {
-            Move_Value(pvs->store, &pvs->selector_cell);
+            Move_Value(pvs->store, &pvs->picker_cell);
             return TRUE;
         }
     }
     else { // object/word and object/value case:
-        Derelativize(&pvs->selector_cell, pvs->item, pvs->item_specifier);
+        Derelativize(&pvs->picker_cell, pvs->item, pvs->item_specifier);
     }
 
     // Disallow voids from being used in path dispatch.  This rule seems like
     // common sense for safety, and also corresponds to voids being illegal
     // to use in SELECT.
     //
-    if (IS_VOID(pvs->selector))
+    if (IS_VOID(pvs->picker))
         fail (Error_No_Value_Core(pvs->item, pvs->item_specifier));
 
     switch (dispatcher(pvs)) {
@@ -163,7 +163,7 @@ REBOOL Do_Path_Throws_Core(
     REBSPC *specifier,
     REBVAL *opt_setval
 ) {
-    // The pvs contains a cell for the selector into which evaluations are
+    // The pvs contains a cell for the picker into which evaluations are
     // done, e.g. `foo/(1 + 2)`.  Because Next_Path() doesn't commit to not
     // performing any evaluations this cell must be guarded.  In the case of
     // a fail() this guard will be released automatically, but to return
@@ -174,10 +174,10 @@ REBOOL Do_Path_Throws_Core(
     // calls, which may still be relevant to why this can't be a C local.
     //
     REBPVS pvs;
-    Prep_Global_Cell(&pvs.selector_cell);
-    SET_END(&pvs.selector_cell);
-    PUSH_GUARD_VALUE(&pvs.selector_cell);
-    pvs.selector = &pvs.selector_cell;
+    Prep_Global_Cell(&pvs.picker_cell);
+    SET_END(&pvs.picker_cell);
+    PUSH_GUARD_VALUE(&pvs.picker_cell);
+    pvs.picker = &pvs.picker_cell;
 
     REBDSP dsp_orig = DSP;
 
@@ -325,11 +325,11 @@ REBOOL Do_Path_Throws_Core(
     }
 
 return_not_thrown:
-    DROP_GUARD_VALUE(&pvs.selector_cell);
+    DROP_GUARD_VALUE(&pvs.picker_cell);
     return FALSE;
 
 return_thrown:
-    DROP_GUARD_VALUE(&pvs.selector_cell);
+    DROP_GUARD_VALUE(&pvs.picker_cell);
     return TRUE;
 }
 
@@ -423,29 +423,24 @@ void Get_Simple_Value_Into(REBVAL *out, const RELVAL *val, REBSPC *specifier)
 //
 REBCTX *Resolve_Path(const REBVAL *path, REBCNT *index_out)
 {
-    RELVAL *selector;
-    const RELVAL *var;
-    REBARR *array;
-    REBCNT i;
+    REBARR *array = VAL_ARRAY(path);
+    RELVAL *picker = ARR_HEAD(array);
 
-    array = VAL_ARRAY(path);
-    selector = ARR_HEAD(array);
-
-    if (IS_END(selector) || !ANY_WORD(selector))
+    if (IS_END(picker) || !ANY_WORD(picker))
         return NULL; // !!! only handles heads of paths that are ANY-WORD!
 
-    var = Get_Opt_Var_May_Fail(selector, VAL_SPECIFIER(path));
+    const RELVAL *var = Get_Opt_Var_May_Fail(picker, VAL_SPECIFIER(path));
 
-    ++selector;
-    if (IS_END(selector))
+    ++picker;
+    if (IS_END(picker))
         return NULL; // !!! does not handle single-element paths
 
-    while (ANY_CONTEXT(var) && IS_WORD(selector)) {
-        i = Find_Canon_In_Context(
-            VAL_CONTEXT(var), VAL_WORD_CANON(selector), FALSE
+    while (ANY_CONTEXT(var) && IS_WORD(picker)) {
+        REBCNT i = Find_Canon_In_Context(
+            VAL_CONTEXT(var), VAL_WORD_CANON(picker), FALSE
         );
-        ++selector;
-        if (IS_END(selector)) {
+        ++picker;
+        if (IS_END(picker)) {
             *index_out = i;
             return VAL_CONTEXT(var);
         }
@@ -453,5 +448,175 @@ REBCTX *Resolve_Path(const REBVAL *path, REBCNT *index_out)
         var = CTX_VAR(VAL_CONTEXT(var), i);
     }
 
-    DEAD_END;
+    return NULL;
+}
+
+
+//
+//  pick*: native [
+//
+//  {Perform a path picking operation, same as `:(:location)/(:picker)`}
+//
+//      return: [<opt> any-value!]
+//          {Picked value, or void if picker can't fulfill the request}
+//      location [any-value!]
+//      picker [any-value!]
+//          {Index offset, symbol, or other value to use as index}
+//  ]
+//
+REBNATIVE(pick_p)
+//
+// In R3-Alpha, PICK was an "action", which dispatched on types through the
+// "action mechanic" for the following types:
+//
+//     [any-series! map! gob! pair! date! time! tuple! bitset! port! varargs!]
+//
+// In Ren-C, PICK is rethought to use the same dispatch mechanic as paths,
+// to cut down on the total number of operations the system has to define.
+{
+    INCLUDE_PARAMS_OF_PICK_P;
+
+    REBVAL *location = ARG(location);
+    REBVAL *picker = ARG(picker);
+
+    // PORT!s are kind of a "user defined type" which historically could
+    // react to PICK and POKE, but which could not override path dispatch.
+    // Use a symbol-based call to bounce the frame to the port, which should
+    // be a compatible frame with the historical "action".
+    //
+    if (IS_PORT(location))
+        return Do_Port_Action(frame_, VAL_CONTEXT(location), SYM_PICK_P);
+
+    REBPVS pvs_decl;
+    REBPVS *pvs = &pvs_decl;
+
+    Prep_Global_Cell(&pvs->picker_cell);
+    SET_TRASH_IF_DEBUG(&pvs->picker_cell); // not used
+    pvs->picker = picker;
+    pvs->store = D_OUT;
+
+    // !!! Sometimes path dispatchers check the item to see if it's at the
+    // end of the path.  The entire thing needs review.  In the meantime,
+    // take advantage of the implicit termination of the frame cell.
+    //
+    Move_Value(D_CELL, picker);
+    assert(IS_END(D_CELL + 1));
+
+    pvs->item = D_CELL;
+    pvs->item_specifier = SPECIFIED;
+    pvs->value = location;
+    pvs->value_specifier = SPECIFIED;
+
+    pvs->label_out = NULL; // applies to e.g. :append/only returning APPEND
+    pvs->orig = location; // expected to be a PATH! for errors, but tolerant
+    pvs->opt_setval = NULL;
+
+    REBPEF dispatcher = Path_Dispatch[VAL_TYPE(location)];
+    assert(dispatcher != NULL); // &PD_Fail is used instead of NULL
+    switch (dispatcher(pvs)) {
+    case PE_OK:
+        break;
+
+    case PE_SET_IF_END:
+        break;
+
+    case PE_NONE:
+        SET_BLANK(pvs->store);
+    case PE_USE_STORE:
+        pvs->value = pvs->store;
+        pvs->value_specifier = SPECIFIED;
+        break;
+
+    default:
+        assert(FALSE);
+    }
+
+    if (pvs->value != pvs->store)
+        Derelativize(D_OUT, pvs->value, pvs->value_specifier);
+
+    return R_OUT;
+}
+
+
+//
+//  poke: native [
+//
+//  {Perform a path poking operation, same as `(:location)/(:picker): :value`}
+//
+//      return: [<opt> any-value!]
+//          {Same as value}
+//      location [any-value!]
+//          {(modified)}
+//      picker
+//          {Index offset, symbol, or other value to use as index}
+//      value [<opt> any-value!]
+//          {The new value}
+//  ]
+//
+REBNATIVE(poke)
+//
+// As with PICK*, POKE is changed in Ren-C from its own action to "whatever
+// path-setting (now path-poking) would do".
+{
+    INCLUDE_PARAMS_OF_POKE;
+
+    REBVAL *location = ARG(location);
+    REBVAL *picker = ARG(picker);
+    REBVAL *value = ARG(value);
+
+    // PORT!s are kind of a "user defined type" which historically could
+    // react to PICK and POKE, but which could not override path dispatch.
+    // Use a symbol-based call to bounce the frame to the port, which should
+    // be a compatible frame with the historical "action".
+    //
+    if (IS_PORT(location))
+        return Do_Port_Action(frame_, VAL_CONTEXT(location), SYM_POKE);
+
+    REBPVS pvs_decl;
+    REBPVS *pvs = &pvs_decl;
+
+    Prep_Global_Cell(&pvs->picker_cell);
+    SET_TRASH_IF_DEBUG(&pvs->picker_cell); // not used
+    pvs->picker = picker;
+    pvs->store = D_OUT;
+
+    // !!! Sometimes the path mechanics do the writes for a poke inside their
+    // dispatcher, vs. delegating via PE_SET_IF_END.  They check to see if
+    // the current pvs->item is at the end.  All of path dispatch was ad hoc
+    // and needs a review.  In the meantime, take advantage of the implicit
+    // termination of the frame cell.
+    //
+    Move_Value(D_CELL, picker);
+    assert(IS_END(D_CELL + 1));
+
+    pvs->item = D_CELL;
+    pvs->item_specifier = SPECIFIED;
+    pvs->value = location;
+    pvs->value_specifier = SPECIFIED;
+
+    pvs->label_out = NULL; // applies to e.g. :append/only returning APPEND
+    pvs->orig = location; // expected to be a PATH! for errors, but tolerant
+    pvs->opt_setval = value;
+
+    REBPEF dispatcher = Path_Dispatch[VAL_TYPE(location)];
+    assert(dispatcher != NULL); // &PD_Fail is used instead of NULL
+    switch (dispatcher(pvs)) {
+    case PE_SET_IF_END:
+        *pvs->value = *pvs->opt_setval;
+        break;
+
+    case PE_OK:
+        // !!! Trust that it wrote?  See above notes about D_CELL.
+        break;
+
+    case PE_NONE:
+    case PE_USE_STORE:
+        fail (picker); // Invalid argument
+
+    default:
+        assert(FALSE);
+    }
+
+    Move_Value(D_OUT, value);
+    return R_OUT;
 }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -323,7 +323,7 @@ REBINT Get_System_Int(REBCNT i1, REBCNT i2, REBINT default_int)
 // Common function.
 //
 void Init_Any_Series_At_Core(
-    REBVAL *out,
+    RELVAL *out, // allows RELVAL slot as input, but will be filled w/REBVAL
     enum Reb_Kind type,
     REBSER *series,
     REBCNT index,
@@ -394,7 +394,11 @@ void Set_Tuple(REBVAL *value, REBYTE *bytes, REBCNT len)
 // is its canon form from a single pointer...the REBVAL sitting in the 0 slot
 // of the context's varlist.
 //
-void Init_Any_Context_Core(REBVAL *out, enum Reb_Kind kind, REBCTX *c) {
+void Init_Any_Context_Core(
+    RELVAL *out, // allows RELVAL slot as input, but will be filled w/REBVAL
+    enum Reb_Kind kind,
+    REBCTX *c
+) {
 #if defined(NDEBUG)
     UNUSED(kind);
 #else

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -330,15 +330,15 @@ static REB_R Transport_Actor(
 
     case SYM_PICK_P: {
         INCLUDE_PARAMS_OF_PICK_P;
-        UNUSED(PAR(aggregate));
+        UNUSED(PAR(location));
 
         // FIRST server-port returns new port connection.
         //
-        REBCNT len = Get_Num_From_Arg(ARG(index));
+        REBCNT len = Get_Num_From_Arg(ARG(picker));
         if (len == 1 && GET_FLAG(sock->modes, RST_LISTEN) && sock->common.data)
             Accept_New_Port(SINK(D_OUT), port, DEVREQ_NET(sock));
         else
-            fail (Error_Out_Of_Range(ARG(index)));
+            fail (Error_Out_Of_Range(ARG(picker)));
         return R_OUT; }
 
     case SYM_QUERY: {

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -512,7 +512,7 @@ REBINT PD_Bitset(REBPVS *pvs)
     REBSER *ser = VAL_SERIES(pvs->value);
 
     if (!pvs->opt_setval) {
-        if (Check_Bits(ser, pvs->selector, FALSE)) {
+        if (Check_Bits(ser, pvs->picker, FALSE)) {
             SET_TRUE(pvs->store);
             return PE_USE_STORE;
         }
@@ -521,7 +521,7 @@ REBINT PD_Bitset(REBPVS *pvs)
 
     if (Set_Bits(
         ser,
-        pvs->selector,
+        pvs->picker,
         BITS_NOT(ser)
             ? IS_CONDITIONAL_FALSE(pvs->opt_setval)
             : IS_CONDITIONAL_TRUE(pvs->opt_setval)
@@ -569,12 +569,10 @@ REBTYPE(Bitset)
 
     switch (action) {
 
-    // Define PICK for BITSETS?  PICK's set bits and returns #?
     // Add AND, OR, XOR
 
-    case SYM_PICK_P:
     case SYM_FIND: {
-        INCLUDE_PARAMS_OF_FIND; // is PICK guaranteed to have CASE at same pos
+        INCLUDE_PARAMS_OF_FIND;
 
         UNUSED(PAR(series));
         UNUSED(PAR(value));
@@ -611,17 +609,14 @@ REBTYPE(Bitset)
 
     case SYM_APPEND:  // Accepts: #"a" "abc" [1 - 10] [#"a" - #"z"] etc.
     case SYM_INSERT:
-        diff = TRUE;
-        goto set_bits;
+        if (BITS_NOT(VAL_SERIES(value)))
+            diff = FALSE;
+        else
+            diff = TRUE;
 
-    case SYM_POKE:
-        if (!IS_LOGIC(D_ARG(3)))
-            fail (D_ARG(3));
-        diff = VAL_LOGIC(D_ARG(3));
-set_bits:
-        if (BITS_NOT(VAL_SERIES(value))) diff = NOT(diff);
-        if (Set_Bits(VAL_SERIES(value), arg, diff)) break;
-        fail (arg);
+        if (NOT(Set_Bits(VAL_SERIES(value), arg, diff)))
+            fail (arg);
+        break;
 
     case SYM_REMOVE: {
         INCLUDE_PARAMS_OF_REMOVE;

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -728,24 +728,6 @@ void Pick_Or_Poke_Date(
 }
 
 
-inline static void Pick_Date(
-    REBVAL *out,
-    const REBVAL *value,
-    const REBVAL *picker
-) {
-    Pick_Or_Poke_Date(out, m_cast(REBVAL*, value), picker, NULL);
-}
-
-
-inline static void Poke_Date_Immediate(
-    REBVAL *value,
-    const REBVAL *picker,
-    const REBVAL *poke
-) {
-    Pick_Or_Poke_Date(NULL, value, picker, poke);
-}
-
-
 //
 //  PD_Date: C
 //
@@ -758,11 +740,13 @@ REBINT PD_Date(REBPVS *pvs)
         // while not affecting the original (unless it was a literal value
         // in source)
         //
-        Poke_Date_Immediate(KNOWN(pvs->value), pvs->selector, pvs->opt_setval);
+        Pick_Or_Poke_Date(
+            NULL, KNOWN(pvs->value), pvs->picker, pvs->opt_setval
+        );
         return PE_OK;
     }
 
-    Pick_Date(pvs->store, KNOWN(pvs->value), pvs->selector);
+    Pick_Or_Poke_Date(pvs->store, KNOWN(pvs->value), pvs->picker, NULL);
     return PE_USE_STORE;
 }
 
@@ -842,20 +826,6 @@ REBTYPE(Date)
 
         case SYM_ODD_Q:
             return (day & 1) == 0 ? R_TRUE : R_FALSE;
-
-        case SYM_PICK_P:
-            assert(D_ARGC > 1);
-            Pick_Date(D_OUT, val, arg);
-            return R_OUT;
-
-        // !!! Because DATE! is an immediate value, POKE is not offered as it
-        // would not actually modify a variable (just the evaluative temporary
-        // from fetching the variable).  But see SET-PATH! notes in PD_Date.
-
-        /* case SYM_POKE:
-            Poke_Date_Immediate(D_OUT, val, arg, D_ARG(3));
-            Move_Value(D_OUT, D_ARG(3));
-            return R_OUT;*/
 
         case SYM_RANDOM: {
             INCLUDE_PARAMS_OF_RANDOM;

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -407,10 +407,10 @@ void TO_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 //
 REBINT PD_Event(REBPVS *pvs)
 {
-    if (IS_WORD(pvs->selector)) {
+    if (IS_WORD(pvs->picker)) {
         if (!pvs->opt_setval || NOT_END(pvs->item + 1)) {
             if (!Get_Event_Var(
-                KNOWN(pvs->value), VAL_WORD_CANON(pvs->selector), pvs->store
+                KNOWN(pvs->value), VAL_WORD_CANON(pvs->picker), pvs->store
             )) {
                 fail (Error_Bad_Path_Set(pvs));
             }
@@ -419,7 +419,7 @@ REBINT PD_Event(REBPVS *pvs)
         }
         else {
             if (!Set_Event_Var(
-                KNOWN(pvs->value), pvs->selector, pvs->opt_setval
+                KNOWN(pvs->value), pvs->picker, pvs->opt_setval
             )) {
                 fail (Error_Bad_Path_Set(pvs));
             }

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -361,7 +361,7 @@ REBNATIVE(func_class_of)
 //
 REBINT PD_Function(REBPVS *pvs)
 {
-    if (IS_BLANK(pvs->selector)) {
+    if (IS_BLANK(pvs->picker)) {
         //
         // Leave the function value as-is, and continue processing.  This
         // enables things like `append/(all [foo 'dup])/only`...
@@ -373,8 +373,8 @@ REBINT PD_Function(REBPVS *pvs)
     // general path mechanic before reaching this dispatch.  So if it's not
     // a word or one of those that evaluated to a word raise an error.
     //
-    if (!IS_WORD(pvs->selector))
-        fail (Error_Bad_Refine_Raw(pvs->selector));
+    if (!IS_WORD(pvs->picker))
+        fail (Error_Bad_Refine_Raw(pvs->picker));
 
     // We could generate a "refined" function variant at each step:
     //
@@ -385,7 +385,7 @@ REBINT PD_Function(REBPVS *pvs)
     // understood to push the canonized word to the data stack in the
     // function case.
     //
-    DS_PUSH(pvs->selector);
+    DS_PUSH(pvs->picker);
 
     // Go ahead and canonize the word symbol so we don't have to do it each
     // time in order to get a case-insensitive compare.  (Note that canons can

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -1016,15 +1016,6 @@ REBTYPE(Image)
         SET_INTEGER(D_OUT, tail > index ? tail - index : 0);
         return R_OUT;
 
-    case SYM_PICK_P:
-        Pick_Image(D_OUT, value, arg);
-        return R_OUT;
-
-    case SYM_POKE:
-        Poke_Image_Fail_If_Read_Only(value, arg, D_ARG(3));
-        Move_Value(D_OUT, D_ARG(3));
-        return R_OUT;
-
     case SYM_SKIP:
     case SYM_AT:
         // This logic is somewhat complicated by the fact that INTEGER args use
@@ -1410,11 +1401,11 @@ REBINT PD_Image(REBPVS *pvs)
 {
     if (pvs->opt_setval) {
         Poke_Image_Fail_If_Read_Only(
-            KNOWN(pvs->value), pvs->selector, pvs->opt_setval
+            KNOWN(pvs->value), pvs->picker, pvs->opt_setval
         );
         return PE_OK;
     }
 
-    Pick_Image(pvs->store, KNOWN(pvs->value), pvs->selector);
+    Pick_Image(pvs->store, KNOWN(pvs->value), pvs->picker);
     return PE_USE_STORE;
 }

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -355,7 +355,7 @@ REBINT PD_Map(REBPVS *pvs)
 
     REBINT n = Find_Map_Entry(
         VAL_MAP(pvs->value),
-        pvs->selector,
+        pvs->picker,
         SPECIFIED,
         setting ? pvs->opt_setval : NULL,
         SPECIFIED,
@@ -697,26 +697,6 @@ REBTYPE(Map)
         Find_Map_Entry(
             map, ARG(key), SPECIFIED, VOID_CELL, SPECIFIED, TRUE
         );
-        return R_OUT; }
-
-    case SYM_POKE: { // CHECK all pokes!!! to be sure they check args now !!!
-        INCLUDE_PARAMS_OF_POKE;
-
-        UNUSED(ARG(series)); // map
-        UNUSED(ARG(index)); // arg
-
-        FAIL_IF_READ_ONLY_ARRAY(MAP_PAIRLIST(map));
-
-        const REBOOL cased = TRUE;
-        Find_Map_Entry(
-            map,
-            arg, // key
-            SPECIFIED,
-            ARG(value), // value... since non-void, inserted if not there
-            SPECIFIED,
-            cased
-        );
-        Move_Value(D_OUT, ARG(value));
         return R_OUT; }
 
     case SYM_LENGTH_OF:

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -457,11 +457,11 @@ REBINT PD_Context(REBPVS *pvs)
 {
     REBCTX *c = VAL_CONTEXT(pvs->value);
 
-    if (NOT(IS_WORD(pvs->selector)))
+    if (NOT(IS_WORD(pvs->picker)))
         fail (Error_Bad_Path_Select(pvs));
 
     REBCNT n = Find_Canon_In_Context(
-        c, VAL_WORD_CANON(pvs->selector), FALSE
+        c, VAL_WORD_CANON(pvs->picker), FALSE
     );
 
     if (n == 0) {
@@ -478,13 +478,13 @@ REBINT PD_Context(REBPVS *pvs)
     }
 
     if (CTX_VARS_UNAVAILABLE(c))
-        fail (Error_No_Relative_Raw(pvs->selector));
+        fail (Error_No_Relative_Raw(pvs->picker));
 
     if (pvs->opt_setval && IS_END(pvs->item + 1)) {
         FAIL_IF_READ_ONLY_CONTEXT(c);
 
         if (GET_VAL_FLAG(CTX_VAR(c, n), VALUE_FLAG_PROTECTED))
-            fail (Error_Protected_Word_Raw(pvs->selector));
+            fail (Error_Protected_Word_Raw(pvs->picker));
     }
 
     pvs->value = CTX_VAR(c, n);

--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -185,7 +185,7 @@ void Min_Max_Pair(REBVAL *out, const REBVAL *a, const REBVAL *b, REBOOL maxed)
 //
 REBINT PD_Pair(REBPVS *pvs)
 {
-    const REBVAL *sel = pvs->selector;
+    const REBVAL *sel = pvs->picker;
     REBINT n = 0;
     REBDEC dec;
 
@@ -362,39 +362,6 @@ REBTYPE(Pair)
         x1 = cast(REBDEC, Random_Range(cast(REBINT, x1), REF(secure)));
         y1 = cast(REBDEC, Random_Range(cast(REBINT, y1), REF(secure)));
         goto setPair; }
-
-    case SYM_PICK_P: {
-        REBVAL *arg = D_ARG(2);
-        REBINT n;
-        if (IS_WORD(arg)) {
-            if (VAL_WORD_SYM(arg) == SYM_X)
-                n = 0;
-            else if (VAL_WORD_SYM(arg) == SYM_Y)
-                n = 1;
-            else
-                fail (arg);
-        }
-        else {
-            n = Get_Num_From_Arg(arg);
-            if (n < 1 || n > 2) fail (Error_Out_Of_Range(arg));
-            n--;
-        }
-///     case SYM_POKE:
-///         if (action == SYM_POKE) {
-///             arg = D_ARG(3);
-///             if (IS_INTEGER(arg)) {
-///                 if (index == 0) x1 = VAL_INT32(arg);
-///                 else y1 = VAL_INT32(arg);
-///             }
-///             else if (IS_DECIMAL(arg)) {
-///                 if (index == 0) x1 = (REBINT)VAL_DECIMAL(arg);
-///                 else y1 = (REBINT)VAL_DECIMAL(arg);
-///             } else
-///                 fail (arg);
-///             goto setPair;
-///         }
-        SET_DECIMAL(D_OUT, n == 0 ? x1 : y1);
-        return R_OUT; }
 
     default:
         break;

--- a/src/core/t-struct.c
+++ b/src/core/t-struct.c
@@ -1344,13 +1344,13 @@ void TO_Struct(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 REBINT PD_Struct(REBPVS *pvs)
 {
     REBSTU *stu = VAL_STRUCT(pvs->value);
-    if (!IS_WORD(pvs->selector))
+    if (!IS_WORD(pvs->picker))
         fail (Error_Bad_Path_Select(pvs));
 
     fail_if_non_accessible(KNOWN(pvs->value));
 
     if (!pvs->opt_setval || NOT_END(pvs->item + 1)) {
-        if (NOT(Get_Struct_Var(pvs->store, stu, pvs->selector)))
+        if (NOT(Get_Struct_Var(pvs->store, stu, pvs->picker)))
             fail (Error_Bad_Path_Select(pvs));
 
         // !!! Comment here said "Setting element to an array in the struct"
@@ -1376,18 +1376,18 @@ REBINT PD_Struct(REBPVS *pvs)
             && IS_BLOCK(pvs->store)
             && IS_END(pvs->item + 2)
         ) {
-            // !!! This is dodgy; it has to copy (as selector is a pointer to
+            // !!! This is dodgy; it has to copy (as picker is a pointer to
             // a memory cell it may not own), has to guard (as the next path
             // evaluation may not protect the result...)
             //
             DECLARE_LOCAL (sel_orig);
-            Move_Value(sel_orig, pvs->selector);
+            Move_Value(sel_orig, pvs->picker);
             PUSH_GUARD_VALUE(sel_orig);
 
             pvs->value = pvs->store;
             pvs->value_specifier = SPECIFIED;
 
-            if (Next_Path_Throws(pvs)) { // updates pvs->store, pvs->selector
+            if (Next_Path_Throws(pvs)) { // updates pvs->store, pvs->picker
                 DROP_GUARD_VALUE(sel_orig);
                 fail (Error_No_Catch_For_Throw(pvs->store)); // !!! Review
             }
@@ -1395,7 +1395,7 @@ REBINT PD_Struct(REBPVS *pvs)
             DECLARE_LOCAL (specific);
             Derelativize(specific, pvs->value, pvs->value_specifier);
 
-            if (!Set_Struct_Var(stu, sel_orig, pvs->selector, specific))
+            if (!Set_Struct_Var(stu, sel_orig, pvs->picker, specific))
                 fail (Error_Bad_Path_Set(pvs));
 
             DROP_GUARD_VALUE(sel_orig);
@@ -1408,7 +1408,7 @@ REBINT PD_Struct(REBPVS *pvs)
     else {
         // setting (because opt_setval is non-NULL, and at end of path)
 
-        if (!Set_Struct_Var(stu, pvs->selector, NULL, pvs->opt_setval))
+        if (!Set_Struct_Var(stu, pvs->picker, NULL, pvs->opt_setval))
             fail (Error_Bad_Path_Set(pvs));
 
         return PE_OK;

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -475,11 +475,11 @@ REBINT PD_Time(REBPVS *pvs)
         // !!! Since TIME! is an immediate value, allowing a SET-PATH! will
         // modify the result of the expression but not the source.
         //
-        Poke_Time_Immediate(KNOWN(pvs->value), pvs->selector, pvs->opt_setval);
+        Poke_Time_Immediate(KNOWN(pvs->value), pvs->picker, pvs->opt_setval);
         return PE_OK;
     }
 
-    Pick_Time(pvs->store, KNOWN(pvs->value), pvs->selector);
+    Pick_Time(pvs->store, KNOWN(pvs->value), pvs->picker);
     return PE_USE_STORE;
 }
 
@@ -694,19 +694,6 @@ REBTYPE(Time)
             }
             secs = Random_Range(secs / SEC_SEC, REF(secure)) * SEC_SEC;
             goto fixTime; }
-
-        case SYM_PICK_P:
-            Pick_Time(D_OUT, val, arg);
-            return R_OUT;
-
-        // !!! TIME! is currently immediate, which means that if you poke
-        // a value it will modify that value directly; this will appear
-        // to have no effect on variables.  But SET-PATH! does it, see PT_Time
-
-        /* case SYM_POKE:
-            Poke_Time_Immediate(val, arg, D_ARG(3));
-            Move_Value(D_OUT, D_ARG(3));
-            return R_OUT;*/
 
         default:
             break;

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -253,12 +253,12 @@ REBINT PD_Tuple(REBPVS *pvs)
         // result in y being 10.20.10, but x is unchanged.
         //
         Poke_Tuple_Immediate(
-            KNOWN(pvs->value), pvs->selector, pvs->opt_setval
+            KNOWN(pvs->value), pvs->picker, pvs->opt_setval
         );
         return PE_OK;
     }
 
-    Pick_Tuple(pvs->store, KNOWN(pvs->value), pvs->selector);
+    Pick_Tuple(pvs->store, KNOWN(pvs->value), pvs->picker);
     return PE_USE_STORE;
 }
 
@@ -438,18 +438,6 @@ REBTYPE(Tuple)
         len = MAX(len, 3);
         SET_INTEGER(D_OUT, len);
         return R_OUT;
-
-    case SYM_PICK_P:
-        Pick_Tuple(D_OUT, value, arg);
-        return R_OUT;
-
-    // !!! TUPLE! is an immediate value at the current time, and does not
-    // support POKE.  But see PD_Tuple for notes on its behavior with SET-PATH!
-    //
-    /*case SYM_POKE:
-        Poke_Tuple_Immediate(value, arg, D_ARG(3));
-        Move_Value(D_OUT, D_ARG(3));
-        return R_OUT;*/
 
     case SYM_REVERSE: {
         INCLUDE_PARAMS_OF_REVERSE;

--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -600,12 +600,12 @@ REBINT PD_Vector(REBPVS *pvs)
 {
     if (pvs->opt_setval) {
         Poke_Vector_Fail_If_Read_Only(
-            KNOWN(pvs->value), pvs->selector, pvs->opt_setval
+            KNOWN(pvs->value), pvs->picker, pvs->opt_setval
         );
         return PE_OK;
     }
 
-    Pick_Vector(pvs->store, KNOWN(pvs->value), pvs->selector);
+    Pick_Vector(pvs->store, KNOWN(pvs->value), pvs->picker);
     return PE_USE_STORE;
 }
 
@@ -616,7 +616,6 @@ REBINT PD_Vector(REBPVS *pvs)
 REBTYPE(Vector)
 {
     REBVAL *value = D_ARG(1);
-    REBVAL *arg = D_ARGC > 1 ? D_ARG(2) : NULL;
     REBSER *ser;
 
     // Common operations for any series type (length, head, etc.)
@@ -629,15 +628,6 @@ REBTYPE(Vector)
     REBSER *vect = VAL_SERIES(value);
 
     switch (action) {
-
-    case SYM_PICK_P:
-        Pick_Vector(D_OUT, value, arg);
-        return R_OUT;
-
-    case SYM_POKE:
-        Poke_Vector_Fail_If_Read_Only(value, arg, D_ARG(3));
-        Move_Value(D_OUT, D_ARG(3));
-        return R_OUT;
 
     case SYM_LENGTH_OF:
         //bits = 1 << (vect->size & 3);

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -308,7 +308,7 @@ inline static REBVAL *CTX_FRAME_FUNC_VALUE(REBCTX *c) {
     ((n) + 1)
 
 #define Init_Any_Context(out,kind,context) \
-    Init_Any_Context_Core(SINK(out), (kind), (context))
+    Init_Any_Context_Core((out), (kind), (context))
 
 #define Init_Object(v,c) \
     Init_Any_Context((v), REB_OBJECT, (c))

--- a/src/include/sys-path.h
+++ b/src/include/sys-path.h
@@ -99,14 +99,14 @@ struct Reb_Path_Value_State {
     //
     REBSPC *item_specifier;
 
-    // `selector` is the result of evaluating the current path item if
+    // `picker` is the result of evaluating the current path item if
     // necessary.  So if the path is `a/(1 + 2)` and processing the second
-    // `item`, then the selector would be the computed value `3`.
+    // `item`, then the picker would be the computed value `3`.
     //
     // (This is what the individual path dispatchers should use.)
     //
-    const REBVAL *selector;
-    REBVAL selector_cell; // selector = &selector_cell (GC guarded value)
+    const REBVAL *picker;
+    REBVAL picker_cell; // picker = &picker_cell (GC guarded value)
 
     // `value` holds the path value that should be chained from.  (It is the
     // type of `value` that dictates which dispatcher is given the `selector`

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -660,7 +660,7 @@ inline static REBYTE *VAL_RAW_DATA_AT(const RELVAL *v) {
 }
 
 #define Init_Any_Series_At(v,t,s,i) \
-    Init_Any_Series_At_Core(SINK(v), (t), (s), (i), SPECIFIED)
+    Init_Any_Series_At_Core((v), (t), (s), (i), SPECIFIED)
 
 #define Init_Any_Series(v,t,s) \
     Init_Any_Series_At((v), (t), (s), 0)

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -19,7 +19,7 @@ REBOL [
 first: redescribe [
     {Returns the first value of a series.}
 ](
-    specialize 'pick [index: 1]
+    specialize 'pick [picker: 1]
 )
 
 first+: func [
@@ -34,55 +34,55 @@ first+: func [
 second: redescribe [
     {Returns the second value of a series.}
 ](
-    specialize 'pick [index: 2]
+    specialize 'pick [picker: 2]
 )
 
 third: redescribe [
     {Returns the third value of a series.}
 ](
-    specialize 'pick [index: 3]
+    specialize 'pick [picker: 3]
 )
 
 fourth: redescribe [
     {Returns the fourth value of a series.}
 ](
-    specialize 'pick [index: 4]
+    specialize 'pick [picker: 4]
 )
 
 fifth: redescribe [
     {Returns the fifth value of a series.}
 ](
-    specialize 'pick [index: 5]
+    specialize 'pick [picker: 5]
 )
 
 sixth: redescribe [
     {Returns the sixth value of a series.}
 ](
-    specialize 'pick [index: 6]
+    specialize 'pick [picker: 6]
 )
 
 seventh: redescribe [
     {Returns the seventh value of a series.}
 ](
-    specialize 'pick [index: 7]
+    specialize 'pick [picker: 7]
 )
 
 eighth: redescribe [
     {Returns the eighth value of a series.}
 ](
-    specialize 'pick [index: 8]
+    specialize 'pick [picker: 8]
 )
 
 ninth: redescribe [
     {Returns the ninth value of a series.}
 ](
-    specialize 'pick [index: 9]
+    specialize 'pick [picker: 9]
 )
 
 tenth: redescribe [
     {Returns the tenth value of a series.}
 ](
-    specialize 'pick [index: 10]
+    specialize 'pick [picker: 10]
 )
 
 last: func [

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -139,7 +139,7 @@ assert-debug: function [
             conditions: pos ;-- move expression position and continue
 
             ; including BAR!s in the failure report looks messy
-            while [bar? conditions/1] [conditions: next conditions]
+            while [bar? :conditions/1] [conditions: next conditions]
         ]
     ]
 

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -118,7 +118,7 @@ parse-asn: function [
     result: make block! 16
     mode: 'type
 
-    while [d: data/1] [
+    while [not void? d: :data/1] [
         switch mode [
             type [
                 constructed?: not zero? (d and* 32)
@@ -629,7 +629,7 @@ parse-messages: function [
         ]
 
         handshake [
-            while [data/1] [
+            while [not tail? data] [
                 msg-type: select message-types data/1
 
                 update-proto-state ctx either ctx/encrypted? ['encrypted-handshake] [msg-type]
@@ -743,7 +743,7 @@ parse-messages: function [
                             length: len
                             certificates-length: to-integer/unsigned copy/part msg-content 3
                             certificate-list: make block! 4
-                            while [msg-content/1] [
+                            while [not tail? msg-content] [
                                 if 0 < clen: to-integer/unsigned copy/part skip msg-content 3 3 [
                                     append certificate-list copy/part at msg-content 7 clen
                                 ]

--- a/src/os/host-repl.r
+++ b/src/os/host-repl.r
@@ -212,7 +212,7 @@ host-repl: function [
             system/state/last-error: last-result
         ]
     ] else [
-        repl/last-result: mold :last-result 
+        repl/last-result: mold :last-result
         repl/print-result
     ]
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -638,7 +638,7 @@ comment [
         print-gap:      proc []  [print-newline]
 
         ;; BEHAVIOR (can be overridden)
-        
+
         input-hook: func [
             {Receives line input, parse/transform, send back to repl eval}
             s

--- a/src/tools/common-parsers.r
+++ b/src/tools/common-parsers.r
@@ -105,7 +105,7 @@ encode-lines: func [
 
     ; Indent head if original text did not start with a newline.
     pos: insert text line-prefix
-    if not equal? newline pos/1 [insert pos indent]
+    if not equal? newline :pos/1 [insert pos indent]
 
     ; Clear indent from tail if present.
     if indent = pos: skip tail text 0 - length indent [clear pos]

--- a/src/tools/make-boot-ext-header.r
+++ b/src/tools/make-boot-ext-header.r
@@ -23,10 +23,10 @@ do %form-header.r
 r3: system/version > 2.100.0
 
 args: parse-args system/options/args
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/include
 
-extensions: either any-string? args/EXTENSIONS [split args/EXTENSIONS #","][[]]
+extensions: either any-string? :args/EXTENSIONS [split args/EXTENSIONS #","][[]]
 
 emit-header "Boot Modules" output-dir/include/tmp-boot-extensions.h
 remove-each ext extensions [empty? ext] ;SPLIT in r3-a111 gives an empty "" at the end

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -30,7 +30,7 @@ do %form-header.r
 
 do %systems.r
 args: parse-args system/options/args
-config: config-system to-value args/OS_ID
+config: config-system to-value :args/OS_ID
 
 first-rebol-commit: "19d4f969b4f5c1536f24b023991ec11ee6d5adfb"
 
@@ -60,7 +60,7 @@ either args/GIT_COMMIT = "unknown" [
 
 change-dir %../boot/
 ;dir: %../core/temp/  ; temporary definition
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/include
 mkdir/deep output-dir/boot
 mkdir/deep output-dir/core
@@ -121,7 +121,7 @@ unless args: any [
     fail "No platform specified."
 ]
 
-product: to-word any [args/PRODUCT  "core"]
+product: to-word any [:args/PRODUCT | "core"]
 
 platform-data: context [type: 'windows]
 build: context [features: [help-strings]]

--- a/src/tools/make-embedded-header.r
+++ b/src/tools/make-embedded-header.r
@@ -20,7 +20,7 @@ do %form-header.r
 
 print "------ Building embedded header file"
 args: parse-args system/options/args
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/core
 
 inp: read fix-win32-path to file! output-dir/include/sys-core.i

--- a/src/tools/make-ext-natives.r
+++ b/src/tools/make-ext-natives.r
@@ -39,7 +39,7 @@ c-src: fix-win32-path to file! ensure string! args/SRC
 print ["building" m-name "from" c-src]
 
 
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/include
 
 

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -23,7 +23,7 @@ do %native-emitters.r ;for emit-include-params-macro and emit-native-include-par
 
 print "------ Building headers"
 args: parse-args system/options/args
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/include
 mkdir/deep output-dir/core
 
@@ -320,7 +320,7 @@ action-list: load output-dir/boot/tmp-actions.r
 ; Search file for definition.  Will be `action-name: action [paramlist]`
 ;
 for-next action-list [
-    if 'action = action-list/2 [
+    if 'action = pick action-list 2 [
         assert [set-word? action-list/1]
         emit-include-params-macro (to-word action-list/1) (action-list/3)
         emit newline

--- a/src/tools/make-host-ext.r
+++ b/src/tools/make-host-ext.r
@@ -24,7 +24,7 @@ do %common.r
 
 do %form-header.r
 args: parse-args system/options/args
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/include
 
 ;-- Collect Sources ----------------------------------------------------------

--- a/src/tools/make-host-init.r
+++ b/src/tools/make-host-init.r
@@ -25,7 +25,7 @@ do %common.r
 do %common-emitter.r
 
 args: parse-args system/options/args
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/os
 
 print "--- Make Host Init Code ---"

--- a/src/tools/make-natives.r
+++ b/src/tools/make-natives.r
@@ -23,7 +23,7 @@ print "------ Generate tmp-natives.r"
 r3: system/version > 2.100.0
 
 args: parse-args system/options/args
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/boot
 
 verbose: false

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -25,8 +25,8 @@ do %common-parsers.r
 do %systems.r
 
 args: parse-args system/options/args
-config: config-system to-value args/OS_ID
-output-dir: fix-win32-path to file! any [args/OUTDIR %../]
+config: config-system to-value :args/OS_ID
+output-dir: fix-win32-path to file! any [:args/OUTDIR %../]
 mkdir/deep output-dir/include
 
 do %form-header.r

--- a/src/tools/make-reb-lib.r
+++ b/src/tools/make-reb-lib.r
@@ -31,7 +31,7 @@ reb-lib: src-dir/a-lib.c
 ext-lib: src-dir/f-extension.c
 
 args: parse-args system/options/args
-output-dir: to file! any [args/OUTDIR %../]
+output-dir: to file! any [:args/OUTDIR %../]
 output-dir: fix-win32-path output-dir
 out-dir: output-dir/include
 mkdir/deep out-dir

--- a/src/tools/native-emitters.r
+++ b/src/tools/native-emitters.r
@@ -100,6 +100,8 @@ emit-include-params-macro: procedure [
 
 emit-native-include-params-macro: proc [native-list [block!]][
     for-next native-list [
+        if tail? next native-list [break]
+
         if any [
             'native = native-list/2
             all [path? native-list/2 | 'native = first native-list/2]

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -102,10 +102,14 @@
     a-value: 1.2.3
     1 == a-value/1
 ]
+
+; Ren-C changed INTEGER! path picking to act as PICK, only ANY-STRING! and
+; WORD! actually merge with a slash.
 [
     a-value: file://a
-    file://a/1 = a-value/1
+    #"f" = a-value/1
 ]
+
 ; calling functions through paths: function in object
 [
     obj: make object! [fun: func [] [1]]
@@ -138,11 +142,13 @@
     error? try [do path]
     true
 ]
+
 ; bug#71
 [
     a: "abcd"
-    error? try [a/x]
+    "abcd/x" = a/x
 ]
+
 ; bug#1820: Word USER can't be selected with path syntax
 [
     b: [user 1 _user 2]


### PR DESCRIPTION
There was significant common code between PICK and POKE and the
GET-PATH! and SET-PATH! operations, with minor differences between
the operations that weren't clearly intentional.

It is not possible to write path processing in terms of PICK and POKE
such that `a/b/c: d` would act as `poke (pick (pick a 'b) 'c) d`.
The reason for this is that the result of the picks is a value taken
out of a position, which no longer has a relationship to the location
from which it was taken.

However, it is mostly possible to write PICK and POKE in terms of path
processing.  The exception is if PICK and POKE are operations used
as port actions, because there is no way for ports to override path
dispatch...and if they did, they would lose the ability to behave as
objects.  (Note: this points to a bigger issue about ports not being
able to serve two masters, as many actions that apply to objects could
be interesting when defining specialized port actions, e.g. APPEND)

This commit forces PICK and POKE through the same code path used by
path getting and setting.  That code is known to be needing attention
to improve it, but this helps ensure that the improvement can benefit
(and be checked) by both operating forms.

In order to work around the current PORT! issue, the SYM_PICK_P and
SYM_POKE symbols are sent explicitly to the port actor.

The most significant impact of this commit that people should notice
is that `blk/picker` will error if the picker does not pick out of
a block, just as `obj/picker` would do if there was nothing picked
out of an object (or `var` would do if there was no variable).  One has
to use `:blk/picker`.  Examining the affected code shows that it is
an apparent benefit to need to distinguish whether you expect a value
or not, but that the hard-to-handle nature of void means one often
has to say `to-value :blk/picker` or other mitigation to get a blank.
This suggests a need to investigate alternatives, e.g. if @blk/picker
could be a request for a void on absence, with :blk/picker being a
request for a blank.