### PR TITLE
Advancements in FILE OF and LINE OF, including for FUNCTION!

### DIFF
--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -75,7 +75,12 @@ rebol
 
 system
 
-;reflectors:
+; REFLECTORS
+;
+; These words are used for things like REFLECT SOME-FUNCTION 'BODY, which then
+; has a convenience wrapper which is infix and doesn't need a quote, as OF.
+; (e.g. BODY OF SOME-FUNCTION)
+;
 index
 xy ;-- !!! There was an INDEX?/XY, which is an XY reflector for the time being 
 length
@@ -92,6 +97,9 @@ values
 types
 title
 context
+file
+line
+function
 
 value ; used by TYPECHECKER to name the argument of the generated function
 
@@ -123,7 +131,7 @@ memory
 debug
 browse
 extension
-file
+;file -- already provided for FILE OF
 dir
 
 ; Time:

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1323,7 +1323,7 @@ void RL_rebPanic(const void *p)
     // Like Panic_Core, the underlying API for rebPanic might want to take an
     // optional file and line.
     //
-    REBYTE *file_utf8 = NULL;
+    char *file = NULL;
     int line = 0;
 
     // !!! Should there be a special bit or dispatcher used on the PANIC and
@@ -1368,7 +1368,7 @@ void RL_rebPanic(const void *p)
         break;
     };
 
-    Panic_Core(p2, tick, file_utf8, line);
+    Panic_Core(p2, tick, file, line);
 }
 
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -781,7 +781,7 @@ static void Init_Root_Vars(void)
     //
     Init_Endlike_Header(&PG_End_Node.header, 0); // mutate to read-only end
 #if !defined(NDEBUG)
-    Set_Track_Payload_Debug(&PG_End_Node, cb_cast(__FILE__), __LINE__);
+    Set_Track_Payload_Debug(&PG_End_Node, __FILE__, __LINE__);
 #endif
     assert(IS_END(END)); // sanity check that it took
     assert(VAL_TYPE_RAW(END) == REB_0); // this implicit END marker has this

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -273,7 +273,15 @@ REBARR *Copy_And_Bind_Relative_Deep_Managed(
     // Both phases are folded into this routine to make it easier to make
     // a one-pass version when time permits.
     //
-    REBARR *copy = COPY_ANY_ARRAY_AT_DEEP_MANAGED(body);
+    REBARR *copy = Copy_Array_Core_Managed(
+        VAL_ARRAY(body),
+        VAL_INDEX(body), // at
+        VAL_SPECIFIER(body),
+        VAL_LEN_AT(body), // tail
+        0, // extra
+        SERIES_FLAG_FILE_LINE, // ask to preserve file and line info
+        TS_SERIES & ~TS_NOT_COPIED // types to copy deeply
+    );
 
     struct Reb_Binder binder;
     INIT_BINDER(&binder);
@@ -443,8 +451,8 @@ void Virtual_Bind_Deep_To_New_Context(
                 VAL_SPECIFIER(body_in_out),
                 ARR_LEN(VAL_ARRAY(body_in_out)), // tail
                 0, // extra
-                TRUE, // deep
-                TS_ARRAY // types
+                SERIES_FLAG_FILE_LINE, // flags
+                TS_ARRAY // types to copy deeply
             )
         );
     }

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -822,7 +822,7 @@ REBCTX *Make_Selfish_Context_Detect(
             CTX_VARS_HEAD(context),
             SPECIFIED,
             CTX_LEN(context),
-            TRUE,
+            SERIES_MASK_NONE,
             TS_CLONE
         );
     }
@@ -1078,7 +1078,7 @@ REBCTX *Merge_Contexts_Selfish(REBCTX *parent1, REBCTX *parent2)
         CTX_VARS_HEAD(merged),
         SPECIFIED,
         CTX_LEN(merged),
