### PR TITLE
Experimental implementation of `<skip>` function arguments

### DIFF
--- a/src/boot/root.r
+++ b/src/boot/root.r
@@ -33,6 +33,7 @@ ellipsis-tag    ; FUNC+PROC use as alternative to [[]] to mark varargs
 opt-tag         ; FUNC+PROC use as alternative to _ to mark optional void? args
 end-tag         ; FUNC+PROC use as alternative to | to mark endable args
 local-tag       ; marks the beginning of a list of "pure locals"
+skip-tag        ; means parameter will be skipped if type doesn't match
 
 ;; !!! See notes on FUNCTION-META in %sysobj.r
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -469,6 +469,7 @@ static void Init_Function_Tags(void)
     Init_Function_Tag(ROOT_OPT_TAG, "opt");
     Init_Function_Tag(ROOT_END_TAG, "end");
     Init_Function_Tag(ROOT_LOCAL_TAG, "local");
+    Init_Function_Tag(ROOT_SKIP_TAG, "skip");
 }
 
 
@@ -802,13 +803,14 @@ static void Init_Root_Vars(void)
     Init_Char(ROOT_NEWLINE_CHAR, '\n');
 
     // BUF_UTF8 not initialized, can't init function tags yet
-    //(at least not how Init_Function_Tags() is written)
+    // (at least not how Init_Function_Tags() is written)
     //
     Init_Unreadable_Blank(ROOT_WITH_TAG);
     Init_Unreadable_Blank(ROOT_ELLIPSIS_TAG);
     Init_Unreadable_Blank(ROOT_OPT_TAG);
     Init_Unreadable_Blank(ROOT_END_TAG);
     Init_Unreadable_Blank(ROOT_LOCAL_TAG);
