### PR TITLE
SET+GET drop /ANY+/OPT to use /ONLY, SET/ONLY => SET/MULTI

### DIFF
--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -420,7 +420,7 @@ REBNATIVE(collect_words)
 //          {If the source looks up to a value, that value--else void}
 //      source [blank! any-word! any-path! block!]
 //          {Word or path to get, or block of words or paths (blank is no-op)}
-//      /opt
+//      /only
 //          {Return void if no value instead of blank}
 //  ]
 //
@@ -428,7 +428,9 @@ REBNATIVE(get)
 //
 // Note: GET* cannot be the fundamental operation, because GET could not be
 // written for blocks (since voids can't be put in blocks, so they couldn't
-// be "blankified")
+// be "blankified").  Well, technically it *could* be fundamental, but GET
+// would have to make multiple calls to GET* in order to process a block and
+// deal with any voids.
 {
     INCLUDE_PARAMS_OF_GET;
 
@@ -441,10 +443,10 @@ REBNATIVE(get)
     if (IS_BLOCK(ARG(source))) {
         //
         // If a BLOCK! of gets are performed, voids cannot be put into the
-        // resulting BLOCK!.  Hence for /OPT to be legal, it would have to
+        // resulting BLOCK!.  Hence for /ONLY to be legal, it would have to
         // give back a BLANK! or other placeholder.  However, since GET-VALUE
-        // is built on GET/OPT, we defer the error until we actually encounter
-        // an unset variable...which produces that error case that could not
+        // is built on GET/ONLY, we defer the error an unset variable is
+        // actually encountered, which produces that error case that could not
         // be done by "checking the block for voids"
 
         source = VAL_ARRAY_AT(ARG(source));
@@ -521,7 +523,7 @@ REBNATIVE(get)
         }
 
         if (IS_VOID(dest)) {
-            if (REF(opt)) {
+            if (REF(only)) {
                 if (IS_BLOCK(ARG(source))) // can't put voids in blocks
                     fail (Error_No_Value_Core(source, specifier));
             }
@@ -710,9 +712,9 @@ REBNATIVE(resolve)
 //      value [<opt> any-value!]
 //          "Value or block of values"
 //      /only
-//          {If target and value are blocks, set each item to the same value}
-//      /opt
 //          {Treat void values as unsetting the target instead of an error}
+//      /multi
+//          {If target and value are blocks, set each item to the same value}
 //      /some
 //          {Blank values (or values past end of block) are not set.}
 //      /enfix
@@ -720,8 +722,6 @@ REBNATIVE(resolve)
 //  ]
 //
 REBNATIVE(set)
-//
-// !!! Note that r3-legacy has a SET which overrides this one at the moment
 //
 // Blocks are supported as:
 //
@@ -739,7 +739,7 @@ REBNATIVE(set)
     const RELVAL *target;
     REBSPC *target_specifier;
 
-    REBOOL only;
+    REBOOL multi;
     if (IS_BLOCK(ARG(target))) {
         //
         // R3-Alpha and Red let you write `set [a b] 10`, since the thing
@@ -749,22 +749,22 @@ REBNATIVE(set)
         // differently, which can bite you if you `set [a b] value` for some
         // generic value.
         //
-        if (IS_BLOCK(ARG(value)) && NOT(REF(only))) {
+        if (IS_BLOCK(ARG(value)) && NOT(REF(multi))) {
             //
             // There is no need to check values for voidness in this case,
             // since arrays cannot contain voids.
             //
             value = VAL_ARRAY_AT(ARG(value));
             value_specifier = VAL_SPECIFIER(ARG(value));
-            only = FALSE;
+            multi = FALSE;
         }
         else {
-            if (IS_VOID(ARG(value)) && NOT(REF(opt)))
+            if (IS_VOID(ARG(value)) && NOT(REF(only)))
                 fail (Error_No_Value(ARG(value)));
 
             value = ARG(value);
             value_specifier = SPECIFIED;
-            only = TRUE;
+            multi = TRUE;
         }
 
         target = VAL_ARRAY_AT(ARG(target));
@@ -784,12 +784,12 @@ REBNATIVE(set)
         target = D_CELL;
         target_specifier = SPECIFIED;
 
-        if (IS_VOID(ARG(value)) && NOT(REF(opt)))
+        if (IS_VOID(ARG(value)) && NOT(REF(only)))
             fail (Error_No_Value(ARG(value)));
 
         value = ARG(value);
         value_specifier = SPECIFIED;
-        only = TRUE;
+        multi = TRUE;
     }
 
     DECLARE_LOCAL (get_path_hack); // runs prep code, don't put inside loop
@@ -797,7 +797,7 @@ REBNATIVE(set)
     for (
         ;
         NOT_END(target);
-        ++target, only || IS_END(value) ? NOOP : (++value, NOOP)
+        ++target, multi || IS_END(value) ? NOOP : (++value, NOOP)
      ){
         if (REF(some)) {
             if (IS_END(value))
@@ -1165,7 +1165,7 @@ inline static REBOOL Is_Set_Modifies(REBVAL *location)
 //
 //      location [any-word! any-path!]
 //  ][
-//      any-value? get/opt location
+//      any-value? get/only location
 //  ]
 //
 REBNATIVE(set_q)
@@ -1183,7 +1183,7 @@ REBNATIVE(set_q)
 //
 //      location [any-word! any-path!]
 //  ][
-//      void? get/opt location
+//      void? get/only location
 //  ]
 //
 REBNATIVE(unset_q)

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -399,7 +399,7 @@ redescribe: function [
                 fail [{archetype META-OF doesn't have DESCRIPTION slot} meta]
             ]
 
-            not notes: to-value :meta/parameter-notes [
+            not notes: get 'meta/parameter-notes [
                 return () ; specialized or adapted, HELP uses original notes
             ]
 
@@ -532,7 +532,7 @@ semiquote: specialize 'identity [quote: true]
 get*: redescribe [
     {Variation of GET which returns void if the source is not set}
 ](
-    specialize 'get [opt: true]
+    specialize 'get [only: true]
 )
 
 get-value: redescribe [
@@ -541,11 +541,10 @@ get-value: redescribe [
     chain [
         :get*
             |
-        func [x [<opt> any-value!]] [
-            unless set? 'x [
+        specialize 'either-test-value [
+            branch: [
                 fail "GET-VALUE requires source variable to be set"
             ]
-            :x
         ]
     ]
 )
@@ -553,7 +552,7 @@ get-value: redescribe [
 set*: redescribe [
     {Variation of SET where voids are tolerated for unsetting variables.}
 ](
-    specialize 'set [opt: true]
+    specialize 'set [only: true]
 )
 
 

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -36,7 +36,7 @@ pi: 3.14159265358979323846
     return: [any-value!]
         "The new state of the variable"
     'var [set-word! set-path!]
-        "Numeric or series variable to update"
+        "Variable to update"
     n
         "Amount to decrement or skip backwards by"
 ][

--- a/tests/comparison/equalq.test.reb
+++ b/tests/comparison/equalq.test.reb
@@ -596,7 +596,7 @@
 ; Evaluates (try [1 / 0]) to get error! value.
 [
     a-value: blank
-    set/opt 'a-value (try [1 / 0])
+    set/only 'a-value (try [1 / 0])
     equal? a-value a-value
 ]
 ; error! structural equivalence

--- a/tests/context/set.test.reb
+++ b/tests/context/set.test.reb
@@ -15,7 +15,7 @@
     a: 10
     b: 20
     all? [
-        [x y] = set/only [a b] [x y]
+        [x y] = set/multi [a b] [x y]
         a = [x y]
         b = [x y]
     ]

--- a/tests/control/apply.test.reb
+++ b/tests/control/apply.test.reb
@@ -55,7 +55,7 @@
         return: [<opt> any-value!]
         x [<opt> any-value!]
     ][
-        get/opt 'x
+        get/only 'x
     ][
         ()
     ]
@@ -64,7 +64,7 @@
         return: [<opt> any-value!]
         'x [<opt> any-value!]
     ][
-        get/opt 'x
+        get/only 'x
     ][
         ()
     ]
@@ -73,7 +73,7 @@
         return: [<opt> any-value!]
         x [<opt> any-value!]
     ][
-        return get/opt 'x
+        return get/only 'x
     ][
         ()
     ]
@@ -82,29 +82,38 @@
         return: [<opt> any-value!]
         'x [<opt> any-value!]
     ][
-        return get/opt 'x
+        return get/only 'x
     ][
         ()
     ]
 ]
-[error? r3-alpha-apply func ['x [<opt> any-value!]] [return get/opt 'x] [make error! ""]]
 [
+    error? r3-alpha-apply func ['x [<opt> any-value!]] [
+        return get/only 'x
+    ][
+        make error! ""
+    ]
+][
     error? r3-alpha-apply/only func [x [<opt> any-value!]] [
-        return get/opt 'x
+        return get/only 'x
     ] head insert copy [] make error! ""
 ][
     error? r3-alpha-apply/only func ['x [<opt> any-value!]] [
-        return get/opt 'x
+        return get/only 'x
     ] head insert copy [] make error! ""
 ]
 [use [x] [x: 1 strict-equal? 1 r3-alpha-apply func ['x] [:x] [:x]]]
 [use [x] [x: 1 strict-equal? 1 r3-alpha-apply func ['x] [:x] [:x]]]
-[use [x] [x: 1 strict-equal? first [:x] r3-alpha-apply/only func [:x] [:x] [:x]]]
 [
+    use [x] [
+        x: 1
+        strict-equal? first [:x] r3-alpha-apply/only func [:x] [:x] [:x]
+    ]
+][
     use [x] [
         unset 'x
         strict-equal? first [:x] r3-alpha-apply/only func ['x [<opt> any-value!]] [
-            return get/opt 'x
+            return get/only 'x
         ] [:x]
     ]
 ]
@@ -116,7 +125,7 @@
     use [x] [
         unset 'x
         strict-equal? 'x r3-alpha-apply/only func ['x [<opt> any-value!]] [
-            return get/opt 'x
+            return get/only 'x
         ] [x]
     ]
 ]

--- a/tests/control/break.test.reb
+++ b/tests/control/break.test.reb
@@ -8,7 +8,7 @@
 ; the "result" of break should not be assignable
 [#1515 | a: 1 | loop 1 [a: break] | :a = 1]
 [#1515 | a: 1 | loop 1 [set 'a break] :a = 1]
-[#1515 | a: 1 | loop 1 [set/opt 'a break] | :a = 1]
+[#1515 | a: 1 | loop 1 [set/only 'a break] | :a = 1]
 
 ; the "result" of break should not be passable to functions
 [#1509 | a: 1 | loop 1 [a: error? break] | :a = 1]

--- a/tests/control/continue.test.reb
+++ b/tests/control/continue.test.reb
@@ -3,7 +3,7 @@
 ; the "result" of continue should not be assignable, bug#1515
 [a: 1 loop 1 [a: continue] :a =? 1]
 [a: 1 loop 1 [set 'a continue] :a =? 1]
-[a: 1 loop 1 [set/opt 'a continue] :a =? 1]
+[a: 1 loop 1 [set/only 'a continue] :a =? 1]
 ; the "result" of continue should not be passable to functions, bug#1509
 [a: 1 loop 1 [a: error? continue] :a =? 1]
 ; bug#1535

--- a/tests/control/exit.test.reb
+++ b/tests/control/exit.test.reb
@@ -12,7 +12,7 @@
 ; the "result" of exit should not be assignable, bug#1515
 [a: 1 eval does [a: exit] :a =? 1]
 [a: 1 eval does [set 'a exit] :a =? 1]
-[a: 1 eval does [set/opt 'a exit] :a =? 1]
+[a: 1 eval does [set/only 'a exit] :a =? 1]
 ; the "result" of exit should not be passable to functions, bug#1509
 [a: 1 eval does [a: error? exit] :a =? 1]
 ; bug#1535

--- a/tests/control/loop.test.reb
+++ b/tests/control/loop.test.reb
@@ -58,7 +58,7 @@
                 use [break] [
                     break: 1
                     f 2
-                    1 = get/opt 'break
+                    1 = get/only 'break
                 ]
             ][
                 false

--- a/tests/control/return.test.reb
+++ b/tests/control/return.test.reb
@@ -21,7 +21,7 @@
 ; the "result" of return should not be assignable, bug#1515
 [a: 1 eval does [a: return 2] :a =? 1]
 [a: 1 eval does [set 'a return 2] :a =? 1]
-[a: 1 eval does [set/opt 'a return 2] :a =? 1]
+[a: 1 eval does [set/only 'a return 2] :a =? 1]
 ; the "result" of return should not be passable to functions, bug#1509
 [a: 1 eval does [a: error? return 2] :a =? 1]
 ; bug#1535

--- a/tests/control/throw.test.reb
+++ b/tests/control/throw.test.reb
@@ -3,10 +3,10 @@
 ; the "result" of throw should not be assignable, bug#1515
 [a: 1 catch [a: throw 2] :a =? 1]
 [a: 1 catch [set 'a throw 2] :a =? 1]
-[a: 1 catch [set/opt 'a throw 2] :a =? 1]
+[a: 1 catch [set/only 'a throw 2] :a =? 1]
 [a: 1 catch/name [a: throw/name 2 'b] 'b :a =? 1]
 [a: 1 catch/name [set 'a throw/name 2 'b] 'b :a =? 1]
-[a: 1 catch/name [set/opt 'a throw/name 2 'b] 'b :a =? 1]
+[a: 1 catch/name [set/only 'a throw/name 2 'b] 'b :a =? 1]
 ; the "result" of throw should not be passable to functions, bug#1509
 [a: 1 catch [a: error? throw 2] :a =? 1]
 ; bug#1535

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -16,7 +16,7 @@
 ;
 [a: 1 error? try [a: 1 / 0] :a =? 1]
 [a: 1 error? try [set 'a 1 / 0] :a =? 1]
-[a: 1 error? try [set/opt 'a 1 / 0] :a =? 1]
+[a: 1 error? try [set/only 'a 1 / 0] :a =? 1]
 
 ; bug#2190
 [127 = catch/quit [attempt [catch/quit [1 / 0]] quit/with 127]]

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -2,7 +2,8 @@
 [void? ()]
 [blank? type-of ()]
 [not void? 1]
-; bug#68
-[void? try [a: ()]]
+
+[#68 | void? try [a: ()]]
+
 [error? try [a: () a]]
-[not error? try [set/opt 'a ()]]
+[not error? try [set/only 'a ()]]

--- a/tests/lib/text-lines.reb
+++ b/tests/lib/text-lines.reb
@@ -65,7 +65,7 @@ for-each-line: func [
     /local eol
 ] [
 
-    set/opt 'result while [not tail? text] [
+    set/only 'result while [not tail? text] [
 
         eol: any [
             find text newline
@@ -78,7 +78,7 @@ for-each-line: func [
         do body
     ]
 
-    get/opt 'result
+    get/only 'result
 ]
 
 lines-exceeding: function [

--- a/tests/old/r2-tests.r
+++ b/tests/old/r2-tests.r
@@ -247,7 +247,7 @@
 ]
 [strict-equal? 2-Jul-2009 2-Jul-2009/22:20]
 [strict-equal? 2-Jul-2009 2-Jul-2009/00:00:00+00:00]
-[use [a] [unset? get/opt 'a]]
+[use [a] [unset? get/only 'a]]
 [unset? any [()]]
 [unset? any [false ()]]
 [unset? any [() false]]
@@ -316,7 +316,7 @@
     b: head insert copy [] try [1 / 0]
     pokus1: func [[catch] block [block!] /local elem] [
         for i 1 length? block 1 [
-            if error? set/opt 'elem first block [
+            if error? set/only 'elem first block [
                 throw make error! {Dangerous element}
             ]
             block: next block

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -20,13 +20,31 @@
 ; the state of variables, that is what NONE! (blank) is for...to serve as
 ; a reified value placeholder when you don't have a value.
 
-[a: 1 set [a] reduce [2 ()] a = 2]
-[x: construct [a: 1] set x reduce [2 ()] x/a = 2]
-[a: 1 set/opt [a] reduce [()] void? get/opt 'a]
-[a: 1 b: 2 set/opt [a b] reduce [3 ()] all [a = 3 void? get/opt 'b]]
-[x: construct [a: 1] set/opt x reduce [()] void? get/opt in x 'a]
-[x: construct [a: 1 b: 2] set/opt x reduce [3 ()] all [a = 3 void? get/opt in x 'b]]
 [
+    a: 1
+    set [a] reduce [2 ()]
+    a = 2
+][
+    x: construct [a: 1]
+    set x reduce [2 ()]
+    x/a = 2
+][
+    a: 1
+    set/only [a] reduce [()]
+    void? get/only 'a
+][
+    a: 1 b: 2
+    set/only [a b] reduce [3 ()]
+    all [a = 3 | void? get/only 'b]
+][
+    x: construct [a: 1]
+    set/only x reduce [()]
+    void? get/only in x 'a
+][
+    x: construct [a: 1 b: 2]
+    set/only x reduce [3 ()]
+    all [a = 3 | void? get/only in x 'b]
+][
     blk: reduce [()]
     blk = compose blk
 ]

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -58,7 +58,7 @@ make object! compose [
             leave
         ]
 
-        error? set/opt 'test-block catch-any test-block 'exception
+        error? set* 'test-block catch-any test-block 'exception
 
         test-block: case [
             exception [spaced ["failed," exceptions/:exception]]
@@ -147,8 +147,11 @@ make object! compose [
                     any [
                         any whitespace
                         [
-                            position: "%"
-                            (set/opt [value next-position] transcode/next position)
+                            position: "%" (
+                                set [value next-position]
+                                    transcode/next
+                                    position
+                            )
                             :next-position
                                 |
                             ; dialect failure?

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -102,12 +102,16 @@ make object! [
                                 )
                             ]
                             blank? next-position
-                        ] [stop: [:position]]
-                        issue? get/opt 'value [
+                        ][
+                            stop: [:position]
+                        ]
+
+                        issue? get 'value [
                             append flags value
                             stop: [end skip]
                         ]
-                        file? get/opt 'value [
+
+                        file? get 'value [
                             collect-tests collected-tests value
                             print ["file:" mold test-file]
                             append collected-tests test-file


### PR DESCRIPTION
SET/ANY was a poor name for what it did, but a suitable name was
difficult to find.  Ren-C started out trying /OPT, but it was not a
slam dunk.  Hence the legacy support for /ANY was kept turned on rather
than force a migration, so that /OPT could be allowed to settle, and
it wouldn't take two churns if a better name was found.

During that time, /OPT was killed off on conditional routines that offered
it and was folded into the /ONLY option on conditionals

Over the same period, SET and GET evolved...notably that the non-OPT/ANY
form of GET would return a BLANK! in the case of an unset variable
rather than being an error.  This simplified several scenarios and
helped alleviate some pain caused by increased void-ing in the system.
A complementary operation GET-VALUE was added to trigger an error if
a variable was void, implemented as a CHAIN on top of GET /ANY+/OPT
which complained if the piped out result was void.

With a new framework of thinking about this, the /ANY or /OPT version
came to seem more like the "fundamental" version, upon which higher
level GETs and SETs were implemented.  This is what /ONLY has come
to mean, and which is being abbreviated as `*` in various places.

So you might think that a GET/ONLY is a GET, only without the
"blankification" applied to voids.  And SET/ONLY is a SET, only without
throwing in an extra parameter check that the value you are trying to
set to is void (hence actually *unsetting* the variable).

One hitch in this plan was that SET/ONLY has a meaning, introduced by
Red, as follows:

    >> set/only [a b] [c d]
    >> a
    == [c d]
    >> b
    == [c d]

So the operation is if the target is a block, and the source is a
block, you do not intend to set it itemwise (e.g. such that a is c
and b is d).  Rather, you meant to set all the targets in the block
to the same block value.

This option was not in R3-Alpha, and once added it was not used
in the Ren-C codebase.  To free up /ONLY for the more useful
definition, this renames that functionality to /MULTI.  (Name subject
to review, MULTIPLE?)

Also speeds up GET-VALUE by modifying the chain to feed into a
native specialization.