### PR TITLE
Fix system/options/home + other related changes

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -106,8 +106,10 @@ locale: construct [] [
 ]
 
 options: construct [] [  ; Options supplied to REBOL during startup
-    boot: _         ; The path to the executable
+    bin: _          ; Path to directory where Rebol executable binary lives
+    boot: _         ; Path of executable, ie. system/options/bin/r3-exe
     home: _         ; Path of home directory
+    resources: _    ; users resources directory (for %user.r, skins, modules etc)
     path: _         ; Where script was started or the startup dir
 
     current-path: _ ; Current URL! or FILE! path to use for relative lookups
@@ -581,7 +583,6 @@ user: construct [] [
    name:           ; User's name
    email:          ; User's default email address
    home:           ; The HOME environment variable
-   rebol:          ; Users rebol customisations dir.  eg. $HOME/.rebol on *nix
    words: _
 ]
 


### PR DESCRIPTION
I believe take 2 of https://gist.github.com/draegtun/f37e0c15afbe1ba1c66527299510a020
is the most logical choice as it brings us closer to what Rebol 2 does/did on `system/options` & `system/user`

So this PR implements a first step towards that...

* `system/options/home` - [CHANGE] Now gives user HOME directory.  Same as Rebol 2 and matches Rebol 3 documentation.  

* `system/options/bin` - [NEW] Directory path where r3 executable binary lives (this is what `system/options/home` was showing previous to this PR

* `system/options/resources` - [NEW] Local user resource directory found under `system/options/home`.   NB. This is where things like `%console-skin.reb` are kept.

NB.  if `/home` or `/resources` cannot be resolved or found at boot then they will be set to `_`

* `--resources "/path/to/resources-dir"` - [NEW] Command-line switch to set `system/options/resources` to whatever you like.  NB. Will error if directory doesn't exist.

* Removed `system/user/rebol` - [CHANGE] Replaced by `system/options/resources`.

* R3 now looks for `%rebol.r` under `system/options/bin` [CHANGE]  NB. `%rebol.r` must sit next to r3 executable binary for it to be run on boot.

I don't think any of these changes are contentious, so I'm planning to commit if it passes all travis checks.

@gchiu - Please check any issues for you on Windows?  
@giuliolunati - Is `%rebol.r` all working OK for you?

Next step - New PR to add back in `%user.r` & create new `--suppress` switch.
Final step - Document it all on wiki.
