### PR TITLE
Discern anonymous functions from ones named --anonymous--

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -442,7 +442,7 @@ inline static REBFRM *Extract_Live_Rebfrm_May_Fail(const REBVAL *frame) {
     if (f == NULL)
         fail ("FRAME! is no longer on stack.");
 
-    assert(Is_Any_Function_Frame(f));
+    assert(Is_Function_Frame(f));
     assert(NOT(Is_Function_Frame_Fulfilling(f)));
     return f;
 }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1844,7 +1844,7 @@ REB_R Returner_Dispatcher(REBFRM *f)
     // to this call is hidden.
     //
     if (!TYPE_CHECK(typeset, VAL_TYPE(f->out)))
-        fail (Error_Bad_Return_Type(f->label, VAL_TYPE(f->out)));
+        fail (Error_Bad_Return_Type(f, VAL_TYPE(f->out)));
 
     return R_OUT;
 }

--- a/src/core/d-break.c
+++ b/src/core/d-break.c
@@ -177,7 +177,7 @@ REBOOL Do_Breakpoint_Throws(
         //
         REBFRM *frame;
         for (frame = FS_TOP; frame != NULL; frame = frame->prior) {
-            if (NOT(Is_Any_Function_Frame(frame)))
+            if (NOT(Is_Function_Frame(frame)))
                 continue;
             if (Is_Function_Frame_Fulfilling(frame))
                 continue;
@@ -454,8 +454,10 @@ REBNATIVE(resume)
 
         frame = FS_TOP;
         for (; frame != NULL; frame = frame->prior) {
-            if (NOT(Is_Any_Function_Frame(frame))) continue;
-            if (Is_Function_Frame_Fulfilling(frame)) continue;
+            if (NOT(Is_Function_Frame(frame)))
+                continue;
+            if (Is_Function_Frame_Fulfilling(frame))
+                continue;
 
             if (
                 FUNC_DISPATCHER(frame->phase) == &N_pause

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -248,14 +248,14 @@ void Dump_Stack(REBFRM *f, REBCNT level)
         return;
     }
 
-   printf(
+    printf(
         "STACK[%d](%s) - %d\n",
         cast(int, level),
-        STR_HEAD(FRM_LABEL(f)),
+        Frame_Label_Or_Anonymous_UTF8(f),
         f->eval_type // note: this is now an ordinary Reb_Kind, stringify it
     );
 
-    if (NOT(Is_Any_Function_Frame(f))) {
+    if (NOT(Is_Function_Frame(f))) {
         printf("(no function call pending or in progress)\n");
         fflush(stdout);
         return;

--- a/src/core/d-stats.c
+++ b/src/core/d-stats.c
@@ -243,8 +243,8 @@ REB_R Apply_Core_Measured(REBFRM * const f)
             // There's no entry yet for this FUNCTION!, initialize one.
 
             REBARR *a = Make_Array(IDX_STATS_MAX);
-            if (STR_SYMBOL(f->label) != SYM___ANONYMOUS__)
-                Init_Word(ARR_AT(a, IDX_STATS_SYMBOL), f->label);
+            if (f->opt_label != NULL)
+                Init_Word(ARR_AT(a, IDX_STATS_SYMBOL), f->opt_label);
             else
                 Init_Blank(ARR_AT(a, IDX_STATS_SYMBOL));
             Init_Integer(ARR_AT(a, IDX_STATS_NUMCALLS), 1);
@@ -279,9 +279,9 @@ REB_R Apply_Core_Measured(REBFRM * const f)
             ){
                 if (
                     IS_BLANK(ARR_AT(a, IDX_STATS_SYMBOL))
-                    && STR_SYMBOL(f->label) != SYM___ANONYMOUS__
+                    && f->opt_label != NULL
                 ){
-                    Init_Word(ARR_AT(a, IDX_STATS_SYMBOL), f->label);
+                    Init_Word(ARR_AT(a, IDX_STATS_SYMBOL), f->opt_label);
                 }
                 Init_Integer(
                     ARR_AT(a, IDX_STATS_NUMCALLS),

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -242,7 +242,7 @@ REB_R Apply_Core_Traced(REBFRM * const f)
         // Only show the label if this phase is the first phase.
 
         Debug_Space(cast(REBCNT, 4 * depth));
-        Debug_Fmt_(RM_TRACE_FUNCTION, STR_HEAD(f->label));
+        Debug_Fmt_(RM_TRACE_FUNCTION, Frame_Label_Or_Anonymous_UTF8(f));
         if (GET_FLAG(Trace_Flags, 1))
             Debug_Values(FRM_ARG(FS_TOP, 1), FRM_NUM_ARGS(FS_TOP), 20);
         else
@@ -262,7 +262,7 @@ REB_R Apply_Core_Traced(REBFRM * const f)
         // Only show the return result if this is the last phase.
 
         Debug_Space(cast(REBCNT, 4 * depth));
-        Debug_Fmt_(RM_TRACE_RETURN, STR_HEAD(f->label));
+        Debug_Fmt_(RM_TRACE_RETURN, Frame_Label_Or_Anonymous_UTF8(f));
 
         switch (r) {
         case R_FALSE:

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1139,7 +1139,7 @@ static void Mark_Frame_Stack_Deep(void)
         if (NOT_END(f->out)) // never NULL, always initialized bit pattern
             Queue_Mark_Opt_Value_Deep(f->out);
 
-        if (NOT(Is_Any_Function_Frame(f))) {
+        if (NOT(Is_Function_Frame(f))) {
             //
             // Consider something like `eval copy quote (recycle)`, because
             // while evaluating the group it has no anchor anywhere in the
@@ -1152,7 +1152,8 @@ static void Mark_Frame_Stack_Deep(void)
             Queue_Mark_Opt_Value_Deep(&f->cell);
 
         Queue_Mark_Function_Deep(f->phase); // never NULL
-        Mark_Rebser_Only(f->label); // also never NULL
+        if (f->opt_label != NULL) // will be NULL if no symbol
+            Mark_Rebser_Only(f->opt_label);
 
         if (!Is_Function_Frame_Fulfilling(f)) {
             assert(IS_END(f->param)); // indicates function is running
@@ -1167,10 +1168,6 @@ static void Mark_Frame_Stack_Deep(void)
             if (NOT_END(f->special) && Is_Value_Managed(f->special))
                 Queue_Mark_Opt_Value_Deep(f->special);
         }
-
-        // Need to keep the label symbol alive for error messages/stacktraces
-        //
-        Mark_Rebser_Only(f->label);
 
         // We need to GC protect the values in the args no matter what,
         // but it might not be managed yet (e.g. could still contain garbage

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -280,7 +280,7 @@ void Pop_Stack_Values_Into(REBVAL *into, REBDSP dsp_start) {
 //
 REBCTX *Context_For_Frame_May_Reify_Managed(REBFRM *f)
 {
-    assert(Is_Any_Function_Frame(f));
+    assert(Is_Function_Frame(f));
     assert(NOT(Is_Function_Frame_Fulfilling(f)));
 
     if (f->varlist != NULL) {

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -247,11 +247,12 @@ REBNATIVE(do)
         if (CTX_VARS_UNAVAILABLE(c))
             fail (Error_Do_Expired_Frame_Raw());
 
+        const REBSTR *opt_label = NULL; // no label available
         return Apply_Def_Or_Exemplar(
             D_OUT,
             source->payload.any_context.phase,
             VAL_BINDING(source),
-            Canon(SYM___ANONYMOUS__),
+            opt_label,
             NOD(VAL_CONTEXT(source))
         ); }
 
@@ -489,10 +490,8 @@ REBNATIVE(apply)
     // the symbol (for debugging, errors, etc.)  If caller passes a WORD!
     // then we lookup the variable to get the function, but save the symbol.
     //
-    REBSTR *name;
-    Get_If_Word_Or_Path_Arg(D_OUT, &name, ARG(value));
-    if (name == NULL)
-        name = Canon(SYM___ANONYMOUS__); // Do_Core requires non-NULL symbol
+    REBSTR *opt_label;
+    Get_If_Word_Or_Path_Arg(D_OUT, &opt_label, ARG(value));
 
     if (!IS_FUNCTION(D_OUT))
         fail (Error_Apply_Non_Function_Raw(ARG(value))); // for SPECIALIZE too
@@ -501,7 +500,7 @@ REBNATIVE(apply)
         D_OUT,
         VAL_FUNC(D_OUT),
         VAL_BINDING(D_OUT),
-        name,
+        opt_label,
         NOD(def)
     );
 }

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -210,7 +210,7 @@ static REBOOL Subparse_Throws(
     Prep_Stack_Cell(&f->args_head[1]);
     Init_Integer(&f->args_head[1], find_flags);
 
-    f->label = Canon(SYM_SUBPARSE);
+    f->opt_label = Canon(SYM_SUBPARSE);
     f->eval_type = REB_FUNCTION;
     f->original = f->phase = NAT_FUNC(subparse);
 

--- a/src/extensions/ffi/t-routine.c
+++ b/src/extensions/ffi/t-routine.c
@@ -284,10 +284,10 @@ static REBUPT arg_to_ffi(
         // because it couldn't do so in the return case where arg was null)
 
         if (!IS_STRUCT(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         if (STU_SIZE(VAL_STRUCT(arg)) != FLD_WIDE(top))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         memcpy(dest, VAL_STRUCT_DATA_AT(arg), STU_SIZE(VAL_STRUCT(arg)));
 
@@ -304,7 +304,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         u = cast(u8, VAL_INT64(arg));
         memcpy(dest, &u, sizeof(u));
@@ -317,7 +317,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         i = cast(i8, VAL_INT64(arg));
         memcpy(dest, &i, sizeof(i));
@@ -330,7 +330,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         u = cast(u16, VAL_INT64(arg));
         memcpy(dest, &u, sizeof(u));
@@ -343,7 +343,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         i = cast(i16, VAL_INT64(arg));
         memcpy(dest, &i, sizeof(i));
@@ -356,7 +356,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         u = cast(u32, VAL_INT64(arg));
         memcpy(dest, &u, sizeof(u));
@@ -369,7 +369,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         i = cast(i32, VAL_INT64(arg));
         memcpy(dest, &i, sizeof(i));
@@ -383,7 +383,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_INTEGER(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         i = VAL_INT64(arg);
         memcpy(dest, &i, sizeof(REBI64));
@@ -431,7 +431,7 @@ static REBUPT arg_to_ffi(
             break;}
 
         default:
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
         }
         break;} // end case FFI_TYPE_POINTER
 
@@ -450,7 +450,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_DECIMAL(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         f = cast(float, VAL_DECIMAL(arg));
         memcpy(dest, &f, sizeof(f));
@@ -463,7 +463,7 @@ static REBUPT arg_to_ffi(
         if (!arg) break;
 
         if (!IS_DECIMAL(arg))
-            fail (Error_Arg_Type(D_LABEL_SYM, param, VAL_TYPE(arg)));
+            fail (Error_Arg_Type(D_FRAME, param, VAL_TYPE(arg)));
 
         d = VAL_DECIMAL(arg);
         memcpy(dest, &d, sizeof(double));

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -166,9 +166,8 @@ inline static REBFRM *CTX_FRAME_IF_ON_STACK(REBCTX *c) {
     assert(
         f == NULL
         || (
-            f->eval_type <= REB_FUNCTION
-            && f->label != NULL
-        ) // Note: inlining of Is_Any_Function_Frame() to break dependency
+            f->eval_type == REB_FUNCTION && f->phase != NULL
+        ) // Note: inlining of Is_Function_Frame() to break dependency
     );
     return f;
 }

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -415,7 +415,7 @@ struct Reb_Frame {
     // Additionally, the actual dispatch may not have started, so if a fail()
     // or other operation occurs it may not be able to assume that eval_type
     // of REB_FUNCTION implies that the arguments have been pushed yet.
-    // See Is_Any_Function_Frame() for notes on this detection.
+    // See Is_Function_Frame() for notes on this detection.
     //
     enum Reb_Kind eval_type;
 
@@ -473,13 +473,16 @@ struct Reb_Frame {
     //
     REBNOD *binding; // either a varlist of a FRAME! or function paramlist
 
-    // `label`
+    // `opt_label`
     //
     // Functions don't have "names", though they can be assigned to words.
+    // However, not all function invocations are through words or paths, so
+    // the label may not be known.  It is NULL to indicate anonymity.
+    //
     // The evaluator only enforces that the symbol be set during function
     // calls--in the release build, it is allowed to be garbage otherwise.
     //
-    REBSTR *label;
+    REBSTR *opt_label;
 
     // `varlist`
     //


### PR DESCRIPTION
Historically, there has been a symbol --anonymous-- which was used in
slots where a function name might appear but there isn't a relevant
one. For instance:

    takes-int: func [x [integer!]] [...]
    do compose [(:takes-int) #not-an-integer]

The error message would say "--anonymous-- does not allow ISSUE! for its
x argument", with the WORD! --anonymous-- fabricated as the parameter
to the error.

Under this scheme, there's no way when interpreting the error/etc.
as talking about a function whose name is *actually* --anonymous-- vs.
one that has been made up.  It also feels rather sketchy to be writing
`label = '--anonymous--` as that test ("wait, how many dashes was it?")

This commit switches to actually having the stack frames distinguish
between having a symbol and not, and when reflecting the anonymous
frames will come back with a BLANK!.  In order to avoid too many sites
having to process the potential NULL of the frame label, operations to
derive UTF-8 string names or a WORD!/BLANK! are generalized vs. the
direct extraction of the label field...leading some routines that used
to take labels to take frames instead.

Also since function frames have been unified, this renames the
"Is_Any_Function_Frame()" test to simply "Is_Function_Frame()"