### PR TITLE
Arity-1 Function Branches receive conditional arguments

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1364,22 +1364,6 @@ reevaluate:;
                 CLEAR_VAL_FLAG(f->out, VALUE_FLAG_UNEVALUATED);
             break;
 
-        case R_OUT_BLANK_IF_VOID:
-            if (IS_VOID(f->out))
-                Init_Blank(f->out);
-            else
-                CLEAR_VAL_FLAG(f->out, VALUE_FLAG_UNEVALUATED);
-            break;
-
-        case R_OUT_VOID_IF_UNWRITTEN_BLANK_IF_VOID:
-            if (IS_END(f->out))
-                Init_Void(f->out);
-            else if (IS_VOID(f->out))
-                Init_Blank(f->out);
-            else
-                CLEAR_VAL_FLAG(f->out, VALUE_FLAG_UNEVALUATED);
-            break;
-
         case R_REDO_CHECKED:
             SET_END(f->out);
             f->special = f->args_head;

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -927,7 +927,7 @@ REBNATIVE(forever)
 
     do {
         const REBOOL only = FALSE;
-        if (Run_Branch_Throws(D_OUT, ARG(body), only)) {
+        if (Run_Branch_Throws(D_OUT, END, ARG(body), only)) {
             REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop)
@@ -1065,7 +1065,7 @@ REBNATIVE(loop)
 
     for (; count > 0; count--) {
         const REBOOL only = FALSE;
-        if (Run_Branch_Throws(D_OUT, ARG(body), only)) {
+        if (Run_Branch_Throws(D_OUT, END, ARG(body), only)) {
             REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop)
@@ -1148,7 +1148,7 @@ inline static REB_R Loop_While_Until_Core(REBFRM *frame_, REBOOL trigger)
     skip_check:;
 
         const REBOOL only = FALSE;
-        if (Run_Branch_Throws(D_OUT, ARG(body), only)) {
+        if (Run_Branch_Throws(D_OUT, END, ARG(body), only)) {
             REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop)
@@ -1242,7 +1242,7 @@ inline static REB_R While_Until_Core(REBFRM *frame_, REBOOL trigger)
     assert(IS_END(D_OUT)); // guaranteed by the evaluator
 
     do {
-        if (Run_Branch_Throws(D_CELL, ARG(condition), only)) {
+        if (Run_Branch_Throws(D_CELL, END, ARG(condition), only)) {
             //
             // A while loop should only look for breaks and continues in its
             // body, not in its condition.  So `while [break] []` is a
@@ -1265,7 +1265,7 @@ inline static REB_R While_Until_Core(REBFRM *frame_, REBOOL trigger)
             return R_OUT_VOID_IF_UNWRITTEN_TRUTHIFY;
         }
 
-        if (Run_Branch_Throws(D_OUT, ARG(body), only)) {
+        if (Run_Branch_Throws(D_OUT, D_CELL, ARG(body), only)) {
             REBOOL stop;
             if (Catching_Break_Or_Continue(D_OUT, &stop)) {
                 if (stop)

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -101,17 +101,6 @@ enum Reb_Result {
     //
     R_OUT_VOID_IF_UNWRITTEN_TRUTHIFY,
 
-    // This converts void into BLANK!, and is used by control constructs
-    // so that they can reserve void for the case they didn't run any branch.
-    //
-    R_OUT_BLANK_IF_VOID,
-
-    // This combines the unwritten and blank path for control constructs.
-    // While it may seem they could do it themselves, having a different
-    // return code is a reminder that some optimization may be possible.
-    //
-    R_OUT_VOID_IF_UNWRITTEN_BLANK_IF_VOID,
-
     // If Do_Core gets back an R_REDO from a dispatcher, it will re-execute
     // the f->phase in the frame.  This function may be changed by the
     // dispatcher from what was originally called.

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -645,19 +645,16 @@ ensure: redescribe [
     {Pass through a value only if it matches types (or TRUE?/FALSE? state)}
 ](
     specialize 'either-test [
-        error-hack: true
-        branch: [
-            ;
+        branch: func [value [<opt> any-value!]] [
+            fail [
+                "ENSURE did not expect argument of type" type-of :value
+            ]
+
             ; !!! There is currently no good way to SPECIALIZE a conditional
             ; which takes a branch, with a branch that refers to parameters
-            ; of the running specialization.  Theoretically we could use the
-            ; BACKTRACE API and look for the frame, but beyond being a very
-            ; hacky idea, the debugger is unstable, so use an ERROR-HACK
-            ; refinement to EITHER-TEST in order to ask it to execute errors
-            ; if we return one...and then it will make the WHERE of the error
-            ; indicate the callsite where value originated.
-            ;
-            make error! "Value did not match test it must ENSURE to pass"
+            ; of the running specialization.  Hence, there's no way to say
+            ; something like /WHERE 'TEST to indicate a parameter from the
+            ; callsite, until a solution is found for that. :-(
         ]
     ]
 )


### PR DESCRIPTION
This changes Run_Branch_Throws() to also take the condition which
triggered the branch.  This way, if the branch is an arity-1 function,
that condition can be provided as a parameter to the function:

    >> if false func [x] [print x | 304]
    ;-- no result

    >> if 1020 func [x] [print x | 304]
    1020
    == 304

It works with loops like WHILE as well, should the body be an arity-1
function, as well as all the conditionals like CASE, THEN, ELSE...
SWITCH is a little odd because there's no such thing as a function
literal, but if you compose a function into the cases block it will
currently do the same thing.

    >> switch 1 compose [1 (func [x] [print x])]
    1
    == _

Also, with "blankification" more uniform as a process, this moves it
into the handler for Run_Branch_Throws() to reduce repetition.  As a
result, the REB_R codes R_OUT_VOID_IF_UNWRITTEN_BLANK_IF_VOID and
R_OUT_BLANK_IF_VOID could be removed.

Effective applications of this feature aren't really explored yet.  But
with this change, there's enough information to give a not-completely
useless message when ensure fails, since it can at least tell you the
type of the failing variable.  So the /ERROR-HACK is removed, and it
demonstrates at least one practical use.