### PR TITLE
Limit Left-Hand Enfixed Normal Fulfillment to "one expression"

### DIFF
--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -213,13 +213,30 @@
     FLAGIT_LEFT(11)
 
 
+//=//// DO_FLAG_DAMPEN_DEFER //////////////////////////////////////////////=//
+//
+// If an enfixed function wishes to complete an expression on its left, it
+// only wants to complete one of them.  `print if false ["a"] else ["b"]`
+// is a case where the ELSE wants to allow `if false ["a"]` to complete,
+// which it does by deferring its execution.  But when that step is finished,
+// the landscape looks like `print *D_OUT* else ["b"]`, and if there is not
+// some indication it might defer again, that would just lead print to
+// continue the process of deferment, consuming the output for itself.
+//
+// This is a flag tagged on the parent frame the first time, so it knows to
+// defer only once.
+//
+#define DO_FLAG_DAMPEN_DEFER \
+    FLAGIT_LEFT(12)
+
+
 // Currently the rightmost two bytes of the Reb_Frame->flags are not used,
 // so the flags could theoretically go up to 31.  It could hold something
 // like the ->eval_type, but performance is probably better to put such
 // information in a platform aligned position of the frame.
 //
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
-    static_assert(11 < 32, "DO_FLAG_XXX too high");
+    static_assert(12 < 32, "DO_FLAG_XXX too high");
 #endif
 
 

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -560,11 +560,11 @@ format: function [
     for-each rule rules [
         if word? :rule [rule: get rule]
 
-        val: val + (switch type-of :rule [
+        val: val + switch type-of :rule [
             :integer! [abs rule]
             :string! [length-of rule]
             :char! [1]
-        ] else 0)
+        ] else 0
     ]
 
     out: make string! val
@@ -630,7 +630,7 @@ split: function [
         size: dlm   ; alias for readability
         
         res: collect [
-            parse series (case [
+            parse series case [
                 all [integer? size | into] [
                     if size < 1 [cause-error 'Script 'invalid-arg size]
                     count: size - 1
@@ -660,7 +660,7 @@ split: function [
                         keep/only copy/part mk1 mk2
                     )]
                 ]
-            ])
+            ]
         ]
 
         ; Special processing, to handle cases where the spec'd more items in

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -60,7 +60,7 @@ register-codec*: func [
 
 
 ; Special import case for extensions:
-append system/options/file-types (switch fourth system/version [
+append system/options/file-types switch fourth system/version [
     3 [
         [%.rx %.dll extension] ; Windows
     ]
@@ -73,7 +73,7 @@ append system/options/file-types (switch fourth system/version [
     ]
 ] else [
     [%.rx extension]
-])
+]
 
 
 decode: function [

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -581,7 +581,7 @@ host-start: function [
     ;;       file (below) -> o/bin (would have been same)
 
 comment [
-    lib/secure (case [
+    lib/secure case [
         o/secure [
             o/secure
         ]
@@ -590,7 +590,7 @@ comment [
         ]
     ] else [
         compose [file throw (file) [allow read] %. allow] ; default
-    ])
+    ]
 ]
 
     ;


### PR DESCRIPTION
When an enfixed function has a "normal" (non-tight) first argument,
the initial implementation would hold lookahead in a suspended state,
leading to full completion of arguments on the left hand side.

This "full" completion led to undesirable effects, such as ELSE's
"Dark Corner".  For instance:

    print if false ["a"] else ["b"]

This would be interpeted as `(print if false ["a"]) else ["b"]`  This
is because when ELSE was first seen, it would be immediately after the
["a"] had been written into the output cell of IF's frame, creating a
situation like this with IF and PRINT on the stack above:

    print>if> *D_OUT* else ["b"]

Rather than take the D_OUT as its left hand side (the way a tight
argument would), it would yield...allowing the expression which had
requested one argument evaluation above to finish (IF), but with PRINT
still on the stack.  The next time ELSE would be seen would be its
next chance:

    print> *D_OUT* else ["b"]

But this situation was indistinguishable; there was no memory or bit
of the fact that ELSE had already had once chance to complete.  So it
would allow PRINT to complete.  This made non-tight left parameters a
bit like a backwards DO instead of a backwards DO/NEXT, which didn't
match the DO/NEXT nature of forward normal argument fulfillment.

The trick in this commit is to add a "dampening" bit onto the frame
above such enfixed functions, if that frame happens to be an argument
fulfillment frame.  Otherwise it falls back to "tight" behavior.

Among other things, this appears to resolve ELSE's dark corner, making
it a (hopefully) universally compatible replacement for EITHER,
SWITCH/DEFAULT, or ending CASEs with [... true ["some catch all"]]