### PR TITLE
DO of FRAME! copies vars for instantiation, FRAME! fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,12 +91,12 @@ matrix:
                       - texinfo
 
         # Windows x86, release, gcc
-        # (Temporarily being done as DEBUG, because it is crashing on startup.)
+        # (Temporarily being done as DEBUG=pathology, it crashes on startup.)
         #
         - os: linux
           sudo: false #Force new container-based infrastructure.
           language: c
-          env: CONFIG=mingw-x86.r OS_ID=0.3.1 DEBUG=symbols TOOLS=i686-w64-mingw32- STANDARD=c RIGOROUS=yes STATIC=yes TCC=i386-win32-tcc TCC_CPP_EXTRA_FLAGS='-I../external/tcc/win32/include -DPVAR=TVAR -DTVAR="extern __attribute__((dllimport))"' HOST=i686-w64-mingw32 ARCH_CFLAGS=-m32 FFI="dynamic" ODBC_REQUIRES_LTDL="no"
+          env: CONFIG=mingw-x86.r OS_ID=0.3.1 DEBUG=pathology TOOLS=i686-w64-mingw32- STANDARD=c RIGOROUS=yes STATIC=yes TCC=i386-win32-tcc TCC_CPP_EXTRA_FLAGS='-I../external/tcc/win32/include -DPVAR=TVAR -DTVAR="extern __attribute__((dllimport))"' HOST=i686-w64-mingw32 ARCH_CFLAGS=-m32 FFI="dynamic" ODBC_REQUIRES_LTDL="no"
           addons:
               apt:
                   packages:

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -1430,22 +1430,30 @@ void Assert_Context_Core(REBCTX *c)
         if (!IS_FRAME(rootvar))
             panic (rootvar);
 
-        // !!! Temporary disablement of an important check!
+        // In a FRAME!, the keylist is for the underlying function.  So to
+        // know what function the frame is actually for, one must look to
+        // the "phase" field...held in the rootvar.
         //
-        // Currently MAKE FRAME! of a FUNCTION! makes the keylist for the
-        // function itself, and not the underlying one.  This is buggy, and
-        // needs to be fixed.  It will require some major changes, though.
-        //
-        /*REBFRM *f = CTX_FRAME_IF_ON_STACK(c);
-        if (f != NULL) {
-            REBFUN *rootkey_fun = VAL_FUNC(rootkey);
-            REBFUN *frame_fun = FRM_UNDERLYING(f);
+        if (
+            FUNC_UNDERLYING(rootvar->payload.any_context.phase)
+            != VAL_FUNC(rootkey)
+        ){
+            panic (rootvar);
+        }
 
-            if (rootkey_fun != frame_fun) {
-                printf("FRAME! context function doesn't match its REBFRM");
-                panic (frame_fun);
+        REBFRM *f = CTX_FRAME_IF_ON_STACK(c);
+        if (f != NULL) {
+            //
+            // If the frame is on the stack, the phase should be something
+            // with the same underlying function as the rootkey.
+            //
+            if (
+                FUNC_UNDERLYING(rootvar->payload.any_context.phase)
+                != VAL_FUNC(rootkey)
+            ){
+                panic (rootvar);
             }
-        }*/
+        }
     }
     else
         panic (rootkey);

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -561,7 +561,9 @@ reevaluate:;
         //
         // Push_Or_Alloc_Args sets the frame's function, sets args_head...
         //
-        Push_Or_Alloc_Args_For_Underlying_Func(f, current_gotten);
+        Push_Or_Alloc_Args_For_Underlying_Func(
+            f, VAL_FUNC(current_gotten), VAL_BINDING(current_gotten)
+        );
 
     do_function_arglist_in_progress:
 
@@ -842,9 +844,12 @@ reevaluate:;
 
     //=//// SPECIALIZED ARG (already filled, so does not consume) /////////=//
 
-                if (IS_VOID(f->special)) {
-                    //
-                    // A void specialized value means this particular argument
+                if (
+                    IS_VOID(f->special)
+                    && NOT(f->flags.bits & DO_FLAG_APPLYING)
+                ){
+                    // When not doing an APPLY (or DO of a FRAME!), then
+                    // a void specialized value means this particular argument
                     // is not specialized.  Still must increment the pointer
                     // before falling through to ordinary fulfillment.
                     //

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -452,11 +452,10 @@ void Init_Any_Context_Core(
 
     Move_Value(out, CTX_VALUE(c));
 
-    // Currently only FRAME! uses the ->binding field.  Following the pattern
-    // of function, we assume the archetype form of a frame has no binding,
-    // and it's only REBVAL instances besides the canon that become bound.
+    // Currently only FRAME! uses the ->binding field, in order to capture the
+    // ->binding of the function value it is linked to (that function is in ->phase)
     //
-    assert(VAL_BINDING(out) == NULL);
+    assert(VAL_BINDING(out) == NULL || CTX_TYPE(c) == REB_FRAME);
 
     // Only FRAME!s are allowed to have phases.
     //

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -798,7 +798,11 @@ static void Propagate_All_GC_Marks(void)
                 Queue_Mark_Context_Deep(meta);
 
             assert(ANY_CONTEXT(v));
-            assert(v->extra.binding == NULL); // archetypes have no binding
+
+            // Currently only FRAME! uses binding
+            //
+            assert(v->extra.binding == NULL || VAL_TYPE(v) == REB_FRAME);
+
             ++v; // context archtype completely marked by this process
         }
         else if (GET_SER_FLAG(a, ARRAY_FLAG_PAIRLIST)) {

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -544,7 +544,7 @@ struct Reb_Frame {
     // incremented on a common code path) if arguments are just being checked
     // vs. fulfilled.
     //
-    REBVAL *special;
+    const REBVAL *special;
 
     // `refine`
     //

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -409,9 +409,9 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         //
         if (cast(REBUPT, v) % sizeof(REBUPT) != 0) {
             printf(
-                "Cell address %p not aligned to %ld bytes\n",
+                "Cell address %p not aligned to %d bytes\n",
                 cast(const void*, v),
-                sizeof(REBUPT)
+                cast(int, sizeof(REBUPT))
             );
             panic_at (v, file, line);
         }

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -708,6 +708,14 @@ switch/default user-config/debug [
         append app-config/cflags <gnu:-fsanitize=address>
         append app-config/ldflags <gnu:-fsanitize=address>
     ]
+
+    ; This is the case we really don't like; bugs that only show up in the
+    ; non-debug build.  It's the case you need symbols in a release build
+    ;
+    pathology [
+        cfg-symbols: true
+        app-config/debug: off
+    ]
 ][
     fail ["unrecognized debug setting:" user-config/debug]
 ]

--- a/tests/control/apply.test.reb
+++ b/tests/control/apply.test.reb
@@ -129,3 +129,11 @@
         ] [x]
     ]
 ]
