### PR TITLE
Only BLOCK!/FUNCTION! branches for conditionals (IF, CASE, etc.)

### DIFF
--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -1256,7 +1256,7 @@ REBNATIVE(every)
 //      count [any-number! logic! blank!]
 //          "Repetitions (true loops infinitely, FALSE? doesn't run)"
 //      body [block! function!]
-//          "Block to evaluate or function to run (may be a BRANCHER)."
+//          "Block to evaluate or function to run."
 //  ]
 //
 REBNATIVE(loop)

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -167,7 +167,7 @@ list-dir: procedure [
     /i "Indent"
         indent
 ][
-    indent: default ""
+    indent: default [""]
 
     save-dir: what-dir
 

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -90,7 +90,7 @@ sign-of: func [
     case [
         positive? number [1]
         negative? number [-1]
-    ] else 0
+    ] else [0]
 ]
 
 

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -176,7 +176,7 @@ replace: function [
 
     len: case [
         ; leave bitset patterns as-is regardless of target type, len = 1
-        bitset? :pattern 1
+        bitset? :pattern [1]
 
         any-string? target [
             unless string? :pattern [pattern: form :pattern]
@@ -190,7 +190,7 @@ replace: function [
         ]
 
         any-block? :pattern [length of :pattern]
-    ] else 1
+    ] else [1]
 
     while [pos: find/(all [case_REPLACE 'case]) target :pattern] [
         ; apply replacement if function, or drops pos if not
@@ -570,7 +570,7 @@ format: function [
             :integer! [abs rule]
             :string! [length of rule]
             :char! [1]
-        ] else 0
+        ] else [0]
     ]
 
     out: make string! val

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -34,7 +34,7 @@ REBOL [
 ;
 ; This should be initialized by make-host-init.r, but set a default just in
 ; case
-host-prot: default _
+host-prot: default [_]
 
 boot-print: procedure [
     "Prints during boot when not quiet."

--- a/tests/control/default.test.reb
+++ b/tests/control/default.test.reb
@@ -1,19 +1,19 @@
 [
     unset 'x
-    x: default 10
+    x: default [10]
     x = 10
 ][
     x: _
-    x: default 10
+    x: default [10]
     x = 10
 ][
     x: 20
-    x: default 10
+    x: default [10]
     x = 20
 ][
     o: make object! [x: 10 y: _ z: ()]
-    o/x: default 20
-    o/y: default 20
-    o/z: default 20
+    o/x: default [20]
+    o/y: default [20]
+    o/z: default [20]
     [10 20 20] = reduce [o/x o/y o/z]
 ]

--- a/tests/control/switch.test.reb
+++ b/tests/control/switch.test.reb
@@ -26,5 +26,5 @@
 ]
 
 [t: 1 | 1 = switch t [(t)]]
-[1 = switch/default 1 [] 1]
+[1 = switch/default 1 [] [1]]
 

--- a/tests/misc/shttpd.r
+++ b/tests/misc/shttpd.r
@@ -45,10 +45,10 @@ send-chunk: func [port] [
 
 handle-request: function [config req] [
     parse to-string req ["get " ["/ " | copy uri: to " "]]
-    uri: default "index.html"
+    uri: default ["index.html"]
     print ["URI:" uri]
     parse uri [some [thru "."] copy ext to end (type: mime-map/:ext)]
-    type: default "application/octet-stream"
+    type: default ["application/octet-stream"]
     if not exists? file: config/root/:uri [return error-response 404 uri]
     if error? try [data: read file] [return error-response 400 uri]
     reduce [200 type data]


### PR DESCRIPTION
This commit backpedals on a change adopted early after R3's open
sourcing, which allowed simple values to be used as branches in a
conditional.  Hence instead of writing:

     x: if 1 < 2 ["one is less than two"]

You could simply write:

     x: if 1 < 2 "one is less than two"

This was in the spirit of Rebol's reluctance to require boilerplate
unless it was absolutely necessary, such as not having the condition
of the IF be in blocks.  The concept wasn't necessarily that people
would stop using the delimiters, but that they might feel other choices
would give them "more bang for the buck" for each character, perhaps
in this case preferring:

     x: if (1 < 2) "one is less than two"

This had some drawbacks, for instance that writing `if condition body`
would look up the variable corresponding to body even if the condition
was false, and it didn't use the fetched value.  However, that was
already the case if `body` is a BLOCK!, so it seemed like no truly
new issues were being introduced.

Time and experience revealed that it actually did introduce somewhat of
an obscuring element.  BLOCK!s (and FUNCTION!s) would execute code
during a kind of "double-evaluation".  Other types would evaluate
the parameter at the callsite, but then not be further processed inside
of the conditional.  For a reader of code (or a writer) it was easy
to make mistakes or be confused about what was going on.

Attempts to add protections to make sure that only literals were being
used in the branch slots for non-BLOCK! and non-FUNCTION! types made
some progress.  However, that impeded abstraction...where code wishing
to pass through an arbitrary branch would have to worry that the act
of passing it through meant transferring a literal via a variable, thus
being against the rules.

In the meantime, conditional operators were introduced that never
evaluated their "branches", but passed through the values directly.
These were ??, !!, and CHOOSE.  Having these as an option made it less
necessary to have branches that weren't blocks, and also addressed
the problem of how to literally return a block (besides [[nesting it]])

This change affects all branches, hence it causes a backwards
incompatibility with R3-Alpha's CASE, which was previously tolerant of
non-BLOCK! branches, so you could write `case [x 1 y 2]`.  One can
either change that to use blocks, or use the CHOOSE operation, which
returns the chosen item literally...even if it's a block.