### PR TITLE
Make source scanning accept a va_list for splicing in REBVALs

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -1218,12 +1218,12 @@ void Startup_Core(void)
     if (utf8 == NULL || SER_LEN(utf8) != NAT_UNCOMPRESSED_SIZE)
         panic ("decompressed native specs size mismatch (try `make clean`)");
 
-    const char *tmp_boot_utf8 = "tmp-boot.r";
-    REBSTR *tmp_boot_filename = Intern_UTF8_Managed(
-        cb_cast(tmp_boot_utf8), strlen(tmp_boot_utf8)
-    );
-    REBARR *boot_array = Scan_UTF8_Managed(
-        BIN_HEAD(utf8), NAT_UNCOMPRESSED_SIZE, tmp_boot_filename
+    // Use Scan_Va_Managed() not because it's actually variadic, but because
+    // there are currently no other usages of the function (rigorous builds
+    // notice when things are defined and not used).
+    //
+    REBARR *boot_array = Scan_Va_Managed(
+        STR("tmp-boot.r"), BIN_HEAD(utf8), END
     );
     PUSH_GUARD_ARRAY(boot_array); // managed, so must be guarded
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -193,7 +193,7 @@ void TO_Array(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
         Init_Any_Array(
             out,
             kind,
-            Scan_UTF8_Managed(BIN_HEAD(utf8), BIN_LEN(utf8), filename)
+            Scan_UTF8_Managed(filename, BIN_HEAD(utf8), BIN_LEN(utf8))
         );
         DROP_GUARD_SERIES(utf8);
     }
@@ -206,7 +206,7 @@ void TO_Array(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
         Init_Any_Array(
             out,
             kind,
-            Scan_UTF8_Managed(VAL_BIN_AT(arg), VAL_LEN_AT(arg), filename)
+            Scan_UTF8_Managed(filename, VAL_BIN_AT(arg), VAL_LEN_AT(arg))
         );
     }
     else if (IS_MAP(arg)) {

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -207,16 +207,36 @@ enum rebol_esc_codes {
 */
 
 typedef struct rebol_scan_state {
+    //
+    // If vaptr is NULL, then it is assumed that the `begin` is the source of
+    // the UTF-8 data to scan.  Otherwise, it is a variadic feed of UTF-8
+    // strings and values that are spliced in.
+    //
+    va_list *vaptr;
+
     const REBYTE *begin;
     const REBYTE *end;
-    const REBYTE *limit;    /* no chars after this point */
+
+    // The "limit" feature was not implemented, scanning stopped on a null
+    // terminator.  It may be interesting in the future, but it doesn't mix
+    // well with scanning variadics which merge REBVAL and UTF-8 strings
+    // together...
+    //
+    /* const REBYTE *limit; */
     
     REBCNT line;
     const REBYTE *line_head; // head of current line (used for errors)
+
     REBCNT start_line;
     const REBYTE *start_line_head;
 
     REBSTR *filename;
+
+    // VALUE_FLAG_LINE appearing on a value means that there is a line break
+    // *before* that value.  Hence when a newline is seen, it means the *next*
+    // value to be scanned will receive the flag.
+    //
+    REBOOL newline_pending;
 
     REBFLGS opts;
     enum Reb_Token token;

--- a/src/os/host-main.c
+++ b/src/os/host-main.c
@@ -535,12 +535,8 @@ int main(int argc, char **argv_ansi)
         if (startup == NULL)
             panic ("Can't decompress %host-start.r linked into executable");
 
-        const char *host_start_utf8 = "host-start.r";
-        REBSTR *host_start_filename = Intern_UTF8_Managed(
-            cb_cast(host_start_utf8), strlen(host_start_utf8)
-        );
         REBARR *array = Scan_UTF8_Managed(
-            BIN_HEAD(startup), BIN_LEN(startup), host_start_filename
+            STR("host-start.r"), BIN_HEAD(startup), BIN_LEN(startup)
         );
 
         // Bind the REPL and startup code into the lib context.


### PR DESCRIPTION
Because of the careful choices made in arranging the bits of headers of
Rebol values, it's possible to know from examining the first byte of
a void pointer whether it is a UTF-8 string or a REBVAL*.

This adapts the scanner to be able to accept a feed of pointers to
UTF-8 strings and Rebol values (as opposed to just one UTF-8 pointer).
If a value is encountered in-between tokens, that value will be
"spliced" into the scan.

Currently this can be used to construct arrays, such as in this code:

    REBVAL *item1 = ...;
    REBVAL *item2 = ...;
    REBVAL *item3 = ...;

    REBSTR *filename = ...; // where to say code came from

    REBARR *result = Scan_Va_Managed(filename,
        "if not", item1, "[\n",
            item2, "| print {Close brace separate from content}\n",
        "] else [\n",
            item3, "| print {Close brace with content}]\n",
        END
    );

While this concept has several applications, the most obvious is in the
creation of a friendly C API for constructing code.