### PR TITLE
Add "falls through" comments

### DIFF
--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -118,6 +118,7 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
 
     case PE_NONE:
         Init_Blank(pvs->store);
+        // falls through
     case PE_USE_STORE:
         pvs->value = pvs->store;
         pvs->value_specifier = SPECIFIED;
@@ -533,6 +534,7 @@ REBNATIVE(pick_p)
 
     case PE_NONE:
         Init_Blank(pvs->store);
+        // falls through
     case PE_USE_STORE:
         pvs->value = pvs->store;
         pvs->value_specifier = SPECIFIED;

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -668,6 +668,7 @@ pick:
 
         case '0':
             padding = '0';
+            // falls through
         case '-':
         case '1':   case '2':   case '3':   case '4':
         case '5':   case '6':   case '7':   case '8':   case '9':

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1152,6 +1152,7 @@ static void Locate_Token_May_Push_Mold(
                     return;
                 fail (Error_Syntax(ss));
             }
+            // falls through
         case LEX_SPECIAL_LESSER:
             if (IS_LEX_ANY_SPACE(cp[1]) || cp[1] == ']' || cp[1] == 0) {
                 ss->token = TOKEN_WORD; // changed for </tag>
@@ -1764,12 +1765,14 @@ static REBARR *Scan_Array(
                 --ss->end;
             }
             bp++;
+            // falls through
         case TOKEN_SET:
             len--;
             if (mode_char == '/' && ss->token == TOKEN_SET) {
                 ss->token = TOKEN_WORD; // will be a PATH_SET
                 ss->end--;  // put ':' back on end but not beginning
             }
+            // falls through
         case TOKEN_WORD: {
             if (len == 0) {
                 --bp;

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -172,6 +172,7 @@ static REB_R Event_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
     //case A_PATH_SET:  // not allowed: above
         if (!IS_EVENT(arg))
             fail (arg);
+        // falls through
     case SYM_PICK_P:
 act_blk:
         Move_Value(save_port, D_ARG(1)); // save for return

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -447,6 +447,7 @@ static void Mold_String_Series(const REBVAL *value, REB_MOLD *mold)
                 *dp++ = c;
                 break;
             }
+        // falls through
         case '\n':
         case '"':
             *dp++ = c;
@@ -693,6 +694,7 @@ static void Mold_Block(const RELVAL *value, REB_MOLD *mold)
             Pre_Mold(value, mold);
             sep = 0;
 
+        // falls through
         case REB_BLOCK:
             if (GET_MOPT(mold, MOPT_ONLY)) {
                 CLR_FLAG(mold->opts, MOPT_ONLY); // only top level

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -454,9 +454,9 @@ static Boolean isLegalUTF8(const UTF8 *source, int length) {
     switch (length) {
     default: return false;
     /* Everything else falls through when "true"... */
-    case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
-    case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
-    case 2: if ((a = (*--srcptr)) > 0xBF) return false;
+    case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false; // falls through
+    case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false; // falls through
+    case 2: if ((a = (*--srcptr)) > 0xBF) return false; // falls through
 
         switch (*source) {
             /* no fall-through in this inner switch */
@@ -464,9 +464,10 @@ static Boolean isLegalUTF8(const UTF8 *source, int length) {
             case 0xED: if (a > 0x9F) return false; break;
             case 0xF0: if (a < 0x90) return false; break;
             case 0xF4: if (a > 0x8F) return false; break;
-            default:   if (a < 0x80) return false;
+            default:   if (a < 0x80) return false; break;
         }
 
+        // falls through
     case 1: if (*source >= 0x80 && *source < 0xC2) return false;
     }
 
@@ -837,11 +838,11 @@ const REBYTE *Back_Scan_UTF8_Char_Core(
     // if (!isLegalUTF8(source, slen+1)) return 0;
 
     switch (trail) {
-        case 5: *out += *source++; *out <<= 6;
-        case 4: *out += *source++; *out <<= 6;
-        case 3: *out += *source++; *out <<= 6;
-        case 2: *out += *source++; *out <<= 6;
-        case 1: *out += *source++; *out <<= 6;
+        case 5: *out += *source++; *out <<= 6; // falls through
+        case 4: *out += *source++; *out <<= 6; // falls through
+        case 3: *out += *source++; *out <<= 6; // falls through
+        case 2: *out += *source++; *out <<= 6; // falls through
+        case 1: *out += *source++; *out <<= 6; // falls through
         case 0: *out += *source++;
     }
     *out -= offsetsFromUTF8[trail];
@@ -1173,9 +1174,9 @@ REBCNT Encode_UTF8_Char(REBYTE *dst, REBCNT src)
     dst += len;
 
     switch (len) {
-        case 4: *--dst = (UTF8)((src | mark) & mask); src >>= 6;
-        case 3: *--dst = (UTF8)((src | mark) & mask); src >>= 6;
-        case 2: *--dst = (UTF8)((src | mark) & mask); src >>= 6;
+        case 4: *--dst = (UTF8)((src | mark) & mask); src >>= 6; // falls through
+        case 3: *--dst = (UTF8)((src | mark) & mask); src >>= 6; // falls through
+        case 2: *--dst = (UTF8)((src | mark) & mask); src >>= 6; // falls through
         case 1: *--dst = (UTF8) (src | firstByteMark[len]);
     }
 

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -1053,6 +1053,7 @@ REBTYPE(Gob)
 
     case SYM_APPEND:
         index = tail;
+        // falls through
     case SYM_INSERT: {
         INCLUDE_PARAMS_OF_INSERT;
 
@@ -1125,6 +1126,7 @@ REBTYPE(Gob)
 
     case SYM_AT:
         index--;
+        // falls through
     case SYM_SKIP:
         index += VAL_INT32(arg);
         goto set_index;

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -508,6 +508,7 @@ REBTYPE(Integer)
 
     case SYM_EVEN_Q:
         num = ~num;
+        // falls through
     case SYM_ODD_Q:
         if (num & 1)
             return R_TRUE;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1423,8 +1423,10 @@ REBNATIVE(subparse)
                     // Note: mincount = maxcount = 1 on entry
                     case SYM_WHILE:
                         flags |= PF_WHILE;
+                        // falls through
                     case SYM_ANY:
                         mincount = 0;
+                        // falls through
                     case SYM_SOME:
                         maxcount = MAX_I32;
                         FETCH_NEXT_RULE_MAYBE_END(f);
@@ -1440,6 +1442,7 @@ REBNATIVE(subparse)
                         goto set_or_copy_pre_rule;
                     case SYM_SET:
                         flags |= PF_SET;
+                        // falls through
                     set_or_copy_pre_rule:
                         FETCH_NEXT_RULE_MAYBE_END(f);
 

--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -435,6 +435,7 @@ static REBYTE *Process_Key(STD_TERM *term, REBYTE *cp)
             // Arrow keys:
             case 'A':   // up arrow
                 term->hist -= 2;
+                // falls through
             case 'B': {  // down arrow
                 int len = term->end;
 
@@ -514,6 +515,7 @@ static REBYTE *Process_Key(STD_TERM *term, REBYTE *cp)
 
         case CR:    // CR
             if (cp[1] == LF) cp++; // eat
+            // falls through
         case LF:    // LF
             WRITE_STR("\r\n");
             Store_Line(term);

--- a/src/tools/file-base.r
+++ b/src/tools/file-base.r
@@ -52,7 +52,7 @@ core: [
     ; (F)???
     f-blocks.c
     f-deci.c
-    [f-dtoa.c <no-uninitialized>]
+    [f-dtoa.c <no-uninitialized> <implicit-fallthu>]
     f-enbase.c
     f-extension.c
     f-int.c
@@ -146,10 +146,10 @@ core: [
 
     ; (U)??? (3rd-party code extractions)
     u-compress.c
-    u-md5.c
+    [u-md5.c <implicit-fallthu>]
     u-parse.c
-    u-sha1.c
-    [u-zlib.c <no-make-header>]
+    [u-sha1.c <implicit-fallthu>]
+    [u-zlib.c <no-make-header> <implicit-fallthu>]
 ]
 
 ; Files created by the make-boot process

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -874,6 +874,9 @@ emit-file-deps: function [
                 <no-uninitialized> "-Wno-uninitialized"
                 <no-unused-parameter> "-Wno-unused-parameter"
                 <no-shift-negative-value> "-Wno-shift-negative-value"
+                ;-Wno-unknown-warning suppresses a warning when
+                ;-Wimplicit-fallthrough is not recognized, e.g. GCC older than 7
+                <implicit-fallthu> "-Wno-unknown-warning -Wno-implicit-fallthrough"
             ][
                 if not find item setting [continue]
 


### PR DESCRIPTION
GCC 7 will have -Wimplicit-fallthrough turned on by -Wextra. There are a
number of ways to inform the compiler that falling through is intended.
This commit just uses the comment to do that, which is the most
conservative (least destructive) way: if the compiler doesn't recognize
it, nothing's gonna be broken.