### PR TITLE
REPL - simple fixes and refactoring

### DIFF
--- a/src/os/host-repl.r
+++ b/src/os/host-repl.r
@@ -180,7 +180,7 @@ host-repl: function [
 ][
     ; REPL is an external object for skinning the behaviour & appearance
     ;
-    ; /cycle - updates internal counter and loads repl-skin on first rotation (ie. once)
+    ; /cycle - updates internal counter and print greeting on first rotation (ie. once)
     ;
     repl: system/repl
     repl/cycle
@@ -203,10 +203,10 @@ host-repl: function [
 
         last-failed [
             assert [error? :last-result]
-            print last-result
+            repl/print-error last-result
 
             unless system/state/last-error [
-                print "** Note: use WHY for more error information"
+                repl/print-info "Note: use WHY for more error information"
             ]
 
             system/state/last-error: last-result
@@ -279,7 +279,7 @@ host-repl: function [
                 ; and needs to be closed.  Invert the symbol.
                 ;
                 unclosed: switch error/arg1 [
-                    "}" ["{"]
+                    "}" ["^{"]
                     ")" ["("]
                     "]" ["["]
                 ]


### PR DESCRIPTION
Following on from #475 I've made the following changes:

* Created a `repl!` object.   NB. @hostilefork - This is defined in `host-start.r`.  If there is a preferred place then I can update in next round of REPL changes.
  
* If last expression in `%repl-skin.reb` is a `repl!` object then this will update `system/repl`  - @zsx 

Here's a %repl-skin.reb example showing the new way to skin REPL:

        Rebol []

        ?: :help

        make repl! [
            ;; switch off gap but print newline after a result
            print-gap: _
            print-result: proc []  [print unspaced [result last-result | ]]
        ]

* `r3 -q` now doesn't print `REPL skinning` -  @giuliolunati 
* `print-error` method added -  @giuliolunati 
* `print-info` method added.   NB.   try `1 / 0` to see its effect :)


What I'm looking at next...

* Refactor repl! object bit more - @zsx (hooks)  @hostilefork (where repl! should live)
* Add command line to pick up alternative skin file.
* Tidy-up HOME / Windows part - @asampal 
* `system/options/resources-dir` - @rgchris suggestion instead of `system/user/rebol`

On last two points I have some questions (for everyone to chime in)....

* Should `system/options/home` be set to users HOME ?    
* Is there a need for `system/user/home` as well?   
* Would (a working) `%user.r` update both `system/user/home` and `system/options/home`?? 

Currently `system/options/home` is set to the directory holding r3.  This is handy info to keep but perhaps needs different name to `home`.
