### PR TITLE
Allow "Sibling Tail Calls" via REDO/OTHER

### DIFF
--- a/tests/functions/redo.test.reb
+++ b/tests/functions/redo.test.reb
@@ -28,48 +28,34 @@
     "success!" = foo 100
 ]
 
-; REDO via information in definitional RETURN
-; (has binding to a FRAME! to know where to return from)
-[
-    foo: func [n] [
-        if n = 0 [
-            return "success!"
-        ]
-        n: n - 1
-        redo :return
-    ]
-
-    "success!" = foo 100
-]
-
 ; REDO locals clearing test
 ; (locals should be cleared on each redo)
 [
     foo: func [n <local> unset-me] [
         if set? 'unset-me [
-            return "failure"
+            return "local not cleared"
         ]
         if n = 0 [
-            return "success!"
+            return <success>
         ]
         n: n - 1
         unset-me: #some-junk
-        redo :return
+        redo 'return
     ]
 
-    "success!" = foo 100
+    <success> = foo 100
 ]
 
 ; REDO type checking test
 ; (args and refinements must pass function's type checking)
 [
-    foo: func [n tag [tag!]] [
+    foo: func [n i [integer!]] [
         if n = 0 [
-            return "success!"
+            return <success> ;-- impossible for this case
         ]
         n: n - 1
-        tag: #some-junk ;-- type check should fail on redo 
-        redo :return
+        i: #some-junk ;-- type check should fail on redo 
+        redo 'return
     ]
 
     error? trap [foo 100]
@@ -80,7 +66,7 @@
 [
     inner: func [n] [
         if n = 0 [
-            return "success!"
+            return <success>
         ]
         n: 0
         redo 'n ;-- should redo INNER, not outer
@@ -88,16 +74,16 @@
 
     outer: adapt 'inner [
         if n = 0 [
-            return "failure"
+            return "outer phase run by redo"
         ]
         ;-- fall through to inner, using same frame
     ]
 
-    "success!" = outer 1
+    <success> = outer 1
 ][
     inner: func [n /captured-frame f] [
         if n = 0 [
-           return "failure"
+           return "inner phase run by redo"
         ]
         n: 0
         redo f ;-- should redo OUTER, not INNER
@@ -105,7 +91,7 @@
 
     outer: adapt 'inner [
         if n = 0 [
-            return "success!"
+            return <success>
         ]
 
         f: context-of 'n
@@ -116,5 +102,91 @@
         ;-- F is a FRAME! value that stowed outer's "phase"
     ]
 
-    "success!" = outer 1
+    <success> = outer 1
+]
+
+; "Sibling" tail-call with compatible function
+;
+; (CHAINs are compatible with functions at head of CHAIN
+;  ADAPTs are compatible with functions they adapt
+;  SPECIALIZEs are compatible with functions they specialize...etc.)
+;
+; If LOG is set to PRINT the following will output:
+;
+;        C: n = 11 delta = 0
+;        S: n = 11 delta = 10
+;     BASE: n = 11 delta = 10
+;        C: n = 1 delta = 10
+;        S: n = 1 delta = 10
+;     BASE: n = 10 delta = 10
+;
+; C is called and captures its frame into F.  Then it uses REDO/OTHER to
+; reuse the frame to call S.  S gets the variables and args that its knows
+; about as C left them--such as N and a captured frame F--but values it takes
+; for granted are reset, which includes specialized delta of 10.
+;
+; (The need to reset specializations for consistency is similar to how locals
+; must be reset--they're not part of the interface of the function, so to
+; reach beneath them does something illegal in terms of parameterization.)
+;
+; S doesn't have any effect besides resetting delta, so it falls through as
+; an adaptation to the base function.  BASE subtracts DELTA from N to get 1,
+; which isn't an exit condition.  The F frame which was set in C and was
+; preserved as an argument to S is then used by BASE to REDO and get back
+; up to the start of C again.
+;
+; Once again C captures its frame and does a REDO to start up S, which now
+; notices that N is 1 so it bumps it up to 10.  (It cannot set DELTA to 1,
+; because as a specialized argument DELTA is not visible to it.)  This time
+; when it falls through to BASE, the subtraction of DELTA from N yields
+; zero so that BASE returns completion.
+;
+; Since the function we originally called and built a frame for was a CHAIN,
+; the REDO is effectively REDO-finishing the frame for the adaptation of
+; BASE that sits at the head of the frame.  That delegation has now finished
+; bouncing around on that single frame and come to a completion, which means
+; the chained functions will get that result.  The string is translated to
+; a tag and signals success.
+[
+    log: :comment ;-- change to :PRINT to see what's going on
+
+    base: func [n delta /captured-frame f [frame!]] [
+        log [{BASE: n =} n {delta =} delta]
+        
+        n: n - delta
+        if n < 0 [return "base less than zero"]
+        if n = 0 [return "base done"]
+        if captured-frame [redo f]
+        return "base got no frame"
+    ]
+
+    c: chain [
+        adapt 'base [
+           log [{   C: n =} n {delta =} delta]
+           
+           f: context-of 'n
+           captured-frame: true
+           redo/other 'n :s
+
+           ;-- fall through to base
+        ]
+            |
+        func [x] [
+            if x = "base done" [
+                <success>
+            ] else [
+                spaced ["base exited with" x]
+            ]
+        ]
+    ]
+
+    s: specialize adapt 'base [
+        log [{   S: n =} n {delta =} delta]
+
+        if n = 1 [n: 10]
+    ][
+        delta: 10
+    ]
+
+    <success> = c 11 0
 ]


### PR DESCRIPTION
Ren-C has a sophisticated model of frame reuse in function composition.
Functions like ADAPT and SPECIALIZE are able to reuse a frame, as
opposed to adding layers to the call stack.  This makes them similar
in nature to tail-calls.

The original conception of REDO was that the only functions you could
REDO would be ones that were part of the current composition.  By
definition, those functions all have a compatible frame layout.  Yet
it's also possible for frames to be compatible when they are not
part of the same composition.  e.g. two distinct adaptations of the
same underlying function both have frames compatible with the
underlying function, hence also with each other.

The idea of doing a tail call optimization which jumps to the top of
another function is called a "sibling tail call".  This commit lets
one do such calls for any frame-compatible FUNCTION! with the frame
(or implied frame) from the first parameter to REDO.

One mechanical aspect of making this work (which was an oversight in
the previous REDO commit) is that if the jump is to a function with
specializations in an exemplar frame, those specializations must be
reset.  Essentially, a REDO or REDO/OTHER should not be able to do
anything a recursion could not--that means no injection of locals, and
no bypassing expected specialization state.

As an additional change in this commit, the REDO :RETURN idiom is
deprecated in favor of REDO 'RETURN, due to issues of efficiency.
(:RETURN must run a GET to fetch the FUNCTION! and then read the
binding property, whereas there is no real evaluation of a LIT-WORD!
'RETURN beyond changing its type in the header, and its binding can
be extracted directly.