### PR TITLE
Splice only BLOCK! by default when no /ONLY (APPEND, INSERT)

### DIFF
--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -62,8 +62,13 @@ REBCNT Modify_Array(
 
     if (action == SYM_APPEND || dst_idx > tail) dst_idx = tail;
 
-    // Check /PART, compute LEN:
-    if (NOT(flags & AM_ONLY) && ANY_ARRAY(src_val)) {
+    // Check /PART, compute LEN.  Note that in Rebol2/R3-Alpha, ANY_ARRAY
+    // was the test for whether splicing would be done.  Ren-C considers
+    // BLOCK! to be the only type that will implicitly splice, and you must
+    // alias other types to a BLOCK! with AS to get the behavior.  This means
+    // that `block: [a b c] | append block 'd/e` will give `[a b c d/e]`
+    //
+    if (NOT(flags & AM_ONLY) && IS_BLOCK(src_val)) {
         // Adjust length of insertion if changing /PART:
         if (action != SYM_CHANGE && (flags & AM_PART))
             ilen = dst_len;

--- a/tests/series/insert.test.reb
+++ b/tests/series/insert.test.reb
@@ -26,7 +26,7 @@
     a: first [(0)]
     b: make group! 0
     insert b first a
-    a == b
+    b == first a
 ]
 [
     a: first [(0)]
@@ -40,12 +40,15 @@
     insert a 0
     a == to path! [0]
 ]
-[
-    a: to path! [0]
-    b: make path! 0
-    insert b first a
-    a == b
-]
+
+; This test makes a path-in-a-path, which aren't currently handled well.
+;[
+;    a: to path! [0]
+;    b: make path! 0
+;    insert b first a
+;    a == b
+;]
+
 [
     a: to path! [0]
     b: make path! 0
@@ -64,12 +67,15 @@
     insert :b first :a
     :a == :b
 ]
-[
-    a: to lit-path! [0]
-    b: make lit-path! 0
-    insert :b :a
-    :a == :b
-]
+
+; This test makes a path-in-a-path, which aren't currently handled well.
+;[
+;    a: to lit-path! [0]
+;    b: make lit-path! 0
+;    insert :b :a
+;    :a == :b
+;]
+
 ; set-path
 [
     a: make set-path! 0
@@ -82,12 +88,15 @@
     insert :b first :a
     :a == :b
 ]
-[
-    a: to set-path! [0]
-    b: make set-path! 0
-    insert :b :a
-    :a == :b
-]
+
+; This test makes a path-in-a-path, which aren't currently handled well
+;[
+;    a: to set-path! [0]
+;    b: make set-path! 0
+;    insert :b :a
+;    :a == :b
+;]
+
 ; string
 [
     a: make string! 0


### PR DESCRIPTION
This is a proposed simplification which would make the splicing
behavior of APPEND, INSERT, and their dependent operations only apply
to BLOCK!.  Hence ANY-PATH! and GROUP! would not splice.

    >> data: copy [a b c]

    >> append data 'd/e
    == [a b c d/e]

    >> append data quote (f g)
    == [a b c d/e (f g)]

    >> append data [h i]
    == [a b c d/e (f g) h i]

    >> append/only data [j k]
    == [a b c d/e (f g) h i [j k]]

Surprisingly (or perhaps unsurprisingly) this didn't seem to have any
obvious effect on the core itself.  It is very rarely desirable to splice a
PATH! or GROUP! into a block, and most operations that wish to add new
elements onto a path or group do so either with items one-at-a-time or
with a BLOCK! to splice.

One aspect of this change is that it makes it easier to produce paths
nested inside of paths.  The system does not handle this very well in
rendering, but it needs to, as they've always been quite possible to
create.  Pursuing an answer to that is discussed here:

https://forum.rebol.info/t/226/3