### PR TITLE
5-second count for Ctrl-C to get console in erroring script

### DIFF
--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -412,7 +412,7 @@ host-start: function [
     ; that arise will be reported and result in exit code 1.
     ;
     instruction: copy [
-        [#quit-if-halt #quit-if-error]
+        [#quit-if-halt #countdown-if-error]
             |
     ]
 


### PR DESCRIPTION
When a script or `--do` is taken on the command line, it may error.
It might be interesting to examine the state of the interpreter, but
this would mean automated processes could not tell the difference
between a crashed script and one that is simply taking a long time.

This implements my suggestion that the default be to count down and
allow user interaction to bring up the console.  That interaction is
currently only able to be Ctrl-C, which doesn't seem so bad a choice
regardless.

More sophisticated command line switches could allow the time to be
adjusted from 5, or `--on-error=console` or `on-error=quit`, or even
to specify some kind of translation of the kind of error to a specific
error code.  This just does a proof of concept that the countdown is
possible (and not too much userspace code to do it)