### PR TITLE
PROBE() passes through value in C++, add BREAK_ON_TICK macro

### DIFF
--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -177,7 +177,9 @@ void Assert_No_Relative(REBARR *array, REBU64 types)
 //
 //  Probe_Core_Debug: C
 //
-void Probe_Core_Debug(
+// Use PROBE() to invoke, see notes there.
+//
+void* Probe_Core_Debug(
     const void *p,
     const char *file,
     int line
@@ -245,6 +247,8 @@ void Probe_Core_Debug(
             GC_Disabled = disabled;
         }
     }
+
+    return m_cast(void*, p); // must be cast back to const if source was const
 }
 
 #endif

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -64,8 +64,10 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // The PROBE macro can be used in debug builds to mold a REBVAL much like the
-// Rebol `probe` operation.  It's actually polymorphic, and if you have
-// a REBSER*, REBCTX*, or REBARR* it can be used with those as well.
+// Rebol `probe` operation.  But it's actually polymorphic, and if you have
+// a REBSER*, REBCTX*, or REBARR* it can be used with those as well.  In C++,
+// you can even get the same value and type out as you put in...just like in
+// Rebol, permitting things like `return PROBE(Make_Some_Series(...));`
 //
 // In order to make it easier to find out where a piece of debug spew is
 // coming from, the file and line number will be output as well.
@@ -75,8 +77,18 @@
 //
 
 #if !defined(NDEBUG)
-    #define PROBE(v) \
-        Probe_Core_Debug((v), __FILE__, __LINE__)
+    #ifdef CPLUSPLUS_11
+        template <typename T>
+        T Probe_Cpp_Helper(T v, const char *file, int line) {
+            return cast(T, Probe_Core_Debug(v, file, line));
+        }
+
+        #define PROBE(v) \
+            Probe_Cpp_Helper((v), __FILE__, __LINE__) // passes input as-is
+    #else
+        #define PROBE(v) \
+            Probe_Core_Debug((v), __FILE__, __LINE__) // just returns void* :(
+    #endif
 #endif
 
 


### PR DESCRIPTION
This adds two debugging conveniences.  One is that in the C++ build,
type templating is used to make it so that PROBE() can return the
exact type, value, and cv-qualifiers it gets in...like Rebol's PROBE.

This means it can be used e.g. as

    return PROBE(Get_Some_Mutable_Series(...));

...or...

    return PROBE(Get_Some_Const_Value(...));

The other addition is something which probably should have been added
much sooner.  Previously you could break on a tick, but it would always
put you in the evaluator loop at the point where the tick was bumped.
If the location you wanted to debug was somewhere else, you'd have to
go put a breakpoint there...but then worry about disabling that
breakpoint on the next debug run and re-enabling it.

This sidesteps all that just by having a BREAK_ON_TICK() macro you can
put with the appropriate number right at the spot you want the debugger
to land.  Though it requires recompilation, it can be well worth it
for complex debugging situations.