### PR TITLE
ENSURE => REALLY, restoring ENSURE to original concept

### DIFF
--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -577,38 +577,11 @@ lib-make: :make
 make: function [
     "Constructs or allocates the specified datatype."
     return: [any-value!]
-    :lookahead [any-value! <...>]
     type [<opt> any-value! <...>]
         "The datatype or an example value"
     def [<opt> any-value! <...>]
         "Attributes or size of the new value (modified)"
 ][
-    switch first lookahead [
-        callback! [
-            verify [function! = take type]
-            def: ensure block! take def
-            ffi-spec: ensure block! first def
-            action: ensure function! reduce second def
-            return make-callback :action ffi-spec
-        ]
-        routine! [
-            verify [function! = take type]
-            def: ensure block! take def
-            ffi-spec: ensure block! first def
-            lib: ensure [integer! library!] reduce second def
-            if integer? lib [ ;-- interpreted as raw function pointer
-                return make-routine-raw lib ffi-spec
-            ]
-            name: ensure string! third def
-            return make-routine lib name ffi-spec
-        ]
-        command! [
-            verify [function! = take type]
-            def: ensure block! take def
-            return make-command def
-        ]
-    ]
-
     type: take type
     def: take def
 

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -170,8 +170,8 @@ secure: function [
 
     ; Set each policy target separately:
     for-each [target pol] policy [
-        ensure [word! file! url!] target
-        ensure [block! word! integer!] pol
+        really [word! file! url!] target
+        really [block! word! integer!] pol
         set-policy target make-policy target pol pol-obj
     ]
 

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -496,7 +496,7 @@ alter: func [
 collect-with: func [
     "Evaluate body, and return block of values collected via keep function."
 
-    return: [block!]
+    return: [any-series!]
     'name [word! lit-word!]
         "Name to which keep function will be assigned (<local> if word!)"
     body [block!]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -129,7 +129,7 @@ do*: function [
     ; LOAD it will trigger before the failure of changing the working dir)
     ; It is loaded as UNBOUND so that DO-NEEDS runs before INTERN.
     ;
-    code: ensure block! (load/header/type source 'unbound)
+    code: really block! (load/header/type source 'unbound)
 
     ; LOAD/header returns a block with the header object in the first
     ; position, or will cause an error.  No exceptions, not even for
@@ -137,7 +137,7 @@ do*: function [
     ;
     ; !!! Should the header always be locked by LOAD?
     ;
-    hdr: lock to-value ensure [object! blank!] first code
+    hdr: lock really [object! blank!] first code
     is-module: 'module = select hdr 'type
     code: next code
 

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -233,7 +233,7 @@ load-header: function [
         :key != 'rebol [
             ; block-embedded script, only script compression, ignore hdr/length
 
-            tmp: ensure binary! rest ; saved for possible checksum calc later
+            tmp: really binary! rest ; saved for possible checksum calc later
 
             ; decode embedded script
             rest: skip first set [data: end:] transcode/next data 2
@@ -257,15 +257,15 @@ load-header: function [
 
     ]
 
-    ensure [binary! blank!] hdr/checksum
-    ensure [block! blank!] hdr/options
+    really [binary! blank!] hdr/checksum
+    really [block! blank!] hdr/options
 
     ; Return a BLOCK! with 3 elements in it
     ;
     return reduce [
-        ensure object! hdr
-        ensure [binary! block!] rest
-        ensure binary! end
+        really object! hdr
+        really [binary! block!] rest
+        really binary! end
     ]
 ]
 
@@ -648,8 +648,8 @@ load-module: function [
                 set [mod: modsum:] next tmp [blank]
 
                 <check> [
-                    ensure [module! block!] mod
-                    ensure [binary! blank!] modsum
+                    really [module! block!] mod
+                    really [binary! blank!] modsum
                 ]
 
                 ; If no further processing is needed, shortcut return
@@ -740,7 +740,7 @@ load-module: function [
         void? :mod [mod: _]
         module? mod [
             delay: no-share: _ hdr: meta-of mod
-            ensure [block! blank!] hdr/options
+            really [block! blank!] hdr/options
         ]
         block? mod [set* [hdr: code:] mod]
 
@@ -791,9 +791,9 @@ load-module: function [
                 block? :mod0 [hdr0: first mod0] ; cached preparsed header
 
                 <check> [
-                    ensure word! name0
-                    ensure object! hdr0
-                    ensure [binary! blank!] sum0
+                    really word! name0
+                    really object! hdr0
+                    really [binary! blank!] sum0
                 ]
 
                 not tuple? ver0: :hdr0/version [ver0: 0.0.0]
@@ -861,8 +861,8 @@ load-module: function [
                 binary? code [code: to block! code]
             ]
 
-            ensure object! hdr
-            ensure block! code
+            really object! hdr
+            really block! code
 
             mod: catch/quit [
                 module/mixin hdr code (opt do-needs/no-user hdr)

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -118,7 +118,7 @@ elf-format: context [
             if endian = 'little [reverse bin]
             set name (to-integer/unsigned bin)
         ][
-            val: ensure integer! get name
+            val: really integer! get name
             bin: skip (tail to-binary val) (negate num-bytes) ;-- big endian
             if endian = 'little [reverse bin]
             change begin bin
@@ -245,7 +245,7 @@ elf-format: context [
                 (mode: 'read) section-header-rule
                 (
                     name-start: skip string-section sh_name
-                    name-end: ensure binary! find name-start #{00}
+                    name-end: really binary! find name-start #{00}
                     section-name: to-string copy/part name-start name-end
                     if name = section-name [
                         return index ;-- sh_offset, sh_size, etc. are set

--- a/src/tools/make-ext-natives.r
+++ b/src/tools/make-ext-natives.r
@@ -33,11 +33,11 @@ args: parse-args system/options/args
 
 config: config-system to-value :args/OS_ID
 
-m-name: ensure string! args/MODULE
+m-name: really string! args/MODULE
 l-m-name: lowercase copy m-name
 u-m-name: uppercase copy m-name
 
-c-src: fix-win32-path to file! ensure string! args/SRC
+c-src: fix-win32-path to file! really string! args/SRC
 
 print ["building" m-name "from" c-src]
 

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -46,6 +46,14 @@ if true = attempt [void? :some-undefined-thing] [
         fail "Do not use THEN in scripts which want compatibility w/R3-Alpha"
     ]
 
+    ; The once-arity-2 primitive known as ENSURE was renamed to REALLY, to
+    ; better parallel MAYBE and free up ENSURE to simply mean "make sure it's
+    ; a value".  But older Ren-Cs have the arity-2 definition.  Adjust it.
+    ;
+    if find spec-of :ensure 'test [
+        really: :ensure
+    ]
+
     QUIT ;-- !!! stops running if Ren-C here.
 ]
 
@@ -646,7 +654,7 @@ make-action: func [
         )
         any [
             set other: [word! | path!] (
-                other: ensure any-context! get other
+                other: really any-context! get other
                 bind new-body other
                 for-each [key val] other [
                     append exclusions key
@@ -736,13 +744,13 @@ procedure: func [spec body] [
 ]
 
 
-; This isn't a full implementation of ENSURE with function-oriented testing,
+; This isn't a full implementation of REALLY with function-oriented testing,
 ; but it works well enough for types.
 ;
-ensure: function [type [datatype!] value [<opt> any-value!]] [
+really: function [type [datatype!] value [<opt> any-value!]] [
     if type != type-of :value [
         probe :value
-        fail ["ENSURE expected:" (mold type) "but got" (mold type-of :value)]
+        fail ["REALLY expected:" (mold type) "but got" (mold type-of :value)]
     ]
     return :value
 ]


### PR DESCRIPTION
Ren-C changed SET-WORD!-based assignments to allow voids without error.

    x: () ;-- legal

There were numerous advantages to allowing this, though it did remove
one potential "safety" check.  So ENSURE was introduced:

    >> x: ensure 3
    == 3

    >> x: ensure () ;-- error

Though in a type-unsafe system, it's hard to say how a variable being
void is that much worse than if it's an integer and you were expecting.
So a "test dialect" started emerging.  This led to two different
rity-2 constructs: MAYBE and ENSURE

    >> x: ensure [integer! string!] "hi"
    == "hi"

    >> x: ensure [integer! string!] <some-tag> ;- error

    >> x: maybe [integer! string!] "hi"
    == "hi"

    >> x: maybe [integer! string!] <some-tag>
    == _

Hence MAYBE and ENSURE were parallel functions, one of which would pass
through values that matched the test or return a blank, while the
other would error.

Yet the initial desire, to simply be able to make sure a value isn't
void (or blank) remained.  It needed a short name.  This switches it
around so that REALLY is the arity-2 complement to MAYBE, while ENSURE
resumes its initial definition.  If ENSURE is used then it makes sure
the value is not a blank or a void before passing through, while if
ENSURE/ONLY or ENSURE* is used, it only rejects void.

This creates a backwards-incompatible change for building with older
Ren-Cs, since ENSURE is used in bootstrap.  Hence, it has to be
shimmed in r2r3-future.r.  Hopefully not too many such situations will
pop up going forward (technically the REALLY checks could just be
removed if needed, but they are helpful.)

Adds DEFAULT* and UPDATE* primitives to treat BLANK! as a value.

Changes COLLECT's return result to ANY-SERIES!, because for reasons
unknown it was set to just BLOCK!.