### PR TITLE
Platform independent tests for CALL

### DIFF
--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -1,0 +1,21 @@
+; call/call.test.reb
+
+[
+    ; small - works
+    data: copy {}
+    call/wait/output [%../make/r3 "--suppress" "*" %call/print.reb "100"] data
+    100 == (length-of data)
+]
+[
+    ; medium - fails test (just under 5000 bytes transferred)
+    data: copy {}
+    call/wait/output [%../make/r3 "--suppress" "*" %call/print.reb "9000"] data
+    9000 == (length-of data)
+]
+[
+    ; crashes :(
+    data: copy {}
+    call/wait/output [%../make/r3 "--suppress" "*" %call/print.reb "80000"] data
+    80'000 == (length-of data)
+]
+

--- a/tests/call/print.reb
+++ b/tests/call/print.reb
@@ -1,0 +1,5 @@
+Rebol []
+
+repeat n to-integer first system/options/args [
+    prin "." 
+]

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -213,4 +213,5 @@
 %system/system.test.reb
 %system/file.test.reb
 %system/gc.test.reb
+%call/call.test.reb
 %source/analysis.test.reb


### PR DESCRIPTION
Tests CALL by running external Rebol program and checking expected output.

There are currently 3 tests:

- Expect 100 bytes back - PASSES
- Expect 9000 bytes back - FAILS
- Expect 80,000 bytes back - CRASHES

This PR is part of Issue #537 so hopefully can fix last two failing/crashing tests.
