### PR TITLE
Tail-Call recursions via REDO primitive

### DIFF
--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -143,6 +143,7 @@
 %functions/chain.test.reb
 %functions/enclose.test.reb
 %functions/hijack.test.reb
+%functions/redo.test.reb
 %functions/specialize.test.reb
 %math/absolute.test.reb
 %math/add.test.reb

--- a/tests/functions/redo.test.reb
+++ b/tests/functions/redo.test.reb
@@ -1,0 +1,120 @@
+; Better-than-nothing REDO tests
+
+; REDO via a direct FRAME! value
+[
+    foo: func [n] [
+        frame: context-of 'n
+        if n = 0 [
+            return "success!" 
+        ]
+        n: n - 1 
+        redo frame
+    ]
+
+    "success!" = foo 100
+]
+
+; REDO via extraction of FRAME! from an ANY-WORD!
+; (has binding to a FRAME! to lookup variable value)
+[
+    foo: func [n] [
+        if n = 0 [
+           return "success!"
+        ]
+        n: n - 1
+        redo 'n
+    ]
+
+    "success!" = foo 100
+]
+
+; REDO via information in definitional RETURN
+; (has binding to a FRAME! to know where to return from)
+[
+    foo: func [n] [
+        if n = 0 [
+            return "success!"
+        ]
+        n: n - 1
+        redo :return
+    ]
+
+    "success!" = foo 100
+]
+
+; REDO locals clearing test
+; (locals should be cleared on each redo)
+[
+    foo: func [n <local> unset-me] [
+        if set? 'unset-me [
+            return "failure"
+        ]
+        if n = 0 [
+            return "success!"
+        ]
+        n: n - 1
+        unset-me: #some-junk
+        redo :return
+    ]
+
+    "success!" = foo 100
+]
+
+; REDO type checking test
+; (args and refinements must pass function's type checking)
+[
+    foo: func [n tag [tag!]] [
+        if n = 0 [
+            return "success!"
+        ]
+        n: n - 1
+        tag: #some-junk ;-- type check should fail on redo 
+        redo :return
+    ]
+
+    error? trap [foo 100]
+] 
+
+; REDO phase test
+; (shared frame compositions should redo the appropriate "phase")
+[
+    inner: func [n] [
+        if n = 0 [
+            return "success!"
+        ]
+        n: 0
+        redo 'n ;-- should redo INNER, not outer
+    ]
+
+    outer: adapt 'inner [
+        if n = 0 [
+            return "failure"
+        ]
+        ;-- fall through to inner, using same frame
+    ]
+
+    "success!" = outer 1
+][
+    inner: func [n /captured-frame f] [
+        if n = 0 [
+           return "failure"
+        ]
+        n: 0
+        redo f ;-- should redo OUTER, not INNER
+    ]
+
+    outer: adapt 'inner [
+        if n = 0 [
+            return "success!"
+        ]
+
+        f: context-of 'n
+        captured-frame: true
+
+        ;-- fall through to inner
+        ;-- it is running in the same frame's memory, but...
+        ;-- F is a FRAME! value that stowed outer's "phase"
+    ]
+
+    "success!" = outer 1
+]


### PR DESCRIPTION
REDO is a function that takes a running FRAME! (or a means of finding
a running FRAME!--such as a WORD! of a local variable, or FUNCTION!
representing a definitional return) and causes it to restart the
function with its current state--without creating another stack frame.

This allows one to program in a style similar to recursion, but
without running the risk of stack overflows.  Consider this recursive
function definition:

    foo: func [n /accum a] [
       case [
           not accum [a: 0]
           n = 0 [return a]
       ]
       foo/accum (n - 1) (a + 2)
    ]

For small initial values of n, such as `foo 1000`, this works fine and
gives back 2000.  But even just `foo 10000` causes a stack overflow.

Using REDO, the function can be implemented in a similar style but
with only one stack frame:

    foo: func [n /accum a] [
        case [
           not accum [a: 0 | accum: true]
           n = 0 [return a]
        ]
        frame: context-of 'n
        n: n - 1
        a: a + 2
        redo frame
    ]

Even if you do `foo 1000000`, only a single stack frame will be used.
Each REDO will leave the arguments and refinements as they were, but
locals are cleared and types are re-checked.

The cleanest way to express a redo is probably to REDO :RETURN the
definitional return for a function.  It could also be a refinement
to the definitional return e.g. RETURN/REDO, however since RETURN
takes an argument to return that would be necessarily discarded.
This makes REDO :RETURN a fairly decent idiom.

    foo: func [n /accum a] [
        case [
           not accum [a: 0 | accum: true]
           n = 0 [return a]
        ]
        n: n - 1
        a: a + 2
        redo :return
    ]