### PR TITLE
TO-LOCAL-FILE/TO-REBOL-FILE as LOCAL-TO-FILE/FILE-TO-LOCAL

### DIFF
--- a/src/extensions/process/ext-process-init.reb
+++ b/src/extensions/process/ext-process-init.reb
@@ -23,7 +23,7 @@ browse*: procedure [
     ;
     for-each template get-os-browsers [
         command: replace/all (copy template) "%1" either file? location [
-            to-local-file location
+            file-to-local location
         ][
             location
         ]

--- a/src/extensions/view/ext-view-init.reb
+++ b/src/extensions/view/ext-view-init.reb
@@ -31,7 +31,7 @@ request-file: adapt :request-file* [
 request-dir: chain [
     adapt :request-dir* [
         if path [
-            dir: lib/replace/all to-local-file dir "/" "//"
+            dir: lib/replace/all file-to-local dir "/" "//"
         ]
     ]
         |

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -17,8 +17,8 @@ launch: func [
     /args arg [string! block! blank!] "Arguments to the script"
     /wait "Wait for the process to terminate"
 ][
-    if file? script [script: to-local-file clean-path script]
-    args: reduce [to-local-file system/options/boot script]
+    if file? script [script: file-to-local clean-path script]
+    args: reduce [file-to-local system/options/boot script]
     unless void? :arg [append args arg]
     either wait [call/wait args] [call args]
 ]

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -12,6 +12,9 @@ REBOL [
 ]
 
 
+file-to-local*: specialize 'file-to-local [only: true]
+local-to-file*: specialize 'local-to-file [only: true]
+
 clean-path: function [
     "Returns new directory path with `//` `.` and `..` processed."
     file [file! url! string!]
@@ -175,7 +178,7 @@ list-dir: procedure [
     switch type-of :path [
         _ [] ; Stay here
         :file! [change-dir path]
-        :string! [change-dir to-rebol-file path]
+        :string! [change-dir local-to-file path]
         :word! :path! [change-dir to-file path]
     ]
 
@@ -255,17 +258,17 @@ to-relative-file: function [
         "Convert to local-style filename if not"
 ][
     either string? file [ ; Local file
-        ; Note: to-local-file drops trailing / in R2, not in R3
-        ; if tmp: find/match file to-local-file what-dir [file: next tmp]
-        file: any [find/match file to-local-file what-dir | file]
+        ; Note: file-to-local drops trailing / in R2, not in R3
+        ; if tmp: find/match file file-to-local what-dir [file: next tmp]
+        file: any [find/match file file-to-local what-dir | file]
         if as-rebol [
-            file: to-rebol-file file
+            file: local-to-file file
             no-copy: true
         ]
     ][
         file: any [find/match file what-dir | file]
         if as-local [
-            file: to-local-file file
+            file: file-to-local file
             no-copy: true
         ]
     ]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -285,6 +285,21 @@ prin: procedure [
 ]
 
 
+to-rebol-file: func [dummy:] [
+    fail/where [
+        {TO-REBOL-FILE is now LOCAL-TO-FILE} |
+        {Take note it only accepts STRING! input and returns FILE!} |
+        {(unless you use LOCAL-TO-FILE*, which is a no-op on FILE!)}
+    ] 'dummy
+]
+
+to-local-file: func [dummy:] [
+    fail/where [
+        {TO-LOCAL-FILE is now FILE-TO-LOCAL} |
+        {Take note it only accepts FILE! input and returns STRING!} |
+        {(unless you use FILE-TO-LOCAL*, which is a no-op on STRING!)}
+    ] 'dummy
+]
 
 ; AJOIN is a kind of ugly name for making an unspaced string from a block.
 ; REFORM is nonsensical looking.  Ren-C has UNSPACED and SPACED.

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -67,7 +67,7 @@ secure: function [
     ][
         case [
             file? target [
-                val: to-local-file/full target
+                val: file-to-local/full target
                 ; This string must have OS-local encoding, because
                 ; the check is done at a lower level of I/O.
                 if system/version/4 != 3 [val: to binary! val]
@@ -144,7 +144,7 @@ secure: function [
                 block? pol [
                     for-each [item pol] pol [
                         if binary? item [item: to-string item] ; utf-8 decode
-                        if string? item [item: to-rebol-file item]
+                        if string? item [item: local-to-file item]
                         join out [item word-policy pol]
                     ]
                 ]

--- a/src/mezz/mezz-shell.r
+++ b/src/mezz/mezz-shell.r
@@ -28,7 +28,7 @@ cd: func [
     switch type-of :path [
         _ [print what-dir]
         :file! [change-dir path]
-        :string! [change-dir to-rebol-file path]
+        :string! [change-dir local-to-file path]
         :word! :path! [change-dir to-file path]
     ]
 ]
@@ -41,7 +41,7 @@ more: func [
     ; !!! to-word necessary as long as OPTIONS_DATATYPE_WORD_STRICT exists
     print deline to-string read switch to-word type-of :file [
         file! [file]
-        string! [to-rebol-file file]
+        string! [local-to-file file]
         word! path! [to-file file]
     ]
 ]

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -313,7 +313,7 @@ host-start: function [
         dir [string!]
     ][
         if empty? dir [return _]
-        dir: clean-path/dir to-rebol-file dir
+        dir: clean-path/dir local-to-file dir
         all [exists? dir | dir]
     ]
 
@@ -382,7 +382,7 @@ host-start: function [
             o/boot: exec-path
             take argv ;consume argv[0] anyway
         ][ ;-- on most systems, argv[0] is the exe path
-            o/boot: clean-path to-rebol-file take argv
+            o/boot: clean-path local-to-file take argv
         ]
         o/bin: first split-path o/boot
     ]
@@ -478,7 +478,7 @@ host-start: function [
             )
         |
             "--import" end (
-                lib/import to-rebol-file param-or-die "IMPORT"
+                lib/import local-to-file param-or-die "IMPORT"
             )
         |
             ["--quiet" | "-q"] end (
@@ -538,7 +538,7 @@ host-start: function [
             )
         |
             "--script" end (
-                o/script: to-rebol-file param-or-die "SCRIPT"
+                o/script: local-to-file param-or-die "SCRIPT"
                 quit-when-done: default [true] ;-- overrides blank, not false
             )
         |
@@ -601,7 +601,7 @@ host-start: function [
     ; the first item after the options is implicitly the script.
     ;
     if all [not o/script | not tail? argv] [
-        o/script: to-rebol-file take argv
+        o/script: local-to-file take argv
         quit-when-done: default [true]
     ]
 

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -4,6 +4,14 @@ do %common.r
 do %systems.r
 file-base: make object! load %file-base.r
 
+; !!! Since %rebmake.r is a module, it presents a challenge for the "shim"
+; code when it depends on a change.  This needs to be addressed in a generic
+; way, but that requires foundational work on modules.
+;
+append lib compose [
+    file-to-local-hack: (:file-to-local)
+    local-to-file-hack: (:local-to-file)
+]
 rebmake: import %rebmake.r
 
 config-dir: %../../make

--- a/src/tools/r2r3-future.r
+++ b/src/tools/r2r3-future.r
@@ -49,6 +49,14 @@ if :choose = () [
     ]
 ]
 
+; Renamed, tightened, and extended with new features (add /ONLY feature?)
+;
+if :file-to-local = () [
+    file-to-local: :to-local-file
+    local-to-file: :to-rebol-file
+]
+
+
 if true = attempt [void? :some-undefined-thing] [
     ;
     ; THEN and ELSE use a mechanic (non-tight infix evaluation) that is simply
@@ -168,7 +176,6 @@ any-value?: func [item [<opt> any-value!]] [not void? :item]
 ;
 any-context!: :any-object!
 any-context?: :any-object?
-
 
 set?: func [
     "Returns whether a bound word has a value (fails if unbound)"

--- a/tests/run-recover.r
+++ b/tests/run-recover.r
@@ -33,7 +33,7 @@ do-core-tests: procedure [] [
         ]
         string? system/script/args [
             interpreter-checksum: checksum/method read-binary
-                to-rebol-file system/script/args 'sha1
+                local-to-file system/script/args 'sha1
         ]
     ] else [
         ; use system/build

--- a/tests/run-tests.r
+++ b/tests/run-tests.r
@@ -35,4 +35,4 @@ run-tests: function [tests] [
     set [log-file: summary:] do-recover tests [] blank log-file-prefix
 ]
 
-run-tests to-rebol-file first system/options/args
+run-tests local-to-file first system/options/args


### PR DESCRIPTION
Rebol wants to standardize FILE! literals to speak in the forward-slash
format.  So `%\foo\bar` gets turned into `%/foo/bar`.

(Arguably, it should complain about the literal form and refuse to
LOAD it instead of losing information)

This tightens the data types such that LOCAL-TO-FILE takes a STRING!
and returns a FILE!, and FILE-TO-LOCAL takes a FILE! and returns a
STRING!.  Another feature added is the /ONLY flag, which permits
pass-thru of an already converted quantity.  So if LOCAL-TO-FILE/ONLY
gets a FILE! as input, it won't error but will return a copy of that
FILE! instead.

(Note: It would be possible to subvert and get re-conversion on a FILE!
by saying AS STRING! MY-FILE, but that would defeat the purpose of
using the datatype to distinguish converted vs. non-converted values.)