### PR TITLE
Invisible mechanic: COMMENT mostly invisible, ELIDE fully so

### DIFF
--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -305,10 +305,13 @@ void Do_Core_Expression_Checks_Debug(REBFRM *f) {
 
     // The only thing the evaluator can take for granted between evaluations
     // about the output cell is that it's not trash.  In the debug build,
-    // give this more teeth by explicitly setting it to an unreadable blank.
+    // give this more teeth by explicitly setting it to an unreadable blank,
+    // but only if it wasn't an END marker (that's how we can tell no
+    // evaluations have been done yet, consider `(comment [...] + 2)`)
     //
     assert(NOT(IS_TRASH_DEBUG(f->out)));
-    Init_Unreadable_Blank(f->out);
+    if (NOT(IS_UNREADABLE_IF_DEBUG(f->out)) && NOT_END(f->out))
+        Init_Unreadable_Blank(f->out);
 
     // Once a throw is started, no new expressions may be evaluated until
     // that throw gets handled.

--- a/src/core/d-stats.c
+++ b/src/core/d-stats.c
@@ -368,6 +368,9 @@ REB_R Apply_Core_Measured(REBFRM * const f)
         case R_REEVALUATE_CELL_ONLY:
             break;
 
+        case R_INVISIBLE:
+            break;
+
         case R_UNHANDLED: // internal use only, shouldn't be returned
             assert(FALSE);
 

--- a/src/core/d-trace.c
+++ b/src/core/d-trace.c
@@ -357,6 +357,11 @@ REB_R Apply_Core_Traced(REBFRM * const f)
             Debug_Fmt("..."); // it's EVAL/ONLY, should we print f->out ?
             break;
 
+        case R_INVISIBLE:
+            // !!! It's really absolutely nothing, so print nothing?
+            Debug_Fmt("\n");
+            break;
+
         case R_UNHANDLED: // internal use only, shouldn't be returned
             assert(FALSE);
 

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -614,26 +614,3 @@ REBNATIVE(also)
     Move_Value(D_OUT, ARG(returned));
     return R_OUT;
 }