-        TRUE,
+        SERIES_MASK_NONE,
         TS_CLONE
     );
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -79,7 +79,7 @@ void Snap_State_Core(struct Reb_State *s)
 //
 void Assert_State_Balanced_Debug(
     struct Reb_State *s,
-    const REBYTE *file,
+    const char *file,
     int line
 ){
     if (s->dsp != DSP) {
@@ -565,7 +565,7 @@ void Set_Location_Of_Error(
             break;
         }
         if (f != NULL) {
-            Init_Word(&vars->file, LINK(f->source.array).filename);
+            Init_Word(&vars->file, LINK(f->source.array).file);
             Init_Integer(&vars->line, MISC(f->source.array).line);
         }
     }

--- a/src/core/d-crash.c
+++ b/src/core/d-crash.c
@@ -62,7 +62,7 @@
 ATTRIBUTE_NO_RETURN void Panic_Core(
     const void *p, // REBSER* (array, context, etc), REBVAL*, or UTF-8 char*
     REBUPT tick,
-    const REBYTE *file_utf8,
+    const char *file, // UTF8
     int line
 ){
     if (p == NULL)
@@ -75,14 +75,14 @@ ATTRIBUTE_NO_RETURN void Panic_Core(
 
 #if defined(NDEBUG)
     UNUSED(tick);
-    UNUSED(file_utf8);
+    UNUSED(file);
     UNUSED(line);
 #else
     //
     // First thing's first in the debug build, make sure the file and the
     // line are printed out, as well as the current evaluator tick.
     //
-    printf("C Source File %s, Line %d\n", cs_cast(file_utf8), line);
+    printf("C Source File %s, Line %d\n", file, line);
     printf("At evaluator tick: %lu\n", cast(unsigned long, tick));
 
     // Generally Rebol does not #include <stdio.h>, but the debug build does.
@@ -262,9 +262,9 @@ REBNATIVE(panic)
     //
 #ifdef NDEBUG
     const REBUPT tick = 0;
-    Panic_Core(utf8, tick, FRM_FILE(frame_), FRM_LINE(frame_));
+    Panic_Core(utf8, tick, FRM_FILE_UTF8(frame_), FRM_LINE(frame_));
 #else
-    Panic_Core(utf8, frame_->tick, FRM_FILE(frame_), FRM_LINE(frame_));
+    Panic_Core(utf8, frame_->tick, FRM_FILE_UTF8(frame_), FRM_LINE(frame_));
 #endif
 }
 
@@ -287,8 +287,10 @@ REBNATIVE(panic_value)
     //
 #ifdef NDEBUG
     const REBUPT tick = 0;
-    Panic_Core(ARG(value), tick, FRM_FILE(frame_), FRM_LINE(frame_));
+    Panic_Core(ARG(value), tick, FRM_FILE_UTF8(frame_), FRM_LINE(frame_));
 #else
-    Panic_Core(ARG(value), frame_->tick, FRM_FILE(frame_), FRM_LINE(frame_));
+    Panic_Core(
+        ARG(value), frame_->tick, FRM_FILE_UTF8(frame_), FRM_LINE(frame_)
+    );
 #endif
 }

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -239,54 +239,6 @@ REBNATIVE(label_of)
 
 
 //
-//  file-of: native [
-//
-//  "Get filename of origin for any series"
-//
-//      return: [file! url! blank!]
-//      series [any-series!]
-//  ]
-//
-REBNATIVE(file_of)
-{
-    INCLUDE_PARAMS_OF_FILE_OF;
-
-    REBSER *s = VAL_SERIES(ARG(series));
-
-    if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
-        return R_BLANK;
-
-    // !!! How to tell whether it's a URL! or a FILE! ?
-    //
-    Scan_File(D_OUT, STR_HEAD(LINK(s).filename), SER_LEN(LINK(s).filename));
-    return R_OUT;
-}
-
-
-//
-//  line-of: native [
-//
-//  "Get line of origin for any series"
-//
-//      return: [integer! blank!]
-//      series [any-series!]
-//  ]
-//
-REBNATIVE(line_of)
-{
-    INCLUDE_PARAMS_OF_LINE_OF;
-
-    REBSER *s = VAL_SERIES(ARG(series));
-
-    if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
-        return R_BLANK;
-
-    Init_Integer(D_OUT, MISC(s).line);
-    return R_OUT;
-}
-
-
-//
 //  function-of: native [
 //
 //  "Get the FUNCTION! for a frame"

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -84,6 +84,26 @@ REB_R Series_Common_Action_Maybe_Unhandled(
         case SYM_PAST_Q:
             return R_FROM_BOOL(LOGICAL(index > tail));
 
+        case SYM_FILE: {
+            REBSER *s = VAL_SERIES(value);
+
+            if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
+                return R_BLANK;
+
+            // !!! How to tell whether it's a URL! or a FILE! ?
+            //
+            Scan_File(D_OUT, STR_HEAD(LINK(s).file), SER_LEN(LINK(s).file));
+            return R_OUT; }
+
+        case SYM_LINE: {
+            REBSER *s = VAL_SERIES(value);
+
+            if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
+                return R_BLANK;
+
+            Init_Integer(D_OUT, MISC(s).line);
+            return R_OUT; }
+
         default:
             break;
         }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -416,6 +416,9 @@ void Init_Any_Context_Core(
 
     assert(GET_SER_FLAG(varlist, ARRAY_FLAG_VARLIST));
 
+    if (GET_SER_FLAG(varlist, SERIES_FLAG_FILE_LINE))
+        panic (varlist);
+
     assert(NOT_SER_FLAG(varlist, SERIES_FLAG_FILE_LINE));
     assert(NOT_SER_FLAG(keylist, SERIES_FLAG_FILE_LINE));
 

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1625,7 +1625,7 @@ scanword:
 //
 void Init_Va_Scan_State_Core(
     SCAN_STATE *ss,
-    REBSTR *filename,
+    REBSTR *file,
     REBUPT line,
     const REBYTE *opt_begin, // preload the scanner outside the va_list
     va_list *vaptr
@@ -1645,7 +1645,7 @@ void Init_Va_Scan_State_Core(
     ss->start_line_head = ss->line_head = NULL;
 
     ss->start_line = ss->line = line;
-    ss->filename = filename;
+    ss->file = file;
 
     ss->newline_pending = FALSE;
 
@@ -1665,7 +1665,7 @@ void Init_Va_Scan_State_Core(
 //
 static void Init_Scan_State(
     SCAN_STATE *ss,
-    REBSTR *filename,
+    REBSTR *file,
     REBUPT line,
     const REBYTE *utf8,
     REBCNT limit
@@ -1686,7 +1686,7 @@ static void Init_Scan_State(
 
     ss->newline_pending = FALSE;
 
-    ss->filename = filename;
+    ss->file = file;
     ss->opts = 0;
 
 #if !defined(NDEBUG)
@@ -2237,7 +2237,7 @@ REBARR *Scan_Array(
             //
             REBSER *s = VAL_SERIES(DS_TOP);
             MISC(s).line = ss->line;
-            LINK(s).filename = ss->filename;
+            LINK(s).file = ss->file;
             SET_SER_FLAG(s, SERIES_FLAG_FILE_LINE);
         }
 

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -133,7 +133,7 @@ static inline void Mark_Rebser_Only(REBSER *s)
     assert(NOT_SER_FLAG(s, SERIES_FLAG_ARRAY));
 
     if (s->header.bits & SERIES_FLAG_FILE_LINE)
-        LINK(s).filename->header.bits |= NODE_FLAG_MARKED;
+        LINK(s).file->header.bits |= NODE_FLAG_MARKED;
     s->header.bits |= NODE_FLAG_MARKED;
 }
 
@@ -209,7 +209,7 @@ inline static void Queue_Mark_Array_Deep(REBARR *a) {
     assert(NOT_SER_FLAG(a, ARRAY_FLAG_PAIRLIST));
 
     if (GET_SER_FLAG(a, SERIES_FLAG_FILE_LINE))
-        LINK(a).filename->header.bits |= NODE_FLAG_MARKED;
+        LINK(a).file->header.bits |= NODE_FLAG_MARKED;
 
     Queue_Mark_Array_Subclass_Deep(a);
 }

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -726,7 +726,7 @@ static REBOOL Series_Data_Alloc(REBSER *s, REBCNT length) {
         RELVAL *ultimate = ARR_AT(ARR(s), s->content.dynamic.rest - 1);
         Init_Endlike_Header(&ultimate->header, 0);
     #if !defined(NDEBUG)
-        Set_Track_Payload_Debug(ultimate, cb_cast(__FILE__), __LINE__);
+        Set_Track_Payload_Debug(ultimate, __FILE__, __LINE__);
     #endif
     }
 
@@ -970,14 +970,12 @@ REBSER *Make_Series_Core(REBCNT capacity, REBYTE wide, REBUPT flags)
     // know about from the source it's running onto this series.
     //
     if (flags & SERIES_FLAG_FILE_LINE) {
-        //
-        // !!! Feature TBD.  Until then take off the flag since leaving it on
-        // and not setting the fields would crash the GC.
-        //
-        // s->link.filename = ???
-        // s->misc.line = ???;
-        //
-        CLEAR_SER_FLAG(s, SERIES_FLAG_FILE_LINE);
+        if (FS_TOP != NULL) {
+            LINK(s).file = FRM_FILE(FS_TOP);
+            MISC(s).line = FRM_LINE(FS_TOP);
+        }
+        else
+            CLEAR_SER_FLAG(s, SERIES_FLAG_FILE_LINE);
     }
 
     assert(s->info.bits & NODE_FLAG_END);

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -264,8 +264,8 @@ REBNATIVE(bind)
             VAL_SPECIFIER(v),
             ARR_LEN(VAL_ARRAY(v)), // tail
             0, // extra
-            TRUE, // deep
-            TS_ARRAY // types
+            SERIES_FLAG_FILE_LINE, // flags
+            TS_ARRAY // types to copy deeply
         );
         INIT_VAL_ARRAY(D_OUT, array); // warning: macro copies args
     }

--- a/src/core/n-protect.c
+++ b/src/core/n-protect.c
@@ -468,13 +468,10 @@ REBNATIVE(lock)
             );
         }
         else if (ANY_CONTEXT(v)) {
-            const REBOOL deep = TRUE;
-            const REBU64 types = TS_STD_SERIES;
-
             Init_Any_Context(
                 D_OUT,
                 VAL_TYPE(v),
-                Copy_Context_Core(VAL_CONTEXT(v), deep, types)
+                Copy_Context_Core(VAL_CONTEXT(v), TS_STD_SERIES)
             );
         }
         else if (ANY_SERIES(v)) {

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -95,7 +95,13 @@ REBOOL Reduce_Any_Array_Throws(
     if (flags & REDUCE_FLAG_INTO)
         Pop_Stack_Values_Into(out, dsp_orig);
     else
-        Init_Any_Array(out, VAL_TYPE(any_array), Pop_Stack_Values(dsp_orig));
+        Init_Any_Array(
+            out,
+            VAL_TYPE(any_array),
+            Pop_Stack_Values_Core(
+                dsp_orig, NODE_FLAG_MANAGED | SERIES_FLAG_FILE_LINE
+            )
+        );
 
     Drop_Frame(f);
     return FALSE;
@@ -301,7 +307,13 @@ REBOOL Compose_Any_Array_Throws(
     if (into)
         Pop_Stack_Values_Into(out, dsp_orig);
     else
-        Init_Any_Array(out, VAL_TYPE(any_array), Pop_Stack_Values(dsp_orig));
+        Init_Any_Array(
+            out,
+            VAL_TYPE(any_array),
+            Pop_Stack_Values_Core(
+                dsp_orig, NODE_FLAG_MANAGED | SERIES_FLAG_FILE_LINE
+            )
+        );
 
     Drop_Frame(f);
     return FALSE;

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -246,7 +246,7 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM action)
                     VAL_SPECIFIER(state),
                     VAL_ARRAY_LEN_AT(state), // tail
                     0, // extra
-                    FALSE, // !deep
+                    SERIES_FLAG_FILE_LINE, // flags
                     TS_STRING // types
                 )
             );

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -940,8 +940,8 @@ REBTYPE(Array)
             specifier,
             tail, // tail
             0, // extra
-            REF(deep), // deep
-            types // types
+            SERIES_FLAG_FILE_LINE, // flags
+            types // types to copy deeply
         );
         Init_Any_Array(D_OUT, VAL_TYPE(value), copy);
         return R_OUT;

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -344,6 +344,36 @@ REBTYPE(Function)
             return R_OUT;
         }
 
