### PR TITLE
Sandbox HOST-CONSOLE calls into usermode code, disable Ctrl-C

### DIFF
--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -143,13 +143,19 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
         break;
 
     case DETECTED_AS_VALUE:
-    case DETECTED_AS_END:
+    case DETECTED_AS_END: {
+        const REBVAL *v = cast(const REBVAL*, p);
     #if defined(NDEBUG)
+        UNUSED(v);
         strncat(buf, "value", PANIC_BUF_SIZE - strlen(buf));
     #else
-        Panic_Value_Debug(cast(const REBVAL*, p));
+        if (IS_ERROR(v)) {
+            printf("...panicking on an ERROR! value...");
+            PROBE(v);
+        }
+        Panic_Value_Debug(v);
     #endif
-        break;
+        break; }
 
     case DETECTED_AS_TRASH_CELL:
     #if defined(NDEBUG)

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -87,6 +87,7 @@ REBNATIVE(eval)
 //          <opt> ;-- should DO accept an optional argument (chaining?)
 //          blank! ;-- same question... necessary, or not?
 //          block! ;-- source code in block form
+//          group! ;-- same as block (or should it have some other nuance?)
 //          string! ;-- source code in text form
 //          binary! ;-- treated as UTF-8
 //          url! ;-- load code from URL via protocol


### PR DESCRIPTION
The HOST-CONSOLE code is called directly from C code, as the topmost
level of evaluation.  So one problem with situations where running
the console raises an error is that there's nowhere to escalate that
error to... *the console is supposed to be the way errors are delivered
and values are probed*.  So a bug in the console basically means the
whole program has to crash out.

This makes the console a bit tough to debug.  With the extensive
usermode skinning added by @draegtun, the potential for errors being
triggered or infinite loops arises even more.  This makes crashes
likely while developing usermode skins.

To address this problem, this commit introduces a new concept of the
HOST-CONSOLE function being able to ask the C code calling it to run
code *on its behalf* as opposed to *on the user's behalf*.  Which is
desired is signaled by whether the code is returned as a BLOCK! or
a GROUP!.  Each time HOST-CONSOLE wants to sandbox some code, it
returns so it is off the stack...and then is re-entered when the
command finished, with a piece of information that can be used to tell
it where to pick up.  (This is a continuation-style/state-machine kind
of approach.)

Then, if one of the executions on its own behalf encounters a FAIL,
the error comes back to the HOST-CONSOLE as a special "bad" signal.
It can respond to this by making the skin fall back to the system
default, giving the user a chance to debug their skin and try again
instead of crashing the executable.

Given this greater bulletproofing, the Ctrl-C signal is disabled
during HOST-CONSOLE itself.  Only code that runs during a skin
(e.g. an overly long printout of a result or error report) can be
interrupted.