+    Init_Unreadable_Blank(ROOT_SKIP_TAG);
 
     // Evaluator not initialized, can't do system construction yet
     //

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1176,8 +1176,88 @@ reevaluate:;
             }
 
             if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC)) {
-                if (NOT(TYPE_CHECK(f->param, VAL_TYPE(f->arg))))
-                    fail (Error_Arg_Type(f, f->param, VAL_TYPE(f->arg)));
+                if (NOT(TYPE_CHECK(f->param, VAL_TYPE(f->arg)))) {
+                    if (
+                        NOT_VAL_FLAG(f->param, TYPESET_FLAG_SKIPPABLE)
+                        || LOGICAL(f->flags.bits & DO_FLAG_APPLYING)
+                        || f->special == f->arg
+                    ){
+                        fail (Error_Arg_Type(f, f->param, VAL_TYPE(f->arg)));
+                    }
+
+                    // !!! Experimental feature!  <skip> parameters.  If we
+                    // are doing ordinary fulfillment (and not type checking
+                    // or applying) which do not type match will be rolled
+                    // over into a valid subsequent argument.
+                    //
+                    assert(IS_END(f->out));
+                    assert(IS_END(&f->cell));
+                    Move_Value(f->out, f->arg);
+                    Move_Value(&f->cell, const_KNOWN(f->param));
+                    Init_Void(f->arg);
+                    while (TRUE) {
+                        ++f->arg;
+                        if (IS_END(f->arg))
+                            fail ("<skip> argument rolled over to end");
+
+                        ++f->param;
+                        pclass = VAL_PARAM_CLASS(f->param);
+                        if (pclass == PARAM_CLASS_REFINEMENT) {
+                            //
+                            // You don't want to have a LOGIC! variable
+                            // being interpreted as "take this refinement".
+                            // Also, f->refine would need to be updated.
+                            //
+                            fail ("<skip> argument rolled into refinement");
+                        }
+
+                        // Specialization already incremented on usage, so
+                        // f->special points to what we should be considering.
+                        // No worries about refinement revocation since voids
+                        // do not mean that, due to check above that we are
+                        // not applying...
+                        //
+                        if (f->special != NULL) {
+                            if (IS_VOID(f->special))
+                                ++f->special;
+                            else {
+                                Prep_Stack_Cell(f->arg);
+                                Move_Value(f->arg, f->special);
+                                ++f->special;
+
+                                // !!! Need better factoring of type checking
+                                // if <skip> feature is to be kept, so that
+                                // varargs type checking works properly.
+                                //
+                                if (TYPE_CHECK(f->param, VAL_TYPE(f->arg)))
+                                    continue;
+
+                                fail (Error_Arg_Type(
+                                    f, f->param, VAL_TYPE(f->arg)
+                                ));
+                            }
+                        }
+
+                        break;
+                    }
+
+                    // !!! This may be stricter than it needs to be, but the
+                    // fundamental idea is that if the argument being skipped
+                    // was evaluated, then the one you roll into can't be
+                    // quoted...because any side-effects from the evaluation
+                    // already happened.  It may be possible for a failed
+                    // quote to roll over to an evaluated parameter, but the
+                    // code isn't set up for that.
+                    //
+                    if (VAL_PARAM_CLASS(&f->cell) != pclass)
+                        fail ("<skip> argument rolled to mismatched class");
+
+                    Prep_Stack_Cell(f->arg);
+                    Move_Value(f->arg, f->out);
+                    SET_END(f->out);
+                    SET_END(&f->cell);
+                    goto check_arg;
+                }
             }
             else {
                 // Varargs are odd, because the type checking doesn't

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -187,6 +187,15 @@ REBOOL Update_Typeset_Bits_Core(
             //
             SET_VAL_FLAG(typeset, TYPESET_FLAG_ENDABLE);
         }
+        else if (keywords && IS_TAG(item) && (
+                0 == Compare_String_Vals(item, ROOT_SKIP_TAG, TRUE)
+            )
+        ){
+            // <skip> is an experiment for ignoring values where the type
+            // does not match, and just going on to the next argument.
+            //
+            SET_VAL_FLAG(typeset, TYPESET_FLAG_SKIPPABLE);
+        }
         else if (
             IS_BLANK(item) || (keywords && IS_TAG(item) && (
                 0 == Compare_String_Vals(item, ROOT_OPT_TAG, TRUE)

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -209,6 +209,22 @@ enum Reb_Param_Class {
 //
 #define TYPESET_FLAG_ENDABLE TYPESET_FLAG(3)
 
+// "Skippability" is an experimental feature which allows a function to
+// specify that if an argument isn't the right type, it should just be skipped
+// and jump to the next one.  e.g.:
+//
+//     emit: func [file [<skip> file!] block [block!]] [...]
+//
+//     emit [a b c]
+//     emit %foo.txt [a b c]
+//
+// As with <end>, this is something that can be done with variadics.  But
+// standardizing this in the function prototype language makes it possible
+// to use conventional APPLY operations, and provides better documentation.
+//
+#define TYPESET_FLAG_SKIPPABLE TYPESET_FLAG(4)
+
+
 // Operations when typeset is done with a bitset (currently all typesets)
 
 #define VAL_TYPESET_BITS(v) ((v)->payload.typeset.bits)

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -21,3 +21,24 @@
     ]
     foo = 5
 ]
+
+
+; doubles as a test for <skip>
+[
+    test: func [f [<skip> file!] b [block!] i [integer!]] [
+        reduce [
+            either set? 'f [f] [blank]
+            b
+            i
+        ]
+    ]
+    
+    sp-test: specialize 'test [b: [x y z]]
+
+    all? [
+        [_ [x y z] 10] = test [x y z] 10
+        [%foo.txt [x y z] 10] = test %foo.txt [x y z] 10
+        [_ [x y z] 10] = sp-test 10
+        [%foo.txt [x y z] 10] = sp-test %foo.txt 10
+    ]
+]


### PR DESCRIPTION
This is a very simplistic hack to try and implement skippable function
parameters, to see how useful or interesting they are...before trying
to go through a code reorganization to support them more legitimately.

Arguments marked `<skip>` will--instead of generating a type error
when a parameter cannot match--set that argument to void and let the
parameter "roll over" to the next compatible parameter.  (e.g. a
quote can roll over to a quote, but an evaluated parameter cannot
roll over to a quote because it's too late.)

    emit: function [file [<skip> file!] block [block!]] [...]

    emit [x y z]
    emit %foo.txt [x y z]

While this could already be done with variadics, including this more
narrow interface makes it possible to use the function normally with
APPLY, and it is easier to write.

Because this case is only handled when an argument has a type mismatch,
the way the feature is implemented here does not affect the speed of
the evaluator.  More invasive changes would be required if someone
comes up with motivating examples for this feature.  It could be
possible to roll over quoted parameters to then perform an evaluation
using the quoted data