### PR TITLE
USE=>native: performance + decouple from "closure" semantics

### DIFF
--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -86,7 +86,12 @@ inline static const REBYTE *VAL_WORD_HEAD(const RELVAL *v) {
 
 inline static void INIT_WORD_CONTEXT(RELVAL *v, REBCTX *context) {
     assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND) && context != SPECIFIED);
+
+    // !!! Is it a good idea to be willing to do the ENSURE here?
+    // See weirdness in Copy_Body_Deep_Bound_To_New_Context()
+    //
     ENSURE_ARRAY_MANAGED(CTX_VARLIST(context));
+
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(context));
     v->extra.binding = CTX_VARLIST(context);
 }

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -970,27 +970,6 @@ once-bar: func [
 ]
 
 
-use: func [
-    {Defines words local to a block.}
-    return: [<opt> any-value!]
-    vars [block! word!] {Local word(s) to the block}
-    body [block!] {Block to evaluate}
-][
-    ; We are building a FUNC out of the body that was passed to us, and that
-    ; body may have RETURN words with bindings in them already that we do
-    ; not want to disturb with the definitional bindings in the new code.
-    ; So that means either using MAKE FUNCTION! (which wouldn't disrupt
-    ; RETURN bindings) or using the more friendly FUNC and `<with> return`
-    ; (they do the same thing, just FUNC is arity-2)
-    ;
-    ; <durable> is used so that the data for the locals will still be
-    ; available if any of the words leak out and are accessed after the
-    ; execution is finished.
-    ;
-    eval func compose [<durable> <local> (vars) <with> return] body
-]
-
-
 ; Shorthand helper for CONSTRUCT (similar to DOES for FUNCTION).
 ;
 has: func [


### PR DESCRIPTION
The R3-Alpha implementation of USE would build a closure (indefinite
extent lifetime for its arguments, refinements, and locals) based on
the given spec.  Then it would DO that function.

There's an inefficiency in this, because it constructs a function, that
takes time and also makes entities that need to be GC'd, when that
function is to be called only once.

This reduces the overhead of USE significantly by making it a native
and reuses the same code that copies and rebinds bodies of loops.
This helps USE not be specifically tied to the behavior or decisions
regarding indefinite or definite lifetimes in functions.  It also
puts the decision closer to behaviors which would be able to take
advantage of working virtual binding.