+        // We use a heuristic that if the first element of a function's body
+        // is a series with the file and line bits set, then that's what it
+        // returns for FILE OF and LINE OF.
+        //
+        case SYM_FILE: {
+            if (NOT(ANY_SERIES(VAL_FUNC_BODY(value))))
+                return R_BLANK;
+
+            REBSER *s = VAL_SERIES(VAL_FUNC_BODY(value));
+
+            if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
+                return R_BLANK;
+
+            // !!! How to tell whether it's a URL! or a FILE! ?
+            //
+            Scan_File(D_OUT, STR_HEAD(LINK(s).file), SER_LEN(LINK(s).file));
+            return R_OUT; }
+
+        case SYM_LINE: {
+            if (NOT(ANY_SERIES(VAL_FUNC_BODY(value))))
+                return R_BLANK;
+
+            REBSER *s = VAL_SERIES(VAL_FUNC_BODY(value));
+
+            if (NOT_SER_FLAG(s, SERIES_FLAG_FILE_LINE))
+                return R_BLANK;
+
+            Init_Integer(D_OUT, MISC(s).line);
+            return R_OUT; }
+
         default:
             fail (Error_Cannot_Reflect(VAL_TYPE(value), arg));
         }

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -584,12 +584,15 @@ REBNATIVE(set_meta)
 // have to be touched up to ensure consistency of the rootval and the
 // relevant ->link and ->misc fields in the series node.
 //
