### PR TITLE
Add AHEAD keyword, fix crash when using INTO during string parse

### DIFF
--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -176,6 +176,7 @@ any
 opt
 not
 and
+ahead
 then
 remove
 insert

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -630,7 +630,7 @@ REBNATIVE(poke)
     if (IS_PORT(location))
         return Do_Port_Action(frame_, VAL_CONTEXT(location), SYM_POKE);
 
-    DECLARE_FRAME(pvs);
+    DECLARE_FRAME (pvs);
 
     Move_Value(D_OUT, location);
     pvs->out = D_OUT;

--- a/tests/parse-tests.r
+++ b/tests/parse-tests.r
@@ -155,3 +155,12 @@
 [not parse [1 + 2] [do [quote 100]]]
 [parse [reverse copy [a b c]] [do [into ['c 'b 'a]]]]
 [not parse [reverse copy [a b c]] [do [into ['a 'b 'c]]]]
+
+; AHEAD and AND are synonyms
+;
+[parse ["aa"] [ahead string! into ["a" "a"]]]
+[parse ["aa"] [and string! into ["a" "a"]]]
+
+; INTO is not legal if a string parse is already running
+;
+[error? trap [parse "aa" [into ["a" "a"]]]]


### PR DESCRIPTION
This adds the AHEAD keyword to PARSE.  Its lookahead behavior means
it's a more intuitive synonym for the AND operation.

It also fixes a crash that was occuring if you were already in the
middle of a string parse, and tried to invoke an INTO operation.  The
correct behavior in that case is to raise an error, as you cannot
currently parse "into" a character.

Tidies up a couple of redundant initializations in the simulated
function application used for SUBPARSE-based frames...which should be
revisited in light of the desire to be able to HIJACK parse recursions
for debugging (as in the ENCLOSE/HIJACK example)