### PR TITLE
Fix REJOIN bug and add REJOIN tests.

### DIFF
--- a/tests/series/rejoin.test.reb
+++ b/tests/series/rejoin.test.reb
@@ -1,0 +1,42 @@
+; series/rejoin.test.reb
+[
+    [] = rejoin []
+]
+[
+    [] = rejoin [[]]
+]
+[
+    "" = rejoin [()]
+]
+[
+    "" = rejoin [() ()]
+]
+[
+    [[]] = rejoin [[][]]
+]
+[
+    [[][]] = rejoin [[][][]]
+]
+[
+    block: [[][]]
+    not same? first block first rejoin block
+]
+[
+    [1] = rejoin [[] 1]
+]
+[
+    'a/b/c = rejoin ['a/b 'c]
+]
+[
+    'a/b/c/d = rejoin ['a/b 'c 'd]
+]
+[
+    "" = rejoin [{}]
+]
+[
+    "1" = rejoin [1]
+]
+[
+    value: 1
+    "1" = rejoin [value]
+]


### PR DESCRIPTION
The original implementation used JOIN-ALL, but JOIN-ALL does not tolerate () which are not in the first position of the block because it is based upon REDUCE.
Reduction in REJOIN needs to be tolerant of () at any position in the block. So I decided to implement a tolerant reduction as part of this implementation of REJOIN.

This implementation and tests are meant to behave as R3 Alpha does.  However, the behaviour of REJOIN look odd when examining some of these test cases. An argument could be made for simplifying REJOIN's behaviour.

I welcome review and update of this implementation to reflect any opportunities that Ren-c offers to make it simpler.