### PR TITLE
WAS operator for getting last value while setting a new one

### DIFF
--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -97,6 +97,19 @@ update: enfix func [
 ]
 
 
+was: func [
+    {Return a variable's value prior to an assignment, then do the assignment}
+
+    return: [<opt> any-value!]
+        {Value of the following SET-WORD! or SET-PATH! before assignment}
+    evaluation [<opt> any-value! <...>]
+        {Used to take the assigned value}
+    :look [set-word! set-path! <...>]
+][
+    (get* first look) also-do [take evaluation]
+]
+
+
 make-action: func [
     {Internal generator used by FUNCTION and PROCEDURE specializations.}
     return: [function!]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -152,11 +152,15 @@ load-header: function [
             return either required ['no-header] [reduce [_ tmp tail of tmp]]
         ]
 
-        ; get 'rebol keyword
-        set* [key: rest:] transcode/only data [blank]
+        true [
+            ; get 'rebol keyword
+            ;
+            set* [key: rest:] transcode/only data
 
-        ; get header block
-        set* [hdr: rest:] transcode/next/relax rest [blank]
+            ; get header block
+            ;
+            set* [hdr: rest:] transcode/next/relax rest
+        ]
 
         not block? :hdr [
             ; header block is incomplete
@@ -219,18 +223,18 @@ load-header: function [
                         return 'bad-compress
                     ]
 
-                    if all [sum | sum != checksum/secure rest] [
+                    if sum and (sum != checksum/secure rest) [
                         return 'bad-checksum
                     ]
                 ] ; else assumed not compressed
 
-                all [sum | sum != checksum/secure/part rest end] [
+                sum and (sum <> checksum/secure/part rest end) [
                     return 'bad-checksum
                 ]
             ]
         ]
 
-        :key != 'rebol [
+        :key <> 'rebol [
             ; block-embedded script, only script compression, ignore hdr/length
 
             tmp: really binary! rest ; saved for possible checksum calc later
@@ -244,12 +248,12 @@ load-header: function [
                         return 'bad-compress
                     ]
 
-                    if all [sum | sum != checksum/secure rest] [
+                    if sum and (sum <> checksum/secure rest) [
                         return 'bad-checksum
                     ]
                 ]
 
-                all [sum | sum != checksum/secure/part tmp back end] [
+                sum and (sum <> checksum/secure/part tmp back end) [
                     return 'bad-checksum
                 ]
             ]

--- a/tests/control/default.test.reb
+++ b/tests/control/default.test.reb
@@ -17,3 +17,18 @@
     o/z: default [20]
     [10 20 20] = reduce [o/x o/y o/z]
 ]
+
+; WAS tests
+[
+    x: 10
+    all [
+        10 = was x: 20
+        x = 20
+    ]
+][
+    x: _
+    all [
+        _ = was x: default [20]
+        x = 20
+    ]
+]


### PR DESCRIPTION
This introduces the WAS operator, which fetches the prior value of a
SET-WORD! or SET-PATH! and evaluates to that, but also performs it as
an assignment.

    >> x: 10

    >> was x: 20
    == 10

    >> x
    == 20

It works based on variadic lookahead, which means it doesn't actually
consume the SET-WORD! as a parameter.  This means it is compatible with
operations that quote backwards to find the SET-WORD!, for example
the DEFAULT operator.

    >> x: _

    >> was x: default [20]
    == _

    >> x
    == 20

Also includes some stray changes to %sys-load.r which make it use the
short circuit AND.