### PR TITLE
Enhance increment (++) and decrement (--) operators

### DIFF
--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -45,18 +45,18 @@ clean-path: function [
     if all [dir | not dir? file] [append file #"/"]
 
     out: make type-of file length-of file ; same datatype
-    cnt: 0 ; back dir counter
+    count: 0 ; back dir counter
 
     parse reverse file [
         some [
-            "../" (++ cnt)
+            "../" (count: ++ 1)
             | "./"
             | #"/" (
                 if any [not file? file | #"/" <> last out] [append out #"/"]
             )
             | copy f [to #"/" | to end] (
-                either cnt > 0 [
-                    -- cnt
+                either count > 0 [
+                    count: -- 1
                 ][
                     unless find ["" "." ".."] as string! f [append out f]
                 ]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -498,7 +498,7 @@ r3-alpha-apply: function [
 ; binding in Ren-C)
 ;
 closure: func [
-    return: [<opt> any-value!]
+    return: [function!]
     spec
     body
 ][
@@ -512,6 +512,8 @@ closure: func [
 ;
 clos: func [
     "Defines a closure function."
+
+    return: [function!]
     spec [block!]
         {Help string (opt) followed by arg words (and opt type and string)}
     body [block!]

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -17,24 +17,34 @@ pi: 3.14159265358979323846
 ; ++ and -- were previously used to take a quoted word and increment
 ; it.  They were ordinary prefix operations
 
-++: func [
-    {Increment an integer or series index. Return its prior value.}
-    'word [word!] "Integer or series variable"
+++: enfix func [
+    {Increment a number or series index.}
+
+    return: [any-value!]
+        "The new state of the variable"
+    'var [set-word! set-path!]
+        "Numeric or series variable to update"
+    n
+        "Amount to increment or skip forwards by"
+
     <local> prior
 ][
-    also (prior: get word) (
-        set word either series? prior [next prior] [prior + 1]
-    )
+    set var either (series? prior: get var) [skip prior n] [prior + n]
 ]
 
---: func [
-    {Decrement an integer or series index. Return its prior value.}
-    'word [word!] "Integer or series variable"
+--: enfix func [
+    {Decrement a number or series index.}
+
+    return: [any-value!]
+        "The new state of the variable"
+    'var [set-word! set-path!]
+        "Numeric or series variable to update"
+    n
+        "Amount to decrement or skip backwards by"
+
     <local> prior
 ][
-    also (prior: get word) (
-        set word either series? prior [back prior] [prior - 1]
-    )
+    set var either (series? prior: get var) [skip prior negate n] [prior - n]
 ]
 
 

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -97,7 +97,7 @@ secure: function [
         n: 1
         for-each act [read write execute] [
             join blk [pick acts 1 + pol/:n act]
-            ++ n
+            n: ++ 1
         ]
         blk
     ])

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -732,8 +732,11 @@ find-all: function [
         "Evaluated for each occurrence"
 ][
     verify [any-series? orig: get series]
-    while [any [set series find get series :value (set series orig false)]] [
+    while [any [
+        | set series find get series :value
+        | (set series orig | false) ;-- reset series and break loop
+    ]][
         do body
-        ++ (series)
+        series: ++ 1
     ]
 ]

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -804,8 +804,8 @@ console!: make object! [
     ; Called on every line of input by HOST-CONSOLE in %os/host-console.r
     ;
     cycle: does [
-        if zero? ++ counter [print-greeting] ;-- only load skin on first cycle
-        counter
+        if zero? counter [print-greeting] ;-- only load skin on first cycle
+        counter: ++ 1
     ]
 
     ;; APPEARANCE (can be overridden)

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -807,7 +807,9 @@ for-each [id val] id-list [
     if block? val [
         parse val [
             any [
-                get-word! (++ n-args)
+                get-word! (
+                    n-args: n-args + 1 ; don't use ++, not R3-Alpha compatible
+                )
                 | skip
             ]
         ]
@@ -835,7 +837,7 @@ for-each [id val] id-list [
             emit-line compose [ {const RELVAL *arg} (i + 1)
                 either i < (n-args - 1) [","] [""]
             ]
-            ++ i
+            i: i + 1 ; don't use ++, not R3-Alpha compatible 
         ]
         emit-line [")"]
         emit-line [ "^{" ]
@@ -844,7 +846,7 @@ for-each [id val] id-list [
         i: 0
         while [i < n-args] [
             append args compose [ {, arg} (i + 1)]
-            ++ i
+            i: i + 1 ; don't use ++, not R3-Alpha comptible
         ]
 
         emit-line/indent [ "return Error(RE_" uppercase c-id args ", END);"]

--- a/src/tools/make-ext-natives.r
+++ b/src/tools/make-ext-natives.r
@@ -204,7 +204,7 @@ for-each native native-specs [
         unless supported? [continue]
     ]
 
-    ++ num-native
+    num-native: num-native + 1
     dump (to block! first native/spec)
     if find to block! first native/spec 'export [append export-list to word! native/name]
     unless blank? native/errors [append error-list native/errors]
@@ -349,7 +349,7 @@ either empty? word-list [
             space
             {Ext_Canons_} m-name {[} word-seq {]}
         ]
-        ++ word-seq
+        word-seq: word-seq + 1
     ]
     emit-line ["#define INIT_" u-m-name "_WORDS" space "\"]
     emit-line/indent [

--- a/tests/atronix/ms-drives.r
+++ b/tests/atronix/ms-drives.r
@@ -11,6 +11,6 @@ while [i < 26] [
     unless zero? maps and* shift 1 i [
         print unspaced [to char! (to integer! #"A") + i ":"]
     ]
-    ++ i
+    i: ++ 1
 ]
 close msvcrt

--- a/tests/atronix/test-libs.r
+++ b/tests/atronix/test-libs.r
@@ -138,7 +138,7 @@ forever [
         a9/j: 490 + i
 
         read-s10 a a1 a2 a3 a4 a5 a6 a7 a8 a9
-        ++ i
+        i: ++ 1
     ]
 
     print ["a9:" mold a9]
@@ -160,7 +160,7 @@ forever [
         print ["i = " i]
         s: return-s i
         print ["s:" mold s]
-        ++ i
+        i: ++ 1
     ]
     print now
     wait [2]

--- a/tests/datatypes/closure.test.reb
+++ b/tests/datatypes/closure.test.reb
@@ -189,7 +189,12 @@
     'a == f
 ]
 ; basic test for recursive closure! invocation
-[i: 0 countdown: closure [n] [if n > 0 [++ i countdown n - 1]] countdown 10 i = 10]
+[
+    i: 0
+    countdown: clos [n] [if n > 0 [i: ++ 1 | countdown n - 1]]
+    countdown 10
+    i = 10
+]
 ; bug#21
 [
     c: closure [a] [return a]

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -270,7 +270,12 @@
 [lf: func ['x] [:x] 30 == lf (10 + 20)]
 [lf: func ['x] [:x] o: context [f: 10] 10 == lf :o/f]
 ; basic test for recursive function! invocation
-[i: 0 countdown: proc [n] [if n > 0 [++ i countdown n - 1]] countdown 10 i = 10]
+[
+    i: 0
+    countdown: proc [n] [if n > 0 [i: ++ 1 | countdown n - 1]]
+    countdown 10
+    i = 10
+]
 
 ; In Ren-C's specific binding, a function-local word that escapes the
 ; function's extent cannot be used when re-entering the same function later

--- a/tests/misc/fib.r
+++ b/tests/misc/fib.r
@@ -42,7 +42,7 @@ fib: func [
         t: i1
         i1: i0 + i1
         i0: t
-        -- n
+        n: -- 1
     ]
     i1
 ]


### PR DESCRIPTION
The ++ and -- operators were not used very frequenty in Rebol, due to
their "non-Rebol" appearance.  They were prefix, would modify their
argument (quoted as a WORD!), and would return the prior result.

    >> x: 10

    >> -- x
    == 10

    >> x
    == 9

To a casual observer, it was not clear that x was being modified...
especially because it wasn't even being passed as a WORD!.  A proposal
favored by @gchiu and @earl was that it might better be an
arity-2 infix operator which would quote its left hand side, and
allow incrementing or decrementing by any amount.  (Hence more like
C's += and -=)

    >> x: 10
    == 10

    >> x: ++ 3 * 3
    == 19

    >> x: -- 2
    == 17

    >> t: 12:00
    == 12:00

    >> t: ++ 3:00:42
    == 15:00:42

    >> s: [a b c d]
    == [a b c d]

    >> s: ++ 2
    == [c d]

If one wished for simple incrementing or decrementing, it doesn't
seem so hard to say `my-variable-name: ++ 1`, as the real goal is
to avoid repeating the variable name.

While the proposal was liked, the technical ability to implement it
wasn't available until relatively recently.  This adds it.  Though it
breaks previous behavior, it's likely not typical that prior usages
of ++ or -- were preceded by a SET-WORD! or SET-PATH!, so they should
hopefully be easy to catch.