### PR TITLE
Permit references to modules by tag in NEEDS header.

### DIFF
--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -469,7 +469,7 @@ do-needs: function [
         opt [opt 'core set vers tuple! (do-needs vers)]
         any [
             here:
-            set name [word! | file! | url!]
+            set name [word! | file! | url! | tag!]
             set vers opt tuple!
             set hash opt binary!
             (join mods [name vers hash])


### PR DESCRIPTION
Allows the following NEEDS form in modules:

```
Rebol [
    Title: "Some Script..."
    Needs: [<json>]
]
```