### PR TITLE
Convert CHANGES.md into CHANGELOG format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,25 @@
-Rebol 3 (Ren/C branch) Changes
-==============================
+# Rebol 3 (Ren/C branch) Changes
 
-This is a stub file for producing a summary of all changes to Rebol since R3-Alpha by version/commit.
+All notable changes to this project will be documented in this file.
 
-For a complete list use these links:
+Alternate ChangeLogs:
 
 * [ChangeLog + pre-built binaries](http://rebolchat.me/t/rebol3-ren-c-branch-change-logs/)
-* [Github commits](https://github.com/metaeducation/ren-c/commits/master)
+* [Complete Github commits](https://github.com/metaeducation/ren-c/commits/master)
 
-Alternatively from Git command-line:
+Alternatively using Git:
 
     git log
 
 
+Below is a stub for summary of changes by version.
+
+## 2.102.0
+### Added
+- Ren/C branch by @hostfilefork
+
+### Changed
+### Fixed
+
+
+## R3-Alpha

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -824,10 +824,15 @@ console!: make object! [
         s
     ]
 
-    shortcuts: make object! [
+    shortcuts: make object! compose/deep [
         q: [quit]
         list-shortcuts: [print system/console/shortcuts]
-        changes: [browse https://github.com/metaeducation/ren-c/blob/master/CHANGES.md]
+        changes: [
+            browse (join-all [
+                https://github.com/metaeducation/ren-c/blob/master/CHANGES.md#
+                join-all ["" system/version/1 "." system/version/2 "." system/version/3]
+            ])
+        ]
     ]
 
     ;; HELPERS (could be overridden!)

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -830,7 +830,7 @@ console!: make object! [
         changes: [
             browse (join-all [
                 https://github.com/metaeducation/ren-c/blob/master/CHANGES.md#
-                join-all ["" system/version/1 "." system/version/2 "." system/version/3]
+                join-all ["" system/version/1 system/version/2 system/version/3]
             ])
         ]
     ]


### PR DESCRIPTION
* see http://keepachangelog.com/en/0.3.0/
* CHANGES console shortcut now jumps to version anchor in CHANGES.md