-REBCTX *Copy_Context_Core(REBCTX *original, REBOOL deep, REBU64 types)
+REBCTX *Copy_Context_Core(REBCTX *original, REBU64 types)
 {
     if (CTX_VARS_UNAVAILABLE(original))
         fail ("Cannot copy a context with unavailable vars"); // !!! improve
 
-    REBARR *varlist = Make_Array(CTX_LEN(original) + 1);
+    REBARR *original_array = NULL; // may not be an array
+    REBARR *varlist = Make_Array_For_Copy(
+        CTX_LEN(original) + 1, SERIES_MASK_NONE, original_array
+    );
     REBVAL *dest = KNOWN(ARR_HEAD(varlist)); // all context vars are SPECIFIED
 
     // The type information and fields in the rootvar (at head of the varlist)
@@ -637,7 +640,7 @@ REBCTX *Copy_Context_Core(REBCTX *original, REBOOL deep, REBU64 types)
             CTX_VARS_HEAD(copy),
             SPECIFIED,
             CTX_LEN(copy),
-            deep,
+            SERIES_MASK_NONE,
             types
         );
     }
@@ -908,11 +911,7 @@ REBTYPE(Context)
         else
             types = 0;
 
-        Init_Any_Context(
-            D_OUT,
-            VAL_TYPE(value),
-            Copy_Context_Core(c, REF(deep), types)
-        );
+        Init_Any_Context(D_OUT, VAL_TYPE(value), Copy_Context_Core(c, types));
         return R_OUT; }
 
     case SYM_SELECT_P:

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -212,22 +212,14 @@ inline static void Push_Frame_Core(REBFRM *f)
     f->phase = NULL;
 
     TRASH_POINTER_IF_DEBUG(f->opt_label);
