### PR TITLE
tools/make-make.r: extend cmdline syntax

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -1,0 +1,1 @@
+do %../src/tools/make-make.r

--- a/src/tools/common.r
+++ b/src/tools/common.r
@@ -294,19 +294,25 @@ find-record-unique: function [
 
 
 parse-args: function [
-    args ;args in form of "NAME=VALUE"
+    args
+    /all "Keeps also args without '=', puts them after a '| ."
 ][
     ret: make block! 4
+    standalone: make block! 4
     args: any [args copy []]
     unless block? args [args: split args [some " "]]
     for-each a args [
-        if idx: find a #"=" [
+        either idx: find a #"=" [; name=value
             name: to word! copy/part a (index-of idx) - 1
             value: copy next idx
             append ret reduce [name value]
+        ][; standalone-arg
+            if all [append standalone a]
         ]
     ]
-    ret
+    if any [not all empty? standalone] [return ret]
+    append ret '|
+    append ret standalone
 ]
 
 fix-win32-path: func [

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -15,11 +15,11 @@ append lib compose [
 rebmake: import %rebmake.r
 
 config-dir: %../../make
-print pwd
+base-dir: pwd
 user-config: make object! load config-dir/default-config.r
 
 ; Load user defined config.r
-args: parse-args system/options/args
+args: parse-args/all system/options/args
 if select args 'CONFIG [
     user-config: make user-config load config-dir/(args/CONFIG)
 ]
@@ -27,6 +27,7 @@ if select args 'CONFIG [
 ; Allow any of the settings in user-config to be overwritten by command line
 ; options
 for-each [name value] args [
+    if name = '| [break] ; begin of standalone args
     switch/default name [
         CONFIG [
             ;pass
@@ -62,6 +63,9 @@ for-each [name value] args [
             load value
     ]
 ]
+; process standalone args
+if args: find args '| [args: next args]
+if not empty? args [user-config/target: load args]
 
 dump user-config
 
@@ -1815,7 +1819,9 @@ solution: make rebmake/solution-class [
     debug: app-config/debug
 ]
 
-switch/default user-config/target [
+target: user-config/target
+if not block? target [target: reduce [target]]
+forall target [switch/default target/1 [
     clean [
         change-dir %../../make
         rebmake/execution/run make rebmake/solution-class [
@@ -1823,7 +1829,21 @@ switch/default user-config/target [
                 clean
             ]
         ]
+        change-dir base-dir
     ]
+    prep [
+        change-dir %../../make
+        rebmake/execution/run make rebmake/solution-class [
+            depends: flatten reduce [
+                vars
+                prep
+                t-folders
+                dynamic-libs
+            ]
+        ]
+        change-dir base-dir
+    ]
+    r3
     execution [
         change-dir %../../make
         rebmake/execution/run make rebmake/solution-class [
@@ -1835,6 +1855,7 @@ switch/default user-config/target [
                 dynamic-libs
             ]
         ]
+        change-dir base-dir
     ]
     makefile [
         rebmake/makefile/generate %../../make/makefile solution
@@ -1851,7 +1872,8 @@ switch/default user-config/target [
     ]
 ][
     fail [
-        "Unsupported target (execution, makefile or nmake):"
+        "Unsupported target"
         user-config/target
+        "^/Choose between: clean prep r3 execution makefile nmake vs2017 visual-studio vs2015"
     ]
-]
+]]

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -20,9 +20,15 @@ user-config: make object! load config-dir/default-config.r
 
 ; Load user defined config.r
 args: parse-args/all system/options/args
-if select args 'CONFIG [
-    user-config: make user-config load config-dir/(args/CONFIG)
+if targets: find args '| [
+    args: copy/part args targets
+    targets: next targets
 ]
+while [a: find args 'CONFIG] [
+    args: next a
+    user-config: make user-config load config-dir/(args/1)
+]
+args: head args
 
 ; Allow any of the settings in user-config to be overwritten by command line
 ; options
@@ -64,8 +70,7 @@ for-each [name value] args [
     ]
 ]
 ; process standalone args
-if args: find args '| [args: next args]
-if not empty? args [user-config/target: load args]
+if not empty? targets [user-config/target: load targets]
 
 dump user-config
 


### PR DESCRIPTION
The goal is to allow one write e.g.

>> ./r3-make make.r prep
or
>> ./r3-make make.r r3
or
>> ./r3-make make.r clean prep r3
etc...

- tools/common.r:
  PARSE-ARGS/ALL accepts 'standalone' args (without '=')

- tools/make-make.r:
  - standalone args interpreted as targets
  - multiple targets allowed
  - `r3` as synonym of `execution` target
  - allowed `prep` target

- make/make.r:
  a wrapper for tools/make-make.r

Examples:

`./r3-make make.r clean`
is the same as
`./r3-make ../src/tools/make-make.r target=clean`

`./r3-make make.r clean r3`
is the same as
`./r3-.ake make.r target='[clean r3]'`
is the same as
`./r3-make ../src/tools/make-make.r target=clean;
./r3-make ../src/tools/make-make.r target=execution`