### PR TITLE
Rename SET/LOOKBACK to SET/ENFIX, LOOKBACK? to ENFIXED?

### DIFF
--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -120,6 +120,4 @@ struct      struct      *       *       -
 library     library     -       *       -
 
 ; Note that the "void?" state has no associated VOID! datatype.  Internally
-; it uses REB_MAX, but like the REB_0 it stays off the type map.  (REB_0
-; is used for lookback as opposed to void in order to implement an
-; optimization in Get_Var_Core())
+; it uses REB_MAX, but like the REB_0 it stays off the type map.

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -835,8 +835,8 @@ REBNATIVE(resolve)
 //          {Treat void values as unsetting the target instead of an error}
 //      /some
 //          {Blank values (or values past end of block) are not set.}
-//      /lookback
-//          {Function uses evaluator lookahead to "look back" (see ENFIX)}
+//      /enfix
+//          {Function calls through this word should get first arg from left}
 //  ]
 //
 REBNATIVE(set)
@@ -850,8 +850,6 @@ REBNATIVE(set)
 //     1
 //     >> print b
 //     2
-//
-// !!! Should the /LOOKBACK refinement be called /ENFIX?
 {
     INCLUDE_PARAMS_OF_SET;
 
@@ -937,8 +935,8 @@ REBNATIVE(set)
             // is not there, so it leads to too many silent errors.
         }
         else if (ANY_WORD(target)) {
-            if (REF(lookback) && NOT(IS_FUNCTION(ARG(value))))
-                fail ("Attempt to SET/LOOKBACK on a non-function");
+            if (REF(enfix) && NOT(IS_FUNCTION(ARG(value))))
+                fail ("Attempt to SET/ENFIX on a non-function");
 
             REBVAL *var = Sink_Var_May_Fail(target, target_specifier);
             Derelativize(
@@ -946,7 +944,7 @@ REBNATIVE(set)
                 IS_END(value) ? BLANK_VALUE : value,
                 value_specifier
             );
-            if (REF(lookback))
+            if (REF(enfix))
                 SET_VAL_FLAG(var, VALUE_FLAG_ENFIXED);
         }
         else if (ANY_PATH(target)) {
@@ -961,12 +959,12 @@ REBNATIVE(set)
                 if (IS_GROUP(temp))
                     fail ("GROUP! can't be in paths with SET");
 
-            // !!! For starters, just the word form is supported for lookback.
-            // Though you can't dispatch a lookback from a path, you should be
-            // able to set a word in a context to one.
+            // !!! For starters, just the word form is supported for enfixing.
+            // Though you can't dispatch enfix from a path (at least not at
+            // present), you should be able to enfix a word in a context.
             //
-            if (REF(lookback))
-                fail ("Cannot currently SET/LOOKBACK on a PATH!");
+            if (REF(enfix))
+                fail ("Cannot currently SET/ENFIX on a PATH!");
 
             DECLARE_LOCAL (specific);
             if (IS_END(value))
@@ -1064,16 +1062,16 @@ REBNATIVE(unset)
 
 
 //
-//  lookback?: native [
+//  enfixed?: native [
 //
 //  {TRUE if looks up to a function and gets first argument before the call}
 //
 //      source [any-word! any-path!]
 //  ]
 //
-REBNATIVE(lookback_q)
+REBNATIVE(enfixed_q)
 {
-    INCLUDE_PARAMS_OF_LOOKBACK_Q;
+    INCLUDE_PARAMS_OF_ENFIXED_Q;
 
     REBVAL *source = ARG(source);
 
@@ -1092,7 +1090,7 @@ REBNATIVE(lookback_q)
 
         // Not implemented yet...
 
-        fail ("LOOKBACK? testing is not currently implemented on PATH!");
+        fail ("ENFIXED? testing is not currently implemented on PATH!");
     }
 }
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -31,15 +31,16 @@ assert: func [
     ; a default hijacking to set it to be equivalent to VERIFY, late in boot.)
 ]
 
