### PR TITLE
Allow enfixing of functions whose first argument is variadic

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -900,18 +900,6 @@ reevaluate:;
                 //
                 f->refine = ORDINARY_ARG;
 
-                // !!! Can a variadic lookback argument be meaningful?
-                // Arguably, if you have an arity-1 function which is variadic
-                // and you enfix it, then giving it a feed of either 0 or 1
-                // values and only letting it take from the left would make
-                // sense.  But if it's arity-2 (e.g. multiple variadic taps)
-                // does that make any sense?
-                //
-                // It may be too wacky to worry about, and SET/LOOKBACK should
-                // just prohibit it.
-                //
-                assert(NOT_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC));
-
                 Prep_Stack_Cell(f->arg);
 
                 if (IS_END(f->out)) {
@@ -928,12 +916,37 @@ reevaluate:;
                     if (f->flags.bits & DO_FLAG_FULFILLING_ARG)
                         fail (Error_Partial_Lookback(f));
 
+                    // If an enfixed function finds it has a variadic in its
+                    // first slot, then nothing available on the left is o.k.
+                    // It means we have to put a VARARGS! in that argument
+                    // slot which will react with TRUE to TAIL?, so feed it
+                    // from the global empty array.
+                    //
+                    if (GET_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC)) {
+                        VAL_RESET_HEADER_EXTRA(
+                            f->arg,
+                            REB_VARARGS,
+                            VARARGS_FLAG_ENFIXED // in case anyone cares
+                        );
+                        INIT_BINDING(f->arg, EMPTY_ARRAY); // feed finished
+
+                        const REBOOL make = FALSE; // use existing array
+                        Link_Vararg_Param_To_Frame(f, make);
+                        goto continue_arg_loop;
+                    }
+
                     if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_ENDABLE))
                         fail (Error_No_Arg(f, f->param));
 
                     Init_Void(f->arg);
                     goto continue_arg_loop;
                 }
+
+                // The argument might be variadic, but even if it is we only
+                // have one argument to be taken from the left.  So start by
+                // calculating that one value into f->arg.
+                //
+                // !!! See notes on potential semantics problem below.
 
                 switch (pclass) {
                 case PARAM_CLASS_NORMAL:
@@ -984,6 +997,41 @@ reevaluate:;
                 }
 
                 SET_END(f->out);
