### PR TITLE
Host-start --verbose changes

### DIFF
--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -279,7 +279,7 @@ host-console: function [
                 ; and needs to be closed.  Invert the symbol.
                 ;
                 unclosed: switch error/arg1 [
-                    "}" ["^{"]
+                    "}" ["{"]
                     ")" ["("]
                     "]" ["["]
                 ]

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -520,7 +520,6 @@ host-start: function [
 
     ; version, import, secure are all of valid type or blank
 
-    if o/verbose [print o]
 
     load-boot-exts boot-exts
 
@@ -555,6 +554,7 @@ comment [
             trap/with [
                 do o/bin/rebol.reb
                 append o/loaded o/bin/rebol.reb
+                loud-print ["Finished evaluating script:" o/bin/rebol.reb]
             ] func [error] [
                 die/error "Error found in rebol.reb script" error
             ]
@@ -575,6 +575,7 @@ comment [
                 ;
                 do o/resources/user.reb
                 append o/loaded o/resources/user.reb
+                loud-print ["Finished evaluating script:" o/resources/user.reb]
             ] func [error] [
                 die/error "Error found in user.reb script" error
             ]
@@ -658,6 +659,8 @@ comment [
     ; See /os/host-console.r where this object is called from
     ;
 
+    loud-print "Starting console..."
+    loud-print ""
     proto-skin: make console! []
     skin-error: _
 


### PR DESCRIPTION
Tidied verbose output by:

* Removing printing of `system/options`

* Added start-up script confirmation (%rebol.reb & %user.reb)

* Added message on start of Console code

Example of `r3 --verbose` with `%rebol.reb` & `%user.reb` start-up scripts present:

    Loading boot extensions...
    Checking for rebol.reb file in /Users/barry/code/GitHub/ren-c/make/
    Script: MyRebolReb Version: Date:
    Finished evaluating script: /Users/barry/code/GitHub/ren-c/make/rebol.reb
    Checking for user.reb file in /Users/barry/.rebol/
    Script: my user.reb Version: 0.0.1 Date: 11-May-2017
    Finished evaluating script: /Users/barry/.rebol/user.reb
    Starting console...

    Rebol 3 (Ren/C branch) [version: 2.102.0.2.5 build: 12-May-2017/18:31:21]

    Welcome to the Rebol console.  For more information please type in the commands below:

      HELP    - For starting information
      ABOUT   - Information about your Rebol
      CHANGES - What's different about this version

    Console skinning:

      Loaded skin - /Users/barry/.rebol/console-skin.reb (CONSOLE updated)

    >>

And now just plain `r3`:

    Script: MyRebolReb Version: Date:
    Script: my user.reb Version: 0.0.1 Date: 11-May-2017
    Rebol 3 (Ren/C branch) [version: 2.102.0.2.5 build: 12-May-2017/18:31:21]

    Welcome to the Rebol console.  For more information please type in the commands below:

      HELP    - For starting information
      ABOUT   - Information about your Rebol
      CHANGES - What's different about this version

    >>

See #501 comments for related info.
