### PR TITLE
Improve performance with DEBUG=asserts, including -O2

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -693,7 +693,8 @@ reevaluate:;
                         // consume lines up.  Make a note of the param
                         // and arg and poke them into the stack value.
                         //
-                        VAL_RESET_HEADER(f->refine, REB_0_PICKUP);
+                        f->refine->header.bits &= CELL_MASK_RESET;
+                        f->refine->header.bits |= HEADERIZE_KIND(REB_0_PICKUP);
                         f->refine->payload.pickup.param
                             = const_KNOWN(f->param);
                         f->refine->payload.pickup.arg = f->arg;

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -101,13 +101,11 @@ inline static RELVAL *ARR_LAST(REBARR *a)
     { return SER_LAST(RELVAL, SER(a)); }
 
 // As with an ordinary REBSER, a REBARR has separate management of its length
-// and its terminator.  Many routines seek to control these independently for
-// performance reasons (for better or worse).
+// and its terminator.  Many routines seek to choose the precise moment to
+// sync these independently for performance reasons (for better or worse).
 //
-inline static REBCNT ARR_LEN(REBARR *a) {
-    assert(GET_SER_FLAG(a, SERIES_FLAG_ARRAY));
-    return SER_LEN(SER(a));
-}
+#define ARR_LEN(a) \
+    SER_LEN(SER(a))
 
 
 // TERM_ARRAY_LEN sets the length and terminates the array, and to get around

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -87,21 +87,25 @@ case [
         asserts: false
         symbols: false
         sanitize: false
+        optimize: true
     ]
     any [blank? args/DEBUG | args/DEBUG = "asserts"] [
         asserts: true
         symbols: false
         sanitize: false
+        optimize: true
     ]
     args/DEBUG = "symbols" [
         asserts: true
         symbols: true
         sanitize: false
+        optimize: false
     ]
     args/DEBUG = "sanitize" [
         asserts: true
         symbols: true
         sanitize: true
+        optimize: false
     ]
     true [
         fail [
@@ -181,16 +185,10 @@ newline
 newline
 
 {DEBUG_FLAGS?=} space (
-    either asserts [
-        either symbols [
-            "-g -O0"
-        ][
-            "-O0"
-        ]
-    ][
-        ; http://stackoverflow.com/questions/9229978/
-        ;
-        "-DNDEBUG -O2"
+    unspaced [
+        either symbols ["-g "] [""]
+        either asserts [""] ["-DNDEBUG "] ; http://stackoverflow.com/q/9229978/
+        either optimize ["-O2"] ["-O0"]
     ]
 ) newline
 


### PR DESCRIPTION
This does some performance improvement of the debug build in general,
along with making it so that the debug build with asserts w/o symbols
uses the optimizer.  (There's not much reason not to use an optimized
build if it's un-debuggable due to lack of symbols...)

Performance improvements were based on noticing spikes in callgrind,
largely related to function facade macros being called often, and
the bit testing in GET_VAL_FLAG being excessive.  This changes to
just check that GET_VAL_FLAG is on a value whose raw type is > REB_0
and <= REB_MAX...which should catch cell-based ends, trash, and most
non-cell-based ends.