### PR TITLE
Add pre-vista build switch

### DIFF
--- a/make/default-config.r
+++ b/make/default-config.r
@@ -53,6 +53,11 @@ odbc-requires-ltdl: no
 
 with-tcc: no
 
+; Console API for windows does not exist before vista.
+;
+pre-vista: no
+
+
 git-commit: _
 
 includes: _

--- a/make/make.r
+++ b/make/make.r
@@ -1032,6 +1032,25 @@ append app-config/cflags opt switch/default user-config/standard [
     ]
 ]
 
+; pre-vista switch
+; Example. Mingw32 does not have access to windows console api prior to vista.
+;
+cfg-pre-vista: false
+append app-config/definitions opt switch/default user-config/pre-vista [
+    #[true] yes on true [
+        cfg-pre-vista: true
+        compose [
+            "PRE_VISTA"
+        ]
+    ]
+    _ #[false] no off false [
+        cfg-pre-vista: false
+        _
+    ]
+][
+    fail ["PRE-VISTA must be yes, no, or logic! not" (user-config/pre-vista)]
+]
+
 cfg-rigorous: false
 append app-config/cflags opt switch/default user-config/rigorous [
     #[true] yes on true [

--- a/src/os/windows/dev-stdio.c
+++ b/src/os/windows/dev-stdio.c
@@ -314,6 +314,12 @@ DEVICE_CMD Read_IO(REBREQ *req)
     // aware cursoring/backspacing/line-editing to the OS.  Which also means
     // a smaller executable than trying to rewrite it oneself.
     //
+
+#ifdef PRE_VISTA
+    // Console api not available prior to Vista (e.g Mingw32).
+    DWORD total;
+    REBOOL ok = ReadConsoleW(Std_Inp, Std_Buf, BUF_SIZE - 1, &total, NULL);
+#else
     CONSOLE_READCONSOLE_CONTROL ctl;
     ctl.nLength = sizeof(CONSOLE_READCONSOLE_CONTROL);
     ctl.nInitialChars = 0; // when hit, empty buffer...no CR LF
@@ -322,6 +328,8 @@ DEVICE_CMD Read_IO(REBREQ *req)
 
     DWORD total;
     REBOOL ok = ReadConsoleW(Std_Inp, Std_Buf, BUF_SIZE - 1, &total, &ctl);
+#endif
+
     if (NOT(ok)) {
         req->error = GetLastError();
         return DR_ERROR;


### PR DESCRIPTION
The console api as used currently in ren-c is not present prior to Windows Vista. This adds a build switch to workaround the issue on systems prior to Vista. This includes trying to compile with Mingw32 on Windows 10.