### PR TITLE
POSIX console UTF8, multiline paste, escape/cancel INPUT

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -538,28 +538,22 @@ REBVAL *RL_rebVoid(void)
 
 
 //
-//  rebEscape: RL_API
+//  rebHalt: RL_API
 //
 // Signal that code evaluation needs to be interrupted.
 //
 // Returns:
 //     nothing
 // Notes:
-//     This function set's a signal that is checked during evaluation
+//     This function sets a signal that is checked during evaluation
 //     and will cause the interpreter to begin processing an escape
 //     trap. Note that control must be passed back to REBOL for the
 //     signal to be recognized and handled.
 //
-void RL_rebEscape(void)
+void RL_rebHalt(void)
 {
     Enter_Api_Clear_Last_Error();
 
-    // How should HALT vs. BREAKPOINT be decided?  When does a Ctrl-C want
-    // to quit entirely vs. begin an interactive debugging session?
-    //
-    // !!! For now default to halting, but use SIG_INTERRUPT when a decision
-    // is made about how to debug break.
-    //
     SET_SIGNAL(SIG_HALT);
 }
 
@@ -1150,6 +1144,17 @@ void RL_rebFree(REBVAL *v)
     UNUSED(key);
 
     Free_Pairing(v);
+}
+
+
+//
+//  rebFail: RL_API
+//
+void RL_rebFail(const void *p)
+{
+    Enter_Api_Cant_Error();
+
+    Fail_Core(p);
 }
 
 

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -255,15 +255,15 @@ host-console: function [
 
     forever [ ;-- gather potentially multi-line input
 
-        line: repl/input-hook input     ;--  pre-processor hook
-        if empty? line [
-            if block? code [break]
-
-            repl/print-error (really error! code)
-            return [] ;-- No-Op execution, just cycles the prompt
+        if blank? line: input [
+            ;
+            ; It was aborted (Ctrl-D on Windows and POSIX, ESC also on POSIX).
+            ; Do a no-op execution that just cycles the prompt.
+            ;
+            return []
         ]
 
-        append source line
+        append source repl/input-hook line ;--  pre-processor hook
 
         trap/with [
             ;

--- a/src/os/windows/dev-stdio.c
+++ b/src/os/windows/dev-stdio.c
@@ -42,10 +42,6 @@
 
 #define BUF_SIZE (16 * 1024)    // MS restrictions apply
 
-#define CONSOLE_MODES \
-        ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_ECHO_INPUT \
-        | 0x0040 | 0x0020       // quick edit and insert mode (not defined in VC6)
-
 static HANDLE Std_Out = NULL;
 static HANDLE Std_Inp = NULL;
 static wchar_t *Std_Buf = NULL; // Used for UTF-8 conversion of stdin/stdout.
@@ -114,8 +110,28 @@ DEVICE_CMD Open_IO(REBREQ *req)
         }
 
         if (!Redir_Inp) {
-            // Make the Win32 console a bit smarter by default.
-            SetConsoleMode(Std_Inp, CONSOLE_MODES);
+            //
+            // Windows offers its own "smart" line editor (with history
+            // management, etc.) in the form of the Windows Terminal.  These
+            // modes only apply if a the input is coming from the terminal,
+            // not if Rebol has a file redirection connected to the input.
+            //
+            // While the line editor is running with ENABLE_LINE_INPUT, there
+            // are very few hooks offered.  (See remarks on ReadConsole() call
+            // about how even being able to terminate the input with escape
+            // is not possible--much less reading function keys, etc.)  For
+            // the moment, delegating the editing process to proven code
+            // built into the OS is considered worth it for the limitations in
+            // the console client--given development priorities.
+            //
+            SetConsoleMode(
+                Std_Inp,
+                ENABLE_LINE_INPUT
+                | ENABLE_PROCESSED_INPUT
+                | ENABLE_ECHO_INPUT
+                | 0x0040 // quick edit (not defined in VC6)
+                | 0x0020 // quick insert (not defined in VC6)
+            );
         }
     }
     else
@@ -229,56 +245,143 @@ DEVICE_CMD Write_IO(REBREQ *req)
 //
 DEVICE_CMD Read_IO(REBREQ *req)
 {
-    DWORD total = 0;
-    DWORD len;
-    BOOL ok;
+    assert(req->length >= 2); // abort is signaled with (ESC '\0')
 
     if (req->modes & RDM_NULL) {
         req->common.data[0] = 0;
         return DR_DONE;
     }
 
-    req->actual = 0;
+    if (Std_Inp == NULL) {
+        req->actual = 0;
+        return DR_DONE;
+    }
 
-    if (Std_Inp) {
+    if (Redir_Inp) { // always UTF-8
+        DWORD len = MIN(req->length, BUF_SIZE);
 
-        if (Redir_Inp) { // always UTF-8
-            len = MIN(req->length, BUF_SIZE);
-            ok = ReadFile(Std_Inp, req->common.data, len, &total, 0);
-        }
-        else {
-            ok = ReadConsoleW(Std_Inp, Std_Buf, BUF_SIZE-1, &total, 0);
-            if (ok) {
-                if (total == 0) {
-                    // WideCharToMultibyte fails if cchWideChar is 0.
-                    assert(req->length >= 2);
-                    strcpy(s_cast(req->common.data), "");
-                }
-                else {
-                    total = WideCharToMultiByte(
-                        CP_UTF8,
-                        0,
-                        Std_Buf,
-                        total,
-                        s_cast(req->common.data),
-                        req->length,
-                        0,
-                        0
-                    );
-                    if (total == 0)
-                        ok = FALSE;
-                }
-            }
-        }
-
+        DWORD total;
+        REBOOL ok = ReadFile(Std_Inp, req->common.data, len, &total, 0);
         if (NOT(ok)) {
             req->error = GetLastError();
             return DR_ERROR;
         }
 
         req->actual = total;
+        return DR_DONE;
     }
 
+    // !!! ReadConsole() in the ENABLE_LINE_INPUT mode is a terribly limited
+    // API, and if you don't use that mode you are basically completely on
+    // your own for line editing (backspace, cursoring, etc.)  It's all or
+    // nothing--there's no way to hook it--and you can't even tell if an
+    // escape is pressed...it always clears to the beginning of line.
+    //
+    // There might seem to be some hope in the CONSOLE_READCONSOLE_CONTROL
+    // parameter.  The structure is horribly documented on MSDN, but it is
+    // supposed to offer a way to register some control keys to break out of
+    // the input besides a completing newline.  It turns out dwCtrlWakeupMask
+    // is (supposedly) a bit mask of 0-31 ASCII points for control characters:
+    //
+    // https://stackoverflow.com/a/43836992/211160
+    //
+    // Theory is that with ENABLE_LINE_INPUT, a successfully completed line
+    // will always end in CR LF for a `total` of at least 2.  Then if
+    // `dwCtrlWakeupMask` is registered for a key, and `nInitialChars` is
+    // set to 0 (preserve nothing), the fact that the user terminated with the
+    // control key *should* be detectable by `total == 0`.
+    //
+    // But as mentioned, masking escape in as (1 << 27) has no effect.  You
+    // can mask in Ctrl-C and it works as advertised--exiting ReadConsole()
+    // and setting the length to `nInitialChars`.  But puzzlingly so, because
+    // it overrides a user-provided SetConsoleCtrlHandler() for handling
+    // CTRL_C_EVENT.  :-/
+    //
+    // Then Ctrl-D can be in the mask.  It does indeed exit the read when it
+    // is hit, but ignores `nInitialChars` and just sticks a codepoint of 4
+    // (^D) wherever the cursor is!!!
+    //
+    // As awful as this all sounds, it actually can be manipulated to give
+    // three different outcomes.  It's just rather rickety-seeming, but the
+    // odds are this all comes from bend-over-backward legacy support of
+    // things that couldn't be changed to be better...so it will probably
+    // be working this way for however long Win32 stays relevant.
+    //
+    // For the moment, having Ctrl-D instead of escape for abort input (vs.
+    // abort script) is accepted as the price paid, to delegate the Unicode
+    // aware cursoring/backspacing/line-editing to the OS.  Which also means
+    // a smaller executable than trying to rewrite it oneself.
+    //
+    CONSOLE_READCONSOLE_CONTROL ctl;
+    ctl.nLength = sizeof(CONSOLE_READCONSOLE_CONTROL);
+    ctl.nInitialChars = 0; // when hit, empty buffer...no CR LF
+    ctl.dwCtrlWakeupMask = (1 << 3) | (1 << 4); // ^C and ^D
+    ctl.dwControlKeyState = 0; // no alt+shift modifiers (beyond ctrl)
+
+    DWORD total;
+    REBOOL ok = ReadConsoleW(Std_Inp, Std_Buf, BUF_SIZE - 1, &total, &ctl);
+    if (NOT(ok)) {
+        req->error = GetLastError();
+        return DR_ERROR;
+    }
+
+    // Ctrl-C and Ctrl-D will terminate input without the newline that is
+    // expected by code calling INPUT.  If these forms of cancellation are
+    // encountered, we write a line to maintain the visual invariant.
+    //
+    wchar_t cr_lf_term[3];
+    cr_lf_term[0] = CR;
+    cr_lf_term[1] = LF;
+    cr_lf_term[2] = '\0';
+
+    if (total == 0) {
+        //
+        // Has to be a Ctrl-C, because it returns 0 total.
+        // Note:  WideCharToMultibyte fails if cchWideChar is 0.
+        //
+        strcpy(s_cast(req->common.data), "");
+        req->actual = 0;
+
+        // Write compensating line.  !!! Check error?
+        //
+        WriteConsoleW(Std_Out, cr_lf_term, 2, NULL, 0);
+        return DR_DONE;
+    }
+
+    DWORD i;
+    for (i = 0; i < total; ++i) {
+        if (Std_Buf[i] == 4) {
+            //
+            // A Ctrl-D poked in at any position means escape.  Return it
+            // as a single-character null terminated string of escape.
+            //
+            strcpy(s_cast(req->common.data), "\x1B"); // 0x1B = 27 (escape)
+            req->actual = 1;
+
+            // Write compensating line.  !!! Check error?
+            //
+            WriteConsoleW(Std_Out, cr_lf_term, 2, NULL, 0);
+            return DR_DONE;
+        }
+    }
+
+    DWORD encoded_len = WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        Std_Buf,
+        total,
+        s_cast(req->common.data),
+        req->length,
+        0,
+        0
+    );
+
+    if (encoded_len == 0) {
+        req->error = GetLastError();
+        return DR_ERROR;
+    }
+
+    req->actual = encoded_len;
     return DR_DONE;
 }
 


### PR DESCRIPTION
The very old/crufty R3-Alpha POSIX termios-based code was considered to
be only a temporary codebase to be replaced with something better.  No
truly suitable replacement has been found, so this commit bites the
bullet and pushes the existing code to make it more tolerable.

It now supports UTF-8 entry...although the cursor-oriented commands
need to be updated to account correctly for multibyte characters.
Though those cursor commands are unfinished, it is still a significant
improvement.

It also supports multiline pasting.  This was inspired by a patch
submitted by @Oldes as a proof of concept (and the provocation for
this reworking).  Consequently hitting enter on an empty line no longer
terminates in-progress multiline input with an error message.

The way to cancel REPL input is now to use Ctrl-D on POSIX and Windows,
or Escape on POSIX.  (The technical reasons why Windows cannot use
Escape are explained in detail in the commit.)  The reaction of the
INPUT native is distinct between Ctrl-C and Ctrl-D/Escape, because
it's the difference between halting the script code completely, or
just returning BLANK! from INPUT and allowing the script to make a
decision on what to do from there.

Unknown escape codes are handled more intelligently, by not letting
stray bytes loose into the input buffer.  In the future, the escape
codes should be bubbling up to usermode somehow, to make it easier
for user customization and so there's less C code overall.

And importantly: the code is restructured and annotated to make it
easier for interested parties to contribute.