### PR TITLE
Make EITHER always use "EITHER/ONLY" semantics

### DIFF
--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -123,21 +123,29 @@ REBNATIVE(unless)
 //      condition [any-value!]
 //      true-branch [<opt> any-value!]
 //      false-branch [<opt> any-value!]
-//      /only
-//          "If branch runs and returns void, do not convert it to BLANK!"
 //  ]
 //
 REBNATIVE(either)
 {
     INCLUDE_PARAMS_OF_EITHER;
 
+    // Unlike conditional constructs that may decide not to run a branch,
+    // either *always* runs a branch.  Using it with ELSE or THEN is thus
+    // pointless, so interfering with the branch return results through the
+    // "barification" interferes with `result: either x [true] [false]`
+    // for no particular benefit.  Rather than cripple it just for the sake
+    // of making that interchangeable with `result: if x [true] else [false]`
+    // we allow EITHER to be different.
+    //
+    const REBOOL only = TRUE;
+
     if (Run_Branch_Throws(
         D_OUT,
         ARG(condition),
-        IS_CONDITIONAL_TRUE(ARG(condition), REF(only))
+        IS_CONDITIONAL_TRUE(ARG(condition), only)
             ? ARG(true_branch)
             : ARG(false_branch),
-        REF(only)
+        only
     )){
         return R_OUT_IS_THROWN;
     }

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -573,12 +573,6 @@ unless*: redescribe [
     specialize 'unless [only: true]
 )
 
-either*: redescribe [
-    {Same as EITHER/ONLY (void, not blank, if branch evaluates to void)}
-](
-    specialize 'either [only: true]
-)
-
 while?: redescribe [
     {Variation of WHILE which returns TRUE if the body ever runs, FALSE if not}
 ](
@@ -923,7 +917,7 @@ right-bar: func [
     also (
         ; We want to make sure `1 |> | 2 3 4` is void, not BAR!
         ;
-        either* bar? first look [void] [take* right]
+        either bar? first look [void] [take* right]
     )(
         loop-until [
             while [bar? first look] [take look]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -350,7 +350,7 @@ try: func [
         "On exception, evaluate code"
     code [block! function!]
 ][
-    either* except [trap/with block :code] [trap block]
+    either except [trap/with block :code] [trap block]
 ]
 
 
@@ -400,7 +400,7 @@ r3-alpha-apply: function [
     using-args: true
 
     until [tail? block] [
-        arg: either* only [
+        arg: either only [
             also block/1 (block: next block)
         ][
             do/next block 'block
@@ -720,7 +720,7 @@ set 'r3-legacy* func [<local> if-flags] [
             any_GET: any
             any: :lib/any
 
-            either* any-context? source [
+            either any-context? source [
                 ;
                 ; In R3-Alpha, this was vars of the context put into a BLOCK!:
                 ;

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -471,7 +471,7 @@ opt: func [
     {Turns blanks to voids, all other value types pass through.}
     value [<opt> any-value!]
 ][
-    either* blank? :value [()] [:value]
+    either blank? :value [()] [:value]
 ]
 
 to-value: func [

--- a/tests/control/either.test.reb
+++ b/tests/control/either.test.reb
@@ -10,11 +10,8 @@
 [1 = either true [1] [2]]
 [2 = either false [1] [2]]
 
-[void? either* true [] [1]]
-[void? either* false [1] []]
-
-[blank? either true [] [1]]
-[blank? either false [1] []]
+[void? either true [] [1]]
+[void? either false [1] []]
 
 [error? either true [try [1 / 0]] []]
 [error? either false [] [try [1 / 0]]]


### PR DESCRIPTION
Unlike conditional constructs that may decide not to run a branch,
either *always* runs a branch.  Using it with ELSE or THEN is thus
pointless, so interfering with the branch return results through the
"blankification" interferes with `result: either x [void] [something]`
for no particular benefit.

This proposal changes things so that rather than cripple EITHER
just for the sake of making it 100% interchangeable with
`result: if x [void] else [something]`, it is allowed to be different.