### PR TITLE
Update host-start.r

### DIFF
--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -276,6 +276,20 @@ host-start: function [
     ;
     ; TBD - check perms are correct (SECURITY)
     ;
+    all [
+	    any [
+		    home: get-env 'HOME
+		    home: default [get-env 'HOMEPATH]
+		]
+        exists? home: dirize to-rebol-file home
+        system/user/home: home
+        rebol-dir: join-of home switch/default system/platform/1 [
+            'Windows [%REBOL/]
+        ][%.rebol/]              ;; default *nix (Linux, MacOS & UNIX)
+        exists? rebol-dir 
+        system/user/rebol: rebol-dir
+     ]
+
     if exists? home: dirize to-file get-env 'HOME [
         system/user/home: home
         rebol-dir: join-of home switch/default system/platform/1 [


### PR DESCRIPTION
_to-file get-env 'HOME_

fails on windows which uses HOMEPATH 
Also switched to using to-rebol-file instead of to-file which doesn't convert to rebol format