### PR TITLE
Add odbc include path to mod-odbc

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -489,6 +489,9 @@ available-modules: reduce [
             ;
             <msc:/wd4201>
         ]
+        includes: [
+            %prep/extensions/odbc ;for %tmp-ext-odbc-init.inc
+        ]
         libraries: to-value switch/default system-config/os-base [
             Windows [
                 [%odbc32]


### PR DESCRIPTION
Include path was missing from `mod-odbc` for the header file `%tmp-ext-odbc-init.inc`, this lets Visual Studio 2017 build properly