### PR TITLE
Add a native to set C break point

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -938,6 +938,32 @@ static void Init_Contexts_Object(void)
     Init_Object(Get_System(SYS_CONTEXTS, CTX_USER), Lib_Context);
 }
 
+#ifndef NDEBUG
+//
+//  Init_Break_Point: C
+//
+// This initializes the break point from env in the debug build
+//
+static void Init_Break_Point(void)
+{
+    TG_Break_At = 0;
+
+    const char *env_break_at = getenv("R3_BREAK_AT");
+    if (env_break_at != NULL) {
+        i64 break_at = CHR_TO_INT(cb_cast(env_break_at));;
+        if(break_at > 0) {
+            Debug_Str(
+                "**\n"
+                "** R3_ALWAYS_MALLOC is TRUE in environment variable!\n"
+                "** Memory allocations aren't pooled, expect slowness...\n"
+                "**\n"
+            );
+            TG_Break_At = cast(REBUPT, break_at);
+        }
+    }
+}
+#endif
+
 
 //
 //  Startup_Task: C
@@ -1097,6 +1123,11 @@ void Startup_Core(void)
 
     Assert_Basics();
     PG_Boot_Time = OS_DELTA_TIME(0, 0);
+
+#ifndef NDEBUG
+    // This might call Debug_Str, which depends on StdIO, and must be called after Start_StdIO;
+    Init_Break_Point();
+#endif
 
 //==//////////////////////////////////////////////////////////////////////==//
 //

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -122,7 +122,7 @@ static inline REBOOL Start_New_Expression_Throws(REBFRM *f) {
         do { \
             START_NEW_EXPRESSION_MAY_THROW_COMMON(f, g); \
             do_count = Do_Core_Expression_Checks_Debug(f); \
-            if (do_count == DO_COUNT_BREAKPOINT) { \
+            if (do_count == TG_Break_At || do_count == DO_COUNT_BREAKPOINT) { \
                 Debug_Fmt("DO_COUNT_BREAKPOINT at %d", f->do_count_debug); \
                 Dump_Frame_Location(f); \
                 debug_break(); /* see %debug_break.h */ \

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -426,3 +426,36 @@ REBNATIVE(check)
     return R_TRUE;
 #endif
 }
+
+//
+//  c-break-debug: native [
+//
+//  "Break at next evaluation point, use ONLY when running under a C debugger"
+//      return: [<opt>]
+//      /skip
+//          points [integer!]
+//          {points to skip before breaking: 0 being next point}
+//      /at
+//          point [integer!]
+//          {Break at a certain point}
+//  ]
+//
+REBNATIVE(c_break_debug)
+{
+#ifndef NDEBUG
+    INCLUDE_PARAMS_OF_C_BREAK_DEBUG;
+
+    if (REF(skip) && REF(at)) {
+        fail (Error_Bad_Refines_Raw());
+    } else if (REF(skip)) {
+        TG_Break_At = frame_->do_count_debug + 1 + VAL_INT64(ARG(points));
+    } else if (REF(at)) {
+        TG_Break_At = VAL_INT64(ARG(point));
+    } else {
+        TG_Break_At = frame_->do_count_debug + 1;
+    }
+#else
+    UNUSED(frame_);
+#endif
+    return R_VOID;
+}

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -151,6 +151,7 @@ TVAR REBUPT Stack_Limit;    // Limit address for CPU stack.
     // other than Do_Next that are contingent on a certain "tick" elapsing.
     //
     TVAR REBUPT TG_Do_Count;
+    TVAR REBUPT TG_Break_At; // The do_count to break
 
     TVAR REBIPT TG_Num_Black_Series;
 #endif


### PR DESCRIPTION
The debug version of the interpreter keeps tracking of a do_count, and
can raise a break signal at a given do_count point before evaluating the
expression. This is very useful for debugging the evaluator, however,
it can only break at a hardcoded point, which means it needs to be
recompiled after changing; moreover, it's very hard to find out the
do_count to break.

This commit adds a rebol function to set such a break point, no
recompilation is needed, and multiple breaking points can be set. When
the function is called, it will break at next point, in next x points
by using /skip, or at an certain point by using /at

e.g.
    c-break-debug
    a: 1

will make it break in Do_Core right before evaluating "a: 1"