### PR TITLE
Stack-based REBFRM* can act as specifiers, kill VALUE_FLAG_RELATIVE

### DIFF
--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -32,7 +32,13 @@ REBOL [
         easier not to forget the importance of the order by keeping the
         macros here.
     }
-    Macros: {
+    Macros: {    
+        #define Is_Bindable(v) \
+            (VAL_TYPE(v) < REB_BAR)
+
+        #define Not_Bindable(v) \
+            (VAL_TYPE(v) >= REB_BAR)
+
         #define IS_ANY_VALUE(v) \
             LOGICAL(VAL_TYPE(v) != REB_MAX_VOID)
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -370,7 +370,7 @@ REBNATIVE(action)
     // save the write action into a global.
     //
     if (VAL_WORD_SYM(ARG(verb)) == SYM_WRITE) {
-        INIT_CELL(&PG_Write_Action);
+        Prep_Non_Stack_Cell(&PG_Write_Action);
         Move_Value(&PG_Write_Action, D_OUT);
     }
 
@@ -633,7 +633,7 @@ static REBARR *Startup_Natives(REBARR *boot_natives)
             *FUNC_BODY(fun) = *body;
         }
 
-        Prep_Global_Cell(&Natives[n]);
+        Prep_Non_Stack_Cell(&Natives[n]);
         Move_Value(&Natives[n], FUNC_VALUE(fun));
 
         // Append the native to the Lib_Context under the name given.
@@ -751,32 +751,32 @@ static void Init_Root_Vars(void)
     // the root set.  Should that change, they could be explicitly added
     // to the GC's root set.
 
-    Prep_Global_Cell(&PG_Void_Cell[0]);
-    Prep_Global_Cell(&PG_Void_Cell[1]);
+    Prep_Non_Stack_Cell(&PG_Void_Cell[0]);
+    Prep_Non_Stack_Cell(&PG_Void_Cell[1]);
     Init_Void(&PG_Void_Cell[0]);
     TRASH_CELL_IF_DEBUG(&PG_Void_Cell[1]);
 
-    Prep_Global_Cell(&PG_Blank_Value[0]);
-    Prep_Global_Cell(&PG_Blank_Value[1]);
+    Prep_Non_Stack_Cell(&PG_Blank_Value[0]);
+    Prep_Non_Stack_Cell(&PG_Blank_Value[1]);
     Init_Blank(&PG_Blank_Value[0]);
     TRASH_CELL_IF_DEBUG(&PG_Blank_Value[1]);
 
-    Prep_Global_Cell(&PG_Bar_Value[0]);
-    Prep_Global_Cell(&PG_Bar_Value[1]);
+    Prep_Non_Stack_Cell(&PG_Bar_Value[0]);
+    Prep_Non_Stack_Cell(&PG_Bar_Value[1]);
     Init_Bar(&PG_Bar_Value[0]);
     TRASH_CELL_IF_DEBUG(&PG_Bar_Value[1]);
 
-    Prep_Global_Cell(&PG_False_Value[0]);
-    Prep_Global_Cell(&PG_False_Value[1]);
+    Prep_Non_Stack_Cell(&PG_False_Value[0]);
+    Prep_Non_Stack_Cell(&PG_False_Value[1]);
     Init_Logic(&PG_False_Value[0], FALSE);
     TRASH_CELL_IF_DEBUG(&PG_False_Value[1]);
 
-    Prep_Global_Cell(&PG_True_Value[0]);
-    Prep_Global_Cell(&PG_True_Value[1]);
+    Prep_Non_Stack_Cell(&PG_True_Value[0]);
+    Prep_Non_Stack_Cell(&PG_True_Value[1]);
     Init_Logic(&PG_True_Value[0], TRUE);
     TRASH_CELL_IF_DEBUG(&PG_True_Value[1]);
 
-    Prep_Global_Cell(&PG_Va_List_Pending);
+    Prep_Non_Stack_Cell(&PG_Va_List_Pending);
 
     // We can't actually put an end value in the middle of a block, so we poke
     // this one into a program global.  It is not legal to bit-copy an
@@ -791,8 +791,10 @@ static void Init_Root_Vars(void)
 
     // The EMPTY_BLOCK provides EMPTY_ARRAY.  It is locked for protection.
     //
-    Init_Block(ROOT_EMPTY_BLOCK, Make_Array(0));
+    PG_Empty_Array = Make_Array(0);
+    Init_Block(ROOT_EMPTY_BLOCK, PG_Empty_Array);
     Deep_Freeze_Array(VAL_ARRAY(ROOT_EMPTY_BLOCK));
+    assert(IS_BLOCK(ROOT_EMPTY_BLOCK));
 
     REBSER *empty_series = Make_Binary(1);
     *BIN_AT(empty_series, 0) = '\0';
@@ -906,13 +908,7 @@ static void Init_System_Object(
 
     // Create system/codecs object
     //
-    {
-        REBCTX *codecs = Alloc_Context(REB_OBJECT, 10);
-        VAL_RESET_HEADER(CTX_VALUE(codecs), REB_OBJECT);
-        CTX_VALUE(codecs)->extra.binding = NULL;
-        CTX_VALUE(codecs)->payload.any_context.phase = NULL;
-        Init_Object(Get_System(SYS_CODECS, 0), codecs);
-    }
+    Init_Object(Get_System(SYS_CODECS, 0), Alloc_Context(REB_OBJECT, 10));
 }
 
 
@@ -1012,7 +1008,7 @@ void Startup_Task(void)
     // The thrown arg is not intended to ever be around long enough to be
     // seen by the GC.
     //
-    Prep_Global_Cell(&TG_Thrown_Arg);
+    Prep_Non_Stack_Cell(&TG_Thrown_Arg);
     Init_Unreadable_Blank(&TG_Thrown_Arg);
 
     Startup_Raw_Print();

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -268,7 +268,7 @@ ATTRIBUTE_NO_RETURN void Fail_Core(const void *p)
 
     case DETECTED_AS_VALUE: {
         const REBVAL *v = cast(const REBVAL*, p);
-        error = Error(RE_INVALID_ARG, v, END);
+        error = Error_Invalid_Arg_Raw(v);
         break; }
 
     default:
@@ -996,7 +996,7 @@ REBCTX *Make_Error_Managed_Core(REBCNT code, va_list *vaptr)
                 }
 
             #if !defined(NDEBUG)
