### PR TITLE
TO-LOGIC -> native, kill TRUE?/FALSE?, add TRUTHY?/FALSEY?

### DIFF
--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1305,45 +1305,22 @@ REBNATIVE(unset_q)
 
 
 //
-//  true?: native/body [
+//  to-logic: native/body [
 //
-//  "Returns true if a value can be used as true."
+//  "Returns true for all values that would cause IF to take the branch"
 //
+//      return: [logic!]
+//          {true if the supplied value is NOT a LOGIC! false or BLANK!}
 //      value [any-value!] ; Note: No [<opt> any-value!] - void must fail
 //  ][
 //      not not :val
 //  ]
 //
-REBNATIVE(true_q)
+REBNATIVE(to_logic)
 {
-    INCLUDE_PARAMS_OF_TRUE_Q;
+    INCLUDE_PARAMS_OF_TO_LOGIC;
 
     return R_FROM_BOOL(IS_CONDITIONAL_TRUE(ARG(value)));
-}
-
-
-//
-//  false?: native/body [
-//
-//  "Returns false if a value is either LOGIC! false or a NONE!."
-//
-//      value [any-value!] ; Note: No [<opt> any-value!] - void must fail.
-//  ][
-//      either any [
-//          blank? :value
-//          :value = false
-//      ][
-//          true
-//      ][
-//          false
-//      ]
-//  ]
-//
-REBNATIVE(false_q)
-{
-    INCLUDE_PARAMS_OF_FALSE_Q;
-
-    return R_FROM_BOOL(IS_CONDITIONAL_FALSE(ARG(value)));
 }
 
 

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -84,7 +84,7 @@ dir?: func [
     {Returns TRUE if the file or url ends with a slash (or backslash).}
     target [file! url!]
 ][
-    true? find "/\" last target
+    find? "/\" last target
 ]
 
 dirize: func [

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -578,13 +578,13 @@ catch?: redescribe [
 any?: redescribe [
     {Shortcut OR, ignores voids. Unlike plain ANY, forces result to LOGIC!}
 ](
-    chain [:any | :to-value | :true?]
+    chain [:any | :to-value | :to-logic]
 )
 
 all?: redescribe [
     {Shortcut AND, ignores voids. Unlike plain ALL, forces result to LOGIC!}
 ](
-    chain [:all | :to-value | :true?]
+    chain [:all | :to-value | :to-logic]
 )
 
 maybe?: redescribe [
@@ -598,7 +598,7 @@ maybe?: redescribe [
 find?: redescribe [
     {Variant of FIND that returns TRUE if present and FALSE if not.}
 ](
-    chain [:find | :true?]
+    chain [:find | :to-logic]
 )
 
 select: redescribe [
@@ -1149,7 +1149,7 @@ ensure: function [
 ][
     case* [
         void? temp: maybe test :arg [
-            assert [any [void? :arg | false? :arg]]
+            assert [any [void? :arg | not :arg]]
 
             ; The test passed but we want to avoid an accidental usage like
             ; `if ensure [logic!] some-false-thing [...]` where the test
@@ -1164,7 +1164,7 @@ ensure: function [
             ] 'arg
         ]
         true [
-            assert [all [true? :temp | :arg = :temp]]
+            assert [all [:temp | :arg = :temp]]
             :temp
         ]
     ]

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -106,7 +106,7 @@ assert-debug: function [
                     |
                 (blank? bad-result) "blank"
                     |
-                (false? bad-result) "false"
+                (bad-result = false) "false"
             ])
             ":"
             expr

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -207,6 +207,25 @@ value?: func [dummy:] [
     ] 'dummy
 ]
 
+true?: func [dummy:] [
+    fail/where [
+        {TRUE? is misleading/ambiguous, use either TO-LOGIC or `= TRUE`} |
+        {(TRUTHY? is also provided to see if anyone actually likes it)}
+    ] 'dummy
+]
+
+false?: func [dummy:] [
+    fail/where [
+        {FALSE? is misleading/ambiguous, use either NOT or `= FALSE`} |
+        {(FALSEY? is still provided to see if anyone actually likes it)}
+    ] 'dummy
+]
+
+; Silly names, but someone might like them
+;
+truthy?: :to-logic
+falsey?: :not
+
 none-of: :none ;-- reduce mistakes for now by renaming NONE out of the way
 
 none?: none!: none: func [dummy:] [
@@ -450,7 +469,7 @@ r3-alpha-apply: function [
         ]
 
         either refinement? params/1 [
-            using-args: set (in frame params/1) true? :arg
+            using-args: set (in frame params/1) to-logic :arg
         ][
             if using-args [
                 set* (in frame params/1) :arg

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -107,7 +107,7 @@ save: function [
         ]
 
         if length_SAVE [
-            ; any true? value will work, but this uses #[true].  (Notation
+            ; any truthy value will work, but this uses #[true].  (Notation
             ; is to help realize this is a *mention*, not *usage* of length.)
             append header-data reduce [(quote length:) (true)]
         ]

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -21,16 +21,16 @@ REBOL [
 ; These must be listed explicitly in order for the words to be collected
 ; as legal "globals" for the mezzanine context (otherwise SET would fail)
 
-; Note that TO-INTEGER and TO-STRING are currently their own natives with
-; additional refinements, and thus should not be overwritten here
+; Note that TO-LOGIC, TO-INTEGER and TO-STRING are currently their own natives
+; (even with additional refinements), and thus should not be overwritten here
 
 to-logic: to-decimal: to-percent: to-money: to-char: to-pair:
 to-tuple: to-time: to-date: to-binary: to-file: to-email: to-url: to-tag:
 to-bitset: to-image: to-vector: to-block: to-group:
 to-path: to-set-path: to-get-path: to-lit-path: to-map: to-datatype: to-typeset:
 to-word: to-set-word: to-get-word: to-lit-word: to-refinement: to-issue:
-to-command: to-closure: to-function: to-object: to-module: to-error: to-port: to-gob:
-to-event:
+to-command: to-closure: to-function: to-object: to-module: to-error: to-port:
+to-gob: to-event:
     blank
 
 ; Auto-build the functions for the above TO-* words.

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -351,7 +351,7 @@ check-response: func [port /local conn res headers d1 d2 line info state awake s
             | (info/response-parsed: 'version-not-supported)
         ]
     ]
-    if all [logic? spec/debug true? spec/debug]  [
+    if spec/debug = true [
         spec/debug: info
     ]
     switch/all info/response-parsed [

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -754,7 +754,7 @@ load-module: function [
             case [
                 word? hdr [cause-error 'syntax hdr source]
                 import blank ; /import overrides 'delay option
-                not delay [delay: true? find hdr/options 'delay]
+                not delay [delay: find? hdr/options 'delay]
             ]
             if hdr/checksum [modsum: copy hdr/checksum]
         ]

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -726,7 +726,7 @@ comment [
             ;; if loaded skin returns console! object then use as prototype
             if all [
                 object? new-skin
-                true? select new-skin 'repl ;; quacks like a REPL so assume its a console!
+                select new-skin 'repl ;; quacks like REPL, say it's a console!
             ][
                 proto-skin: new-skin
                 proto-skin/updated?: true

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -79,7 +79,7 @@ to-c-name: function [
         true [ ;-- !!! See notes above, don't change to an ELSE!
             ;
             ; If these symbols occur composite in a longer word, they use a
-            ; shorthand; e.g. `true?` => `true_q`
+            ; shorthand; e.g. `foo?` => `foo_q`
 
             for-each [reb c] [
                 -   "_"

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -438,15 +438,15 @@ eval: get 'do
 ; In some cases, the bitwise and will be good enough for logic purposes...
 ;
 and*: get 'and
-and?: func [a b] [true? all [:a :b]]
+and?: func [a b] [to-logic all [:a :b]]
 and: get 'and ; see above
 
 or+: get 'or
-or?: func [a b] [true? any [:a :b]]
+or?: func [a b] [to-logic any [:a :b]]
 or: get 'or ; see above
 
 xor+: get 'xor
-xor?: func [a b] [true? any [all [:a (not :b)] all [(not :a) :b]]]
+xor?: func [a b] [to-logic any [all [:a (not :b)] all [(not :a) :b]]]
 
 
 ; UNSPACED in Ren-C corresponds rougly to AJOIN, and SPACED corresponds very

--- a/tests/comparison/equalq.test.reb
+++ b/tests/comparison/equalq.test.reb
@@ -542,7 +542,7 @@
     test: :equal?
     equal?
         test a-value b-value
-        true? for-each [w v] a-value [
+        to-logic for-each [w v] a-value [
             unless test :v select b-value w [break]
         ]
 ]
@@ -564,7 +564,7 @@
     test: :equal?
     equal?
         test a-value b-value
-        true? for-each [w v] a-value [
+        to-logic for-each [w v] a-value [
             unless test :v select b-value w [break]
         ]
 ]


### PR DESCRIPTION
TRUE? and FALSE? are too misleading to exist.  This changes the core to
use TO-LOGIC and NOT, which is probably what everyone should do.  But
to some people's tastes, they may prefer TRUTHY? and FALSEY? to convey
the meaning.  Add those and let people experiment with them to see if
they really can stand them and like them better than TO-LOGIC or NOT.