### PR TITLE
Take tick breakpoint on command line (--breakpoint NNN)

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -944,32 +944,6 @@ static void Init_Contexts_Object(void)
     Init_Object(Get_System(SYS_CONTEXTS, CTX_USER), Lib_Context);
 }
 
-#ifndef NDEBUG
-//
-//  Init_Break_Point: C
-//
-// This initializes the break point from env in the debug build
-//
-static void Init_Break_Point(void)
-{
-    TG_Break_At_Tick = 0;
-
-    const char *env_break_at = getenv("R3_BREAK_AT");
-    if (env_break_at != NULL) {
-        i64 break_at = CHR_TO_INT(cb_cast(env_break_at));;
-        if(break_at > 0) {
-            Debug_Str(
-                "**\n"
-                "** R3_BREAK_AT is set in environment variable!\n"
-                "** Will break in Do_Core or crash (if not launched by a debugger)\n"
-                "**\n"
-            );
-            TG_Break_At_Tick = cast(REBUPT, break_at);
-        }
-    }
-}
-#endif
-
 
 //
 //  Startup_Task: C
@@ -1152,14 +1126,6 @@ void Startup_Core(void)
 
     Assert_Basics();
     PG_Boot_Time = OS_DELTA_TIME(0);
-
-#ifndef NDEBUG
-    //
-    // This might call Debug_Str, which depends on StdIO, and must be called
-    // after Startup_StdIO()
-    //
-    Init_Break_Point();
-#endif
 
 //==//////////////////////////////////////////////////////////////////////==//
 //


### PR DESCRIPTION
This commit uses a clever mathematical trick to round up the tick
count to a consistent point, regardless of whether some amount of
additional processing is required in usermode to process a breakpoint
request or not.  The premise and method is explained here:

https://math.stackexchange.com/q/2521219/

A special function call (C-DEBUG-BREAK-AT/COMPENSATE) is run when the
usermode PARSE-based command-line processing is finished.  It takes an
upper bound on how many ticks may or may not have happened in order
to process the `--breakpoint` option.  The tick count is jumped ahead
according to a formula that can account for a variation of up to 1000
stray ticks.