### PR TITLE
Check more source

### DIFF
--- a/tests/read-deep.reb
+++ b/tests/read-deep.reb
@@ -1,0 +1,67 @@
+REBOL [
+    Title: "Read-deep"
+    Rights: {
+        Copyright 2018 Brett Handley
+    }
+    License: {
+        Licensed under the Apache License, Version 2.0
+        See: http://www.apache.org/licenses/LICENSE-2.0
+    }
+    Author: "Brett Handley"
+    Purpose: "Recursive READ strategies."
+]
+
+;; read-deep-seq aims to be as simple as possible. I.e. relative paths
+;; can be derived after the fact.  It uses a state to next state approach
+;; which means client code can use it iteratively which is useful to avoid
+;; reading the full tree up front, or for sort/merge type routines.
+;; The root (seed) path is included as the first result.
+;; Output can be made relative by stripping the root (seed) path from
+;; each returned file.
+;;
+
+read-deep-seq: function [
+    {Iterative read deep.}
+    queue [block!]
+][
+    item: take queue
+
+    if equal? #"/" last item [
+        insert queue map-each x read item [join-of item x]
+    ]
+
+    item
+]
+
+;; read-deep provide convenience over read-deep-seq.
+;;
+
+read-deep: function [
+    {Return files and folders using recursive read strategy.}
+    root [file! url! block!]
+    /full {Includes root path and retains full paths instead returning relative paths.}
+    /strategy {Allows Queue building to be overridden.}
+    take [function!] {TAKE next item from queue, building the queue as necessary.}
+][
+    unless strategy [take: :read-deep-seq]
+
+    result: make block! []
+
+    queue: compose [(root)]
+
+    while [not tail? queue][
+        path: take queue
+        append result :path ; Possible void.
+    ]
+
+    unless full [
+        remove result ; No need for root in result.
+        len: length of root
+        for i 1 length of result 1 [
+            ; Strip off root path from locked paths.
+            poke result i copy skip result/:i len
+        ]
+    ]
+
+    result
+]

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -11,15 +11,14 @@ REBOL [
     Purpose: {Process the source of Rebol.}
 ]
 
-ren-c-repo: any [
-    if exists? %../src/tools/ [%../]
-    if exists? %../ren-c/src/tools/ [%../ren-c/]
-]
+; Root folder of the repository.
+; This script makes some assumptions about the structure of the repo.
+;
 
-ren-c-repo: clean-path ren-c-repo
+ren-c-repo: clean-path %../
 
-do ren-c-repo/src/tools/common.r
-do ren-c-repo/src/tools/common-parsers.r
+do ren-c-repo/make/common.r
+do ren-c-repo/make/common-parsers.r
 do %lib/text-lines.reb
 do %read-deep.reb
 


### PR DESCRIPTION
Modify source analysis for recursive read strategy

A number of source files were ignored by the source analysis routines because they were not included in the fixed path configuration. Originally this was to avoid an R3 Alpha READ bug on linux.  As the source tools can now assume they will be run by the recent build, a recursive read strategy for %src/ has been implemented.

The %tests/ folder has also been included for source analysis.

In addition this PR fixes some paths in source-tools.reb that were broken by recent repo changes.
