### PR TITLE
Invisible C-DEBUG-BREAK, QUOTE/SOFT, UNEVAL voids/BAR!s

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -112,8 +112,6 @@ Script: [
 
     enfix-path-group:   [:arg1 {GROUP! can't be in a lookback quoted PATH!}]
 
-    hard-quote-void:    [:arg1 {is hard quoted and can't be optionally void}]
-
     reduce-made-void:   {Expression in REDUCE evaluated to void}
     break-not-continue: {Use BREAK/WITH when body is the breaking condition}
 

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -317,9 +317,6 @@ sigxcpu
 sigxfsz
 
 bits
-crash
-crash-dump
-watch-recycle
 
 uid
 euid

--- a/src/core/a-constants.c
+++ b/src/core/a-constants.c
@@ -169,10 +169,3 @@ const char RM_TRACE_PARSE_VALUE[] = "Parse %s: %r";
 const char RM_TRACE_PARSE_INPUT[] = "Parse input: %s";
 
 const char RM_BACKTRACE_NOT_ENABLED[] = "backtrace not enabled";
-
-const char RM_EVOKE_HELP[] = "Evoke values:\n"
-    "[stack-size n] crash-dump delect\n"
-    "watch-recycle watch-obj-copy crash\n"
-    "1: watch expand\n"
-    "2: check memory pools\n"
-    "3: check bind table\n";

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1243,13 +1243,22 @@ void RL_rebPanic(const void *p)
     // because it's a pairing.)  Workaround for the moment by extracting to
     // a non-pairing value.
     //
+    DECLARE_LOCAL (temp);
+    const void *hack;
     if (Detect_Rebol_Pointer(p) == DETECTED_AS_VALUE) {
-        DECLARE_LOCAL (temp);
         Move_Value(temp, cast(const REBVAL*, p));
-        Panic_Core(temp, __FILE__, __LINE__);
+        hack = temp;
     }
+    else
+        hack = p;
 
-    Panic_Core(p, __FILE__, __LINE__);
+    // Like Panic_Core, the underlying API for rebPanic might want to take an
+    // optional file and line.
+    //
+    REBYTE *file_utf8 = NULL;
+    int line = 0;
+
+    panic_at (hack, file_utf8, line);
 }
 
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -781,7 +781,7 @@ static void Init_Root_Vars(void)
     //
     Init_Endlike_Header(&PG_End_Node.header, 0); // mutate to read-only end
 #if !defined(NDEBUG)
-    Set_Track_Payload_Debug(&PG_End_Node, __FILE__, __LINE__);
+    Set_Track_Payload_Debug(&PG_End_Node, cb_cast(__FILE__), __LINE__);
 #endif
     assert(IS_END(END)); // sanity check that it took
     assert(VAL_TYPE_RAW(END) == REB_0); // this implicit END marker has this
@@ -952,7 +952,7 @@ static void Init_Contexts_Object(void)
 //
 static void Init_Break_Point(void)
 {
-    TG_Break_At = 0;
+    TG_Break_At_Tick = 0;
 
     const char *env_break_at = getenv("R3_BREAK_AT");
     if (env_break_at != NULL) {
@@ -964,7 +964,7 @@ static void Init_Break_Point(void)
                 "** Will break in Do_Core or crash (if not launched by a debugger)\n"
                 "**\n"
             );
-            TG_Break_At = cast(REBUPT, break_at);
+            TG_Break_At_Tick = cast(REBUPT, break_at);
         }
     }
 }

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -79,9 +79,9 @@ void Snap_State_Core(struct Reb_State *s)
 //
 void Assert_State_Balanced_Debug(
     struct Reb_State *s,
-    const char *file,
+    const REBYTE *file,
     int line
-) {
+){
     if (s->dsp != DSP) {
         printf(
             "DS_PUSH()x%d without DS_POP/DS_DROP\n",

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -353,18 +353,6 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                     fail (Error_Refinement_Arg_Opt_Raw());
             }
 
-
-            // A hard quote can only get a void if it is an <end>, and that
-            // is not reflected in the typeset but in TYPESET_FLAG_ENDABLE
-            //
-            if (VAL_PARAM_CLASS(typeset) == PARAM_CLASS_HARD_QUOTE) {
-                if (TYPE_CHECK(typeset, REB_MAX_VOID)) {
-                    DECLARE_LOCAL (param_name);
-                    Init_Word(param_name, VAL_PARAM_SPELLING(typeset));
-                    fail (Error_Hard_Quote_Void_Raw(param_name));
-                }
-            }
-
             has_types = TRUE;
             continue;
         }
@@ -2046,7 +2034,7 @@ REB_R Apply_Def_Or_Exemplar(
     // checks.  It also checks the top of stack, so that has to be set as well.
     // So this has to come before Push_Args
     //
-    SNAP_STATE(&f->state_debug);
+    SNAP_STATE(&f->state);
 #endif
 
     Push_Function(f, opt_label, fun, binding);

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -62,7 +62,7 @@ ATTRIBUTE_NO_RETURN void Panic_Value_Debug(const RELVAL *v) {
     case REB_BAR:
         printf(
             "REBVAL init on tick #%d at %s:%d\n",
-            cast(unsigned int, v->extra.do_count),
+            cast(unsigned int, v->extra.tick),
             v->payload.track.filename,
             v->payload.track.line
         );
@@ -172,13 +172,13 @@ void Assert_No_Relative(REBARR *array, REBOOL deep)
 //
 void Probe_Core_Debug(
     const void *p,
-    const char *file,
+    const REBYTE *file,
     int line
 ) {
     const struct Reb_Header *h = cast(const struct Reb_Header*, p);
 
     printf("\n** PROBE() ");
-    printf("tick %d %s:%d\n", cast(int, TG_Do_Count), file, line);
+    printf("tick %d %s:%d\n", cast(int, TG_Tick), file, line);
 
     fflush(stdout);
     fflush(stderr);

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -43,7 +43,8 @@
 //
 ATTRIBUTE_NO_RETURN void Panic_Core(
     const void *p, // REBSER* (array, context, etc), REBVAL*, or UTF-8 char*
-    const char *file,
+    REBUPT tick,
+    const REBYTE *file_utf8,
     int line
 ) {
     if (p == NULL)
@@ -55,15 +56,16 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
     GC_Disabled = TRUE;
 
 #if defined(NDEBUG)
-    UNUSED(file);
+    UNUSED(tick);
+    UNUSED(file_utf8);
     UNUSED(line);
 #else
     //
     // First thing's first in the debug build, make sure the file and the
     // line are printed out, as well as the current evaluator tick.
     //
-    printf("C Source File %s, Line %d\n", file, line);
-    printf("On evaluator tick: %lu\n", cast(unsigned long, TG_Do_Count));
+    printf("C Source File %s, Line %d\n", cs_cast(file_utf8), line);
+    printf("At evaluator tick: %lu\n", cast(unsigned long, tick));
 
     // Generally Rebol does not #include <stdio.h>, but the debug build does.
     // It's often used for debug spew--as opposed to Debug_Fmt()--when there
@@ -85,11 +87,13 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
     title[0] = '\0';
     buf[0] = '\0';
 
-#if !defined(NDEBUG)
-    if (Reb_Opts && Reb_Opts->crash_dump) {
-        Dump_Info();
-        Dump_Stack(NULL, 0);
-    }
+#if !defined(NDEBUG) && 0
+    //
+    // These are currently disabled, because they generate too much junk.
+    // Address Sanitizer gives a reasonable idea of the stack.
+    //
+    Dump_Info();
+    Dump_Stack(NULL, 0);
 #endif
 
     strncat(title, "PANIC()", PANIC_TITLE_BUF_SIZE - 0);

--- a/src/core/d-dump.c
+++ b/src/core/d-dump.c
@@ -273,11 +273,17 @@ void Dump_Stack(REBFRM *f, REBCNT level)
     REBVAL *param = FUNC_PARAMS_HEAD(f->phase);
 
     for (; NOT_END(param); ++param, ++arg, ++n) {
-        Debug_Fmt(
-            "    %s: %72r",
-            STR_HEAD(VAL_PARAM_SPELLING(param)),
-            arg
-        );
+        if (IS_VOID(arg))
+            Debug_Fmt(
+                "    %s:",
+                STR_HEAD(VAL_PARAM_SPELLING(param))
+            );
+        else
+            Debug_Fmt(
+                "    %s: %72r",
+                STR_HEAD(VAL_PARAM_SPELLING(param)),
+                arg
+            );
     }
 
     if (f->prior)

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -726,7 +726,7 @@ static REBOOL Series_Data_Alloc(REBSER *s, REBCNT length) {
         RELVAL *ultimate = ARR_AT(ARR(s), s->content.dynamic.rest - 1);
         Init_Endlike_Header(&ultimate->header, 0);
     #if !defined(NDEBUG)
-        Set_Track_Payload_Debug(ultimate, __FILE__, __LINE__);
+        Set_Track_Payload_Debug(ultimate, cb_cast(__FILE__), __LINE__);
     #endif
     }
 
@@ -900,7 +900,7 @@ REBSER *Make_Series_Core(REBCNT capacity, REBYTE wide, REBUPT flags)
     // the pool node so pointer-aligned entries are given out, so might as well
     // make that hold a useful value--the tick count when the series was made
     //
-    s->do_count = TG_Do_Count;
+    s->tick = TG_Tick;
 #endif
 
     // The info bits must be able to implicitly terminate the `content`,
@@ -1047,7 +1047,7 @@ REBVAL *Alloc_Pairing(REBFRM *opt_owning_frame) {
     s->guard = cast(int*, malloc(sizeof(*s->guard)));
     free(s->guard);
 
-    s->do_count = TG_Do_Count;
+    s->tick = TG_Tick;
 #endif
 
     return paired;
@@ -1093,7 +1093,7 @@ void Free_Pairing(REBVAL *paired) {
     Free_Node(SER_POOL, series);
 
 #if !defined(NDEBUG)
-    series->do_count = TG_Do_Count;
+    series->tick = TG_Tick; // update to be tick on which node was freed
 #endif
 }
 
@@ -1600,10 +1600,7 @@ void GC_Kill_Series(REBSER *s)
 
 #if !defined(NDEBUG)
     PG_Reb_Stats->Series_Freed++;
-
-    // Update the do count to be the count on which the series was freed
-    //
-    s->do_count = TG_Do_Count;
+    s->tick = TG_Tick; // update to be tick on which series was freed
 #endif
 }
 

--- a/src/core/m-series.c
+++ b/src/core/m-series.c
@@ -504,7 +504,7 @@ ATTRIBUTE_NO_RETURN void Panic_Series_Debug(REBSER *s)
         printf("freed");
     else
         printf("created");
-    printf(" during evaluator tick: %lu\n", cast(unsigned long, s->do_count));
+    printf(" during evaluator tick: %lu\n", cast(unsigned long, s->tick));
 
     fflush(stdout);
 

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -55,13 +55,11 @@ REBNATIVE(eval)
 {
     INCLUDE_PARAMS_OF_EVAL;
 
-    REBFRM *f = frame_; // implicit parameter to every dispatcher/native
-
     // The REEVALUATE instructions explicitly understand that the value to
     // do reevaluation of is held in the frame's f->cell.  (It would be unsafe
     // to evaluate something held in f->out.)
     //
-    Move_Value(&f->cell, ARG(value));
+    Move_Value(D_CELL, ARG(value));
 
     if (REF(only)) {
         //
@@ -69,7 +67,7 @@ REBNATIVE(eval)
         // mode.  But we still want the eval cell itself to be treated
         // evaluatively despite that.  So flip its special evaluator bit.
         //
-        SET_VAL_FLAG(&f->cell, VALUE_FLAG_EVAL_FLIP);
+        SET_VAL_FLAG(D_CELL, VALUE_FLAG_EVAL_FLIP);
         return R_REEVALUATE_CELL_ONLY;
     }
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -1322,7 +1322,7 @@ REBNATIVE(subparse)
     const REBCNT *pos_debug = &P_POS;
     (void)pos_debug; // UNUSED() forces corruption in C++11 debug builds
 
-    REBUPT do_count = TG_Do_Count; // helpful to cache for visibility also
+    REBUPT tick = TG_Tick; // helpful to cache for visibility also
 #endif
 
     DECLARE_LOCAL (save);
@@ -1371,9 +1371,9 @@ REBNATIVE(subparse)
         UPDATE_EXPRESSION_START(f);
 
     #if !defined(NDEBUG)
-        ++TG_Do_Count;
-        do_count = TG_Do_Count;
-        cast(void, do_count); // suppress compiler warning about lack of use
+        ++TG_Tick;
+        tick = TG_Tick;
+        cast(void, tick); // suppress compiler warning about lack of use
     #endif
 
     //==////////////////////////////////////////////////////////////////==//

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -129,7 +129,7 @@ typedef u16 REBUNI;
 #ifdef REB_DEF
     struct Reb_Cell;
 
-    #if  !defined(__cplusplus) || __cplusplus < 201103L
+    #if !defined(__cplusplus) || __cplusplus < 201103L
         #define RELVAL struct Reb_Cell
         #define REBVAL struct Reb_Cell
         #define const_RELVAL_NO_END_PTR const struct Reb_Cell *

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -73,7 +73,7 @@
         FALSE
 #else
     #define SPORADICALLY(modulus) \
-        (TG_Do_Count % modulus == 0)
+        (TG_Tick % modulus == 0)
 #endif
 
 inline static REBOOL IS_QUOTABLY_SOFT(const RELVAL *v) {
@@ -180,7 +180,7 @@ inline static void Push_Frame_Core(REBFRM *f)
 
     TRASH_POINTER_IF_DEBUG(f->opt_label);
 #if !defined(NDEBUG)
-    TRASH_POINTER_IF_DEBUG(f->label_debug);
+    TRASH_POINTER_IF_DEBUG(f->label_utf8);
 #endif
 }
 
@@ -280,7 +280,7 @@ inline static void Recover_Frame(REBFRM *f)
 
     TRASH_POINTER_IF_DEBUG(f->opt_label);
 #if !defined(NDEBUG)
-    TRASH_POINTER_IF_DEBUG(f->label_debug);
+    TRASH_POINTER_IF_DEBUG(f->label_utf8);
 #endif
 }
 
@@ -313,7 +313,7 @@ inline static void Fetch_Next_In_Frame(REBFRM *f) {
 
         f->value = f->source.pending;
     #if !defined(NDEBUG)
-        f->kind_debug = VAL_TYPE(f->value);
+        f->kind = VAL_TYPE(f->value);
     #endif
 
         ++f->source.pending; // might be becoming an END marker, here
@@ -327,7 +327,7 @@ inline static void Fetch_Next_In_Frame(REBFRM *f) {
     end_of_input:
         f->value = NULL;
     #if !defined(NDEBUG)
-        f->kind_debug = REB_0;
+        f->kind = REB_0;
         TRASH_POINTER_IF_DEBUG(f->source.pending);
     #endif
     }
@@ -378,7 +378,7 @@ inline static void Fetch_Next_In_Frame(REBFRM *f) {
             // take time to answer, but this partial code points toward
             // where the bridge to the scanner would be.
             //
-            panic ("String-based rebDo() not actually ready yet.")
+            panic ("String-based rebDo() not actually ready yet.");
         }
 
         case DETECTED_AS_SERIES: {
@@ -398,7 +398,7 @@ inline static void Fetch_Next_In_Frame(REBFRM *f) {
             SET_VAL_FLAG(&f->cell, VALUE_FLAG_EVAL_FLIP);
             f->value = &f->cell;
         #if !defined(NDEBUG)
-            f->kind_debug = VAL_TYPE(f->value);
+            f->kind = VAL_TYPE(f->value);
         #endif
 
             // !!! Ideally we would free the array here, but since the free
@@ -418,7 +418,7 @@ inline static void Fetch_Next_In_Frame(REBFRM *f) {
             f->source.array = NULL;
             f->value = cast(const RELVAL*, p); // not END, detected separately
         #if !defined(NDEBUG)
-            f->kind_debug = VAL_TYPE(f->value);
+            f->kind = VAL_TYPE(f->value);
         #endif
             assert(
                 (
@@ -490,7 +490,7 @@ inline static REBOOL Do_Next_Mid_Frame_Throws(REBFRM *f) {
 
     REBDSP prior_dsp_orig = f->dsp_orig; // Do_Core() overwrites on entry
 #if !defined(NDEBUG)
-    assert(f->state_debug.dsp == f->dsp_orig);
+    assert(f->state.dsp == f->dsp_orig);
 #endif
 
     SET_END(f->out);
@@ -502,7 +502,7 @@ inline static REBOOL Do_Next_Mid_Frame_Throws(REBFRM *f) {
     
     f->dsp_orig = prior_dsp_orig;
 #if !defined(NDEBUG)
-    f->state_debug.dsp = prior_dsp_orig;
+    f->state.dsp = prior_dsp_orig;
 #endif
 
     // Note: f->eval_type will have changed, but it should not matter to
@@ -557,7 +557,7 @@ inline static REBOOL Do_Next_In_Subframe_Throws(
 
     child->value = parent->value;
 #if !defined(NDEBUG)
-    child->kind_debug = parent->kind_debug;
+    child->kind = parent->kind;
 #endif
 
     child->specifier = parent->specifier;
@@ -579,7 +579,7 @@ inline static REBOOL Do_Next_In_Subframe_Throws(
 
     parent->value = child->value;
 #if !defined(NDEBUG)
-    parent->kind_debug = child->kind_debug;
+    parent->kind = child->kind;
 #endif
 
     parent->gotten = child->gotten;

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -153,8 +153,8 @@ TVAR REBUPT Stack_Limit;    // Limit address for CPU stack.
     // used for many purposes...including setting breakpoints in routines
     // other than Do_Next that are contingent on a certain "tick" elapsing.
     //
-    TVAR REBUPT TG_Do_Count;
-    TVAR REBUPT TG_Break_At; // The do_count to break
+    TVAR REBUPT TG_Tick; // expressions, EVAL moments, PARSE steps bump this
+    TVAR REBUPT TG_Break_At_Tick; // runtime break tick set by C-DEBUG_BREAK
 
     TVAR REBIPT TG_Num_Black_Series;
 #endif

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -580,15 +580,15 @@ struct Reb_Frame {
 
 #if !defined(NDEBUG)
     //
-    // `label_debug` [DEBUG]
+    // `label` [DEBUG]
     //
     // Knowing the label symbol is not as handy as knowing the actual string
     // of the function this call represents (if any).  It is in UTF8 format,
     // and cast to `char*` to help debuggers that have trouble with REBYTE.
     //
-    const char *label_debug;
+    const char *label_utf8;
 
-    // `file_debug` [DEBUG]
+    // `file` [DEBUG]
     //
     // An emerging feature in the system is the ability to connect user-seen
     // series to a file and line number associated with their creation,
@@ -596,30 +596,30 @@ struct Reb_Frame {
     // them.  As the feature gets better, it will certainly be useful to be
     // able to quickly see the information in the debugger for f->source.
     //
-    const char *file_debug;
-    int line_debug;
+    const char *file; // is REBYTE (UTF-8), but char* for debug watch
+    int line;
 
-    // `kind_debug` [DEBUG]
+    // `kind` [DEBUG]
     //
     // The fetching mechanics cache the type of f->value
     //
-    enum Reb_Kind kind_debug;
+    enum Reb_Kind kind;
 
-    // `do_count_debug` [DEBUG]
+    // `tick` [DEBUG]
     //
-    // The `do_count` represents the expression evaluation "tick" where the
-    // Reb_Frame is starting its processing.  This is helpful for setting
-    // breakpoints on certain ticks in reproducible situations.
+    // The expression evaluation "tick" where the Reb_Frame is starting its
+    // processing.  This is helpful for setting breakpoints on certain ticks
+    // in reproducible situations.
     //
-    REBUPT do_count_debug; // !!! Should this be available in release builds?
+    REBUPT tick; // !!! Should this be available in release builds?
 
-    // `state_debug` [DEBUG]
+    // `state` [DEBUG]
     //
     // Debug reuses PUSH_TRAP's snapshotting to check for leaks at each stack
     // level.  It can also be made to use a more aggresive leak check at every
     // evaluator step--see BALANCE_CHECK_EVERY_EVALUATION_STEP.
     //
-    struct Reb_State state_debug;
+    struct Reb_State state;
 #endif
 };
 

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -806,7 +806,7 @@ struct Reb_Series {
 
 #if !defined(NDEBUG)
     int *guard; // intentionally alloc'd and freed for use by Panic_Series
-    REBUPT do_count; // also maintains sizeof(REBSER) % sizeof(REBI64) == 0
+    REBUPT tick; // also maintains sizeof(REBSER) % sizeof(REBI64) == 0
 #endif
 };
 

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -339,7 +339,7 @@
 
 #if !defined(NDEBUG)
     struct Reb_Track {
-        const char *filename;
+        const char *filename; // is REBYTE (UTF-8), but char* for debug watch
         int line;
     };
 #endif
@@ -747,7 +747,7 @@ union Reb_Value_Extra {
     REBARR *singular;
 
 #if !defined(NDEBUG)
-    REBUPT do_count; // used by track payloads
+    REBUPT tick; // value initialization tick if the payload is Reb_Track
 #endif
 };
 
@@ -910,6 +910,8 @@ struct Reb_Cell
             : p (p) {}
 
         operator const Reb_Relative_Value* () { return p; }
+        
+        const Reb_Relative_Value* operator-> () { return p; } 
 
         const_Reb_Relative_Value_No_End_Ptr operator= (
             const Reb_Relative_Value *rhs

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -583,7 +583,7 @@ inline static void Drop_Guard_Value_Common(const RELVAL *v) {
 #else
     inline static void Drop_Guard_Series_Debug(
         REBSER *s,
-        const char *file,
+        const REBYTE *file,
         int line
     ) {
         if (s != *SER_LAST(REBSER*, GC_Guarded))
@@ -593,7 +593,7 @@ inline static void Drop_Guard_Value_Common(const RELVAL *v) {
 
     inline static void Drop_Guard_Value_Debug(
         const RELVAL *v,
-        const char *file,
+        const REBYTE *file,
         int line
     ) {
         if (v != *SER_LAST(RELVAL*, GC_Guarded))
@@ -602,10 +602,10 @@ inline static void Drop_Guard_Value_Common(const RELVAL *v) {
     }
 
     #define DROP_GUARD_SERIES(s) \
-        Drop_Guard_Series_Debug(s, __FILE__, __LINE__);
+        Drop_Guard_Series_Debug(s, cb_cast(__FILE__), __LINE__);
 
     #define DROP_GUARD_VALUE(v) \
-        Drop_Guard_Value_Debug(v, __FILE__, __LINE__);
+        Drop_Guard_Value_Debug(v, cb_cast(__FILE__), __LINE__);
 #endif
 
 

--- a/src/include/sys-trap.h
+++ b/src/include/sys-trap.h
@@ -251,7 +251,7 @@ inline static void DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(struct Reb_State *s) {
     #define ASSERT_STATE_BALANCED(s) NOOP
 #else
     #define ASSERT_STATE_BALANCED(s) \
-        Assert_State_Balanced_Debug((s), __FILE__, __LINE__)
+        Assert_State_Balanced_Debug((s), cb_cast(__FILE__), __LINE__)
 #endif
 
 
@@ -368,8 +368,18 @@ inline static void DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(struct Reb_State *s) {
 // NOTE: It's desired that there be a space in `panic (...)` to make it look
 // more "keyword-like" and draw attention to the fact it is a `noreturn` call.
 //
-#define panic(v) \
-    Panic_Core((v), __FILE__, __LINE__);
+#ifdef NDEBUG
+    #define panic(v) \
+        Panic_Core((v), 0, NULL, 0)
 
-#define panic_at(v,file,line) \
-    Panic_Core((v), (file), (line));
+    #define panic_at(v,file,line) \
+        (void)file; \
+        (void)line; \
+        panic(v)
+#else
+    #define panic(v) \
+        Panic_Core((v), TG_Tick, cb_cast(__FILE__), __LINE__)
+
+    #define panic_at(v,file,line) \
+        Panic_Core((v), TG_Tick, (file), (line))
+#endif

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -76,7 +76,7 @@
 
 #if !defined(NDEBUG)
     #define PROBE(v) \
-        Probe_Core_Debug((v), __FILE__, __LINE__)
+        Probe_Core_Debug((v), cb_cast(__FILE__), __LINE__)
 #endif
 
 
@@ -100,11 +100,11 @@
 
 #if !defined NDEBUG
     inline static void Set_Track_Payload_Debug(
-        RELVAL *v, const char *file, int line
+        RELVAL *v, const REBYTE *file, int line
     ){
-        v->payload.track.filename = file;
+        v->payload.track.filename = cs_cast(file); // cast for debug watch
         v->payload.track.line = line;
-        v->extra.do_count = TG_Do_Count;
+        v->extra.tick = TG_Tick;
     }
 #endif
 
@@ -161,7 +161,7 @@
         FLAGIT_LEFT(23)
 
     inline static enum Reb_Kind VAL_TYPE_Debug(
-        const RELVAL *v, const char *file, int line
+        const RELVAL *v, const REBYTE *file, int line
     ){
         // VAL_TYPE is called *a lot*, and this makes it a great place to do
         // sanity checks in the debug build.  But a debug build will not
@@ -211,7 +211,7 @@
     }
 
     #define VAL_TYPE(v) \
-        VAL_TYPE_Debug((v), __FILE__, __LINE__)
+        VAL_TYPE_Debug((v), cb_cast(__FILE__), __LINE__)
 #endif
 
 
@@ -416,7 +416,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 #else
     inline static void Assert_Cell_Writable(
         const RELVAL *v,
-        const char *file,
+        const REBYTE *file,
         int line
     ){
         // REBVALs should not be written at addresses that do not match the
@@ -452,7 +452,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         RELVAL *v,
         enum Reb_Kind kind,
         REBUPT extra,
-        const char *file,
+        const REBYTE *file,
         int line
     ){
         ASSERT_CELL_WRITABLE(v, file, line);
@@ -468,7 +468,8 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define VAL_RESET_HEADER_EXTRA(v,kind,extra) \
-        VAL_RESET_HEADER_EXTRA_Debug((v), (kind), (extra), __FILE__, __LINE__)
+        VAL_RESET_HEADER_EXTRA_Debug((v), (kind), (extra), \
+            cb_cast(__FILE__), __LINE__)
 
     // VAL_RESET is a variant of VAL_RESET_HEADER_EXTRA that actually
     // overwrites the payload with tracking information.  It should not be
@@ -479,7 +480,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         RELVAL *v,
         enum Reb_Kind kind,
         REBUPT extra,
-        const char *file,
+        const REBYTE *file,
         int line
     ){
         VAL_RESET_HEADER_EXTRA_Debug(v, kind, extra, file, line);
@@ -487,10 +488,10 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define VAL_RESET(v,kind,extra) \
-        VAL_RESET_Debug((v), (kind), (extra), __FILE__, __LINE__)
+        VAL_RESET_Debug((v), (kind), (extra), cb_cast(__FILE__), __LINE__)
 
     inline static void Prep_Non_Stack_Cell_Debug(
-        struct Reb_Cell *c, const char *file, int line
+        struct Reb_Cell *c, const REBYTE *file, int line
     ){
         c->header.bits =
             NODE_FLAG_NODE | NODE_FLAG_FREE | NODE_FLAG_CELL
@@ -499,10 +500,10 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define Prep_Non_Stack_Cell(c) \
-        Prep_Non_Stack_Cell_Debug((c), __FILE__, __LINE__)
+        Prep_Non_Stack_Cell_Debug((c), cb_cast(__FILE__), __LINE__)
 
     inline static void Prep_Stack_Cell_Debug(
-        struct Reb_Cell *c, const char *file, int line
+        struct Reb_Cell *c, const REBYTE *file, int line
     ){
         c->header.bits = NODE_FLAG_NODE | NODE_FLAG_FREE | NODE_FLAG_CELL
             | HEADERIZE_KIND(REB_MAX_PLUS_ONE_TRASH) | VALUE_FLAG_STACK;
@@ -510,7 +511,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define Prep_Stack_Cell(c) \
-        Prep_Stack_Cell_Debug((c), __FILE__, __LINE__)
+        Prep_Stack_Cell_Debug((c), cb_cast(__FILE__), __LINE__)
 #endif
 
 #define VAL_RESET_HEADER(v,t) \
@@ -522,7 +523,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     // the type and bits (e.g. changing ANY-WORD! to another ANY-WORD!).
     // Otherwise the value-specific flags might be misinterpreted.
     //
-    ASSERT_CELL_WRITABLE(v, __FILE__, __LINE__);
+    ASSERT_CELL_WRITABLE(v, cb_cast(__FILE__), __LINE__);
     CLEAR_8_RIGHT_BITS(v->header.bits);
     v->header.bits |= HEADERIZE_KIND(kind);
 }
@@ -547,20 +548,20 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 #else
     inline static void Set_Trash_Debug(
         RELVAL *v,
-        const char *file,
+        const REBYTE *file,
         int line
-    ) {
+    ){
         ASSERT_CELL_WRITABLE(v, file, line);
 
         v->header.bits &= CELL_MASK_RESET;
         v->header.bits |= NODE_FLAG_FREE
-            | HEADERIZE_KIND(REB_MAX_PLUS_ONE_TRASH);
+          | HEADERIZE_KIND(REB_MAX_PLUS_ONE_TRASH);
 
         Set_Track_Payload_Debug(v, file, line);
     }
 
     #define TRASH_CELL_IF_DEBUG(v) \
-        Set_Trash_Debug((v), __FILE__, __LINE__)
+        Set_Trash_Debug((v), cb_cast(__FILE__), __LINE__)
 
     inline static REBOOL IS_TRASH_DEBUG(const RELVAL *v) {
         assert(v->header.bits & NODE_FLAG_CELL);
@@ -616,7 +617,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 #else
     inline static REBOOL IS_END_Debug(
         const RELVAL *v,
-        const char *file,
+        const REBYTE *file,
         int line
     ){
         if (v->header.bits & NODE_FLAG_FREE) {
@@ -659,9 +660,9 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 #endif
 
     #define IS_END(v) \
-        IS_END_Debug((v), __FILE__, __LINE__)
+        IS_END_Debug((v), cb_cast(__FILE__), __LINE__)
 
-    inline static void SET_END_Debug(RELVAL *v, const char *file, int line) {
+    inline static void SET_END_Debug(RELVAL *v, const REBYTE *file, int line) {
         ASSERT_CELL_WRITABLE(v, file, line);
         v->header.bits &= CELL_MASK_RESET; // leaves NODE_FLAG_CELL, etc.
         v->header.bits |= NODE_FLAG_END | HEADERIZE_KIND(REB_0);
@@ -669,11 +670,11 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define SET_END(v) \
-        SET_END_Debug((v), __FILE__, __LINE__)
+        SET_END_Debug((v), cb_cast(__FILE__), __LINE__)
 
     inline static enum Reb_Kind VAL_TYPE_OR_0_Debug(
         const RELVAL *v,
-        const char *file,
+        const REBYTE *file,
         int line
     ){
         if (v->header.bits & NODE_FLAG_END) {
@@ -690,7 +691,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     // Warning: Only use on valid non-END REBVAL -or- on global END value
     //
     #define VAL_TYPE_OR_0(v) \
-        VAL_TYPE_OR_0_Debug((v), __FILE__, __LINE__)
+        VAL_TYPE_OR_0_Debug((v), cb_cast(__FILE__), __LINE__)
 #endif
 
 #define NOT_END(v) \
@@ -836,7 +837,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     //
     inline static REBVAL *Sink_Debug(
         RELVAL *v,
-        const char *file,
+        const REBYTE *file,
         int line
     ) {
         ASSERT_CELL_WRITABLE(v, file, line);
@@ -860,7 +861,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define SINK(v) \
-        Sink_Debug((v), __FILE__, __LINE__)
+        Sink_Debug((v), cb_cast(__FILE__), __LINE__)
 
 #endif
 
@@ -894,7 +895,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
         GET_VAL_FLAG((v), VALUE_FLAG_FALSEY)
 #else
     inline static REBOOL IS_FALSEY_Debug(
-        const RELVAL *v, const char *file, int line
+        const RELVAL *v, const REBYTE *file, int line
     ){
         if (IS_VOID(v)) {
             printf("Conditional true/false test on void\n");
@@ -904,7 +905,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define IS_FALSEY(v) \
-        IS_FALSEY_Debug((v), __FILE__, __LINE__)
+        IS_FALSEY_Debug((v), cb_cast(__FILE__), __LINE__)
 #endif
 
 #define IS_TRUTHY(v) \
@@ -1531,7 +1532,7 @@ inline static void Move_Value_Header(RELVAL *out, const RELVAL *v)
         && NOT(v->header.bits & (NODE_FLAG_END | NODE_FLAG_FREE))
     );
 
-    ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);
+    ASSERT_CELL_WRITABLE(out, cb_cast(__FILE__), __LINE__);
 
     out->header.bits &= CELL_MASK_RESET;
     out->header.bits |= v->header.bits & CELL_MASK_COPY;
@@ -1633,7 +1634,7 @@ inline static void Blit_Cell(RELVAL *out, const RELVAL *v)
         && NOT(v->header.bits & (NODE_FLAG_END | NODE_FLAG_FREE))
     );
 
-    ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);
+    ASSERT_CELL_WRITABLE(out, cb_cast(__FILE__), __LINE__);
 
     // Examine just the cell's preparation bits.  Are they identical?  If so,
     // we are not losing any information by blindly copying the header in

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -362,7 +362,13 @@ host-console: function [
             ]
         ]
         return compose/deep/only [
-            system/console/print-result quote (:result) ; don't run FUNCTION!
+            ;
+            ; Can't pass `result` in directly, because it might be a FUNCTION!
+            ; (which when composed in will execute instead of be passed as a
+            ; parameter).  Can't use QUOTE because it would not allow BAR!.
+            ; Use UNEVAL, which is a stronger QUOTE created for this purpose.
+            ;
+            system/console/print-result uneval (:result)
                 |
             <needs-prompt>
         ]
@@ -398,12 +404,12 @@ host-console: function [
             <no-prompt> [needs-prompt: needs-gap: false]
             <no-gap> [needs-gap: false]
         ] else [
-            return compose/deep [
+            return compose/deep/only [
                 #no-unskin-if-error
                     |
-                print mold (prior)
+                print mold uneval (prior)
                     |
-                fail ["Bad REPL continuation:" quote (result)]
+                fail ["Bad REPL continuation:" uneval (result)]
             ]
         ]
     ]


### PR DESCRIPTION
The "C-DEBUG-BREAK" native is helpful for interrupting evaluation to
kick into the C debugger at a "just-in-time" moment where you want to
step through a specific call.  But if you wrote something like:

    print c-debug-break mold foo

...it took no arguments, and returned nothing.  So it would not be
possible to continue after this operation...as PRINT cannot print void.

The same mechanism that PROBE uses can't be used here.  PROBE takes an
evaluated parameter, and then passes it through as its result.  But if
C-DEBUG-BREAK did that, it would undermine the point: e.g. in the
example above, it's supposed to break into the debugger *before* the
MOLD, not after it.

This commit makes C-DEBUG-BREAK an arity-1 hard quoted operation.  It
then queues up its break, and proceeds to take the hard quoted item
and put it into the frame's cell to retrigger through the same
mechanic used by EVAL.  The effect is to appear "invisible" like PROBE,
*but* breaking before the "argument" gets evaluated.

In order to generalize this, it needs to be able to accept `<end>` (e.g.
so that plain C-DEBUG-BREAK entered at a prompt would not be an error).
Yet taking voids had been prohibited by hard quotes, based on the
premise that "it could never happen".  It was checked at FUNCTION!
creation time.

This prescriptivism was designed to help user understanding, since it
seemed to suggest an ignorance of what `QUOTE ()` meant if someone
tried to make such an operator take void.  But developments on the
libRebol API has shown the need for the general principle to be
relaxed, as rebDo() API needs to be able to pass "pre-evaluated" voids
coming from C into `<opt>` parameters.

Therefore the check mechanically prohibiting `<opt>` or `<end>` on hard
quoted function args is scrapped in this commit.  However, QUOTE
remains unchanged--as it is an inappropriate generalized operator to be
using for splicing unevaluated slots (since it prohibits passing BAR!
for safety).

The missing operation of a "raw" hard quote is instead added as a new
function: UNEVAL.  It will blindly pass through anything--voids, BAR!s,
etc.

(Note: An important recent place that needed this operation is the
recently updated console code...which previously could not print out a
BAR! due to its use of QUOTE to suppress function evaluation.)

This motivated the need to bump the TG_Do_Count on EVAL operations,
which required splitting out the idea of starting a new expression
(which EVAL should not do) with the idea of bumping the count for
debug purposes.  It also motivated touching up the Dump_Frame_Location
code to give better results after turning the 'current' cell pointer
into a local variable in Do_Core() to coalesce eval with "looking ahead
for lookback quoting operations".

Also adds a /SOFT refinement to QUOTE, which efficiently splices the
argument into the evaluation stream vs. starting a new frame.

Additionally this renamed C-BREAK-DEBUG to C-DEBUG-BREAK, because
debug_break() is the name of the C function (picked by a third party,
not chosen by us) and I always got confused. :P