+
 #if !defined(NDEBUG)
     TRASH_POINTER_IF_DEBUG(f->label_utf8);
-#endif
 
-#if !defined(NDEBUG) // !!! should be updated on each f->source.array change
-    if (
-        NOT(FRM_IS_VALIST(f))
-        && GET_SER_FLAG(f->source.array, SERIES_FLAG_FILE_LINE)
-    ){
-        f->file = cast(const char*, STR_HEAD(LINK(f->source.array).filename));
-        f->line = MISC(f->source.array).line;
-    }
-    else {
-        f->file = "(no file info)";
-        f->line = 0;
-    }
+    // !!! TBD: the relevant file/line update when f->source.array changes
+    //
+    f->file = FRM_FILE_UTF8(f);
+    f->line = FRM_LINE(f);
 #endif
 
     f->prior = TG_Frame_Stack;

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -118,7 +118,7 @@ inline static REBCNT FRM_EXPR_INDEX(REBFRM *f) {
         : f->expr_index - 1;
 }
 
-inline static const REBYTE* FRM_FILE(REBFRM *f) {
+inline static REBSTR* FRM_FILE(REBFRM *f) {
     //
     // !!! the rebDo function could be a variadic macro in C99 or higher, as
     // `rebDoFileLine(__FILE__, __LINE__, ...`.  This could let the file and
@@ -128,12 +128,16 @@ inline static const REBYTE* FRM_FILE(REBFRM *f) {
     // as a series.  But for now, just signal that it came from C code.
     //
     if (f->source.array == NULL)
-        return cb_cast("(api-client-file).c");
+        return Canon(SYM___ANONYMOUS__);
 
     if (NOT_SER_FLAG(f->source.array, SERIES_FLAG_FILE_LINE))
-        return STR_HEAD(Canon(SYM___ANONYMOUS__));
+        return Canon(SYM___ANONYMOUS__);;
 
-    return STR_HEAD(LINK(SER(f->source.array)).filename);
+    return LINK(f->source.array).file;
+}
+
+inline static const char* FRM_FILE_UTF8(REBFRM *f) {
+    return cs_cast(STR_HEAD(FRM_FILE(f)));
 }
 
 inline static int FRM_LINE(REBFRM *f) {

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -92,6 +92,10 @@
 // also prefer the header vs. info?  Such separation might help with caching.
 //
 
+#define SERIES_MASK_NONE \
+    0 // helps locate places that want to say "no flags"
+
+
 //=//// ARRAY_FLAG_VOIDS_LEGAL ////////////////////////////////////////////=//
 //
 // Identifies arrays in which it is legal to have void elements.  This is true
@@ -556,7 +560,7 @@ union Reb_Series_Link {
     // source that was running at the time is propagated into the new
     // second-generation series.
     //
-    REBSTR *filename;
+    REBSTR *file;
 
     // REBCTX types use this field of their varlist (which is the identity of
     // an ANY-CONTEXT!) to find their "keylist".  It is stored in the REBSER

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -339,7 +339,7 @@
 
 #if !defined(NDEBUG)
     struct Reb_Track {
-        const char *filename; // is REBYTE (UTF-8), but char* for debug watch
+        const char *file; // is REBYTE (UTF-8), but char* for debug watch
         int line;
     };
 #endif

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -230,7 +230,7 @@ typedef struct rebol_scan_state {
     REBCNT start_line;
     const REBYTE *start_line_head;
 
-    REBSTR *filename;
+    REBSTR *file;
 
     // VALUE_FLAG_LINE appearing on a value means that there is a line break
     // *before* that value.  Hence when a newline is seen, it means the *next*

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -583,7 +583,7 @@ inline static void Drop_Guard_Value_Common(const RELVAL *v) {
 #else
     inline static void Drop_Guard_Series_Debug(
         REBSER *s,
-        const REBYTE *file,
+        const char *file,
         int line
     ) {
         if (s != *SER_LAST(REBSER*, GC_Guarded))
@@ -593,7 +593,7 @@ inline static void Drop_Guard_Value_Common(const RELVAL *v) {
 
     inline static void Drop_Guard_Value_Debug(
         const RELVAL *v,
-        const REBYTE *file,
+        const char *file,
         int line
     ) {
         if (v != *SER_LAST(RELVAL*, GC_Guarded))
@@ -602,10 +602,10 @@ inline static void Drop_Guard_Value_Common(const RELVAL *v) {
     }
 
     #define DROP_GUARD_SERIES(s) \
-        Drop_Guard_Series_Debug(s, cb_cast(__FILE__), __LINE__);
+        Drop_Guard_Series_Debug(s, __FILE__, __LINE__);
 
     #define DROP_GUARD_VALUE(v) \
-        Drop_Guard_Value_Debug(v, cb_cast(__FILE__), __LINE__);
+        Drop_Guard_Value_Debug(v, __FILE__, __LINE__);
 #endif
 
 

--- a/src/include/sys-trap.h
+++ b/src/include/sys-trap.h
@@ -251,7 +251,7 @@ inline static void DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(struct Reb_State *s) {
     #define ASSERT_STATE_BALANCED(s) NOOP
 #else
     #define ASSERT_STATE_BALANCED(s) \
-        Assert_State_Balanced_Debug((s), cb_cast(__FILE__), __LINE__)
+        Assert_State_Balanced_Debug((s), __FILE__, __LINE__)
 #endif
 
 
@@ -378,7 +378,7 @@ inline static void DROP_TRAP_SAME_STACKLEVEL_AS_PUSH(struct Reb_State *s) {
         panic(v)
 #else
     #define panic(v) \
-        Panic_Core((v), TG_Tick, cb_cast(__FILE__), __LINE__)
+        Panic_Core((v), TG_Tick, __FILE__, __LINE__)
 
     #define panic_at(v,file,line) \
         Panic_Core((v), TG_Tick, (file), (line))

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -76,7 +76,7 @@
 
 #if !defined(NDEBUG)
     #define PROBE(v) \
-        Probe_Core_Debug((v), cb_cast(__FILE__), __LINE__)
+        Probe_Core_Debug((v), __FILE__, __LINE__)
 #endif
 
 
@@ -100,9 +100,9 @@
 
 #if !defined NDEBUG
     inline static void Set_Track_Payload_Debug(
-        RELVAL *v, const REBYTE *file, int line
+        RELVAL *v, const char *file, int line
     ){
-        v->payload.track.filename = cs_cast(file); // cast for debug watch
+        v->payload.track.file = file;
         v->payload.track.line = line;
         v->extra.tick = TG_Tick;
     }
@@ -161,7 +161,7 @@
         FLAGIT_LEFT(23)
 
     inline static enum Reb_Kind VAL_TYPE_Debug(
-        const RELVAL *v, const REBYTE *file, int line
+        const RELVAL *v, const char *file, int line
     ){
         // VAL_TYPE is called *a lot*, and this makes it a great place to do
         // sanity checks in the debug build.  But a debug build will not
@@ -211,7 +211,7 @@
     }
 
     #define VAL_TYPE(v) \
-        VAL_TYPE_Debug((v), cb_cast(__FILE__), __LINE__)
+        VAL_TYPE_Debug((v), __FILE__, __LINE__)
 #endif
 
 
@@ -416,7 +416,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
 #else
     inline static void Assert_Cell_Writable(
         const RELVAL *v,
-        const REBYTE *file,
+        const char *file,
         int line
     ){
         // REBVALs should not be written at addresses that do not match the
@@ -452,7 +452,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         RELVAL *v,
         enum Reb_Kind kind,
         REBUPT extra,
-        const REBYTE *file,
+        const char *file,
         int line
     ){
         ASSERT_CELL_WRITABLE(v, file, line);
@@ -468,8 +468,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define VAL_RESET_HEADER_EXTRA(v,kind,extra) \
-        VAL_RESET_HEADER_EXTRA_Debug((v), (kind), (extra), \
-            cb_cast(__FILE__), __LINE__)
+        VAL_RESET_HEADER_EXTRA_Debug((v), (kind), (extra), __FILE__, __LINE__)
 
     // VAL_RESET is a variant of VAL_RESET_HEADER_EXTRA that actually
     // overwrites the payload with tracking information.  It should not be
@@ -480,7 +479,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
         RELVAL *v,
         enum Reb_Kind kind,
         REBUPT extra,
-        const REBYTE *file,
+        const char *file,
         int line
     ){
         VAL_RESET_HEADER_EXTRA_Debug(v, kind, extra, file, line);
@@ -488,10 +487,10 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define VAL_RESET(v,kind,extra) \
-        VAL_RESET_Debug((v), (kind), (extra), cb_cast(__FILE__), __LINE__)
+        VAL_RESET_Debug((v), (kind), (extra), __FILE__, __LINE__)
 
     inline static void Prep_Non_Stack_Cell_Debug(
-        struct Reb_Cell *c, const REBYTE *file, int line
+        struct Reb_Cell *c, const char *file, int line
     ){
         c->header.bits =
             NODE_FLAG_NODE | NODE_FLAG_FREE | NODE_FLAG_CELL
@@ -500,10 +499,10 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define Prep_Non_Stack_Cell(c) \
-        Prep_Non_Stack_Cell_Debug((c), cb_cast(__FILE__), __LINE__)
+        Prep_Non_Stack_Cell_Debug((c), __FILE__, __LINE__)
 
     inline static void Prep_Stack_Cell_Debug(
-        struct Reb_Cell *c, const REBYTE *file, int line
+        struct Reb_Cell *c, const char *file, int line
     ){
         c->header.bits = NODE_FLAG_NODE | NODE_FLAG_FREE | NODE_FLAG_CELL
             | HEADERIZE_KIND(REB_MAX_PLUS_ONE_TRASH) | VALUE_FLAG_STACK;
@@ -511,7 +510,7 @@ inline static void VAL_RESET_HEADER_common( // don't call directly
     }
 
     #define Prep_Stack_Cell(c) \
-        Prep_Stack_Cell_Debug((c), cb_cast(__FILE__), __LINE__)
+        Prep_Stack_Cell_Debug((c), __FILE__, __LINE__)
 #endif
 
 #define VAL_RESET_HEADER(v,t) \
@@ -523,7 +522,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     // the type and bits (e.g. changing ANY-WORD! to another ANY-WORD!).
     // Otherwise the value-specific flags might be misinterpreted.
     //
-    ASSERT_CELL_WRITABLE(v, cb_cast(__FILE__), __LINE__);
+    ASSERT_CELL_WRITABLE(v, __FILE__, __LINE__);
     CLEAR_8_RIGHT_BITS(v->header.bits);
     v->header.bits |= HEADERIZE_KIND(kind);
 }
@@ -548,7 +547,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 #else
     inline static void Set_Trash_Debug(
         RELVAL *v,
-        const REBYTE *file,
+        const char *file,
         int line
     ){
         ASSERT_CELL_WRITABLE(v, file, line);
@@ -561,7 +560,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define TRASH_CELL_IF_DEBUG(v) \
-        Set_Trash_Debug((v), cb_cast(__FILE__), __LINE__)
+        Set_Trash_Debug((v), __FILE__, __LINE__)
 
     inline static REBOOL IS_TRASH_DEBUG(const RELVAL *v) {
         assert(v->header.bits & NODE_FLAG_CELL);
@@ -617,7 +616,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 #else
     inline static REBOOL IS_END_Debug(
         const RELVAL *v,
-        const REBYTE *file,
+        const char *file,
         int line
     ){
         if (v->header.bits & NODE_FLAG_FREE) {
@@ -660,9 +659,9 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 #endif
 
     #define IS_END(v) \
-        IS_END_Debug((v), cb_cast(__FILE__), __LINE__)
+        IS_END_Debug((v), __FILE__, __LINE__)
 
-    inline static void SET_END_Debug(RELVAL *v, const REBYTE *file, int line) {
+    inline static void SET_END_Debug(RELVAL *v, const char *file, int line) {
         ASSERT_CELL_WRITABLE(v, file, line);
         v->header.bits &= CELL_MASK_RESET; // leaves NODE_FLAG_CELL, etc.
         v->header.bits |= NODE_FLAG_END | HEADERIZE_KIND(REB_0);
@@ -670,11 +669,11 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define SET_END(v) \
-        SET_END_Debug((v), cb_cast(__FILE__), __LINE__)
+        SET_END_Debug((v), __FILE__, __LINE__)
 
     inline static enum Reb_Kind VAL_TYPE_OR_0_Debug(
         const RELVAL *v,
-        const REBYTE *file,
+        const char *file,
         int line
     ){
         if (v->header.bits & NODE_FLAG_END) {
@@ -691,7 +690,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     // Warning: Only use on valid non-END REBVAL -or- on global END value
     //
     #define VAL_TYPE_OR_0(v) \
-        VAL_TYPE_OR_0_Debug((v), cb_cast(__FILE__), __LINE__)
+        VAL_TYPE_OR_0_Debug((v), __FILE__, __LINE__)
 #endif
 
 #define NOT_END(v) \
@@ -837,7 +836,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     //
     inline static REBVAL *Sink_Debug(
         RELVAL *v,
-        const REBYTE *file,
+        const char *file,
         int line
     ) {
         ASSERT_CELL_WRITABLE(v, file, line);
@@ -861,7 +860,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define SINK(v) \
-        Sink_Debug((v), cb_cast(__FILE__), __LINE__)
+        Sink_Debug((v), __FILE__, __LINE__)
 
 #endif
 
@@ -895,7 +894,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
         GET_VAL_FLAG((v), VALUE_FLAG_FALSEY)
 #else
     inline static REBOOL IS_FALSEY_Debug(
-        const RELVAL *v, const REBYTE *file, int line
+        const RELVAL *v, const char *file, int line
     ){
         if (IS_VOID(v)) {
             printf("Conditional true/false test on void\n");
@@ -905,7 +904,7 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
     }
 
     #define IS_FALSEY(v) \
-        IS_FALSEY_Debug((v), cb_cast(__FILE__), __LINE__)
+        IS_FALSEY_Debug((v), __FILE__, __LINE__)
 #endif
 
 #define IS_TRUTHY(v) \
@@ -1554,7 +1553,7 @@ inline static void Move_Value_Header(RELVAL *out, const RELVAL *v)
         && NOT(v->header.bits & (NODE_FLAG_END | NODE_FLAG_FREE))
     );
 
-    ASSERT_CELL_WRITABLE(out, cb_cast(__FILE__), __LINE__);
+    ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);
 
     out->header.bits &= CELL_MASK_RESET;
     out->header.bits |= v->header.bits & CELL_MASK_COPY;
@@ -1656,7 +1655,7 @@ inline static void Blit_Cell(RELVAL *out, const RELVAL *v)
         && NOT(v->header.bits & (NODE_FLAG_END | NODE_FLAG_FREE))
     );
 
-    ASSERT_CELL_WRITABLE(out, cb_cast(__FILE__), __LINE__);
+    ASSERT_CELL_WRITABLE(out, __FILE__, __LINE__);
 
     // Examine just the cell's preparation bits.  Are they identical?  If so,
     // we are not losing any information by blindly copying the header in

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -129,7 +129,17 @@ make-action: func [
         new-body exclusions locals defaulters statics
 ][
     exclusions: copy []
-    new-spec: make block! length of spec
+
+    ; Rather than MAKE BLOCK! LENGTH OF SPEC here, we copy the spec and clear
+    ; it.  This costs slightly more, but it means we inherit the file and line
+    ; number of the original spec...so when we pass NEW-SPEC to FUNC or PROC
+    ; it uses that to give the FILE OF and LINE OF the function itself.
+    ;
+    ; !!! General API control to set the file and line on blocks is another
+    ; possibility, but since it's so new, we'd rather get experience first.
+    ;
+    new-spec: clear copy spec
+
     new-body: _
     statics: _
     defaulters: _

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -110,6 +110,8 @@ type-of: specialize 'reflect [property: 'type]
 context-of: specialize 'reflect [property: 'context]
 head-of: specialize 'reflect [property: 'head]
 tail-of: specialize 'reflect [property: 'tail]
+file-of: specialize 'reflect [property: 'file]
+line-of: specialize 'reflect [property: 'line]
 
 
 ; General renamings away from non-LOGIC!-ending-in-?-functions


### PR DESCRIPTION
This makes reflectors for FILE and LINE, so that they can be used with
OF.  (Hence FILE OF FOO, LINE OF FOO.)  They are specialized as FILE-OF
and LINE-OF.  The ability to get file and line numbers from a function
is also added...though there still needs to be some work on deciding
what the best heuristic is.

It now uses knowledge of the file and line where the evaluator is
processing to tag newly created arrays.  For an operation like a
COMPOSE or REDUCE, this will indicate the array being processed...
because an evaluative frame has been set up on that array.

COPY also tries to use the file and line of the original material.  So:

    foo: [a b c] ;-- line 1
    ...
    ...
    bar: copy [a b c]
    print line of bar ;-- will be 1

These features are still very new, and still has no accounting for the
number of lines in the headers of files...so it counts lines after
the header ends.