### PR TITLE
Add IDENTITY, have GROUP! not affect VALUE_FLAG_UNEVALUATED

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1612,7 +1612,11 @@ reevaluate:;
             goto finished;
         }
 
-        CLEAR_VAL_FLAG(f->out, VALUE_FLAG_UNEVALUATED);
+        // Leave VALUE_FLAG_UNEVALUATED as it was.  If we added it, then
+        // things like `if condition (semiquote do [1 + 1])` wouldn't work, so
+        // one would be forced to write `if condition semiquote do [1 + 1]`.
+        // This would limit the flexiblity of grouping.
+        //
         break; }
 
 //==//////////////////////////////////////////////////////////////////////==//

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1126,24 +1126,37 @@ REBNATIVE(semiquoted_q)
 
 
 //
-//  semiquote: native [
+//  identity: native [
 //
-//  {Marks a function argument to be treated as if it had been literal source}
+//  {Function for returning the same value that it got in (identity function)}
 //
-//      value [any-value!]
+//      return: [<opt> any-value!]
+//      value [<opt> any-value!]
+//      /quote
+//          {Make it seem that the return result was quoted}
 //  ]
 //
-REBNATIVE(semiquote)
+REBNATIVE(identity)
+//
+// https://en.wikipedia.org/wiki/Identity_function
+// https://stackoverflow.com/q/3136338
+//
+// !!! Quoting version is currently specialized as SEMIQUOTE, for convenience.
 {
-    INCLUDE_PARAMS_OF_SEMIQUOTE;
+    INCLUDE_PARAMS_OF_IDENTITY;
 
     Move_Value(D_OUT, ARG(value));
 
-    // We cannot set the VALUE_FLAG_UNEVALUATED bit here and make it stick,
-    // because the bit would just get cleared off by Do_Core when the
-    // function finished.  So ask the evaluator to set the bit for us.
+    if (REF(quote)) {
+        //
+        // We can't set the VALUE_FLAG_UNEVALUATED bit here and make it stick,
+        // because the bit would just get cleared off by Do_Core when the
+        // function finished.  So ask the evaluator to set the bit for us.
+        //
+        return R_OUT_UNEVALUATED;
+    }
 
-    return R_OUT_UNEVALUATED;
+    return R_OUT; // clears VALUE_FLAG_UNEVALUATED by default
 }
 
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -468,6 +468,9 @@ redescribe [
     {Define an action with set-words as locals, that doesn't return a value.}
 ] :procedure
 
+; Though this name is questionable, it's nice to be easier to call
+;
+semiquote: specialize 'identity [quote: true]
 
 get*: redescribe [
     {Variation of GET which returns void if the source is not set}
@@ -729,8 +732,6 @@ nfix?: function [
             "Use LOOKBACK? for generalized (tricky) testing"
         ]
     ]
-
-
 ]
 
 endfix?: redescribe [

--- a/tests/control/if.test.reb
+++ b/tests/control/if.test.reb
@@ -29,9 +29,11 @@
 [if #{00} [true]]
 ; bitset
 [if make bitset! "" [true]]
+
 ; literal blocks illegal as condition in Ren-C, but evaluation products ok
 [error? trap [if [] [true]]]
-[if ([]) [true]]
+[if identity [] [true]]
+
 ; datatype
 [if blank! [true]]
 ; typeset


### PR DESCRIPTION
This changes the logic of how the evaluated/unevaluated bit is done
such that groups don't affect it.  Hence `(1 2 3)` would come back
with 3 and consider it to be "unevaluated", while `(1 + 2)` would
give back a 3 and consider it evaluated.

This means that should IF not welcome evaluated integers and you need
to subvert that, you can write `if condition (semiquote do [1 + 1])`.
Otherwise you're forced to write `if condition semiquote do [1 + 1]`.
This would limit the caller's flexiblity of grouping for readability.

However, putting a value in a GROUP! was the previous way of forcing
the evaluated bit onto things.  Rather than introduce a SEMIEVAL
function, this observes that really what SEMIEVAL is is the Identity
Function:

https://en.wikipedia.org/wiki/Identity_function
https://stackoverflow.com/q/3136338

Rather than use a silly name for the identity function, this just goes
ahead and uses "identity".  Despite being nounish, it is standard,
and contexts that don't use it can use it as a variable name (as with
other things... HEAD, CASE, etc.)  Then /QUOTE is added as a refinement
with SEMIQUOTE just a specialization.

Though SEMIQUOTE is still a silly name in its own right, it is at
least not going to be taken for anything else.  So it is being kept
until there's a better suggestion.  (UNEVAL perhaps?)