### PR TITLE
Fold AND~/OR~/XOR~ in INTERSECT/UNION/DIFFERENCE, AND*=>AND+

### DIFF
--- a/make/r2r3-future.r
+++ b/make/r2r3-future.r
@@ -537,7 +537,7 @@ eval: get 'do
 ; There is no way to get a conditional infix AND using those binaries.
 ; In some cases, the bitwise and will be good enough for logic purposes...
 ;
-and*: get 'and
+and+: get 'and
 and?: func [a b] [to-logic all [:a :b]]
 and: get 'and ; see above
 

--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -55,23 +55,66 @@ power: action [
     exponent [any-number!]
 ]
 
-and~: action [
-    {Returns the first value ANDed with the second.}
-    value1 [logic! integer! char! tuple! binary! bitset! typeset! datatype!]
-    value2 [logic! integer! char! tuple! binary! bitset! typeset! datatype!]
+
+intersect: action [
+    {Returns the intersection (AND) of two values.}
+    value1 [
+        logic! integer! char! tuple! ;-- math
+        any-array! any-string! bitset! typeset! ;-- sets
+        binary! ;-- ???
+    ]
+    value2 [
+        logic! integer! char! tuple! ;-- math
+        any-array! any-string! bitset! typeset! ;-- sets
+        binary! ;-- ???
+    ]
+    /case
+        "Uses case-sensitive comparison"
+    /skip
+        "Treat the series as records of fixed size"
+    size [integer!]
 ]
 
-or~: action [
-    {Returns the first value ORed with the second.}
-    value1 [logic! integer! char! tuple! binary! bitset! typeset! datatype!]
-    value2 [logic! integer! char! tuple! binary! bitset! typeset! datatype!]
+union: action [
+    {Returns the union (OR) of two values.}
+    value1 [
+        logic! integer! char! tuple! ;-- math
+        any-array! any-string! bitset! typeset! ;-- sets
+        binary! ;-- ???
+    ]
+    value2 [
+        logic! integer! char! tuple! ;-- math
+        any-array! any-string! bitset! typeset! ;-- sets
+        binary! ;-- ???
+    ]
+    /case
+        "Use case-sensitive comparison"
+    /skip
+        "Treat the series as records of fixed size"
+    size [integer!]
 ]
 
-xor~: action [
-    {Returns the first value exclusive ORed with the second.}
-    value1 [logic! integer! char! tuple! binary! bitset! typeset! datatype!]
-    value2 [logic! integer! char! tuple! binary! bitset! typeset! datatype!]
+difference: action [
+    {Returns the special difference (XOR) of two values.}
+    value1 [
+        logic! integer! char! tuple! ;-- math
+        any-array! any-string! bitset! typeset! ;-- sets
+        binary! ;-- ???
+        date! ;-- !!! Under review, this really doesn't fit
+    ]
+    value2 [
+        logic! integer! char! tuple! ;-- math
+        any-array! any-string! bitset! typeset! ;-- sets
+        binary! ;-- ???
+        date! ;-- !!! Under review, this really doesn't fit
+    ]
+    /case
+        "Uses case-sensitive comparison"
+    /skip
+        "Treat the series as records of fixed size"
+    size [integer!]
 ]
+
 
 ;-- Unary
 

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -151,6 +151,69 @@ REB_R Series_Common_Action_Maybe_Unhandled(
         Move_Value(D_OUT, value);
         return R_OUT; }
 
+    case SYM_INTERSECT: {
+        if (IS_BINARY(value))
+            return R_UNHANDLED; // !!! use bitwise math, for now
+
+        INCLUDE_PARAMS_OF_INTERSECT;
+
+        UNUSED(ARG(value1)); // covered by value
+
+        Init_Any_Series(
+            D_OUT,
+            VAL_TYPE(value),
+            Make_Set_Operation_Series(
+                value,
+                ARG(value2),
+                SOP_FLAG_CHECK,
+                REF(case),
+                REF(skip) ? Int32s(ARG(size), 1) : 1
+            )
+        );
+        return R_OUT; }
+
+    case SYM_UNION: {
+        if (IS_BINARY(value))
+            return R_UNHANDLED; // !!! use bitwise math, for now
+
+        INCLUDE_PARAMS_OF_UNION;
+
+        UNUSED(ARG(value1)); // covered by value
+
+        Init_Any_Series(
+            D_OUT,
+            VAL_TYPE(value),
+            Make_Set_Operation_Series(
+                value,
+                ARG(value2),
+                SOP_FLAG_BOTH,
+                REF(case),
+                REF(skip) ? Int32s(ARG(size), 1) : 1
+            )
+        );
+        return R_OUT; }
+
+    case SYM_DIFFERENCE: {
+        if (IS_BINARY(value))
+            return R_UNHANDLED; // !!! use bitwise math, for now
+
+        INCLUDE_PARAMS_OF_DIFFERENCE;
+
+        UNUSED(ARG(value1)); // covered by value
+
+        Init_Any_Series(
+            D_OUT,
+            VAL_TYPE(value),
+            Make_Set_Operation_Series(
+                value,
+                ARG(value2),
+                SOP_FLAG_BOTH | SOP_FLAG_CHECK | SOP_FLAG_INVERT,
+                REF(case),
+                REF(skip) ? Int32s(ARG(size), 1) : 1
+            )
+        );
+        return R_OUT; }
+
     default:
         break;
     }

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -696,9 +696,9 @@ REBTYPE(Bitset)
         Clear_Series(VAL_SERIES(value));
         goto return_bitset;
 
-    case SYM_AND_T:
-    case SYM_OR_T:
-    case SYM_XOR_T:
+    case SYM_INTERSECT:
+    case SYM_UNION:
+    case SYM_DIFFERENCE:
         if (!IS_BITSET(arg) && !IS_BINARY(arg))
             fail (Error_Math_Args(VAL_TYPE(arg), action));
         ser = Xandor_Binary(action, value, arg);

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -220,17 +220,17 @@ REBTYPE(Char)
         chr %= arg;
         break;
 
-    case SYM_AND_T:
+    case SYM_INTERSECT:
         arg = Math_Arg_For_Char(D_ARG(2), action);
         chr &= cast(REBUNI, arg);
         break;
 
-    case SYM_OR_T:
+    case SYM_UNION:
         arg = Math_Arg_For_Char(D_ARG(2), action);
         chr |= cast(REBUNI, arg);
         break;
 
-    case SYM_XOR_T:
+    case SYM_DIFFERENCE:
         arg = Math_Arg_For_Char(D_ARG(2), action);
         chr ^= cast(REBUNI, arg);
         break;

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -939,7 +939,7 @@ REBTYPE(Date)
         }
     }
     else {
-        switch(action) {
+        switch (action) {
         case SYM_EVEN_Q:
             return ((~day) & 1) == 0 ? R_TRUE : R_FALSE;
 
@@ -982,6 +982,32 @@ REBTYPE(Date)
 
         case SYM_ABSOLUTE:
             goto setDate;
+
+        case SYM_DIFFERENCE: {
+            INCLUDE_PARAMS_OF_DIFFERENCE;
+
+            REBVAL *val1 = ARG(value1);
+            REBVAL *val2 = ARG(value2);
+
+            if (REF(case))
+                fail (Error_Bad_Refines_Raw());
+
+            if (REF(skip))
+                fail (Error_Bad_Refines_Raw());
+            UNUSED(PAR(size));
+
+            // !!! Plain SUBTRACT on dates has historically given INTEGER! of
+            // days, while DIFFERENCE has given back a TIME!.  This is not
+            // consistent with the "symmetric difference" that all other
+            // applications of difference are for.  Review.
+            //
+            // https://forum.rebol.info/t/486
+            //
+            if (NOT(IS_DATE(val2)))
+                fail (Error_Unexpected_Type(VAL_TYPE(val1), VAL_TYPE(val2)));
+
+            Subtract_Date(val1, val2, D_OUT);
+            return R_OUT; }
 
         default:
             fail (Error_Illegal_Action(REB_DATE, action));

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -386,9 +386,9 @@ REBTYPE(Integer)
         || action == SYM_MULTIPLY
         || action == SYM_DIVIDE
         || action == SYM_POWER
-        || action == SYM_AND_T
-        || action == SYM_OR_T
-        || action == SYM_XOR_T
+        || action == SYM_INTERSECT
+        || action == SYM_UNION
+        || action == SYM_DIFFERENCE
         || action == SYM_REMAINDER
     ){
         if (IS_INTEGER(val2))
@@ -490,15 +490,15 @@ REBTYPE(Integer)
         num = (arg != -1) ? (num % arg) : 0; // !!! was macro called REM2 (?)
         break;
 
-    case SYM_AND_T:
+    case SYM_INTERSECT:
         num &= arg;
         break;
 
-    case SYM_OR_T:
+    case SYM_UNION:
         num |= arg;
         break;
 
-    case SYM_XOR_T:
+    case SYM_DIFFERENCE:
         num ^= arg;
         break;
 

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -235,17 +235,17 @@ REBTYPE(Logic)
 
     switch (action) {
 
-    case SYM_AND_T:
+    case SYM_INTERSECT:
         val2 = Math_Arg_For_Logic(D_ARG(2));
         val1 = LOGICAL(val1 && val2);
         break;
 
-    case SYM_OR_T:
+    case SYM_UNION:
         val2 = Math_Arg_For_Logic(D_ARG(2));
         val1 = LOGICAL(val1 || val2);
         break;
 
-    case SYM_XOR_T:
+    case SYM_DIFFERENCE:
         val2 = Math_Arg_For_Logic(D_ARG(2));
         val1 = LOGICAL(!val1 != !val2);
         break;

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1368,9 +1368,9 @@ REBTYPE(String)
 
     //-- Bitwise:
 
-    case SYM_AND_T:
-    case SYM_OR_T:
-    case SYM_XOR_T: {
+    case SYM_INTERSECT:
+    case SYM_UNION:
+    case SYM_DIFFERENCE: {
         if (NOT(IS_BINARY(arg)))
             fail (arg);
 

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -328,9 +328,9 @@ REBTYPE(Tuple)
         || action == SYM_MULTIPLY
         || action == SYM_DIVIDE
         || action == SYM_REMAINDER
-        || action == SYM_AND_T
-        || action == SYM_OR_T
-        || action == SYM_XOR_T
+        || action == SYM_INTERSECT
+        || action == SYM_UNION
+        || action == SYM_DIFFERENCE
     ){
         assert(vp);
 
@@ -392,15 +392,15 @@ REBTYPE(Tuple)
                 v %= a;
                 break;
 
-            case SYM_AND_T:
+            case SYM_INTERSECT:
                 v &= a;
                 break;
 
-            case SYM_OR_T:
+            case SYM_UNION:
                 v |= a;
                 break;
 
-            case SYM_XOR_T:
+            case SYM_DIFFERENCE:
                 v ^= a;
                 break;
 

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -378,21 +378,23 @@ REBTYPE(Typeset)
 
         fail (arg);
 
-    case SYM_AND_T:
-    case SYM_OR_T:
-    case SYM_XOR_T:
+    case SYM_INTERSECT:
+    case SYM_UNION:
+    case SYM_DIFFERENCE:
         if (IS_DATATYPE(arg)) {
             VAL_TYPESET_BITS(arg) = FLAGIT_KIND(VAL_TYPE(arg));
         }
         else if (NOT(IS_TYPESET(arg)))
             fail (arg);
 
-        if (action == SYM_OR_T)
+        if (action == SYM_UNION)
             VAL_TYPESET_BITS(val) |= VAL_TYPESET_BITS(arg);
-        else if (action == SYM_AND_T)
+        else if (action == SYM_INTERSECT)
             VAL_TYPESET_BITS(val) &= VAL_TYPESET_BITS(arg);
-        else
+        else {
+            assert(action == SYM_DIFFERENCE);
             VAL_TYPESET_BITS(val) ^= VAL_TYPESET_BITS(arg);
+        }
         Move_Value(D_OUT, D_ARG(1));
         return R_OUT;
 

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -360,6 +360,14 @@ enum {
     COPY_SAME = 16
 };
 
+// Mathematical set operations for UNION, INTERSECT, DIFFERENCE
+enum {
+    SOP_NONE = 0, // used by UNIQUE (other flags do not apply)
+    SOP_FLAG_BOTH = 1 << 0, // combine and interate over both series
+    SOP_FLAG_CHECK = 1 << 1, // check other series for value existence
+    SOP_FLAG_INVERT = 1 << 2 // invert the result of the search
+};
+
 
 // Breakpoint hook callback, signature:
 //

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -50,21 +50,16 @@ r3-alpha-quote: func [:spelling [word! string!]] [
 
 ; Make top-level words for things not added by %b-init.c (e.g. /, //)
 ;
-+: -: *: **: and*: or+: xor+: _
++: -: *: **: _
 
 for-each [math-op function-name] [
     +       add
     -       subtract
     *       multiply
-    **      power
-
     /       divide ;-- !!! may become pathing operator (which also divides)
 
-    //      remainder ;-- !!! bad WORD!... https://forum.rebol.info/t/275
-
-    and*    and~
-    or+     or~
-    xor+    xor~
+    **      power ;-- !!! more a separator? https://forum.rebol.info/t/474/4
+    //      remainder ;-- !!! new comment? https://forum.rebol.info/t/275
 ][
     ; Ren-C's infix math obeys the "tight" parameter convention of R3-Alpha.
     ; But since the prefix functions themselves have normal parameters, this
@@ -78,6 +73,27 @@ for-each [math-op function-name] [
     ; one wants (e.g. to switch one parameter from normal to quoted).
     ;
     set/enfix math-op (tighten get function-name)
+]
+
+
+; Make top-level words
+;
+and+: or+: xor+: _
+
+for-each [set-op function-name] [
+    and+    intersect
+    or+     union
+    xor+    difference
+][
+    ; The enfixed versions of the set operations currently can't take any
+    ; refinements, so we go ahead and specialize them out.  (It's also the
+    ; case that TIGHTEN currently changes all normal parameters to #tight,
+    ; which creates an awkward looking /SKIP's SIZE.
+    ;
+    set/enfix set-op (tighten specialize function-name [
+        case: false
+        skip: false
+    ])
 ]
 
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -1283,7 +1283,7 @@ set 'r3-legacy* func [<local> if-flags] [
 
     ; In the object appending model above, can't use ENFIX or SET/ENFIX...
     ;
-    system/contexts/user/and: enfix tighten :and*
+    system/contexts/user/and: enfix tighten :and+
     system/contexts/user/or: enfix tighten :or+
     system/contexts/user/xor: enfix tighten :xor+
 

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -123,24 +123,24 @@ parse-asn: function [
     while [d: first data] [
         switch mode [
             type [
-                constructed?: not zero? (d and* 32)
+                constructed?: not zero? (d and+ 32)
                 class: pick class-types 1 + shift d -6
 
                 switch class [
                     universal [
-                        tag: pick universal-tags 1 + (d and* 31)
+                        tag: pick universal-tags 1 + (d and+ 31)
                     ]
                     context-specific [
                         tag: class
-                        val: d and* 31
+                        val: d and+ 31
                     ]
                 ]
                 mode: 'size
             ]
 
             size [
-                size: d and* 127
-                unless zero? (d and* 128) [
+                size: d and+ 127
+                unless zero? (d and+ 128) [
                     ; long form
                     ln: size
                     size: to-integer/unsigned copy/part next data size

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -449,8 +449,8 @@ do-needs: function [
                     blank
                 ]
 
-                (needs and* 0.0.0.255.255)
-                != (system/version and* 0.0.0.255.255) [
+                (needs and+ 0.0.0.255.255)
+                <> (system/version and+ 0.0.0.255.255) [
                     cause-error 'syntax 'needs reduce ['core needs]
                 ]
             ]

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -185,7 +185,7 @@ usage: procedure [
 ]
 
 boot-welcome:
-{Welcome to the Rebol console.  For more information please type in the commands below:
+{Welcome to Rebol.  For more information please type in the commands below:
 
   HELP    - For starting information
   ABOUT   - Information about your Rebol

--- a/src/os/unzip.reb
+++ b/src/os/unzip.reb
@@ -88,9 +88,9 @@ ctx-zip: context [
     ][
         value: get-ishort value
         to time! reduce [
-            63488 and* value / 2048
-            2016 and* value / 32
-            31 and* value * 2
+            63488 and+ value / 2048
+            2016 and+ value / 32
+            31 and+ value * 2
         ]
     ]
 
@@ -100,9 +100,9 @@ ctx-zip: context [
     ][
         value: get-ishort value
         to date! reduce [
-            65024 and* value / 512 + 1980
-            480 and* value / 32
-            31 and* value
+            65024 and+ value / 512 + 1980
+            480 and+ value / 32
+            31 and+ value
         ]
     ]
 
@@ -195,13 +195,13 @@ ctx-zip: context [
     ]
 
     any-file?: func [
-        "Returns TRUE for file and* url values." value [<opt> any-value!]
+        "Returns TRUE for file and url values." value [<opt> any-value!]
     ][
         any [file? value url? value]
     ]
 
     to-path-file: func [
-        {Converts url! to file! and* removes heading "/"}
+        {Converts url! to file! and removes heading "/"}
         value [file! url!] "AnyValue to convert"
     ][
         if file? value [
@@ -337,7 +337,7 @@ ctx-zip: context [
                 (nb-entries: nb-entries + 1)
                 2 skip ; version
                 copy flags: 2 skip
-                    (if not zero? flags/1 and* 1 [return false])
+                    (if not zero? flags/1 and+ 1 [return false])
                 copy method-number: 2 skip (
                     method-number: get-ishort method-number
                     method: select [0 store 8 deflate] method-number
@@ -419,7 +419,7 @@ ctx-zip: context [
                             empty? uncompressed-data
                         ][blank][uncompressed-data]
                     ][
-                        ; make directory and* / or+ write file
+                        ; make directory and/or write file
                         either #"/" = last name [
                             if not exists? where/:name [
                                 make-dir/deep where/:name

--- a/tests/atronix/ms-drives.r
+++ b/tests/atronix/ms-drives.r
@@ -8,7 +8,7 @@ getdrives: make-routine msvcrt "_getdrives" compose/deep [
 maps: getdrives
 i: 0
 while [i < 26] [
-    unless zero? maps and* shift 1 i [
+    unless zero? maps and (shift 1 i) [
         print unspaced [to char! (to integer! #"A") + i ":"]
     ]
     i: ++ 1

--- a/tests/control/case.test.reb
+++ b/tests/control/case.test.reb
@@ -50,7 +50,7 @@
         true [s1: true]
         true [s2: true]
     ]
-    s1 and* s2
+    s1 and (s2)
 ]
 ; recursivity
 [1 = case [true [case [true [1]]]]]

--- a/tests/control/for.test.reb
+++ b/tests/control/for.test.reb
@@ -4,9 +4,9 @@
     num: 0
     for i 1 10 1 [
         num: num + 1
-        success: (i = num) and* success
+        success: success and (i = num)
     ]
-    (10 = num) and* success
+    success and (10 = num)
 ]
 ; cycle return value
 [bar? for i 1 1 1 [false]]

--- a/tests/control/repeat.test.reb
+++ b/tests/control/repeat.test.reb
@@ -4,9 +4,9 @@
     num: 0
     repeat i 10 [
         num: num + 1
-        success: (i = num) and* success
+        success: success and (i = num)
     ]
-    (10 = num) and* success
+    success and (10 = num)
 ]
 ; cycle return value
 [bar? repeat i 1 [false]]

--- a/tests/datatypes/closure.test.reb
+++ b/tests/datatypes/closure.test.reb
@@ -67,7 +67,7 @@
 [
     a-value: first [:a]
     f: closure [] [:a-value]
-    (same? :a-value f) and* (:a-value == f)
+    (same? :a-value f) and (:a-value == f)
 ]
 [
     f: closure [] [#"^@"]

--- a/tests/datatypes/decimal.test.reb
+++ b/tests/datatypes/decimal.test.reb
@@ -5,6 +5,7 @@
 [decimal? 1.0]
 [decimal? -1.0]
 [decimal? 1.5]
+
 ; LOAD decimal and to binary! tests
 ; 64-bit IEEE 754 maximum
 [equal? #{7FEFFFFFFFFFFFFF} to binary! 1.7976931348623157e308]
@@ -26,15 +27,18 @@
 [equal? #{8010000000000000} to binary! -2.2250738585072014E-308]
 ; 64-bit IEEE 754 minimum
 [equal? #{FFEFFFFFFFFFFFFF} to binary! -1.7976931348623157e308]
-; bug#729
+
 ; MOLD decimal accuracy tests
 [
+    #729
     system/options/decimal-digits: 17
     system/options/decimal-digits = 17
 ]
+
 ; 64-bit IEEE 754 maximum
 [zero? 1.7976931348623157e308 - load mold 1.7976931348623157e308]
 [same? 1.7976931348623157e308 load mold 1.7976931348623157e308]
+
 ; Minimal positive normalized
 [zero? 2.2250738585072014E-308 - load mold 2.2250738585072014E-308]
 [same? 2.2250738585072014E-308 load mold 2.2250738585072014E-308]
@@ -70,11 +74,13 @@
 [same? 0.30000000000000004 load mold 0.30000000000000004]
 [zero? 9.9999999999999926e152 - load mold 9.9999999999999926e152]
 [same? 9.9999999999999926e152 load mold 9.9999999999999926e152]
-; bug#718
+
 [
+    #718
     a: 9.9999999999999926e152 * 1e-138
     zero? a - load mold a
 ]
+
 ; bug#897
 ; MOLD/ALL decimal accuracy tests
 ; 64-bit IEEE 754 maximum
@@ -115,6 +121,7 @@
 [same? 0.30000000000000004 load mold/all 0.30000000000000004]
 [zero? 9.9999999999999926e152 - load mold/all 9.9999999999999926e152]
 [same? 9.9999999999999926e152 load mold/all 9.9999999999999926e152]
+
 ; LOAD decimal accuracy tests
 [equal? to binary! 2.2250738585072004e-308 #{000FFFFFFFFFFFFE}]
 [equal? to binary! 2.2250738585072005e-308 #{000FFFFFFFFFFFFE}]
@@ -127,8 +134,13 @@
 [equal? to binary! 2.2250738585072012e-308 #{0010000000000000}]
 [equal? to binary! 2.2250738585072013e-308 #{0010000000000000}]
 [equal? to binary! 2.2250738585072014e-308 #{0010000000000000}]
-; bug#1753
-[c: last mold/all 1e16 (#"0" <= c) and* (#"9" >= c)]
+
+[
+    #1753
+    c: last mold/all 1e16
+    (#"0" <= c) and (#"9" >= c)
+]
+
 ; alternative form
 [1.1 == 1,1]
 [1.1 = make decimal! 1.1]
@@ -136,8 +148,12 @@
 [1.1 = to decimal! 1.1]
 [1.1 = to decimal! "1.1"]
 [error? try [to decimal! "t"]]
+
 ; decimal! to binary! and binary! to decimal!
 [equal? #{3ff0000000000000} to binary! 1.0]
 [same? to decimal! #{3ff0000000000000} 1.0]
-; bug#747
-[equal? #{3FF0000000000009} to binary! to decimal! #{3FF0000000000009}]
+
+[
+    #747
+    equal? #{3FF0000000000009} to binary! to decimal! #{3FF0000000000009}
+]

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -69,7 +69,7 @@
 [
     a-value: first [:a]
     f: does [:a-value]
-    (same? :a-value f) and* (:a-value == f)
+    (same? :a-value f) and (:a-value == f)
 ]
 [
     f: does [#"^@"]

--- a/tests/math/and.test.reb
+++ b/tests/math/and.test.reb
@@ -1,30 +1,36 @@
-; functions/math/and.r
-[true and* true = true]
-[true and* false = false]
-[false and* true = false]
-[false and* false = false]
-; integer
-[1 and* 1 = 1]
-[1 and* 0 = 0]
-[0 and* 1 = 0]
-[0 and* 0 = 0]
-[1 and* 2 = 0]
-[2 and* 1 = 0]
-[2 and* 2 = 2]
-; char
-[#"^(00)" and* #"^(00)" = #"^(00)"]
-[#"^(01)" and* #"^(00)" = #"^(00)"]
-[#"^(00)" and* #"^(01)" = #"^(00)"]
-[#"^(01)" and* #"^(01)" = #"^(01)"]
-[#"^(01)" and* #"^(02)" = #"^(00)"]
-[#"^(02)" and* #"^(02)" = #"^(02)"]
-; tuple
-[0.0.0 and* 0.0.0 = 0.0.0]
-[1.0.0 and* 1.0.0 = 1.0.0]
-[2.0.0 and* 2.0.0 = 2.0.0]
-[255.255.255 and* 255.255.255 = 255.255.255]
-; binary
-[#{030000} and* #{020000} = #{020000}]
+; logic!
+[true and+ true = true]
+[true and+ false = false]
+[false and+ true = false]
+[false and+ false = false]
+
+; integer!
+[1 and+ 1 = 1]
+[1 and+ 0 = 0]
+[0 and+ 1 = 0]
+[0 and+ 0 = 0]
+[1 and+ 2 = 0]
+[2 and+ 1 = 0]
+[2 and+ 2 = 2]
+
+; char!
+[#"^(00)" and+ #"^(00)" = #"^(00)"]
+[#"^(01)" and+ #"^(00)" = #"^(00)"]
+[#"^(00)" and+ #"^(01)" = #"^(00)"]
+[#"^(01)" and+ #"^(01)" = #"^(01)"]
+[#"^(01)" and+ #"^(02)" = #"^(00)"]
+[#"^(02)" and+ #"^(02)" = #"^(02)"]
+
+; tuple!
+[0.0.0 and+ 0.0.0 = 0.0.0]
+[1.0.0 and+ 1.0.0 = 1.0.0]
+[2.0.0 and+ 2.0.0 = 2.0.0]
+[255.255.255 and+ 255.255.255 = 255.255.255]
+
+; binary!
+[#{030000} and+ #{020000} = #{020000}]
+
+; !!! arccosing tests that somehow are in and.test.reb
 [0 = arccosine 1]
 [0 = arccosine/radians 1]
 [30 = arccosine (square-root 3) / 2]

--- a/tests/old/r2-tests.r
+++ b/tests/old/r2-tests.r
@@ -416,7 +416,7 @@
 [#"^(fe)" = add #"^(ff)" #"^(ff)"]
 ; tuple
 ; string
-["^(03)^(00)" and* "^(02)^(00)" = "^(02)^(00)"]
+["^(03)^(00)" and+ "^(02)^(00)" = "^(02)^(00)"]
 ; functions/math/arccosine.r
 ; char
 [#"^(ff)" = complement #"^@"]


### PR DESCRIPTION
This folds the prefix form of "bitwise" math into the corresponding
set operations, and then makes AND+/OR+/XOR+ the enfixed versions of
those operations.  This broadens the applicable types that can be used
with the infix operator:

    >> "ade" or+ "bcf"
    == "adebcf"

It also gets rid of the not-very-well-named prefix forms of the math
operation.

This change was proposed long ago to accompany the switch of plain
AND and OR to be "conditional" boolean logic operations.  However, two
details were glossed over.  One is that what should happen on a
BINARY! is slightly ambiguous, as it might be desirable to treat it
as a set of bytes vs. as something to operate on bitwise.  The other
issue is that DIFFERENCE on DATE! is an outlier in when the behavior
is conceptually an XOR, and is more a play on the word "difference"
than an actual fit for the operation.

This commit punts on both issues for the moment, preserving the legacy
behavior on both counts.