### PR TITLE
SET-META individually on ANY-CONTEXT! (including FRAME!)

### DIFF
--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -562,7 +562,7 @@ void Set_Location_Of_Error(
         for (; f != NULL; f = f->prior) {
             if (FRM_IS_VALIST(f))
                 continue;
-            if (NOT(GET_SER_FLAG(f->source.array, SERIES_FLAG_FILE_LINE)))
+            if (NOT_SER_FLAG(f->source.array, SERIES_FLAG_FILE_LINE))
                 continue;
             break;
         }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -410,13 +410,14 @@ void Init_Any_Context_Core(
     assert(VAL_CONTEXT(archetype) == c);
 
     assert(CTX_TYPE(c) == kind);
-    if (CTX_KEYLIST(c) == NULL)
-        panic (c);
 
-    assert(GET_SER_FLAG(CTX_VARLIST(c), ARRAY_FLAG_VARLIST));
+    REBARR *varlist = CTX_VARLIST(c);
+    REBARR *keylist = CTX_KEYLIST(c);
 
-    assert(NOT_SER_FLAG(CTX_VARLIST(c), SERIES_FLAG_FILE_LINE));
-    assert(NOT_SER_FLAG(CTX_KEYLIST(c), SERIES_FLAG_FILE_LINE));
+    assert(GET_SER_FLAG(varlist, ARRAY_FLAG_VARLIST));
+
+    assert(NOT_SER_FLAG(varlist, SERIES_FLAG_FILE_LINE));
+    assert(NOT_SER_FLAG(keylist, SERIES_FLAG_FILE_LINE));
 
     if (IS_FRAME(CTX_VALUE(c)))
         assert(IS_FUNCTION(CTX_FRAME_FUNC_VALUE(c)));
@@ -424,7 +425,10 @@ void Init_Any_Context_Core(
     // !!! Currently only a context can serve as the "meta" information,
     // though the interface may expand.
     //
-    assert(CTX_META(c) == NULL || ANY_CONTEXT(CTX_VALUE(CTX_META(c))));
+    assert(
+        MISC(varlist).meta == NULL
+        || ANY_CONTEXT(CTX_VALUE(MISC(varlist).meta))
+    );
 #endif
 
     // Some contexts (stack frames in particular) start out unmanaged, and

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -763,7 +763,7 @@ REBSER *Try_Find_Containing_Series_Debug(const void *p)
                 continue;
             }
 
-            if (NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))) {
+            if (NOT_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)) {
                 if (
                     p >= cast(void*, &s->content)
                     && p < cast(void*, &s->content + 1)
@@ -2076,7 +2076,7 @@ REBCNT Check_Memory_Debug(void)
             if (GET_SER_FLAG(s, NODE_FLAG_CELL))
                 continue; // a pairing
 
-            if (NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)))
+            if (NOT_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
                 continue; // data lives in the series node itself
 
             if (SER_REST(s) == 0)

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1150,7 +1150,7 @@ void Assert_Array_Core(REBARR *a)
     //
     Assert_Series_Core(SER(a));
 
-    if (NOT(GET_SER_FLAG(a, SERIES_FLAG_ARRAY)))
+    if (NOT_SER_FLAG(a, SERIES_FLAG_ARRAY))
         panic (a);
 
     RELVAL *item = ARR_HEAD(a);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -223,7 +223,7 @@ REBTYPE(Function)
         );
         ARR_HEAD(proxy_paramlist)->payload.function.paramlist
             = proxy_paramlist;
-        LINK(proxy_paramlist).meta = VAL_FUNC_META(value);
+        MISC(proxy_paramlist).meta = VAL_FUNC_META(value);
         SET_SER_FLAG(proxy_paramlist, ARRAY_FLAG_PARAMLIST);
 
         // If the function had code, then that code will be bound relative

--- a/src/core/t-library.c
+++ b/src/core/t-library.c
@@ -67,8 +67,8 @@ void MAKE_Library(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     VAL_RESET_HEADER(ARR_HEAD(singular), REB_LIBRARY);
     ARR_HEAD(singular)->payload.library.singular = singular;
 
-    MISC(singular).fd = fd;
-    LINK(singular).meta = NULL; // build from spec, e.g. arg?
+    LINK(singular).fd = fd;
+    MISC(singular).meta = NULL; // build from spec, e.g. arg?
 
     MANAGE_ARRAY(singular);
     Move_Value(out, KNOWN(ARR_HEAD(singular)));
@@ -119,7 +119,7 @@ REBTYPE(Library)
         }
         else {
             OS_CLOSE_LIBRARY(VAL_LIBRARY_FD(lib));
-            MISC(VAL_LIBRARY(lib)).fd = NULL;
+            LINK(VAL_LIBRARY(lib)).fd = NULL;
         }
         return R_VOID; }
 

