### PR TITLE
Added back %user.r start-up script

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -110,6 +110,8 @@ options: construct [] [  ; Options supplied to REBOL during startup
     boot: _         ; Path of executable, ie. system/options/bin/r3-exe
     home: _         ; Path of home directory
     resources: _    ; users resources directory (for %user.r, skins, modules etc)
+    suppress: _     ; block of user --suppress items, eg [%rebol.r %user.r %console-skin.reb]
+    loaded: []      ; block with full paths to loaded start-up scripts
     path: _         ; Where script was started or the startup dir
 
     current-path: _ ; Current URL! or FILE! path to use for relative lookups


### PR DESCRIPTION
`%user.r` is resurrected!

* `%user.r` is loaded if found under `system/options/resources` directory.

* This is a change to Rebol 2 (looks first in current directory and then directory where r3 executable lives) and the Rebol 3 docs (looks first in `system/options/home` and then in current directory).

* There is nothing special about how it runs/loads `%user.r` (ie. doesn't pick up last expression ala `%console-skin.reb`).  So if you want to set anything in `system/user` then it needs to be:

        system/user/name: "Bazza"

* New `--suppress` command-line switch

        r3 --suppress "%console-reb.skin"      # stops skinning
        r3 --suppress "%rebol.r %user.r"       # stop both these files loading
        r3 --suppress "*"               # suppresses %rebol.r, %user.r & %console-skin.reb

* `system/options/suppress` - blank! if nothing suppressed.  Otherwise block of suppressed file! (from `--suppress` command-line switch)

* `system/options/loaded` - List of all start-up script(s) loaded (with their full paths)

Now onto doing docs!
 