+
+; The system should be able to preserve the binding of a definitional return
+; when a `MAKE FRAME! :RETURN` is used.  The FRAME! value itself holds the
+; binding, even though the keylist only identifies the underlying native.
+; FUNCTION-OF can also extract the binding from the FRAME! and put it together
+; with the .phase field.
+;
+[1 == eval does [r3-alpha-apply :return [1] 2]]

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -3,10 +3,22 @@
 [
     append-123: specialize :append [value: [1 2 3] only: true]
     [a b c [1 2 3] [1 2 3]] = append-123/dup [a b c] 2
-]
-[
+][
     append-123: specialize :append [value: [1 2 3] only: true]
     append-123-twice: specialize :append-123 [dup: true count: 2]
     [a b c [1 2 3] [1 2 3]] = append-123-twice [a b c]
+][
+    append-10: specialize 'append [value: 10]
+    f: make frame! :append-10
+    f/series: copy [a b c]
+    do f
+    f/value: 20
+    [a b c 10 20] = do f
+][
+    foo: does [
+        return-5: specialize 'return [value: 5]
+        return-5
+        "this shouldn't be returned"
+    ]
+    foo = 5
 ]
-

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -54,18 +54,6 @@
 ;
 [typeset? complement make typeset! [unset!]]
 
-; There is an issue with doing a MAKE FRAME! for a definitional return and
-; then DOing that frame.  The problem is that while the behavior of each
-; RETURN looks like a unique function, it isn't.  So if you try to execute
-; the frame to call the "Unique" function, there is no way to target that
-; instance.  So the `exit_from` frame inside the definitional return has
-; to get tunneled in somehow as the "function" of the definitional return
-; to know where to make the call.
-;
-; Technically possible.  Just not on the priority list ATM.
-;
-[1 == eval does [r3-alpha-apply :return [1] 2]]
-
 ; For bridging purposes, MAKE is currently a "sniffing" variadic.  These are
 ; evil, but helpful because it wants to examine its arguments before deciding
 ; whether to evaluate or quote them at the callsite.  So long as it is evil


### PR DESCRIPTION
A concept tried in Ren-C early on was that when you create a frame via
MAKE FRAME! :SOME-FUNCTION, the frame context would be used directly
for the instance of the function call.  The frame's variables would not
be copied when you would DO it--actual heap-based context fields would
be used--as opposed to pushing new stack-based variables and copying
the MAKE'd frame's fields into them.

This turned out to be a bad idea for several reasons.

For one thing, the person who built the FRAME! and is DO-ing it now has
access to the state of the frame after the function has finished.
Rebol functions make no promises about the values of their arguments at
the end of execution...they only promise a return value.  But by using
the FRAME! that the caller had built directly, a non-debug caller can
see the state of every local and argument at the end of the function.
This breaks the contract, making every local and argument a potential
"return value".  It also completely undermines the idea of reusability
of the FRAME! for multiple successive calls, which is kind of the
reason the feature exists in the first place (!)

(Another reason is more esoteric and technical, and has to do with the
optimization which is used to avoid needing to sweep across stack
variables to prep them for the garbage collector.  If the evaluator
can't always assume it's operating on the chunk stack, it loses this
optimization...and must preformat stack cells on each function call.)

This commit ties up loose-ends with how DO of a FRAME! works.  One very
important issue is that a frame must use the keylist for the
*underlying* function that will ultimately be called, but it also has
to be aware of the *specific* function that it invokes--including that
function's "binding".  To give a fairly pathological case:

    assert [
        5 = eval does [
            r: specialize 'return [value: 5]
            f: make frame! r
            do f
            print "this print shouldn't run
        ]
    ]

The keylist of F has to have RETURN's arguments, so it will mention
`value`.  Yet when you DO F, it has to run R...so it must have a way
to find that function.  Additionally, it needs to be able to remember
that the generic RETURN native is hooked to that *particular* DOES
to return from.

This is accomplished by putting the necessary fields into the FRAME!
REBVAL.  The frame keylist is the underlying one, e.g. RETURN.  Then
`v->payload.any_context.phase` is the REBFUN* for R, and then
`v->extra.binding` is the REBFUN* for the DOES.  These pieces must be
reassembled by code that wishes to execute frames or extract
information about them.

This enables several scenarios which have not worked since the
beginning of frames and specializations.