### PR TITLE
ENCLOSE call to "inner" function in an "outer" function

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -97,7 +97,6 @@ Script: [
     multiple-do-errors: [{DO-ALL encountered multiple failures} :arg1 :arg2]
 
     apply-too-many:     {Too many values in processed argument block of APPLY.}
-    apply-non-function: [:arg1 {needs to be a function for APPLY/SPECIALIZE}]
 
     invalid-tighten:    {TIGHTEN does not support SPECIALIZE/ADAPT/CHAIN}
     print-needs-eval:   {PRINT needs /EVAL to process non-literal blocks}

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -258,6 +258,15 @@ standard: construct [] [
             _
     ]
 
+    enclosed-meta: construct [] [
+        description:
+        inner:
+        inner-name:
+        outer:
+        outer-name:
+            _
+    ]
+
     chained-meta: construct [] [
         description:
         chainees:

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1520,7 +1520,8 @@ reevaluate:;
             DECLARE_LOCAL (fun);
             Move_Value(fun, DS_TOP);
 
-            if (Apply_Only_Throws(f->out, TRUE, fun, &f->cell, END)) {
+            const REBOOL fully = TRUE;
+            if (Apply_Only_Throws(f->out, fully, fun, &f->cell, END)) {
                 Abort_Function(f);
                 goto finished;
             }

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -483,7 +483,7 @@ repush:
 //  {Invoke a function with all required arguments specified.}
 //
 //      return: [<opt> any-value!]
-//      value [function! any-word! any-path!]
+//      applicand [function! any-word! any-path!]
 //          {Function or specifying word (preserves word name for debug info)}
 //      def [block!]
 //          {Frame definition block (will be bound and evaluated)}
@@ -493,24 +493,20 @@ REBNATIVE(apply)
 {
     INCLUDE_PARAMS_OF_APPLY;
 
-    REBVAL *def = ARG(def);
+    REBVAL *applicand = ARG(applicand);
 
-    // We don't limit to taking a FUNCTION! value directly, because that loses
-    // the symbol (for debugging, errors, etc.)  If caller passes a WORD!
-    // then we lookup the variable to get the function, but save the symbol.
-    //
     REBSTR *opt_label;
-    Get_If_Word_Or_Path_Arg(D_OUT, &opt_label, ARG(value));
-
+    Get_If_Word_Or_Path_Arg(D_OUT, &opt_label, applicand);
     if (!IS_FUNCTION(D_OUT))
-        fail (Error_Apply_Non_Function_Raw(ARG(value))); // for SPECIALIZE too
+        fail (applicand);
+    Move_Value(applicand, D_OUT);
 
     return Apply_Def_Or_Exemplar(
         D_OUT,
-        VAL_FUNC(D_OUT),
-        VAL_BINDING(D_OUT),
+        VAL_FUNC(applicand),
+        VAL_BINDING(applicand),
         opt_label,
-        NOD(def)
+        NOD(ARG(def))
     );
 }
 

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -141,6 +141,7 @@
 %functions/adapt.test.reb
 %functions/apply.test.reb
 %functions/chain.test.reb
+%functions/enclose.test.reb
 %functions/hijack.test.reb
 %functions/specialize.test.reb
 %math/absolute.test.reb

--- a/tests/functions/enclose.test.reb
+++ b/tests/functions/enclose.test.reb
@@ -1,0 +1,22 @@
+; better-than-nothing ENCLOSE tests
+
+[
+    e-multiply: enclose 'multiply function [f [frame!]] [
+        diff: abs (f/value1 - f/value2)
+        result: do f
+        return result + diff
+    ]
+
+    73 = e-multiply 7 10
+][
+    n-add: enclose 'add function [f [frame!]] [
+        if 10 = f/value1 [return blank]
+        f/value1: 5 
+        do f
+    ]
+
+    all? [
+        blank? n-add 10 20
+        25 = n-add 20 20 
+    ]
+]


### PR DESCRIPTION
This adds a new function generator called ENCLOSE.  It is similar to
a combination of ADAPT and CHAIN, but is strictly more powerful than
both (alone or combined).

ENCLOSE takes an outer function and an inner function.  The outer
function should be single-arity, and accept a fulfilled frame for
invoking the inner function (which it does with DO, as DO on a FRAME!
knows what function that frame is for).

This allows code to be run both before and after the wrapped function's
execution--as well as mutations to the wrapped function's frame before
running (similar to ADAPT).  But it can also carry state across the
execution and use it to mutate the result (whereas CHAIN has to be
a pure function of the output of the previous function in the chain)

Imagine you want a hooked version of multiply that always adds the
difference of the arguments to the result:

    >> e-multiply: enclose 'multiply function [f [frame!]] [
        diff: abs (f/value1 - f/value2)
        result: do f
        return result + diff
    ]

    >> e-multiply 7 10
    == 73

Here's mutating the frame before invocation, and choosing not to pick
a moment to run the DO at all:

    >> n-print: enclose 'print procedure [f [frame!]] [
        if #"n" = first f/value [leave]
        f/value: reverse copy f/value
        do f
    ]

    >> n-print "fun with ENCLOSE"
    ESOLCNE htiw nuf

    >> n-print "not printing because starts with n"
    ;-- no result

Since ENCLOSE needs to take a single argument, it needs to be a
FUNCTION! that takes a FRAME!...vs the convenience of a BLOCK! like
ADAPT that receives bindings for the frame.  However, IN can be used to
smooth over the problem (but less efficiently than using ADAPT):

    >> n-print: enclose 'print procedure [f [frame!]] [
        do in f [
           if #"n" = first value [leave]
           value: reverse copy value
           do f
        ]
    ]