### PR TITLE
Added DIE, a graceful way to FAIL in host-start

### DIFF
--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -266,8 +266,24 @@ host-start: function [
     system/product: 'core
 
     ;
-    ; helper path functions
+    ; helper functions
     ;
+    die: func [
+        {A gracefully way to FAIL during startup}
+        reason [string!]
+            {Error message}
+        /error e [error!]
+            {Error object, shown if --verbose switch used}
+        <with> return
+    ][
+        print "Startup encountered an error!"
+        print ["**" reason]
+        if error [
+            print either o/verbose [e] ["!! use --verbose for more detail"]
+        ]
+        return 1
+    ]
+
     to-dir: function [
         {Convert string path to absolute dir! path.  Return blank! if not found}
         dir [string!]
@@ -547,7 +563,7 @@ comment [
                 do o/bin/rebol.reb
                 append o/loaded o/bin/rebol.reb
             ] func [error] [
-                fail "Error in rebol.reb script"
+                die/error "Error found in rebol.reb script" error
             ]
         ]
     ]
@@ -567,7 +583,7 @@ comment [
                 do o/resources/user.reb
                 append o/loaded o/resources/user.reb
             ] func [error] [
-                fail "Error in user.reb script"
+                die/error "Error found in user.reb script" error
             ]
         ]
     ]


### PR DESCRIPTION
see: #499 

Any evaluation errors found in`%rebol.reb` or `%user.reb` startup scripts will now fail gracefully.

Example of a bad `%user.reb` file:

    Rebol [
        title: "my user.reb"
        file: %user.reb
        version: 0.0.1
        date: 11-May-2017
    ]

    xxx

When `r3` is run this produces following output:

    Script: my user.reb Version: 0.0.1 Date: 11-May-2017
    Startup encountered an error!
    ** Error found in user.reb script
    !! use --verbose for more detail

Doing `r3 --verbose` produces following output:

    ...
    ... culled other verbose messages...
    ...
    Script: my user.reb Version: 0.0.1 Date: 11-May-2017
    Startup encountered an error!
    ** Error found in user.reb script
    ** Script Error: xxx has no value
    ** Where: do catch either either --anonymous-- do trap if if --anonymous--
    ** Near: ... make object! [
        [self: title name type version date f...


**Tech note**

New local `die` function added to `host-start`.  Use this to FAIL gracefully:

    die "Error in --blah switch"

    die/error "Error in user.reb" error-object

The `/error` refinement allows you to pass on error object which is shown when `--verbose` switch is set.

