### PR TITLE
Primordial "DON'T" primitive for neutral evaluation analysis

### DIFF
--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -216,13 +216,24 @@
     FLAGIT_LEFT(12)
 
 
+//=//// DO_FLAG_NEUTRAL ///////////////////////////////////////////////////=//
+//
+// !!! Experimental feature puts the evaluator into neutral and throws up
+// the stack in the case that it cannot skip without actually having side
+// effects.  It will be a trick to do efficiently, but for starters doing it
+// at all would be interesting.
+//
+#define DO_FLAG_NEUTRAL \
+    FLAGIT_LEFT(13)
+
+
 // Currently the rightmost two bytes of the Reb_Frame->flags are not used,
 // so the flags could theoretically go up to 31.  It could hold something
 // like the ->eval_type, but performance is probably better to put such
 // information in a platform aligned position of the frame.
 //
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
-    static_assert(12 < 32, "DO_FLAG_XXX too high");
+    static_assert(13 < 32, "DO_FLAG_XXX too high");
 #endif
 
 

--- a/src/include/sys-varargs.h
+++ b/src/include/sys-varargs.h
@@ -56,7 +56,7 @@
 
 inline static REBOOL Is_Block_Style_Varargs(
     REBVAL **shared_out,
-    RELVAL *vararg
+    const RELVAL *vararg
 ){
     assert(IS_VARARGS(vararg));
 
@@ -85,7 +85,7 @@ inline static REBOOL Is_Block_Style_Varargs(
 
 inline static REBOOL Is_Frame_Style_Varargs_May_Fail(
     REBFRM **f,
-    RELVAL *vararg
+    const RELVAL *vararg
 ){
     assert(IS_VARARGS(vararg));
 

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -77,7 +77,8 @@ to-c-name: function [
             ; shorthand; e.g. `foo?` => `foo_q`
 
             for-each [reb c] [
-                -   "_"
+              #"'"  ""      ; isn't => isnt, don't => dont 
+                -   "_"     ; foo-bar => foo_bar
                 *   "_p"    ; !!! because it symbolizes a (p)ointer in C??
                 .   "_"     ; !!! same as hyphen?
                 ?   "_q"    ; (q)uestion

--- a/tests/control/dont.test.reb
+++ b/tests/control/dont.test.reb
@@ -1,0 +1,53 @@
+; DON'T is an experimental exposure of a "neutral" form of DO, which will
+; only return whether or not the position of the end of the evaluation can
+; be reliably determined.  It cannot handle variadic functions (including
+; EVAL, which is effectively variadic)
+;
+; These are some relatively basic tests, but much better would be to run
+; the "idle" evaluator in parallel against the non-idle evaluator and make
+; sure they stay in alignment, as a comprehensive debug mode.
+
+[
+    pos: _
+    all? [
+        don't []
+        don't/next [] 'pos
+        pos = []
+    ]
+]
+
+[
+    success: true 
+    all? [
+        don't [success: false (success: false) :abs set 'success <bad>]
+        success = true
+    ]
+][
+    pos: _
+    success: true
+    code: [success: 1 + 2 (success: false) :abs set 'success <bad>]
+    all? [
+        don't code
+        don't/next code 'pos 
+        pos = [(success: false) :abs set 'success <bad>]
+        don't/next pos 'pos
+        pos = [:abs set 'success <bad>]
+        don't/next pos 'pos
+        pos = [set 'success <bad>]
+        don't/next pos 'pos
+        pos = []
+        don't/next pos 'pos
+        pos = []
+        success = true 
+    ]
+]
+
+[
+    false = don't [eval :abs -1] ;-- EVAL is effectively variadic
+]
+
+[
+    true = don't [throw 10]
+][
+    true = don't [return 20]
+]

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -101,6 +101,7 @@
 %control/default.test.reb
 %control/disarm.test.reb
 %control/do.test.reb
+%control/dont.test.reb
 %control/either.test.reb
 %control/else.test.reb
 %control/exit.test.reb


### PR DESCRIPTION
This is a very early-stage implementation of a primitive called DON'T.
Its goal is to be able to answer whether expressions have a knowable
arity (e.g. do not have variadic character) and thus can be skipped
over safely.

It uses a new evaluator flag DO_FLAG_NEUTRAL which is supposed to tell
all expressions that could have side effects not to have them.  (This
isn't working perfectly yet, e.g. GROUP!s inside of PATH!s currently
still evaluate--but fixing that likely will involve eliminating the
specialized REBPVS path-value-state structure and merging path dispatch
with REBFRM for frames.)

Since there's no value to return, DON'T returns either TRUE or FALSE.
If FALSE, that means there was some variadic element which inhibited
the ability of it to determine the expression evaluation positions.

Example from testing:

    pos: _
    success: true
    code: [success: 1 + 2 (success: false) :abs set 'success <bad>]
    all? [
        don't code
        don't/next code 'pos
        pos = [(success: false) :abs set 'success <bad>]
        don't/next pos 'pos
        pos = [:abs set 'success <bad>]
        don't/next pos 'pos
        pos = [set 'success <bad>]
        don't/next pos 'pos
        pos = []
        don't/next pos 'pos
        pos = []
        success = true ;-- not affected despite evaluation scanning
    ]