### PR TITLE
REMOVE-EACH locks series until end, performs all removes atomically

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -266,7 +266,7 @@ Access: [
     
     series-protected:   {series read-only due to PROTECT (see UNPROTECT)}
     series-frozen:      {series is source or permanently locked, can't modify}
-    series-running:     {series temporarily read-only for running (DO, PARSE)}
+    series-held:        {series has temporary read-only hold for iteration}
 
     hidden:             {not allowed - would expose or modify hidden values}
 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -331,7 +331,7 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
     // itself, but should stop modifications from user code.
     //
     if (f->flags.bits & DO_FLAG_NATIVE_HOLD)
-        SET_SER_INFO(f->varlist, SERIES_INFO_RUNNING);
+        SET_SER_INFO(f->varlist, SERIES_INFO_HOLD);
 
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(c));
     MANAGE_ARRAY(f->varlist);

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -396,7 +396,7 @@ inline static void SET_FRAME_VALUE(REBFRM *f, const RELVAL *value) {
 inline static void Enter_Native(REBFRM *f) {
     f->flags.bits |= DO_FLAG_NATIVE_HOLD;
     if (f->varlist != NULL)
-        SET_SER_INFO(f->varlist, SERIES_INFO_RUNNING);
+        SET_SER_INFO(f->varlist, SERIES_INFO_HOLD);
 }
 
 

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -113,13 +113,14 @@
 #define DO_FLAG_4_IS_TRUE FLAGIT_LEFT(4) // NODE_FLAG_END
 
 
-//=//// DO_FLAG_TOOK_FRAME_LOCK ///////////////////////////////////////////=//
+//=//// DO_FLAG_TOOK_FRAME_HOLD ///////////////////////////////////////////=//
 //
 // While R3-Alpha permitted modifications of an array while it was being
-// executed, Ren-C does not.  It takes a lock if the source is not already
-// read only, and sets it back when Do_Core is finished (or on errors)
+// executed, Ren-C does not.  It takes a temporary read-only "hold" if the
+// source is not already read only, and sets it back when Do_Core is
+// finished (or on errors).  See SERIES_INFO_HOLD for more about this.
 //
-#define DO_FLAG_TOOK_FRAME_LOCK \
+#define DO_FLAG_TOOK_FRAME_HOLD \
     FLAGIT_LEFT(5)
 
 

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -321,16 +321,20 @@
     FLAGIT_LEFT(5)
 
 
-//=//// SERIES_INFO_RUNNING ///////////////////////////////////////////////=//
+//=//// SERIES_INFO_HOLD //////////////////////////////////////////////////=//
 //
-// Set in the header while a DO is happening on (or a PARSE, etc.) and gives
-// it a temporarily protected state.  It will be released when the execution
-// is finished, which distinguishes it from SERIES_INFO_FROZEN, from which it
-// will never come back, as long as it lives...
+// Set in the header whenever some stack-based operation wants a temporary
+// hold on a series, to give it a protected state.  This will happen with a
+// DO, or PARSE, or enumerations.  Even REMOVE-EACH will transition the series
+// it is operating on into a HOLD state while the removal signals are being
+// gathered, and apply all the removals at once before releasing the hold.
+//
+// It will be released when the execution is finished, which distinguishes it
+// from SERIES_INFO_FROZEN, which will never be reset, as long as it lives...
 //
 // Note: Same bit as NODE_FLAG_SPECIAL, should not be relevant.
 // 
-#define SERIES_INFO_RUNNING \
+#define SERIES_INFO_HOLD \
     FLAGIT_LEFT(6)
 
 

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -784,13 +784,19 @@ struct Reb_Value
 // Note that this will clear NODE_FLAG_FREE, so it should be checked by the
 // debug build before resetting.
 //
+// Note also that NODE_FLAG_MARKED usage is a relatively new concept, e.g.
+// to allow REMOVE-EACH to mark values in a locked series as to which should
+// be removed when the enumeration is finished.  This *should* not be able
+// to interfere with the GC, since userspace arrays don't use that flag with
+// that meaning, but time will tell if it's a good idea to reuse the bit.
+//
 
 #define CELL_MASK_RESET \
     (NODE_FLAG_NODE | NODE_FLAG_CELL \
         | NODE_FLAG_MANAGED | VALUE_FLAG_STACK)
 
 #define CELL_MASK_COPY \
-    ~(CELL_MASK_RESET \
+    ~(CELL_MASK_RESET | NODE_FLAG_MARKED \
         | VALUE_FLAG_ENFIXED | VALUE_FLAG_PROTECTED | VALUE_FLAG_UNEVALUATED)
 
 

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -487,7 +487,7 @@ inline static REBOOL Is_Series_Frozen(REBSER *s) {
 
 inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
     return ANY_SER_INFOS(
-        s, SERIES_INFO_FROZEN | SERIES_INFO_RUNNING | SERIES_INFO_PROTECTED
+        s, SERIES_INFO_FROZEN | SERIES_INFO_HOLD | SERIES_INFO_PROTECTED
     );
 }
 
@@ -500,8 +500,8 @@ inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
 //
 inline static void FAIL_IF_READ_ONLY_SERIES(REBSER *s) {
     if (Is_Series_Read_Only(s)) {
-        if (GET_SER_INFO(s, SERIES_INFO_RUNNING))
-            fail (Error_Series_Running_Raw());
+        if (GET_SER_INFO(s, SERIES_INFO_HOLD))
+            fail (Error_Series_Held_Raw());
 
         if (GET_SER_INFO(s, SERIES_INFO_FROZEN))
             fail (Error_Series_Frozen_Raw());

--- a/tests/control/remove-each.test.reb
+++ b/tests/control/remove-each.test.reb
@@ -2,8 +2,112 @@
 [
     remove-each i s: [1 2] [true]
     empty? s
-]
-[
+][
     remove-each i s: [1 2] [false]
     [1 2] = s
+]
+
+; BLOCK!
+[
+    block: copy [1 2 3 4]
+    remove-each i block [
+        all [i > 1 | i < 4]
+    ]
+    block = [1 4]
+][
+    block: copy [1 2 3 4]
+    remove-each i block [
+        if i = 3 [break]
+        true
+    ]
+    block = [3 4]
+][
+    block: copy [1 2 3 4]
+    trap [
+        remove-each i block [
+            if i = 3 [fail "midstream failure"]
+            true
+        ]
+    ]
+    block = [3 4]
+][
+    b-was-void: false
+
+    block: copy [1 2 3 4 5]
+    remove-each [a b] block [
+        if a = 5 [
+            b-was-void: void? :b
+        ]
+    ]
+    b-was-void
+]
+
+; STRING!
+[
+    string: copy "1234"
+    remove-each i string [
+        any [i = #"2" | i = #"3"]
+    ]
+    string = "14"
+][
+    string: copy "1234"
+    remove-each i string [
+        if i = #"3" [break]
+        true
+    ]
+    string = "34"
+][
+    string: copy "1234"
+    trap [
+        remove-each i string [
+            if i = #"3" [fail "midstream failure"]
+            true
+        ]
+    ]
+    string = "34"
+][
+    b-was-void: false
+
+    string: copy "12345"
+    remove-each [a b] string [
+        if a = #"5" [
+            b-was-void: void? :b
+        ]
+    ]
+    b-was-void
+]
+
+; BINARY!
+[
+    binary: copy #{01020304}
+    remove-each i binary [
+        any [i = 2 | i = 3]
+    ]
+    binary = #{0104}
+][
+    binary: copy #{01020304}
+    remove-each i binary [
+        if i = 3 [break]
+        true
+    ]
+    binary = #{0304}
+][
+    binary: copy #{01020304}
+    trap [
+        remove-each i binary [
+            if i = 3 [fail "midstream failure"]
+            true
+        ]
+    ]
+    binary = #{0304}
+][
+    b-was-void: false
+
+    binary: copy #{0102030405}
+    remove-each [a b] binary [
+        if a = 5 [
+            b-was-void: void? :b
+        ]
+    ]
+    b-was-void
 ]


### PR DESCRIPTION
The REMOVE-EACH primitive was unusual because it would perform mutation
on the very series it was iterating, based on the results of calling
into arbitrary user code.  This gives rise to a category of problems,
one very simple one being:

    data: copy [1 2 3 4]
    remove-each item data [
        protect data
        true
    ]

Since user code can transition a series from being mutable to being
immutable, this meant there'd have to be a check of whether that had
changed on every step of the REMOVE-EACH.  This isn't the only problem,
but it demonstrates the slippery slope one starts to be on if the
attempted answer is to add a "did-the-protection-status-change" test
on every loop iteration.

The need to constantly keep the input array in sync with the removals
also presented a performance problem, because each removal in a Rebol
series requires sliding up the remaining data to "close the gap".
Hence a series of length N that requested a removal on each step would
wind up doing N-1 "slides" of however much data was remaining, which
is effectively O(N^2) operations.

This motivated a rethinking of the native, and SERIES_INFO_RUNNING
(which was used to put temporary holds on blocks for frames) is now
SERIES_INFO_HOLD, so that it can more generally apply to enumerations
on strings or binaries.  Besides just being read-only during the life
of the REMOVE-EACH,, the implementation is changed to not reflect
any of the requested removals until the operation is completed--either
normally, by a BREAK, by a THROW, or via a fail().  All exit paths
then atomically perform the removals.

Different methods are used to accomplish this for arrays vs. strings or
binaries.  Since values in arrays have header bits which can be used,
the NODE_FLAG_MARKED (which is not used by GC for in user arrays) is
used to mark all the removals.  Move_Value and Derelativize then do
not propagate this flag, so it won't escape the use of the operation.
No such bit is available for strings or binaries, so they build new
underlying data arrays which are swapped in to back the input series,
with the original underlying data freed.