-                if (GET_VAL_FLAG(arg, VALUE_FLAG_RELATIVE)) {
+                if (IS_RELATIVE(cast(const RELVAL*, arg))) {
                     //
                     // Make_Error doesn't have any way to pass in a specifier,
                     // so only specific values should be used.

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -200,7 +200,7 @@ REBOOL Do_Path_Throws_Core(
     // calls, which may still be relevant to why this can't be a C local.
     //
     REBPVS pvs;
-    Prep_Global_Cell(&pvs.picker_cell);
+    Prep_Stack_Cell(&pvs.picker_cell);
     SET_END(&pvs.picker_cell);
     PUSH_GUARD_VALUE(&pvs.picker_cell);
     pvs.picker = KNOWN(&pvs.picker_cell);
@@ -517,7 +517,7 @@ REBNATIVE(pick_p)
     REBPVS pvs_decl;
     REBPVS *pvs = &pvs_decl;
 
-    Prep_Global_Cell(&pvs->picker_cell);
+    Prep_Stack_Cell(&pvs->picker_cell);
     TRASH_CELL_IF_DEBUG(&pvs->picker_cell); // not used
     pvs->picker = picker;
     pvs->store = D_OUT;
@@ -603,7 +603,7 @@ REBNATIVE(poke)
     REBPVS pvs_decl;
     REBPVS *pvs = &pvs_decl;
 
-    Prep_Global_Cell(&pvs->picker_cell);
+    Prep_Stack_Cell(&pvs->picker_cell);
     TRASH_CELL_IF_DEBUG(&pvs->picker_cell); // not used
     pvs->picker = picker;
     pvs->store = D_OUT;

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -91,7 +91,6 @@ ATTRIBUTE_NO_RETURN void Panic_Value_Debug(const RELVAL *v) {
 //
 REBCTX *VAL_SPECIFIC_Debug(const REBVAL *v)
 {
-    assert(NOT_VAL_FLAG(v, VALUE_FLAG_RELATIVE));
     assert(
         ANY_WORD(v)
         || ANY_ARRAY(v)
@@ -102,7 +101,7 @@ REBCTX *VAL_SPECIFIC_Debug(const REBVAL *v)
 
     REBCTX *specific = VAL_SPECIFIC_COMMON(v);
 
-    if (specific != SPECIFIED) {
+    if (AS_SPECIFIER(specific) != SPECIFIED) {
         //
         // Basic sanity check: make sure it's a context at all
         //

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -220,7 +220,6 @@ static void Do_Core_Shared_Checks_Debug(REBFRM *f) {
 #ifdef BALANCE_CHECK_EVERY_EVALUATION_STEP
     ASSERT_STATE_BALANCED(&f->state_debug);
 #endif
-
     assert(f == FS_TOP);
     assert(f->state_debug.top_chunk == TG_Top_Chunk);
     /* assert(DSP == f->dsp_orig); */ // !!! not true now with push SET-WORD!

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -327,7 +327,7 @@ void Init_Any_Series_At_Core(
     enum Reb_Kind type,
     REBSER *series,
     REBCNT index,
-    REBSPC *specifier
+    REBNOD *binding
 ) {
     ENSURE_SERIES_MANAGED(series);
 
@@ -351,15 +351,12 @@ void Init_Any_Series_At_Core(
     VAL_RESET_HEADER(out, type);
     out->payload.any_series.series = series;
     VAL_INDEX(out) = index;
-    if (specifier == SPECIFIED)
-        INIT_SPECIFIC(out, SPECIFIED);
-    else
-        INIT_SPECIFIC(out, CTX(specifier));
+    INIT_BINDING(out, binding);
 
 #if !defined(NDEBUG)
-    if (GET_SER_FLAG(series, SERIES_FLAG_ARRAY) && specifier == SPECIFIED) {
+    if (GET_SER_FLAG(series, SERIES_FLAG_ARRAY) && binding == UNBOUND) {
         //
-        // If a SPECIFIED is used for an array, then that top level of the
+        // If UNBOUND is used for an array, then that top level of the
         // array cannot have any relative values in it.  Catch it here vs.
         // waiting until a later assertion.
         //
@@ -455,7 +452,7 @@ void Init_Any_Context_Core(
     // Currently only FRAME! uses the ->binding field, in order to capture the
     // ->binding of the function value it links to (which is in ->phase)
     //
-    assert(VAL_BINDING(out) == NULL || CTX_TYPE(c) == REB_FRAME);
+    assert(VAL_BINDING(out) == UNBOUND || CTX_TYPE(c) == REB_FRAME);
 
     // FRAME!s must always fill in the phase slot, but that piece of the
     // REBVAL is reserved for future use in other context types...so make

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -160,7 +160,7 @@ REBNATIVE(make)
         // If there's any chance that the argument could produce voids, we
         // can't guarantee an array can be made out of it.
         //
-        if (arg->extra.binding == NULL) {
+        if (arg->payload.varargs.facade == NULL) {
             //
             // A vararg created from a block AND never passed as an argument
             // so no typeset or quoting settings available.  Can't produce
@@ -168,7 +168,7 @@ REBNATIVE(make)
             //
             assert(
                 NOT_SER_FLAG(
-                    arg->payload.varargs.feed, ARRAY_FLAG_VARLIST
+                    arg->extra.binding, ARRAY_FLAG_VARLIST
                 )
             );
         }

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -689,7 +689,7 @@ static REBOOL Series_Data_Alloc(REBSER *s, REBCNT length) {
         // caller to manage...they do not know about the ->rest
         //
         for (n = 0; n < length; n++)
-            INIT_CELL(ARR_AT(ARR(s), n));
+            Prep_Non_Stack_Cell(ARR_AT(ARR(s), n));
 
         // !!! We should intentionally mark the overage range as not having
         // NODE_FLAG_CELL in the debug build.  Then have the series go through
@@ -705,7 +705,7 @@ static REBOOL Series_Data_Alloc(REBSER *s, REBCNT length) {
         // up front, or only on expansions?
         //
         for(; n < s->content.dynamic.rest - 1; n++) {
-            INIT_CELL(ARR_AT(ARR(s), n));
+            Prep_Non_Stack_Cell(ARR_AT(ARR(s), n));
         }
 
         // The convention is that the *last* cell in the allocated capacity
@@ -924,7 +924,7 @@ REBSER *Make_Series_Core(REBCNT capacity, REBYTE wide, REBUPT flags)
         // be less than a full cell's size.
         //
         assert(NOT_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC));
-        INIT_CELL(&s->content.values[0]);
+        Prep_Non_Stack_Cell(&s->content.values[0]);
     }
     else if (capacity * wide <= sizeof(s->content)) {
         assert(NOT_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC));
@@ -1013,7 +1013,7 @@ REBVAL *Alloc_Pairing(REBCTX *opt_owning_frame) {
     REBVAL *key = cast(REBVAL*, s);
     REBVAL *paired = key + 1;
 
-    INIT_CELL(key);
+    Prep_Non_Stack_Cell(key);
     if (opt_owning_frame) {
         Init_Any_Context(key, REB_FRAME, opt_owning_frame);
         SET_VAL_FLAGS(
@@ -1029,7 +1029,7 @@ REBVAL *Alloc_Pairing(REBCTX *opt_owning_frame) {
         TRASH_CELL_IF_DEBUG(key);
     }
 
-    INIT_CELL(paired);
+    Prep_Non_Stack_Cell(paired);
     TRASH_CELL_IF_DEBUG(paired);
 
 #if !defined(NDEBUG)
@@ -1214,7 +1214,7 @@ void Expand_Series(REBSER *s, REBCNT index, REBCNT delta)
             // but when it is this will be useful.
             //
             for (index = 0; index < delta; index++)
-                INIT_CELL(ARR_AT(ARR(s), index));
+                Prep_Non_Stack_Cell(ARR_AT(ARR(s), index));
         }
     #endif
         return;
@@ -1265,7 +1265,7 @@ void Expand_Series(REBSER *s, REBCNT index, REBCNT delta)
             //
             while (delta != 0) {
                 --delta;
-                INIT_CELL(ARR_AT(ARR(s), index + delta));
+                Prep_Non_Stack_Cell(ARR_AT(ARR(s), index + delta));
             }
         }
     #endif

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -159,8 +159,8 @@ void Expand_Data_Stack_May_Fail(REBCNT amount)
     //
     REBVAL *end_top = DS_Movable_Base + DSP;
     assert(IS_END(end_top));
-    assert(end_top == KNOWN(ARR_TAIL(DS_Array))); // can't push RELVALs
-    assert(end_top - KNOWN(ARR_HEAD(DS_Array)) == cast(int, len_old));
+    assert(cast(RELVAL*, end_top) == ARR_TAIL(DS_Array)); // can't push RELVALs
+    assert(cast(RELVAL*, end_top) - ARR_HEAD(DS_Array) == cast(int, len_old));
 #endif
 
     // If adding in the requested amount would overflow the stack limit, then
@@ -177,7 +177,7 @@ void Expand_Data_Stack_May_Fail(REBCNT amount)
     // dereference into a single dereference in the common case, and it was
     // how R3-Alpha did it).
     //
-    DS_Movable_Base = KNOWN(ARR_HEAD(DS_Array)); // must do before using DS_TOP
+    DS_Movable_Base = cast(REBVAL*, ARR_HEAD(DS_Array)); // before using DS_TOP
 
     // We fill in the data stack with "GC safe trash" (which is void in the
     // release build, but will raise an alarm if VAL_TYPE() called on it in
@@ -268,7 +268,7 @@ void Pop_Stack_Values_Into(REBVAL *into, REBDSP dsp_start) {
 
 
 //
-//  Reify_Frame_Context_Maybe_Fulfilling: C
+//  Context_For_Frame_May_Reify_Managed: C
 //
 // A Reb_Frame does not allocate a REBSER for its frame to be used in the
 // context by default.  But one can be allocated on demand, even for a NATIVE!
@@ -278,20 +278,20 @@ void Pop_Stack_Values_Into(REBVAL *into, REBDSP dsp_start) {
 //
 // If there's already a frame this will return it, otherwise create it.
 //
-void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
-    assert(Is_Any_Function_Frame(f)); // varargs reifies while still pending
+REBCTX *Context_For_Frame_May_Reify_Managed(REBFRM *f)
+{
+    assert(Is_Any_Function_Frame(f));
+    assert(NOT(Is_Function_Frame_Fulfilling(f)));
 
     if (f->varlist != NULL) {
-        //
-        // We have our function call's args in an array, but it is not yet
-        // a context.  !!! Really this cannot reify if we're in arg gathering
-        // mode, calling MANAGE_ARRAY is illegal -- need test for that !!!
-        //
-        assert(NOT_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST));
-        SET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST);
+        if (GET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST))
+            return CTX(f->varlist);
 
+        // Function call's args in an array, but it is not yet a context.
+        //
         assert(IS_TRASH_DEBUG(ARR_AT(f->varlist, 0))); // we fill this in
         assert(GET_SER_INFO(f->varlist, SERIES_INFO_HAS_DYNAMIC));
+        SET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST);
     }
     else {
         f->varlist = Alloc_Singular_Array_Core(ARRAY_FLAG_VARLIST);
@@ -306,7 +306,7 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
     //
     INIT_CTX_KEYLIST_SHARED(c, FUNC_PARAMLIST(FRM_UNDERLYING(f)));
 
-    // When in ET_FUNCTION or ET_LOOKBACK, the arglist will be marked safe from
+    // When running a function frame, the arglist will be marked safe from
     // GC. It is managed because the pointer makes its way into bindings that
     // ANY-WORD! values may have, and they need to not crash.
     //
@@ -319,7 +319,7 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
     VAL_RESET_HEADER(rootvar, REB_FRAME);
     rootvar->payload.any_context.varlist = f->varlist;
     rootvar->payload.any_context.phase = f->phase;
-    rootvar->extra.binding = f->binding;
+    INIT_BINDING(rootvar, f->binding);
 
     SER(f->varlist)->misc.f = f;
 
@@ -330,6 +330,7 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
     // running...which should not stop FRM_ARG from working in the native
     // itself, but should stop modifications from user code.
     //
+    SER(CTX_VARLIST(c))->misc.f = f;
     if (f->flags.bits & DO_FLAG_NATIVE_HOLD)
         SET_SER_INFO(f->varlist, SERIES_INFO_HOLD);
 
@@ -346,4 +347,6 @@ void Reify_Frame_Context_Maybe_Fulfilling(REBFRM *f) {
         ASSERT_CONTEXT(c);
     assert(NOT(CTX_VARS_UNAVAILABLE(c)));
 #endif
+
+    return c;
 }

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -696,14 +696,8 @@ REBNATIVE(same_q)
         //
         if (VAL_WORD_SPELLING(value1) != VAL_WORD_SPELLING(value2))
             return R_FALSE;
-        if (IS_WORD_BOUND(value1) != IS_WORD_BOUND(value2))
+        if (NOT(Same_Binding(VAL_BINDING(value1), VAL_BINDING(value2))))
             return R_FALSE;
-        if (IS_WORD_BOUND(value1)) {
-            REBCTX *ctx1 = VAL_WORD_CONTEXT(value1);
-            REBCTX *ctx2 = VAL_WORD_CONTEXT(value2);
-            if (ctx1 != ctx2)
-                return R_FALSE;
-        }
         return R_TRUE;
     }
 

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -410,7 +410,7 @@ void Init_Map(REBVAL *out, REBMAP *map)
     ENSURE_ARRAY_MANAGED(MAP_PAIRLIST(map));
 
     VAL_RESET_HEADER(out, REB_MAP);
-    out->extra.binding = (REBARR*)SPECIFIED; // !!! cast() gripes, investigate
+    INIT_BINDING(out, UNBOUND);
     out->payload.any_series.series = SER(MAP_PAIRLIST(map));
     out->payload.any_series.index = 0;
 }

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -377,7 +377,7 @@ void MAKE_Event(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 
     if (IS_BLOCK(arg)) {
         CLEARS(out);
-        INIT_CELL(out);
+        Prep_Non_Stack_Cell(out);
         VAL_RESET_HEADER(out, REB_EVENT);
         Set_Event_Vars(
             out,

--- a/src/extensions/ffi/t-routine.c
+++ b/src/extensions/ffi/t-routine.c
@@ -1184,7 +1184,7 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
     RELVAL *rootparam = ARR_HEAD(paramlist);
     VAL_RESET_HEADER(rootparam, REB_FUNCTION);
     rootparam->payload.function.paramlist = paramlist;
-    rootparam->extra.binding = NULL;
+    INIT_BINDING(rootparam, UNBOUND);
 
     SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
     MANAGE_ARRAY(paramlist);

--- a/src/include/reb-event.h
+++ b/src/include/reb-event.h
@@ -75,6 +75,11 @@ typedef struct {
 #pragma pack()
 
 // Special event flags:
+//
+// !!! So long as events are directly hooking into the low-level REBVAL
+// implementation, this could just use EVENT_FLAG_XXX flags.  eventee could
+// be a binding to a REBNOD that was able to inspect that node to get the
+// data "model".  
 
 enum {
     EVF_COPIED,     // event data has been copied

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -197,8 +197,7 @@ inline static REBVAL *CTX_VAR(REBCTX *c, REBCNT n) {
 
     var = CTX_VARS_HEAD(c) + (n) - 1;
 
-    assert(NOT(var->header.bits & VALUE_FLAG_RELATIVE));
-
+    assert(NOT(IS_RELATIVE(cast(RELVAL*, var))));
     return var;
 }
 

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -99,6 +99,8 @@ PVAR REBVAL PG_Bar_Value[2];
 PVAR REBVAL PG_False_Value[2];
 PVAR REBVAL PG_True_Value[2];
 
+PVAR REBARR* PG_Empty_Array; // optimization of VAL_ARRAY(EMPTY_BLOCK)
+
 // Special (but standards-legal) REBVAL* used in the `pending` field of a frame
 // to indicate it fetches its values from a C va_list.
 //

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -471,7 +471,7 @@ struct Reb_Frame {
     // to exit.  The additional pointer of context is binding, and it is
     // extracted from the function REBVAL.
     //
-    REBARR *binding; // either a varlist of a FRAME! or function paramlist
+    REBNOD *binding; // either a varlist of a FRAME! or function paramlist
 
     // `label`
     //
@@ -639,7 +639,7 @@ struct Reb_Frame {
 #define DECLARE_FRAME(name) \
     REBFRM name##struct; \
     REBFRM * const name = &name##struct; \
-    Prep_Global_Cell(&name->cell)
+    Prep_Stack_Cell(&name->cell)
 
 
 // Hookable "Rebol DO Function" and "Rebol APPLY Function".  See PG_Do and

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -108,7 +108,13 @@
             || std::is_same<T, REBARR>::value,
             "SER works on: void*, REBNOD*, REBSTR*, REBARR*"
         );
-        return cast(REBSER*, p);
+        REBSER *s = cast(REBSER*, p);
+        assert(
+            NOT(s->header.bits & NODE_FLAG_FREE)
+            && NOT(s->header.bits & NODE_FLAG_CELL)
+            && NOT(s->header.bits & NODE_FLAG_END)
+        );
+        return s;
     }
 
     template <>
@@ -658,7 +664,7 @@ inline static REBYTE *VAL_RAW_DATA_AT(const RELVAL *v) {
 }
 
 #define Init_Any_Series_At(v,t,s,i) \
-    Init_Any_Series_At_Core((v), (t), (s), (i), SPECIFIED)
+    Init_Any_Series_At_Core((v), (t), (s), (i), UNBOUND)
 
 #define Init_Any_Series(v,t,s) \
     Init_Any_Series_At((v), (t), (s), 0)

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -415,18 +415,17 @@ inline static REBVAL* Push_Value_Chunk_Of_Length(REBCNT num_values) {
 
     TG_Top_Chunk = chunk;
 
-
-    // Set all chunk cells writable.
+    // Make the chunk cells completely unformatted space in debug build.
+    // The parameter fulfillment walk has to do its own Prep_Stack_Cell
     //
-    // !!! Should be using VALUE_FLAG_STACK
-    {
+#if !defined(NDEBUG)
     REBCNT index;
     for (index = 0; index < num_values; index++)
-        INIT_CELL(&chunk->values[index]);
-    }
+        chunk->values[index].header.bits = 0;
+#endif
 
     assert(CHUNK_FROM_VALUES(&chunk->values[0]) == chunk);
-    return KNOWN(&chunk->values[0]);
+    return cast(REBVAL*, &chunk->values[0]);
 }
 
 

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -49,22 +49,13 @@
         (FLAGIT_LEFT(TYPE_SPECIFIC_BIT + (n)) | HEADERIZE_KIND(REB_WORD))
 #endif
 
-// `WORD_FLAG_BOUND` answers whether a word is bound, but it may be
-// relatively bound if `VALUE_FLAG_RELATIVE` is set.  In that case, it
-// does not have a context pointer but rather a function pointer, that
-// must be combined with more information to get the FRAME! where the
-// word should actually be looked up.
-//
-// If VALUE_FLAG_RELATIVE is set, then WORD_FLAG_BOUND must also be set.
-//
-#define WORD_FLAG_BOUND WORD_FLAG(0)
-
+inline static REBOOL IS_WORD_UNBOUND(const RELVAL *v) {
+    assert(ANY_WORD(v));
+    return LOGICAL(v->extra.binding == UNBOUND);
+}
 
 #define IS_WORD_BOUND(v) \
-    GET_VAL_FLAG((v), WORD_FLAG_BOUND)
-
-#define IS_WORD_UNBOUND(v) \
-    NOT(IS_WORD_BOUND(v))
+    NOT(IS_WORD_UNBOUND(v))
 
 inline static REBSTR *VAL_WORD_SPELLING(const RELVAL *v) {
     assert(ANY_WORD(v));
@@ -85,35 +76,41 @@ inline static const REBYTE *VAL_WORD_HEAD(const RELVAL *v) {
 }
 
 inline static void INIT_WORD_CONTEXT(RELVAL *v, REBCTX *context) {
-    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND) && context != SPECIFIED);
-
+    //
     // !!! Is it a good idea to be willing to do the ENSURE here?
     // See weirdness in Copy_Body_Deep_Bound_To_New_Context()
     //
     ENSURE_ARRAY_MANAGED(CTX_VARLIST(context));
 
     ASSERT_ARRAY_MANAGED(CTX_KEYLIST(context));
-    v->extra.binding = CTX_VARLIST(context);
+    INIT_BINDING(v, context);
 }
 
 inline static REBCTX *VAL_WORD_CONTEXT(const REBVAL *v) {
-    assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
-    return VAL_SPECIFIC(v);
-}
+    assert(IS_WORD_BOUND(v));
+    REBNOD *binding = VAL_BINDING(v);
+    if (binding->header.bits & NODE_FLAG_CELL) {
+        //
+        // Bound specifically to a REBFRM* that isn't reified.  Force
+        // a reification, for now.
+        //
+        REBFRM *f = cast(REBFRM*, binding);
+        return Context_For_Frame_May_Reify_Managed(f);
+    }
 
-inline static void INIT_WORD_FUNC(RELVAL *v, REBFUN *func) {
-    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND));
-    v->extra.binding = FUNC_PARAMLIST(func);
+    // Bound specifically to a REBCTX*.
+    //
+    assert(binding->header.bits & ARRAY_FLAG_VARLIST);
+    return CTX(binding);
 }
 
 inline static REBFUN *VAL_WORD_FUNC(const RELVAL *v) {
-    assert(GET_VAL_FLAG(v, WORD_FLAG_BOUND));
+    assert(IS_WORD_BOUND(v));
     return VAL_RELATIVE(v);
 }
 
 inline static void INIT_WORD_INDEX(RELVAL *v, REBCNT i) {
-    assert(ANY_WORD(v));
-    assert(GET_VAL_FLAG((v), WORD_FLAG_BOUND));
+    assert(IS_WORD_BOUND(v));
     assert(SAME_STR(
         VAL_WORD_SPELLING(v),
         IS_RELATIVE(v)
@@ -124,14 +121,14 @@ inline static void INIT_WORD_INDEX(RELVAL *v, REBCNT i) {
 }
 
 inline static REBCNT VAL_WORD_INDEX(const RELVAL *v) {
-    assert(ANY_WORD(v));
+    assert(IS_WORD_BOUND(v));
     REBINT i = v->payload.any_word.index;
     assert(i > 0);
     return cast(REBCNT, i);
 }
 
 inline static void Unbind_Any_Word(RELVAL *v) {
-    CLEAR_VAL_FLAGS(v, WORD_FLAG_BOUND | VALUE_FLAG_RELATIVE);
+    INIT_BINDING(v, UNBOUND);
 #if !defined(NDEBUG)
     v->payload.any_word.index = 0;
 #endif
@@ -146,6 +143,7 @@ inline static void Init_Any_Word(
 
     assert(spelling != NULL);
     out->payload.any_word.spelling = spelling;
+    INIT_BINDING(out, UNBOUND);
 
 #if !defined(NDEBUG)
     out->payload.any_word.index = 0;
@@ -182,9 +180,7 @@ inline static void Init_Any_Word_Bound(
     REBCTX *context,
     REBCNT index
 ) {
-    assert(CTX_KEY_CANON(context, index) == STR_CANON(spelling));
-
-    VAL_RESET_HEADER_EXTRA(out, type, WORD_FLAG_BOUND);
+    VAL_RESET_HEADER(out, type);
 
     assert(spelling != NULL);
     out->payload.any_word.spelling = spelling;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -848,7 +848,7 @@ int main(int argc, char **argv_ansi)
 
     volatile REBOOL finished; // without volatile, gets "clobbered" warning
 
-    Prep_Global_Cell(&HG_Host_Repl);
+    Prep_Non_Stack_Cell(&HG_Host_Repl);
     Init_Blank(&HG_Host_Repl);
 
     if (error != NULL) {


### PR DESCRIPTION
This is a significant commit which introduces the new idea of being
able to put pointers to C stack memory variables inside REBVALs.

That can't be universally safe, since some REBVALs live in arrays or
objects.  The stack level where a stack-based pointer originates from
might get popped while the pointer is still referenced.  Hence it must
be possible to tell by looking at a cell what its duration is...and if
a raw pointer held in a source cell can't be put into a destination
cell safely, it must be reified into a heap pointer and managed by GC.

Included in the design is the concept of deciding the nature of a
binding (relative vs. specific) entirely by examining the flags of the
REBSER node to which a value is bound.  The binding is also never set
to NULL...the global empty array series is used, which allows to test
series bits without a NULL check.

Although this means a REBFRM* does not need to be "reified" immediately
on calling a user function (as it did before), the conservative logic
for reification during `Move_Value()` is only a prototype.  Any leaked
words to *any* cell will cause a reification at the moment--just to be
on the safe side.  But even this should be an improvement, as native
functions still will never reify (since they don't leak bound words
referring to their arg locals) and not all user functions involve
moving words bound to their arguments or locals into new REBVAL slots
for those words.

This pioneers generic approaches to using stack values to augment the
interpretation of REBVALs without the overhead of dynamic allocation
or creating entities that will tax the GC...so-called "virtual binding"