### PR TITLE
Require GROUP! for right hand side of short-circuit AND/OR/etc.

### DIFF
--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -132,7 +132,7 @@ assert-debug: function [
             ]
 
             result: do/next conditions quote pos:
-            if active and any [not set? 'result | not :result] [
+            if active and (any [not set? 'result | not :result]) [
                 failure-helper (copy/part conditions pos) :result
             ]
 


### PR DESCRIPTION
When short-circuiting was introduced for the conditional logic
operators, the idea of being able to "run the evaluator in neutral" to
skip expressions did not work unless the expression was in a GROUP!.
This furthers that restriction, by demanding that the short-circuit
expression indeed be a literal GROUP!.

Whether this will be the ultimate definition of AND/OR/etc. or not is
up in the air, but is submitted for continued experimentation.

For details, see:

https://github.com/rebol/rebol-issues/issues/1879