### PR TITLE
Add "DID" native, remove ! as built-in synonym for NOT

### DIFF
--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -92,12 +92,31 @@ REBNATIVE(nand_q)
 
 
 //
+//  did?: native [
+//
+//  "Clamps a value to LOGIC! (e.g. a synonym for NOT? NOT? or TO-LOGIC)"
+//
+//      return: [logic!]
+//          "Only LOGIC!'s FALSE and BLANK! for value return FALSE"
+//      value [any-value!]
+//  ]
+//
+REBNATIVE(did_q)
+{
+    INCLUDE_PARAMS_OF_DID_Q;
+
+    return R_FROM_BOOL(IS_TRUTHY(ARG(value)));
+}
+
+
+//
 //  not?: native [
 //
 //  "Returns the logic complement."
 //
+//      return: [logic!]
+//          "Only LOGIC!'s FALSE and BLANK! for value return TRUE"
 //      value [any-value!]
-//          "(Only LOGIC!'s FALSE and BLANK! return TRUE)"
 //  ]
 //
 REBNATIVE(not_q)

--- a/src/mezz/base-constants.r
+++ b/src/mezz/base-constants.r
@@ -49,7 +49,7 @@ crlf:      "^M^J"
 
 ;-- Function synonyms:
 not: :not?
-!: :not?
+did: :did?
 min: :minimum
 max: :maximum
 abs: :absolute

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -237,22 +237,16 @@ value?: func [dummy:] [
 
 true?: func [dummy:] [
     fail/where [
-        {TRUE? is misleading/ambiguous, use either TO-LOGIC or `= TRUE`} |
-        {(TRUTHY? is also provided to see if anyone actually likes it)}
+        {Historical TRUE? is ambiguous, use either TO-LOGIC or `= TRUE`} |
+        {(experimental alternative of DID as "anti-NOT" is also offered)}
     ] 'dummy
 ]
 
 false?: func [dummy:] [
     fail/where [
-        {FALSE? is misleading/ambiguous, use either NOT or `= FALSE`} |
-        {(FALSEY? is still provided to see if anyone actually likes it)}
+        {Historical FALSE? is ambiguous, use either NOT or `= FALSE`}
     ] 'dummy
 ]
-
-; Silly names, but someone might like them
-;
-truthy?: :to-logic
-falsey?: :not
 
 none-of: :none ;-- reduce mistakes for now by renaming NONE out of the way
 

--- a/tests/series/difference.test.reb
+++ b/tests/series/difference.test.reb
@@ -2,5 +2,18 @@
 [[1 3] = difference [1 2] [2 3]]
 [[[1 2] [3 4]] = difference [[1 2] [2 3]] [[2 3] [3 4]]]
 [[path/1 path/3] = difference [path/1 path/2] [path/2 path/3]]
-; bug#799
-[equal? make typeset! [decimal!] difference make typeset! [decimal! integer!] make typeset! [integer!]]
+
+[
+    #799
+    equal?
+        make typeset! [decimal!]
+        difference make typeset! [decimal! integer!] make typeset! [integer!]
+]
+
+[
+    #1822
+    did all [
+        12:00 = difference 13/1/2011/12:00 13/1/2011
+        12:00 = difference 13/1/2011/12:00 13/1/2011/0:0
+    ]
+]


### PR DESCRIPTION
TRUTHY? and FALSEY? operators were added to see if anyone liked them,
but they were unpleasant.  This removes them, assuming you would use
NOT anytime you would want FALSEY?.

Yet there is no general consensus on what the "opposite of NOT is",
since usually the opposite of NOT is just taking it away.  TO-LOGIC is
a substitute, but it feels a bit drawn-out and long.

A suggestion came up that at least sometimes seems okay.  DID.

    logic-variable: did find [a b c] 'd
    flag1: did all [...]
    flag2: did any [...]

While it is somewhat strange to say `did 1` -> true, if one didn't
have the background to understand it then `not 1` -> false might also
look quite strange.  So in the interest of perhaps being a trendsetter,
this goes ahead and gives it a try...it's not hard to beat TRUTHY?.

    logic-variable: truthy? find [a b c] 'd
    flag1: truthy? all [...]
    flag2: truthy? any [...]

Additionally this removes the built-in choice to make ! a synonym for
NOT, as that is not something to be encouraged in Rebol code.