+
+                // Now that we've gotten the argument figured out, make a
+                // singular array to feed it to the variadic.
+                //
+                // !!! See notes on VARARGS_FLAG_ENFIXED about how this is
+                // somewhat shady, as any evaluations happen *before* the
+                // TAKE on the VARARGS.  Experimental feature.
+                //
+                if (GET_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC)) {
+                    REBARR *feed = Alloc_Singular_Array();
+                    Move_Value(ARR_HEAD(feed), f->arg);
+                    MANAGE_ARRAY(feed);
+
+                    REBARR *array1 = Alloc_Singular_Array();
+                    Init_Block(ARR_HEAD(array1), feed); // index 0 for feeding
+                    MANAGE_ARRAY(array1);
+
+                    VAL_RESET_HEADER_EXTRA(
+                        f->arg,
+                        REB_VARARGS,
+                        VARARGS_FLAG_ENFIXED // don't evaluate *again* on TAKE
+                    );
+                    INIT_BINDING(f->arg, array1);
+
+                    const REBOOL make = FALSE; // use existing array
+                    Link_Vararg_Param_To_Frame(f, make);
+                    goto continue_arg_loop;
+
+                    // As written, the type will be checked when (and if) a
+                    // TAKE happens.  Whether that's good or bad depends on
+                    // the bigger issue of whether this feature is misguided.
+                    //
+                    goto continue_arg_loop;
+                }
+
                 goto check_arg;
             }
 

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -205,6 +205,24 @@ REB_R Do_Vararg_Op_May_Throw(
         if (r != R_UNHANDLED)
             goto type_check_and_return;
 
+        if (GET_VAL_FLAG(vararg, VARARGS_FLAG_ENFIXED)) {
+            //
+            // See notes on VARARGS_FLAG_ENFIXED about how the left hand side
+            // is synthesized into an array-style varargs with either 0 or
+            // 1 item to be taken.  But any evaluation has already happened
+            // before the TAKE.  So although we honor the pclass to disallow
+            // TAIL? or FIRST testing on evaluative parameters, we don't
+            // want to double evaluation...so return that single element.
+            //
+            assert(VAL_ARRAY_LEN_AT(shared) == 1);
+            Derelativize(out, VAL_ARRAY_AT(shared), SPECIFIED);
+            if (GET_VAL_FLAG(VAL_ARRAY_AT(shared), VALUE_FLAG_UNEVALUATED))
+                SET_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED); // not auto-copied
+            VAL_INDEX(shared) += 1;
+            r = R_OUT;
+            goto type_check_and_return;
+        }
+
         switch (pclass) {
         case PARAM_CLASS_NORMAL:
         case PARAM_CLASS_TIGHT: {
@@ -270,6 +288,11 @@ REB_R Do_Vararg_Op_May_Throw(
         //
         // "Ordinary" case... use the original frame implied by the VARARGS!
         // (so long as it is still live on the stack)
+
+        // The enfixed case always synthesizes an array to hold the evaluated
+        // left hand side value.  (See notes on VARARGS_FLAG_ENFIXED.)
+        //
+        assert(NOT_VAL_FLAG(vararg, VARARGS_FLAG_ENFIXED));
 
         opt_vararg_frame = f;
         arg = FRM_ARG(f, vararg->payload.varargs.param_offset + 1);

--- a/src/include/sys-varargs.h
+++ b/src/include/sys-varargs.h
@@ -54,6 +54,28 @@
 #endif
 
 
+// While it would be possible to say that enfixing a function whose first
+// argument is a VARARGS! is plainly illegal, we experimentally allow the
+// left hand side of an evaluation to be a source of "0 or 1" arguments for
+// a VARARGS!.
+//
+// !!! This is a bit shady (in cases besides an <end> on the left being a
+// varargs that reports TAIL? as TRUE).  That's because most variadics expect
+// their evaluation to happen when they TAKE a VARARGS!, and not beforehand.
+// But you can't defer the evaluation of a left-hand expression, because it's
+// usually too late.  Even if it isn't technically too late for some reason
+// (e.g. it's #tight, or quoted) there's still a bit of an oddity, because
+// variadics on the right have the option to *not* do a TAKE and leave the
+// value for consumption by the next operation.  That doesn't apply when the
+// variadic is being "faked in" from the left.
+//
+// But despite the lack of "purity", one might argue it's better to do
+// something vs. just give an error.  Especially since people are unlikely to
+// enfix a variadic on accident, and may be fine with these rules.
+//
+#define VARARGS_FLAG_ENFIXED VARARGS_FLAG(0)
+
+
 inline static REBOOL Is_Block_Style_Varargs(
     REBVAL **shared_out,
     RELVAL *vararg


### PR DESCRIPTION
Previously it was illegal to enfixing a function whose first argument
is a VARARGS!, as you clearly can't write:

    1 + 2 4 + 5 my-enfixed-op

...with the expectation that it can take backwards twice and get 9 and
3.  The result of 1 + 2 is discarded during left to right evaluation
before the enfixed op gets a chance to see it.  Trying this would cause
an assert.

Rather than turn this assertion to an error, this commit implements a
potentially more interesting behavior.  It allow the left hand side of
an enfix to be a source of "0 or 1" arguments for a VARARGS!.  This is
identical to what is possible with an `<end>`-able argument, however it
means you don't have to rewrite a variadic function if this behavior
suits you.

Note: This is a bit shady (in cases besides an <end> on the left being
a varargs that reports TAIL? as TRUE).  That's because most variadics
expect their evaluation to happen when they TAKE a VARARGS!, and not
beforehand.  But you can't defer the evaluation of a left-hand
expression, because it's usually too late. Even if it isn't technically
too late for some reason (e.g. it's #tight, or quoted) there's still a
bit of an oddity, because variadics on the right have the option to
*not* do a TAKE and leave the value for consumption by the next
operation.  That doesn't apply when the variadic is being "faked in"
from the left.

But despite the lack of "purity", one might argue it's better to do
something vs. just give an error.  Especially since people are unlikely
to enfix a variadic on accident, and may be fine with these rules.