### PR TITLE
LIT-WORD! passed as loop variable reuses existing binding

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -279,7 +279,7 @@ static REBARR *Startup_Datatypes(REBARR *boot_types, REBARR *boot_typespecs)
         // a limited sense.)
         //
         assert(value == Get_Type(cast(enum Reb_Kind, n)));
-        SET_VAL_FLAG(CTX_VAR(Lib_Context, n), VALUE_FLAG_PROTECTED);
+        SET_VAL_FLAG(CTX_VAR(Lib_Context, n), CELL_FLAG_PROTECTED);
 
         Append_Value(catalog, KNOWN(word));
     }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -701,8 +701,12 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         //
         src = DS_AT(dsp_orig + 1) + 3;
         for (; src <= DS_TOP; src += 3, ++dest) {
-            if (!Try_Remove_Binder_Index(&binder, VAL_PARAM_CANON(src)))
+            if (
+                Remove_Binder_Index_Else_0(&binder, VAL_PARAM_CANON(src))
+                == 0
+            ){
                 assert(duplicate != NULL);
+            }
         }
 
         SHUTDOWN_BINDER(&binder);

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -201,7 +201,8 @@ void Clonify_Values_Len_Managed(
     REBOOL deep,
     REBU64 types
 ) {
-    if (C_STACK_OVERFLOWING(&len)) Trap_Stack_Overflow();
+    if (C_STACK_OVERFLOWING(&len))
+        Trap_Stack_Overflow();
 
     RELVAL *v = head;
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -303,17 +303,20 @@ REBNATIVE(use)
 // As it stands, the code already existed for loop bodies to do this more
 // efficiently.  The hope is that with virtual binding, such constructs will
 // become even more efficient--for loops, BIND, and USE.
+//
+// !!! Should USE allow LIT-WORD!s to mean basically a no-op, just for common
+// interface with the loops?
 {
     INCLUDE_PARAMS_OF_USE;
 
     REBCTX *context;
-    REBARR *copy = Copy_Body_Deep_Bound_To_New_Context(
-        &context,
-        ARG(vars), // similar to the "spec" of a loop, WORD! or BLOCK!
-        ARG(body)
+    Virtual_Bind_Deep_To_New_Context(
+        ARG(body), // may be replaced with rebound copy, or left the same
+        &context, // winds up managed; if no references exist, GC is ok
+        ARG(vars) // similar to the "spec" of a loop: WORD!/LIT-WORD!/BLOCK!
     );
 
-    if (Do_At_Throws(D_OUT, copy, 0, SPECIFIED)) // Will lock for GC
+    if (Do_Any_Array_At_Throws(D_OUT, ARG(body)))
         return R_OUT_IS_THROWN;
 
     return R_OUT;

--- a/src/core/n-protect.c
+++ b/src/core/n-protect.c
@@ -46,9 +46,9 @@ static void Protect_Key(REBCTX *context, REBCNT index, REBFLGS flags)
     //
     if (GET_FLAG(flags, PROT_WORD)) {
         if (GET_FLAG(flags, PROT_SET))
-            SET_VAL_FLAG(var, VALUE_FLAG_PROTECTED);
+            SET_VAL_FLAG(var, CELL_FLAG_PROTECTED);
         else
-            CLEAR_VAL_FLAG(var, VALUE_FLAG_PROTECTED);
+            CLEAR_VAL_FLAG(var, CELL_FLAG_PROTECTED);
     }
 
     if (GET_FLAG(flags, PROT_HIDE)) {

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -190,13 +190,13 @@ static void Append_To_Context(REBCTX *context, REBVAL *arg)
 
     // Set new values to obj words
     for (word = item; NOT_END(word); word += 2) {
-        REBCNT i = Try_Get_Binder_Index(&binder, VAL_WORD_CANON(word));
+        REBCNT i = Get_Binder_Index_Else_0(&binder, VAL_WORD_CANON(word));
         assert(i != 0);
 
         REBVAL *key = CTX_KEY(context, i);
         REBVAL *var = CTX_VAR(context, i);
 
-        if (GET_VAL_FLAG(var, VALUE_FLAG_PROTECTED))
+        if (GET_VAL_FLAG(var, CELL_FLAG_PROTECTED))
             fail (Error_Protected_Key(key));
 
         if (GET_VAL_FLAG(key, TYPESET_FLAG_HIDDEN))
@@ -487,7 +487,7 @@ REBINT PD_Context(REBPVS *pvs)
     if (pvs->opt_setval && IS_END(pvs->item + 1)) {
         FAIL_IF_READ_ONLY_CONTEXT(c);
 
-        if (GET_VAL_FLAG(CTX_VAR(c, n), VALUE_FLAG_PROTECTED))
+        if (GET_VAL_FLAG(CTX_VAR(c, n), CELL_FLAG_PROTECTED))
             fail (Error_Protected_Word_Raw(pvs->picker));
     }
 

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -148,7 +148,7 @@ inline static void Add_Binder_Index(
 }
 
 
-inline static REBINT Try_Get_Binder_Index( // 0 if not present
+inline static REBINT Get_Binder_Index_Else_0( // 0 if not present
     struct Reb_Binder *binder,
     REBSTR *canon
 ){
@@ -161,7 +161,7 @@ inline static REBINT Try_Get_Binder_Index( // 0 if not present
 }
 
 
-inline static REBINT Try_Remove_Binder_Index( // 0 if failure, else old index
+inline static REBINT Remove_Binder_Index_Else_0( // return old value if there
     struct Reb_Binder *binder,
     REBSTR *canon
 ){
@@ -192,7 +192,7 @@ inline static void Remove_Binder_Index(
     struct Reb_Binder *binder,
     REBSTR *canon
 ){
-    REBINT old_index = Try_Remove_Binder_Index(binder, canon);
+    REBINT old_index = Remove_Binder_Index_Else_0(binder, canon);
 
 #if defined(NDEBUG)
     UNUSED(old_index);
@@ -280,7 +280,7 @@ inline static REBVAL *Get_Var_Core(
             if (f->flags.bits & DO_FLAG_NATIVE_HOLD)
                 fail (Error(RE_PROTECTED_WORD, any_word)); // different error?
             
-            if (GET_VAL_FLAG(var, VALUE_FLAG_PROTECTED))
+            if (GET_VAL_FLAG(var, CELL_FLAG_PROTECTED))
                 fail (Error(RE_PROTECTED_WORD, any_word));
         }
 
@@ -316,7 +316,7 @@ inline static REBVAL *Get_Var_Core(
                 if (f->flags.bits & DO_FLAG_NATIVE_HOLD)
                     fail (Error(RE_PROTECTED_WORD, any_word)); // different?
             
-                if (GET_VAL_FLAG(var, VALUE_FLAG_PROTECTED))
+                if (GET_VAL_FLAG(var, CELL_FLAG_PROTECTED))
                     fail (Error(RE_PROTECTED_WORD, any_word));
             }
 
@@ -392,7 +392,7 @@ inline static REBVAL *Get_Var_Core(
         // The PROTECT command has a finer-grained granularity for marking
         // not just contexts, but individual fields as protected.
         //
-        if (GET_VAL_FLAG(var, VALUE_FLAG_PROTECTED))
+        if (GET_VAL_FLAG(var, CELL_FLAG_PROTECTED))
             fail (Error_Protected_Word_Raw(any_word));
 
     }
@@ -493,6 +493,7 @@ inline static REBVAL *Derelativize(
     assert(!IS_TRASH_DEBUG(v));
 
     ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);
+    assert(NOT(out->header.bits & CELL_FLAG_PROTECTED));
 
     out->header.bits &= CELL_MASK_RESET;
     out->header.bits |= v->header.bits & CELL_MASK_COPY;

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -121,10 +121,13 @@
 //
 // !!! Strictly speaking, SERIES_FLAG_NO_RELOCATE could be different
 // from fixed size... if there would be a reason to reallocate besides
-// changing size (such as memory compaction).
+// changing size (such as memory compaction).  For now, just make the two
+// equivalent but let the callsite distinguish the intent.
 //
 #define SERIES_FLAG_FIXED_SIZE \
     FLAGIT_LEFT(GENERAL_SERIES_BIT + 0)
+
+#define SERIES_FLAG_DONT_RELOCATE SERIES_FLAG_FIXED_SIZE
 
 
 //=//// SERIES_FLAG_FILE_LINE /////////////////////////////////////////////=//
@@ -310,7 +313,7 @@
 // size or values from modification.  It is the usermode analogue of
 // SERIES_INFO_FROZEN, but can be reversed.
 //
-// Note: There is a feature in PROTECT (VALUE_FLAG_PROTECTED) which protects
+// Note: There is a feature in PROTECT (CELL_FLAG_PROTECTED) which protects
 // a certain variable in a context from being changed.  It is similar, but
 // distinct.  SERIES_INFO_PROTECTED is a protection on a series itself--which
 // ends up affecting all values with that series in the payload.

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -232,7 +232,7 @@
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  VALUE_FLAG_PROTECTED
+//  CELL_FLAG_PROTECTED
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
@@ -241,8 +241,14 @@
 // another location will not propagate the protectedness from the original
 // value to the copy.
 //
+// This is called a CELL_FLAG and not a VALUE_FLAG because any formatted cell
+// can be tested for it, even if it is "trash".  This means writing routines
+// that are putting data into a cell for the first time can check the bit.
+// (Series, having more than one kind of protection, put those bits in the
+// "info" so they can all be checked at once...otherwise there might be a
+// shared NODE_FLAG_PROTECTED in common.)
 
-#define VALUE_FLAG_PROTECTED \
+#define CELL_FLAG_PROTECTED \
     FLAGIT_LEFT(GENERAL_VALUE_BIT + 5)
 
 
@@ -781,8 +787,8 @@ struct Reb_Value
         | NODE_FLAG_MANAGED | VALUE_FLAG_STACK)
 
 #define CELL_MASK_COPY \
-    ~(CELL_MASK_RESET | NODE_FLAG_MARKED \
-        | VALUE_FLAG_ENFIXED | VALUE_FLAG_PROTECTED | VALUE_FLAG_UNEVALUATED)
+    ~(CELL_MASK_RESET | NODE_FLAG_MARKED | CELL_FLAG_PROTECTED \
+        | VALUE_FLAG_ENFIXED | VALUE_FLAG_UNEVALUATED)
 
 
 //=////////////////////////////////////////////////////////////////////////=//

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1509,6 +1509,7 @@ inline static REBVAL *Move_Value(RELVAL *out, const REBVAL *v)
     );
     assert(NOT_END(v));
     ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);
+    assert(NOT(out->header.bits & CELL_FLAG_PROTECTED));
 
     out->header.bits &= CELL_MASK_RESET;
     out->header.bits |= v->header.bits & CELL_MASK_COPY;

--- a/tests/control/for-each.test.reb
+++ b/tests/control/for-each.test.reb
@@ -73,3 +73,70 @@
 [
     error? trap [for-each [:x] [] []]
 ]
+
+; A LIT-WORD! does not create a new variable or binding, but a WORD! does
+[
+    x: 10
+    sum: 0
+    for-each x [1 2 3] [sum: sum + x]
+    all? [x = 10 | sum = 6]
+][
+    x: 10
+    sum: 0
+    for-each 'x [1 2 3] [sum: sum + x]
+    all? [x = 3 | sum = 6]
+][
+    x: 10
+    y: 20
+    sum: 0
+    for-each ['x y] [1 2 3 4] [sum: sum + x + y]
+    all? [x = 3 | y = 20 | sum = 10]
+]
+
+; Redundancy is checked for.  LIT-WORD! redundancy is legal because those
+; words may have distinct bindings and the same spelling, and they're not
+; being fabricated.
+;
+; !!! Note that because FOR-EACH soft quotes, the COMPOSE would be interpreted
+; as the loop variable if you didn't put it in parentheses!
+[
+    #2273
+
+    x: 10
+    obj1: make object! [x: 20]
+    obj2: make object! [x: 30]
+    sum: 0
+    all? [
+        error? trap [for-each [x x] [1 2 3 4] [sum: sum + x]]
+        error? trap [
+            for-each (compose [ ;-- see above
+                x (bind quote 'x obj1)
+            ])[
+                1 2 3 4
+            ][
+                sum: sum + x
+            ]
+        ]
+        error? trap [
+            for-each (compose [ ;-- see above
+                (bind quote 'x obj2) x
+            ])[
+                1 2 3 4
+            ][
+                sum: sum + x
+            ]
+        ]
+        not error? trap [
+            for-each (compose [ ;-- see above
+                (bind quote 'x obj1) (bind quote 'x obj2)
+            ])[
+                1 2 3 4
+            ][
+                sum: sum + obj1/x + obj1/y
+            ]
+        ]
+        sum = 10
+        obj1/x = 3
+        obj2/x = 4
+    ]
+]


### PR DESCRIPTION
This change allows a LIT-WORD! to be passed to loops, e.g. FOR-EACH,
and signify that an existing variable should be assigned instead of
a new variable and binding.  So:

    >> x: 10 | for-each 'x [1 2 3] [print x] | print x
    1
    2
    3
    3

This contrasts with (and is faster than) WORD!, which generates a new
variable and will currently deep copy and rebind the body to that new
variable:

    >> x: 10 | for-each x [1 2 3] [print x] | print x
    1
    2
    3
    10

(Note that as of time of writing, Red has chosen the LIT-WORD! semantic
for regular WORD!s--a breaking change from historical Rebol.)

If multiple variables are specified, e.g. `for-each [x 'y z] ...`, then
each individual variable will be handled according to the WORD! or
LIT-WORD! status.  Presently this means that if any ordinary WORD! are
used, then the body will be deep copied and rebound.  Future plans
hope to make all aspects of such binding practical and lightweight,
even for deeply nested loops.

Also included in this change is protection against duplicate variables
in a block, e.g. `for-each [x x x] ...` will generate an error.  This
protection is not applied to lit-words like `for-each ['x 'x 'x] ...`
because since they do not represent new bindings, they could each be
bound to different x variables in different contexts.

Additionally, the fabricated object underlying the loop iterations is
protected from expansion...since the loops themselves cache pointers
into the keylist and varlist across arbitrary user evaluations.