### PR TITLE
Make core DO and APPLY actions hookable, implement TRACE as hook

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1279,6 +1279,14 @@ void Startup_Core(void)
 //
 //==//////////////////////////////////////////////////////////////////////==//
 
+    // Initialize the "Do" handler to the default, Do_Core(), and the "Apply"
+    // of a FUNCTION! handler to Apply_Core().  These routines have no
+    // tracing, no debug handling, etc.  If those features are needed, an
+    // augmented function must be substituted.
+    //
+    PG_Do = &Do_Core;
+    PG_Apply = &Apply_Core;
+
     // boot->natives is from the automatically gathered list of natives found
     // by scanning comments in the C sources for `native: ...` declarations.
     //

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -2038,7 +2038,7 @@ void Get_If_Word_Or_Path_Arg(
 
 
 //
-//  Apply_Core: C
+//  Apply_Def_Or_Exemplar: C
 //
 // Factors out common code used by DO of a FRAME!, and APPLY.
 //
@@ -2054,7 +2054,7 @@ void Get_If_Word_Or_Path_Arg(
 // experiment with for other reasons (e.g. continuations), so that is what
 // is used here.
 //
-REB_R Apply_Core(
+REB_R Apply_Def_Or_Exemplar(
     REBVAL *out,
     REBFUN *fun,
     REBARR *binding,
@@ -2192,7 +2192,7 @@ REB_R Apply_Core(
 
     SET_END(f->out);
 
-    Do_Core(f);
+    (*PG_Do)(f);
 
     Drop_Frame_Core(f);
 

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -264,7 +264,7 @@ REBNATIVE(do)
         if (CTX_VARS_UNAVAILABLE(c))
             fail (Error_Do_Expired_Frame_Raw());
 
-        return Apply_Core(
+        return Apply_Def_Or_Exemplar(
             D_OUT,
             source->payload.any_context.phase,
             VAL_BINDING(source),
@@ -498,7 +498,7 @@ REBNATIVE(apply)
     if (!IS_FUNCTION(D_OUT))
         fail (Error_Apply_Non_Function_Raw(ARG(value))); // for SPECIALIZE too
 
-    return Apply_Core(
+    return Apply_Def_Or_Exemplar(
         D_OUT,
         VAL_FUNC(D_OUT),
         VAL_BINDING(D_OUT),

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -240,8 +240,6 @@ REBNATIVE(stats)
             Init_Integer(stats, Eval_Cycles + Eval_Dose - Eval_Count);
             stats++;
             Init_Integer(stats, 0); // no such thing as natives, only functions
-            stats++;
-            Init_Integer(stats, Eval_Functions);
 
             stats++;
             Init_Integer(stats, PG_Reb_Stats->Series_Made);

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -289,7 +289,7 @@ inline static REBOOL Do_Next_In_Frame_Throws(
 
     SET_END(out);
     f->out = out;
-    Do_Core(f); // should already be pushed
+    (*PG_Do)(f); // should already be pushed
 
     // Since Do_Core() currently makes no guarantees about the state of
     // f->eval_type when an operation is over, restore it to a benign REB_0
@@ -324,7 +324,7 @@ inline static REBOOL Do_Next_Mid_Frame_Throws(REBFRM *f) {
 #endif
 
     SET_END(f->out);
-    Do_Core(f); // should already be pushed
+    (*PG_Do)(f); // should already be pushed
 
     // The & on the following line is purposeful.  See Init_Endlike_Header.
     //
@@ -398,7 +398,7 @@ inline static REBOOL Do_Next_In_Subframe_Throws(
     child->pending = parent->pending;
 
     Push_Frame_Core(child);
-    Do_Core(child);
+    (*PG_Do)(child);
     Drop_Frame_Core(child);
 
     // !!! `print 1 + 2 <| print 1 + 7` wishes to print 3 and then 8, rather
@@ -481,7 +481,7 @@ inline static REBIXO DO_NEXT_MAY_THROW(
     f->out = out;
 
     Push_Frame_Core(f);    
-    Do_Core(f);
+    (*PG_Do)(f);
     Drop_Frame_Core(f); // Drop_Frame() requires f->eval_type to be REB_0
 
     if (THROWN(out))
@@ -538,7 +538,7 @@ inline static REBIXO Do_Array_At_Core(
     f->pending = NULL;
 
     Push_Frame_Core(f);
-    Do_Core(f);
+    (*PG_Do)(f);
     Drop_Frame_Core(f);
 
     if (THROWN(f->out))
@@ -738,7 +738,7 @@ inline static REBIXO Do_Va_Core(
     Init_Endlike_Header(&f->flags, flags | DO_FLAG_VA_LIST); // see notes
 
     Push_Frame_Core(f);
-    Do_Core(f);
+    (*PG_Do)(f);
     Drop_Frame_Core(f);
 
     // Note: While on many platforms va_end() is a no-op, the C standard is

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -118,6 +118,14 @@ PVAR REBBRK PG_Breakpoint_Quitting_Hook;
 //
 PVAR REBVAL PG_Write_Action;
 
+
+// It is possible to swap out the evaluator for one that does tracing, or
+// single step debugging, etc.
+//
+PVAR REBDOF PG_Do; // Rebol "DO function" (takes REBFRM, returns void)
+PVAR REBAPF PG_Apply; // Rebol "APPLY function" (takes REBFRM, returns REB_R)
+
+
 /***********************************************************************
 **
 **  Thread Globals - Local to each thread
@@ -204,7 +212,5 @@ TVAR REBINT Trace_Level;    // Trace depth desired
 TVAR REBINT Trace_Depth;    // Tracks trace indentation
 TVAR REBCNT Trace_Limit;    // Backtrace buffering limit
 TVAR REBSER *Trace_Buffer;  // Holds backtrace lines
-
-TVAR REBI64 Eval_Functions;
 
 TVAR REBVAL Callback_Error; //Error produced by callback!, note it's not callback://

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -640,3 +640,10 @@ struct Reb_Frame {
     REBFRM name##struct; \
     REBFRM * const name = &name##struct; \
     Prep_Global_Cell(&name->cell)
+
+
+// Hookable "Rebol DO Function" and "Rebol APPLY Function".  See PG_Do and
+// PG_Apply for usage.
+//
+typedef void (*REBDOF)(REBFRM * const);
+typedef REB_R (*REBAPF)(REBFRM * const);


### PR DESCRIPTION
Ren-C reimagined the evaluator in terms of acting on a C structure that
reflects the run state (a "REBFRM"), which could then be tied to a
Rebol value that introspected it (a "FRAME!").  This meant that the
entire evaluator was--effectively--a void function taking a single
parameter.  This function is called Do_Core().

One consequence of this is that the evaluator can be swapped out...
most likely for another evaluator that augments Do_Core() but uses it
as part of the implementation.  These augmentations could add tracing,
statistics, or debugging features.

Historically TRACE was implemented by setting Trace_Flags, and then the
choice to output trace information was made by doing `if (Trace_Flags)`
multiple times in the Do_Core() routine.  This commit institutes a new
strategy: to make all evaluator calls go through a level of dereference
and swap in `Do_Core_Traced()` as an augmented evaluator.

A second swap point is instituted to specifically hook the evaluation
of a function with its frame completed.  Due to the evaluator design,
this hook presently gets access to each phase of a composite function,
and has to simulate the processing of the R_XXX codes.  It may be that
this handling can be moved into Apply_Core, but the workings of some
`goto` instructions make that not feasible at this time.

While adding the level of dereference does have some performance
implications, it comes out relatively even due to the removal of branching
code based on flags.  Hence it completely decouples TRACE from the
core, and is a generalized approach that allows more stacks of behavior
to be plugged in without adding cost for each feature added (for those
not using the feature)