### PR TITLE
Specialization uses facades to suppress hidden keys in frames

### DIFF
--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -260,8 +260,8 @@ REBNATIVE(make_native)
     REBFUN *fun = Make_Function(
         Make_Paramlist_Managed_May_Fail(ARG(spec), MKF_NONE),
         &Pending_Native_Dispatcher, // will be replaced e.g. by COMPILE
-        NULL, // no underlying function, this is fundamental
-        NULL // not providing a specialization
+        NULL, // no facade (use paramlist)
+        NULL // no specialization exemplar (or inherited exemplar)
     );
 
     REBARR *info = Make_Array(3); // [source name tcc_state]

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1027,7 +1027,7 @@ static void Mold_Or_Form_Map(REB_MOLD *mo, const RELVAL *v, REBOOL form)
 }
 
 
-static void Form_Object(REB_MOLD *mo, const RELVAL *v)
+static void Form_Any_Context(REB_MOLD *mo, const RELVAL *v)
 {
     REBCTX *c = VAL_CONTEXT(v);
 
@@ -1062,7 +1062,7 @@ static void Form_Object(REB_MOLD *mo, const RELVAL *v)
 }
 
 
-static void Mold_Object(REB_MOLD *mo, const RELVAL *v)
+static void Mold_Any_Context(REB_MOLD *mo, const RELVAL *v)
 {
     REBCTX *c = VAL_CONTEXT(v);
 
@@ -1111,18 +1111,14 @@ static void Mold_Object(REB_MOLD *mo, const RELVAL *v)
 
     REBVAL *key = keys_head;
     for (; NOT_END(key); ++key) {
+        if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
+            continue;
+
         if (key != keys_head)
             Append_Codepoint_Raw(mo->series, ' ');
 
-        // !!! Feature of hidden words in object specs not yet implemented,
-        // but if it paralleled how function specs work it would be SET-WORD!
-        //
         DECLARE_LOCAL (any_word);
-        Init_Any_Word(
-            any_word,
-            GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN) ? REB_SET_WORD : REB_WORD,
-            VAL_KEY_SPELLING(key)
-        );
+        Init_Any_Word(any_word, REB_WORD, VAL_KEY_SPELLING(key));
         Mold_Value(mo, any_word);
     }
 