--- a/src/extensions/ffi/t-routine.c
+++ b/src/extensions/ffi/t-routine.c
@@ -1187,9 +1187,10 @@ REBFUN *Alloc_Ffi_Function_For_Spec(REBVAL *ffi_spec, ffi_abi abi) {
     INIT_BINDING(rootparam, UNBOUND);
 
     SET_SER_FLAG(paramlist, ARRAY_FLAG_PARAMLIST);
+    LINK(paramlist).facade = paramlist;
+    MISC(paramlist).meta = NULL;
+
     MANAGE_ARRAY(paramlist);
-    LINK(paramlist).meta = NULL;
-    MISC(paramlist).facade = paramlist;
 
     REBFUN *fun = Make_Function(
         paramlist,

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -227,7 +227,7 @@ inline static REBARR *Make_Array_Core(REBCNT capacity, REBUPT flags)
 
     assert(
         capacity <= 1
-            ? NOT(GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC))
+            ? NOT_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
             : GET_SER_INFO(s, SERIES_INFO_HAS_DYNAMIC)
     );
 

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -526,15 +526,16 @@ inline static void Drop_Function_Core(
             goto finished;
     }
 
-    assert(GET_SER_FLAG(f->varlist, SERIES_FLAG_ARRAY));
+    assert(GET_SER_FLAG(f->varlist, SERIES_FLAG_ARRAY | ARRAY_FLAG_VARLIST));
     ASSERT_ARRAY_MANAGED(f->varlist);
 
     // The varlist is going to outlive this call, so the frame correspondence
     // in it needs to be cleared out, so callers will know the frame is dead.
+    // We substitute the paramlist of the original function the frame is for
+    // in the keysource slot.
     //
-    assert(MISC(f->varlist).f == f);
-    MISC(f->varlist).f = NULL;
-    assert(GET_SER_FLAG(f->varlist, ARRAY_FLAG_VARLIST));
+    assert(cast(REBFRM*, LINK(f->varlist).keysource) == f);
+    LINK(f->varlist).keysource = NOD(FUNC_PARAMLIST(f->original));
 
     if (NOT_SER_INFO(f->varlist, CONTEXT_INFO_STACK)) {
         //

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -95,7 +95,7 @@ inline static REBCNT FUNC_NUM_PARAMS(REBFUN *f) {
 }
 
 inline static REBCTX *FUNC_META(REBFUN *f) {
-    return LINK(FUNC_PARAMLIST(f)).meta;
+    return MISC(FUNC_PARAMLIST(f)).meta;
 }
 
 // *** These FUNC_FACADE fetchers are called VERY frequently, so it is best
@@ -105,7 +105,7 @@ inline static REBCTX *FUNC_META(REBFUN *f) {
 // really good reason...and seeing the impact on the debug build!!! ***
 
 #define FUNC_FACADE(f) \
-    MISC(FUNC_PARAMLIST(f)).facade
+    LINK(FUNC_PARAMLIST(f)).facade
 
 #define FUNC_FACADE_NUM_PARAMS(f) \
     (ARR_LEN(FUNC_FACADE(f)) - 1)
@@ -257,7 +257,7 @@ inline static REBNAT VAL_FUNC_DISPATCHER(const RELVAL *v)
     { return MISC(v->payload.function.body_holder).dispatcher; }
 
 inline static REBCTX *VAL_FUNC_META(const RELVAL *v)
-    { return LINK(v->payload.function.paramlist).meta; }
+    { return MISC(v->payload.function.paramlist).meta; }
 
 inline static REBOOL IS_FUNCTION_INTERPRETED(const RELVAL *v) {
     //

--- a/src/include/sys-library.h
+++ b/src/include/sys-library.h
@@ -32,15 +32,15 @@
 //
 
 inline static void *LIB_FD(REBLIB *l) {
-    return MISC(l).fd; // file descriptor
+    return LINK(l).fd; // file descriptor
 }
 
 inline static REBOOL IS_LIB_CLOSED(REBLIB *l) {
-    return LOGICAL(MISC(l).fd == NULL);
+    return LOGICAL(LINK(l).fd == NULL);
 }
 
 inline static REBCTX *VAL_LIBRARY_META(const RELVAL *v) {
-    return LINK(v->payload.library.singular).meta;
+    return MISC(v->payload.library.singular).meta;
 }
 
 inline static REBLIB *VAL_LIBRARY(const RELVAL *v) {

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -447,7 +447,7 @@ struct Reb_Function {
     // for the function can be found (although this value is archetypal, and
     // loses the `binding` property--which must be preserved other ways)
     //
-    // The `link.meta` field of the paramlist holds a meta object (if any)
+    // The `misc.meta` field of the paramlist holds a meta object (if any)
     // that describes the function.  This is read by help.
     //
     REBARR *paramlist;
@@ -579,8 +579,8 @@ struct Reb_Handle {
 };
 
 
-// Meta information in singular->link.meta
-// File descriptor in singular->misc.fd
+// File descriptor in singular->link.fd
+// Meta information in singular->misc.meta
 //
 struct Reb_Library {
     REBARR *singular; // singular array holding this library value


### PR DESCRIPTION
There are two spare platform-pointer-size fields in every REBSER node
which are used for various purposes, depending on the role of that
node.  The early development of the "meta" feature would use one of
the fields on the *keylist* of objects to store the pointer to the
ANY-CONTEXT! to serve as the meta object.  But since keylists may be
shared between object instances, this didn't allow different object
instances with shared keylists to have distinct meta object.

This moves the meta link to the varlist to solve that problem.  But
that raised another issue where although FRAME! was an ANY-CONTEXT!, it
was using the varlist slot for an important shared property--namely
the reverse link to the C struct representing an active call frame,
which needed to be NULLed out in the series node so that all FRAME!
REBVALs could tell they had expired.

While it would have been possible to just disallow setting meta-objects
on FRAME!, a relatively elegant solution is to unify the "keylist"
REBARR pointer and the "f" REBFRM pointer into a single field.  A
live frame simply points to the frame, and then decays to the function
of the frame's paramlist when execution has terminated.  Since a REBARR
and a REBFRM can be distinguished by the NODE_FLAG_CELL on the cell
at the head of the Reb_Frame, it's easy to test which situation
applies...which actually increases the performance of CTX_KEYLIST from
its prior implementation.