-set/lookback quote enfix: proc [
-    "Convenience version of SET/LOOKBACK, e.g `+: enfix :add`"
+set/enfix quote enfix: proc [
+    "Convenience version of SET/ENFIX, e.g `+: enfix :add`"
     :target [set-word! set-path!]
     action [function!]
 ][
-    set/lookback target :action
+    set/enfix target :action
 
     ; return value can't currently be given back as enfix, since it is a
-    ; property of words and not values.  Should it be given back at all?
+    ; property of words and not values.  So it isn't given back at all (as
+    ; this is a PROC).  Is this sensible?
 ]
 
 default: enfix func [
@@ -723,7 +724,7 @@ nfix?: function [
     source [any-word! any-path!]
 ][
     case [
-        not lookback? source [false]
+        not enfixed? source [false]
         equal? n arity: arity-of source [true]
         n < arity [
             ; If the queried arity is lower than the arity of the function,
@@ -733,21 +734,15 @@ nfix?: function [
         ]
     ] else [
         fail [
-            name "used on lookback function with arity" arity
+            name "used on enfixed function with arity" arity
                 |
-            "Use LOOKBACK? for generalized (tricky) testing"
+            "Use ENFIXED? for generalized (tricky) testing"
         ]
     ]
 ]
 
-endfix?: redescribe [
-    {TRUE if a no-argument function is SET/LOOKBACK to not allow right infix.}
-](
-    specialize :nfix? [n: 0 | name: "ENDFIX?"]
-)
-
 postfix?: redescribe [
-    {TRUE if an arity 1 function is SET/LOOKBACK to act as postfix.}
+    {TRUE if an arity 1 function is SET/ENFIX to act as postfix.}
 ](
     specialize :nfix? [n: 1 | name: "POSTFIX?"]
 )
@@ -757,39 +752,6 @@ infix?: redescribe [
 ](
     specialize :nfix? [n: 2 | name: "INFIX?"]
 )
-
-
-set-nfix: function [
-    return: [function!]
-    n [integer!]
-    name [string!]
-    target [any-word! any-path!]
-    value [function!]
-][
-    unless equal? n arity-of :value [
-        fail [name "requires arity" n "functions, see SET/LOOKAHEAD"]
-    ]
-    set/lookback target :value
-]
-
-set-endfix: redescribe [
-    {Convenience wrapper for SET/LOOKBACK that ensures function is arity 0.}
-](
-    specialize :set-nfix [n: 0 | name: "SET-ENDFIX"]
-)
-
-set-postfix: redescribe [
-    {Convenience wrapper for SET/LOOKBACK that ensures a function is arity 1.}
-](
-    specialize :set-nfix [n: 1 | name: "SET-POSTFIX"]
-)
-
-set-infix: redescribe [
-    {Convenience wrapper for SET/LOOKBACK that ensures a function is arity 2.}
-](
-    specialize :set-nfix [n: 2 | name: "SET-INFIX"]
-)
-
 
 lambda: function [
     {Convenience variadic wrapper for FUNC and FUNCTION constructors}

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -434,8 +434,8 @@ help: procedure [
 
     ; Get value (may be a function, so handle with ":")
     either path? :topic [
-        print ["!!! NOTE: Infix testing not currently supported for paths !!!"]
-        lookback: false
+        print ["!!! NOTE: Enfix testing not currently supported for paths"]
+        enfixed: false
         if any [
             error? value: trap [get :topic] ;trap reduce [to-get-path topic]
             not set? 'value
@@ -444,7 +444,7 @@ help: procedure [
             leave
         ]
     ][
-        lookback: lookback? :topic
+        enfixed: enfixed? :topic
         value: get :topic
     ]
 
@@ -483,9 +483,9 @@ help: procedure [
     ]
 
     ; Output exemplar calling string, e.g. LEFT + RIGHT or FOO A B C
-    ; !!! Should refinement args be shown for lookback case??
+    ; !!! Should refinement args be shown for enfixed case??
     ;
-    either lookback [
+    either enfixed [
         print [space4 args/1 (uppercase mold topic) next args]
     ][
         print [space4 (uppercase mold topic) args refinements]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -331,7 +331,7 @@ set: function [
         "Treat void values as unsetting the target instead of an error"
     /some
         {Blank values (or values past end of block) are not set.}
-    /lookback
+    /enfix
         {If value is a function, then make the bound word dispatch infix}
     /any
         "Deprecated legacy synonym for /opt"
@@ -349,7 +349,7 @@ set: function [
         only: only
         opt: any? [set_ANY set_OPT]
         some: set_SOME
-        lookback: lookback
+        enfix: enfix
     ]
 ]
 

--- a/tests/datatypes/op.test.reb
+++ b/tests/datatypes/op.test.reb
@@ -1,6 +1,6 @@
 ; datatypes/op.r
-[lookback? '+]
-[error? try [lookback? 1]]
+[enfixed? '+]
+[error? try [enfixed? 1]]
 [function? get '+]
 
 ; #1934


### PR DESCRIPTION
This consolidates the two names for making functions that get their
first argument from the left under the single term "enfix", as it is
the more user-facing concept...while lookback is more of an internal
detail of the evaluator.

For full discussion, see:

https://forum.rebol.info/t/214/8

This commit also deletes some superfluous helpers like SET-INFIX and
SET-POSTFIX which were conveniences introduced prior to ENFIX's
existence (or before it could have existed, due to no left quoting
in enfixed functions).

Several comments are also brought up to date.