-
-
-//
-//  comment: native [
-//
-//  {Ignores the argument value.}
-//
-//      return: [<opt>]
-//          {Nothing.}
-//      :value [block! any-string! binary! any-scalar!]
-//          "Literal value to be ignored."
-//  ]
-//
-REBNATIVE(comment)
-{
-    INCLUDE_PARAMS_OF_COMMENT;
-
-    // All the work was already done (at the cost of setting up
-    // state that would just have to be torn down).
-
-    UNUSED(PAR(value)); // avoid unused variable warning
-    return R_VOID;
-}

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -116,6 +116,11 @@ enum Reb_Result {
     R_REEVALUATE_CELL,
     R_REEVALUATE_CELL_ONLY,
 
+    // See FUNC_FLAG_INVISIBLE...this is what any function with that flag
+    // needs to return.
+    //
+    R_INVISIBLE,
+
     // This is a signal that isn't accepted as a return value from a native,
     // so it can be used by common routines that return REB_R values and need
     // an "escape" code.

--- a/src/include/sys-function.h
+++ b/src/include/sys-function.h
@@ -219,6 +219,17 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
 //
 #define FUNC_FLAG_UNLOADABLE_NATIVE FUNC_FLAG(5)
 
+// An "invisible" function is one that does not touch its frame output cell,
+// leaving it completely alone.  This is how `10 comment ["hi"] + 20` can
+// work...if COMMENT destroyed the 10 in the output cell it would be lost and
+// the addition could no longer work.
+//
+// !!! One property considered for invisible items was if they might not be
+// quoted in soft-quoted positions.  This would require fetching something
+// that might not otherwise need to be fetched, to test the flag.  Review.
+//
+#define FUNC_FLAG_INVISIBLE FUNC_FLAG(6)
+
 #if !defined(NDEBUG)
     //
     // If a function is a native then it may provide return information as
@@ -227,13 +238,14 @@ inline static REBRIN *FUNC_ROUTINE(REBFUN *f) {
     // to double-check.  So when MKF_FAKE_RETURN is used in a debug build,
     // it leaves this flag on the function.
     //
-    #define FUNC_FLAG_RETURN_DEBUG FUNC_FLAG(6)
+    #define FUNC_FLAG_RETURN_DEBUG FUNC_FLAG(7)
 #endif
 
 // These are the flags which are scanned for and set during Make_Function
 //
 #define FUNC_FLAG_CACHED_MASK \
-    (FUNC_FLAG_DEFERS_LOOKBACK | FUNC_FLAG_QUOTES_FIRST_ARG)
+    (FUNC_FLAG_DEFERS_LOOKBACK | FUNC_FLAG_QUOTES_FIRST_ARG \
+        | FUNC_FLAG_INVISIBLE)
 
 
 inline static REBFUN *VAL_FUNC(const RELVAL *v) {

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -28,6 +28,35 @@ REBOL [
 blank: _
 bar: '|
 
+; Because it has `return: []`, a comment is effectively "invisible".  Internal
+; optimizations make it so COMMENT doesn't need to be a native...the empty
+; body triggers an "eliding noop dispatcher".  To avoid looking deceptive,
+; you can only comment out inert types (e.g. no `comment (print "hi")`)
+;
+comment: func [
+    {Ignores the argument value, but does no evaluation (see also ELIDE).}
+
+    return: []
+        {The evaluator will skip over the result (not seen, not even void)}
+    :value [block! any-string! binary! any-scalar!]
+        "Literal value to be ignored."
+][
+    ; no body
+]
+
+set/enfix quote elide: func [
+    {Argument is evaluative, but discarded (see also COMMENT).}
+
+    return: []
+        {The evaluator will skip over the result (not seen, not even void)}
+    #returned [<opt> <end> any-value!]
+        {By protocol of `return: []`, this is the return value when enfixed}
+    #discarded [<opt> any-value!]
+        {Evaluative argument, tight semantics (so `1 elide "hi" + 2` works)}
+][
+    ; no body
+]
+
 ; Despite being very "noun-like", HEAD and TAIL have classically been "verbs"
 ; in Rebol.  Ren-C builds on the concept of REFLECT, so that REFLECT STR 'HEAD
 ; will get the head of a string.  An enfix left-soft-quoting operation is

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -96,8 +96,11 @@ dump-obj: function [
 ]
 
 
-dump: proc [
+dump: func [
     {Show the name of a value (or block of expressions) with the value itself}
+
+    return: []
+        {Doesn't return anything, not even void (so like a COMMENT)}
     :value [any-value! <...>]
     <local>
         dump-one dump-val clip-string item set-word result

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -143,6 +143,7 @@
 %functions/chain.test.reb
 %functions/enclose.test.reb
 %functions/hijack.test.reb
+%functions/invisible.test.reb
 %functions/redo.test.reb
 %functions/specialize.test.reb
 %math/absolute.test.reb

--- a/tests/functions/invisible.test.reb
+++ b/tests/functions/invisible.test.reb
@@ -1,0 +1,87 @@
+; COMMENT is *mostly* invisible, but interrupts evaluator order for simplicity
+; https://trello.com/c/dWQnsspG
+
+[
+    1 = do [comment "a" 1]
+][
+    1 = do [1 comment "a"]
+][
+    () = do [comment "a"]
+]
+
+[
+    pos: _
+    do/next [1 + comment "a" comment "b" 2 * 3 fail "didn't stop"] 'pos
+    pos = [fail "didn't stop"]
+][
+    pos: _
+    val: do/next [1 comment "a" + comment "b" 2 * 3 fail "didn't stop"] 'pos
+    all? [
+        val = 1
+        pos = [+ comment "b" 2 * 3 fail "didn't stop"]
+    ]
+][
+    pos: _
+    val: do/next [1 comment "a" comment "b" + 2 * 3 fail "didn't stop"] 'pos
+    all? [
+        val = 1
+        pos = [+ 2 * 3 fail "didn't stop"] 'pos
+    ]
+]
+
+; ELIDE is fully invisible, but slaved to the evaluator order
+; https://trello.com/c/snnG8xwW
+
+[
+    1 = do [elide "a" 1]
+][
+    1 = do [1 elide "a"]
+][
+    () = do [elide "a"]
+]
+
+[
+    pos: _
+    do/next [1 + comment "a" comment "b" 2 * 3 fail "didn't stop"] 'pos
+    pos = [fail "didn't stop"]
+][
+    pos: _
+    do/next [1 elide "a" + elide "b" 2 * 3 fail "didn't stop"] 'pos
+    pos = [fail "didn't stop"]
+][
+    pos: _
+    do/next [1 elide "a" elide "b" + 2 * 3 fail "didn't stop"] 'pos
+    pos = [fail "didn't stop"]
+]
+
+[
+    unset 'x
+    x: 1 + 2 * 3 elide (y: :x)
+    all? [
+        x = 9
+        not set? 'y
+    ]
+][
+    unset 'x
+    x: 1 + elide (y: 10) 2 * 3
+    all? [
+        x = 9
+        y = 10
+    ]
+]
+
+[
+    unset 'x
+    unset 'y
+    unset 'z
+
+    x: 10
+    y: 1 elide [+ 2
+    z: 30] + 7
+
+    all? [
+        x = 10
+        y = 8
+        not set? 'z
+    ]
+]


### PR DESCRIPTION
This introduces two new categories of "invisible" functions.  They are
designed to return nothing--not even void.

The way to say how a function is in this category in the moment is to
give it a `return: []` in its spec, to say the null set (even excluding
`<opt>` for void) is what it can return.  This means it will do its
best to omit any influence from the chain of evaluator (outside running
the body of the function itself).

Category #1 is when the function is not enfix.  This simplification
will attempt to complete the left-hand side of an expression before
running.  This gives a mostly-intuitive order of evaluation, as shown
by the DUMP debug primitive--which has been changed to be invisible:

    >> x: 10
    >> y: 20
    >> z: 1 + 2 * 3 dump [z y x]

    z: => 9
    y: => 20
    x: => 10
    == 9

The cost of such a model is that it can't be truly invisible, since
it has intruded on what the evaluative order would have been as seen
by any enfix operations on their right.  e.g. forcing (print 1) to
complete below means the 1 is no longer available for the (1 + 2)
that would happen if the comment weren't there:

    >> print 1 comment "hi" + 2
    ** Script Error: + requires value1 argument to not be void

Category #2 is achieved by making such a function enfix.  By convention
it will retain the state of the frame's output cell, instead of
erasing it after extracting into the left hand parameter slot of the
function.  This gives that function access to the state being passed
through it--as well as allowing the evaluator to retain enough of its
internal state to make it "fully invisible" regarding characteristics
not exposed (such as: there is no END! datatype to pass through to
write an `<end> status on the output).

A basic operator which provides commenting and evaluation in this
model is provided called ELIDE.  It can be used to erase any code if
passed a BLOCK!

    x: 10
    y: 1 elide [+ 2
    z: 30] + 7

It can also be passed a GROUP!, but the order of evaluation may be
surprising due to its tight-enfixing character.  For instance, the
ELIDE below must be done at the moment of evaluation of the 2, not
deferred after `y: 1 + 2` has all been completed:

    >> y: 1 + 2 elide (print y)
    ** Script error: y has no value

(Note: This commit includes clarifying code rearrangements which
involved changing indentation levels, so it appears larger than it is.)