@@ -1179,7 +1175,7 @@ static void Mold_Or_Form_Error(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     // Protect against recursion. !!!!
     //
     if (NOT(form)) {
-        Mold_Object(mo, v);
+        Mold_Any_Context(mo, v);
         return;
     }
 
@@ -1567,9 +1563,9 @@ void Mold_Or_Form_Value(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     case REB_PORT:
     case REB_FRAME:
         if (form)
-            Form_Object(mo, v);
+            Form_Any_Context(mo, v);
         else
-            Mold_Object(mo, v);
+            Mold_Any_Context(mo, v);
         break;
 
     case REB_ERROR:
@@ -1609,7 +1605,7 @@ void Mold_Or_Form_Value(REB_MOLD *mo, const RELVAL *v, REBOOL form)
 
         REBCTX *meta = VAL_LIBRARY_META(v);
         if (meta)
-            Mold_Object(mo, CTX_VALUE(meta));
+            Mold_Any_Context(mo, CTX_VALUE(meta));
 
         End_Mold(mo);
         break; }

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -163,8 +163,6 @@ REBTYPE(Function)
         // code, yet has a distinct identity.  This means it would not be
         // HIJACK'd if the function that it was copied from was.
 
-        REBFUN *underlying = FUNC_UNDERLYING(VAL_FUNC(value));
-
         REBARR *proxy_paramlist = Copy_Array_Deep_Managed(
             VAL_FUNC_PARAMLIST(value),
             SPECIFIED // !!! Note: not actually "deep", just typesets
@@ -183,8 +181,8 @@ REBTYPE(Function)
         REBFUN *proxy = Make_Function(
             proxy_paramlist,
             FUNC_DISPATCHER(VAL_FUNC(value)),
-            underlying,
-            NULL // not changing the specialization
+            FUNC_FACADE(VAL_FUNC(value)), // can reuse the facade
+            FUNC_EXEMPLAR(VAL_FUNC(value)) // not changing the specialization
         );
 
         // A new body_holder was created inside Make_Function().

--- a/src/core/t-routine.c
+++ b/src/core/t-routine.c
@@ -1352,8 +1352,8 @@ static REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
     REBFUN *fun = Make_Function(
         paramlist,
         &Routine_Dispatcher,
-        NULL, // no underlying function, this is fundamental
-        NULL // not providing a specialization
+        NULL, // no facade (use paramlist)
+        NULL // no specialization exemplar (or inherited exemplar)
     );
 
     // The "body" value of a routine is the routine info array.

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -560,7 +560,8 @@ struct Reb_Series {
 
     // The `link` field is generally used for pointers to something that
     // when updated, all references to this series would want to be able
-    // to see.
+    // to see.  This cannot be done (easily) for properties that are held
+    // in REBVAL cells directly.
     //
     // This field is in the second pointer-sized slot in the REBSER node to
     // push the `content` so it is 64-bit aligned on 32-bit platforms.  This

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1311,6 +1311,8 @@ inline static void SET_GOB(RELVAL *v, REBGOB *g) {
 //
 inline static REBVAL *Move_Value(RELVAL *out, const REBVAL *v)
 {
+    assert(out != v); // usually a sign of a mistake; not worth supporting
+
     assert(
         ALL_VAL_FLAGS(v, NODE_FLAG_CELL | NODE_FLAG_NODE)
         && NOT_VAL_FLAG(v, NODE_FLAG_FREE)

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -580,8 +580,8 @@ void Init_Debug_Extension(void) {
         REBFUN *debug_native = Make_Function(
             Make_Paramlist_Managed_May_Fail(spec, MKF_KEYWORDS),
             &N_debug,
-            NULL, // no underlying function, this is fundamental
-            NULL // not providing a specialization
+            NULL, // no facade (use paramlist)
+            NULL // no specialization exemplar (or inherited exemplar)
         );
 
         Move_Value(

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -12,8 +12,7 @@
     f: make frame! :append-10
     f/series: copy [a b c]
     do f
-    f/value: 20
-    [a b c 10 20] = do f
+    [a b c 10 10] = do f
 ][
     foo: does [
         return-5: specialize 'return [value: 5]


### PR DESCRIPTION
The concept of a FRAME! is to enable the representation of a state of
a Rebol function invocation (or a potential invocation) of a Rebol
function, or specific invocation, as a context that resembles OBJECT!.
Not only is this useful in debugging, but in the design of custom
APPLY-like operations.

That model is complex to simulate for the user, because the operations
that do function compositions (SPECIALIZE, CHAIN, ADAPT, HIJACK...)
don't actually create distinct stack frames to run their code.  This
gives them a significant performance advantage over methods which would
rewrite the bodies of functions or otherwise execute more retriggering
levels.  An adaptation of a specialization of an adaptation of a
specialization would find each adaptation layer "perceiving" a
different number of parameters to the function.

In the initial implementation, no attempt was made to filter the number
of parameters seen in frame creation.  Hence if a FRAME! was made for
a function with 10 parameters that had 9 specialized out, it would
still appear to be a frame with 10 keys and values instead of 1.

Eventually, a ->phase field that is the currently represented FUNCTION!
for a given capture of a FRAME! REBVAL was introduced.  This commit
introduces a new concept of making specializations create a "facade"
pseudo-paramlist which hides the appropriate fields, and adapts the
CTX_KEYLIST() function to use that facade instead of either the
function's paramlist or the underlying function's paramlist--neither
of which would be appropriate.

Redundancy in Make_Frame_For_Function() & Specialize_Function_Throws()
was also noticed and removed.