### PR TITLE
MAYBE+REALLY => arity 1, MATCH+ENSURE => arity 2

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -169,7 +169,7 @@ gen-obj: func [
                     <msc:/wd4127>
                 ]
             ][
-                really [string! tag!] flag
+                ensure [string! tag!] flag
             ]
         ]
         s: s/1

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -157,9 +157,9 @@ for-each-record type boot-types [
             e-dispatch/emit-item "T_Unhooked"
         ]
     ][ ; All other types should have handlers
-        e-dispatch/emit-item ["T_" propercase-of really word! type/class]
+        e-dispatch/emit-item ["T_" propercase-of ensure word! type/class]
     ]
-    e-dispatch/emit-annotation really [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] type/name
 ]
 e-dispatch/emit-end
 
@@ -177,16 +177,16 @@ for-each-record type boot-types [
     switch/default type/path [
         - [e-dispatch/emit-item "PD_Fail"]
         + [e-dispatch/emit-item [
-            "PD_" propercase-of really word! type/class]
+            "PD_" propercase-of ensure word! type/class]
         ]
         * [e-dispatch/emit-item "PD_Unhooked"]
     ][
         ; !!! Today's PORT! path dispatches through context even though that
         ; isn't its technical "class" for responding to actions.
         ;
-        e-dispatch/emit-item ["PD_" propercase-of really word! type/path]
+        e-dispatch/emit-item ["PD_" propercase-of ensure word! type/path]
     ]
-    e-dispatch/emit-annotation really [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] type/name
 ]
 e-dispatch/emit-end
 
@@ -204,13 +204,13 @@ for-each-record type boot-types [
     switch/default type/make [
         - [e-dispatch/emit-item "MAKE_Fail"]
         + [e-dispatch/emit-item [
-            "MAKE_" propercase-of really word! type/class]
+            "MAKE_" propercase-of ensure word! type/class]
         ]
         * [e-dispatch/emit-item "MAKE_Unhooked"]
     ][
         fail "MAKE in %types.r should be, -, +, or *"
     ]
-    e-dispatch/emit-annotation really [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] type/name
 ]
 e-dispatch/emit-end
 
@@ -228,13 +228,13 @@ for-each-record type boot-types [
     switch/default type/make [
         - [e-dispatch/emit-item "TO_Fail"]
         + [e-dispatch/emit-item [
-            "TO_" propercase-of really word! type/class
+            "TO_" propercase-of ensure word! type/class
         ]]
         * [e-dispatch/emit-item "TO_Unhooked"]
     ][
         fail "TO in %types.r should be -, +, or *"
     ]
-    e-dispatch/emit-annotation really [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] type/name
 ]
 e-dispatch/emit-end
 
@@ -252,7 +252,7 @@ for-each-record type boot-types [
     switch/default type/mold [
         - [e-dispatch/emit-item "MF_Fail"]
         + [e-dispatch/emit-item [
-            "MF_" propercase-of really word! type/class
+            "MF_" propercase-of ensure word! type/class
         ]]
         * [e-dispatch/emit-item "MF_Unhooked"]
     ][
@@ -260,9 +260,9 @@ for-each-record type boot-types [
         ; beyond the class (falls through to ANY-CONTEXT! for mold), and
         ; BINARY! has a different handler than strings
         ;
-        e-dispatch/emit-item ["MF_" propercase-of really word! type/mold]
+        e-dispatch/emit-item ["MF_" propercase-of ensure word! type/mold]
     ]
-    e-dispatch/emit-annotation really [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] type/name
 ]
 e-dispatch/emit-end
 
@@ -281,9 +281,9 @@ for-each-record type boot-types [
         0 [e-dispatch/emit-item "NULL"]
         * [e-dispatch/emit-item "CT_Unhooked"]
     ][
-        e-dispatch/emit-item ["CT_" propercase-of really word! type/class]
+        e-dispatch/emit-item ["CT_" propercase-of ensure word! type/class]
     ]
-    e-dispatch/emit-annotation really [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] type/name
 ]
 e-dispatch/emit-end
 
@@ -318,7 +318,7 @@ for-each-record type boot-types [
     either type/name = 0 [
         e-types/emit-item/assign "REB_0" 0
     ][
-        e-types/emit-item/assign/upper ["REB_" really word! type/name] n
+        e-types/emit-item/assign/upper ["REB_" ensure word! type/name] n
     ]
     e-types/emit-annotation n
 
@@ -366,7 +366,7 @@ for-each-record type boot-types [
 ; reminded of the importance of adjusting them.
 ;
 types-header: first load/header %types.r
-e-types/emit trim/auto copy really string! types-header/macros
+e-types/emit trim/auto copy ensure string! types-header/macros
 
 
 e-types/emit {

--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -39,11 +39,11 @@ args: parse-args system/options/args
 
 config: config-system to-value :args/OS_ID
 
-m-name: really string! args/MODULE
+m-name: ensure string! args/MODULE
 l-m-name: lowercase copy m-name
 u-m-name: uppercase copy m-name
 
-c-src: join-of %../../src/ fix-win32-path to file! really string! args/SRC
+c-src: join-of %../../src/ fix-win32-path to file! ensure string! args/SRC
 
 print ["building" m-name "from" c-src]
 
@@ -51,10 +51,10 @@ output-dir: system/options/path/prep
 mkdir/deep output-dir/include
 
 e-first: (make-emitter "Module C Header File Preface"
-    really file! join-all [output-dir/include/tmp-mod- l-m-name %-first.h])
+    ensure file! join-all [output-dir/include/tmp-mod- l-m-name %-first.h])
 
 e-last: (make-emitter "Module C Header File Epilogue"
-    really file! join-all [output-dir/include/tmp-mod- l-m-name %-last.h])
+    ensure file! join-all [output-dir/include/tmp-mod- l-m-name %-last.h])
 
 
 verbose: false

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -102,10 +102,16 @@ if true = attempt [void? :some-undefined-thing] [
 
     ; The once-arity-2 primitive known as ENSURE was renamed to REALLY, to
     ; better parallel MAYBE and free up ENSURE to simply mean "make sure it's
-    ; a value".  But older Ren-Cs have the arity-2 definition.  Adjust it.
+    ; a value".  Then it was changed back, when MAYBE and REALLY were moved
+    ; to be single arity and MATCH was introduced.  Try and smooth that over.
     ;
-    if find spec-of :ensure 'test [
-        really: :ensure
+    either all [
+        () <> :really
+        find spec-of :really 'test
+    ][
+        ensure: :really ;-- Ren-Cs up to around Jan 27, 2018
+    ][
+        assert [find spec-of :ensure 'test]
     ]
 
     QUIT ;-- !!! stops running if Ren-C here.

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1484,6 +1484,7 @@ REBOOL Specialize_Function_Throws(
     assert(out != specializee);
 
     REBCTX *exemplar = Make_Frame_For_Function(specializee);
+    MANAGE_ARRAY(CTX_VARLIST(exemplar));
 
     // Bind all the SET-WORD! in the body that match params in the frame
     // into the frame.  This means `value: value` can very likely have

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -121,7 +121,7 @@ assert-debug: function [
         ; Otherwise it's a block!
         active: true
         until [tail? conditions] [
-            if option: maybe [issue! tag!] :conditions/1 [
+            if option: match [issue! tag!] :conditions/1 [
                 unless active: select live-asserts-map option [
                     ;
                     ; if not found in the map, go with default behavior.

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -58,9 +58,9 @@ dump-obj: function [
         for-each [word val] obj [
             type: type of :val
 
-            str: either maybe [function! object!] :type [
+            str: if match [function! object!] :type [
                 spaced [word _ mold spec-of :val _ words of :val]
-            ][
+            ] else [
                 form word
             ]
 
@@ -185,18 +185,18 @@ spec-of: function [
 
     value [function!]
 ][
-    meta: maybe object! meta-of :value
+    meta: match object! meta-of :value
 
-    specializee: maybe function! select meta 'specializee
-    adaptee: maybe function! select meta 'specializee
-    original-meta: maybe object! any [
+    specializee: match function! select meta 'specializee
+    adaptee: match function! select meta 'specializee
+    original-meta: match object! any [
         all [:specializee | meta-of :specializee]
         all [:adaptee | meta-of :adaptee]
     ]
 
     spec: copy []
 
-    if description: maybe string! any [
+    if description: match string! any [
         select meta 'description
         select original-meta 'description
     ][
@@ -204,11 +204,11 @@ spec-of: function [
         new-line back spec true
     ]
 
-    return-type: maybe block! any [
+    return-type: match block! any [
         select meta 'return-type
         select original-meta 'return-type
     ]
-    return-note: maybe string! any [
+    return-note: match string! any [
         select meta 'return-note
         select original-meta 'return-note
     ]
@@ -218,11 +218,11 @@ spec-of: function [
         if return-note [append spec return-note]
     ]
 
-    types: maybe frame! any [
+    types: match frame! any [
         select meta 'parameter-types
         select original-meta 'parameter-types
     ]
-    notes: maybe frame! any [
+    notes: match frame! any [
         select meta 'parameter-notes
         select original-meta 'parameter-notes
     ]
@@ -342,7 +342,7 @@ help: procedure [
     ; but they exist...e.g. DEFAULT.)  To make sure HELP DEFAULT works, HELP
     ; must hard quote and simulate its own soft quote semantics.
     ;
-    if maybe [group! get-word! get-path!] :topic [
+    if match [group! get-word! get-path!] :topic [
         topic: reduce target
     ]
 
@@ -369,7 +369,7 @@ help: procedure [
     if all [
         doc
         word? :topic
-        maybe [function! datatype!] get :topic
+        match [function! datatype!] get :topic
     ][
         item: form :topic
         if function? get :topic [
@@ -467,10 +467,10 @@ help: procedure [
             (uppercase mold topic) "is" (type-name :value) "of value: "
         ]
         print unspaced collect [
-            either maybe [object! port!] value [
+            if match [object! port!] value [
                 keep newline
                 keep dump-obj value
-            ][
+            ] else [
                 keep mold value
             ]
         ]
@@ -520,7 +520,7 @@ help: procedure [
     ;
     meta: meta-of :value
     all [
-        original-name: maybe word! (
+        original-name: match word! (
             any [
                 select meta 'specializee-name
                 select meta 'adaptee-name
@@ -529,9 +529,9 @@ help: procedure [
         original-name: uppercase mold original-name
     ]
 
-    specializee: maybe function! select meta 'specializee
-    adaptee: maybe function! select meta 'adaptee
-    chainees: maybe block! select meta 'chainees
+    specializee: match function! select meta 'specializee
+    adaptee: match function! select meta 'adaptee
+    chainees: match block! select meta 'chainees
 
     classification: case [
         :specializee [
@@ -569,8 +569,8 @@ help: procedure [
 
     print-args: procedure [list /indent-words] [
         for-each param list [
-            note: maybe string! select notes to-word param
-            type: maybe [block! any-word!] select types to-word param
+            note: match string! select notes to-word param
+            type: match [block! any-word!] select types to-word param
 
             ;-- parameter name and type line
             if type and (not refinement? param) [
@@ -646,7 +646,8 @@ source: make function! [[
                 ]
             ]
         ]
-        maybe [word! path!] :arg [
+
+        match [word! path!] :arg [
             name: arg
             f: get :arg
         ]

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -478,7 +478,7 @@ r3-alpha-apply: function [
 ; warning: `apply :foo [| comment {This is a new APPLY} ...]`
 ;
 apply: adapt 'apply [
-    if not maybe [set-word! bar! blank!] first def [
+    if not match [set-word! bar! blank!] first def [
         fail {APPLY takes frame def block (or see r3-alpha-apply)}
     ]
 ]
@@ -1323,7 +1323,7 @@ set 'r3-legacy* func [<local> if-flags] [
                 adapt 'switch [use [last-was-block] [
                     last-was-block: false
                     for-next cases [
-                        if maybe [get-word! get-path! group!] cases/1 [
+                        if match [get-word! get-path! group!] cases/1 [
                             fail [{SWITCH non-<r3-legacy> evaluates} (cases/1)]
                         ]
                         if block? cases/1 [

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -116,7 +116,7 @@ save: function [
             method: _
         ]
 
-        length_SAVE: maybe integer! select header-data 'length
+        length_SAVE: match integer! select header-data 'length
         header-data: body-of header-data
     ]
 

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -170,8 +170,8 @@ secure: function [
 
     ; Set each policy target separately:
     for-each [target pol] policy [
-        really [word! file! url!] target
-        really [block! word! integer!] pol
+        ensure [word! file! url!] target
+        ensure [block! word! integer!] pol
         set-policy target make-policy target pol pol-obj
     ]
 

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -251,18 +251,16 @@ reword: function [
         ]
 
         block? delimiters [
-            unless (parse delimiters [
+            unless parse delimiters [
                 set prefix delimiter-types
                 set suffix opt delimiter-types
-            ])[
+            ][
                 fail ["Invalid /ESCAPE delimiter block" delimiters]
             ]
         ]
-
-        true [
-            assert [maybe? delimiter-types prefix]
-            prefix: delimiters
-        ]
+    ] else [
+        assert [match delimiter-types prefix]
+        prefix: delimiters
     ]
 
     ; MAKE MAP! will create a map with no duplicates from the input if it
@@ -293,7 +291,7 @@ reword: function [
     ;
     any-keyword-rule: collect [
         for-each [keyword value] values [
-            unless maybe? keyword-types keyword [
+            unless match keyword-types keyword [
                 fail ["Invalid keyword type:" keyword]
             ]
 
@@ -305,9 +303,9 @@ reword: function [
                 ; will work...so the keyword must be string converted for
                 ; the purposes of this rule.
                 ;
-                either maybe? [integer! word!] keyword [
+                if match [integer! word!] keyword [
                     to-string keyword
-                ][
+                ] else [
                     keyword
                 ]
 
@@ -344,8 +342,8 @@ reword: function [
     ;
     ; Integers have to be converted also.
     ;
-    if maybe [integer! word!] prefix [prefix: to-string prefix]
-    if maybe [integer! word!] suffix [suffix: to-string suffix]
+    if match [integer! word!] prefix [prefix: to-string prefix]
+    if match [integer! word!] suffix [suffix: to-string suffix]
 
     rule: [
         ; Begin marking text to copy verbatim to output
@@ -660,7 +658,7 @@ split: function [
                 ; apply to parse rules that were all integers, e.g. [1 1 1],
                 ; since those style blocks are handled by the other branch.
                 ;
-                assert [maybe [bitset! any-string! char! block!] dlm]
+                assert [match [bitset! any-string! char! block!] dlm]
                 [
                     any [mk1: some [mk2: dlm break | skip] (
                         keep/only copy/part mk1 mk2
@@ -691,7 +689,7 @@ split: function [
             integer? dlm []
         ]
         else [
-            assert [maybe [bitset! any-string! char! block!] dlm]
+            assert [match [bitset! any-string! char! block!] dlm]
 
             ; If the last thing in the series is a delimiter, there is an
             ; implied empty field after it, which we add here.

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -129,7 +129,7 @@ do*: function [
     ; LOAD it will trigger before the failure of changing the working dir)
     ; It is loaded as UNBOUND so that DO-NEEDS runs before INTERN.
     ;
-    code: really block! (load/header/type source 'unbound)
+    code: ensure block! (load/header/type source 'unbound)
 
     ; LOAD/header returns a block with the header object in the first
     ; position, or will cause an error.  No exceptions, not even for
@@ -137,7 +137,7 @@ do*: function [
     ;
     ; !!! Should the header always be locked by LOAD?
     ;
-    hdr: lock really [object! blank!] first code
+    hdr: lock ensure [object! blank!] first code
     is-module: 'module = select hdr 'type
     code: next code
 
@@ -170,7 +170,7 @@ do*: function [
         ; define a standard for that)
         ;
         if all [
-            maybe? [file! url!] source
+            match [file! url!] source
             file: find/last/tail source slash
         ][
             change-dir copy/part source file

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -237,7 +237,7 @@ load-header: function [
         :key <> 'rebol [
             ; block-embedded script, only script compression, ignore hdr/length
 
-            tmp: really binary! rest ; saved for possible checksum calc later
+            tmp: ensure binary! rest ; saved for possible checksum calc later
 
             ; decode embedded script
             rest: skip first set [data: end:] transcode/next data 2
@@ -261,15 +261,15 @@ load-header: function [
 
     ]
 
-    really [binary! blank!] hdr/checksum
-    really [block! blank!] hdr/options
+    ensure [binary! blank!] hdr/checksum
+    ensure [block! blank!] hdr/options
 
     ; Return a BLOCK! with 3 elements in it
     ;
     return reduce [
-        really object! hdr
-        really [binary! block!] rest
-        really binary! end
+        ensure object! hdr
+        ensure [binary! block!] rest
+        ensure binary! end
     ]
 ]
 
@@ -339,7 +339,7 @@ load: function [
         ]
 
         ;-- What type of file? Decode it too:
-        maybe? [file! url!] source [
+        match [file! url!] source [
             file: source
             line: 1
 
@@ -648,12 +648,13 @@ load-module: function [
                 ; Return blank if no module of that name found
                 not tmp: find/skip system/modules source 3 [return blank]
 
-                ; get the module
-                set [mod: modsum:] next tmp [blank]
+                true [
+                    ; get the module
+                    ;
+                    set [mod: modsum:] next tmp
 
-                <check> [
-                    really [module! block!] mod
-                    really [binary! blank!] modsum
+                    ensure [module! block!] mod
+                    ensure [binary! blank!] modsum
                 ]
 
                 ; If no further processing is needed, shortcut return
@@ -665,7 +666,7 @@ load-module: function [
         binary? source [data: source]
         string? source [data: to binary! source]
 
-        any [file? source | url? source] [
+        match [file! url!] source [
             tmp: file-type? source
             case [ ; Return blank if read or load-extension fails
                 not tmp [
@@ -744,7 +745,7 @@ load-module: function [
         void? :mod [mod: _]
         module? mod [
             delay: no-share: _ hdr: meta-of mod
-            really [block! blank!] hdr/options
+            ensure [block! blank!] hdr/options
         ]
         block? mod [set* [hdr: code:] mod]
 
@@ -794,10 +795,10 @@ load-module: function [
                 module? :mod0 [hdr0: meta-of mod0] ; final header
                 block? :mod0 [hdr0: first mod0] ; cached preparsed header
 
-                <check> [
-                    really word! name0
-                    really object! hdr0
-                    really [binary! blank!] sum0
+                true [
+                    ensure word! name0
+                    ensure object! hdr0
+                    ensure [binary! blank!] sum0
                 ]
 
                 not tuple? ver0: :hdr0/version [ver0: 0.0.0]
@@ -865,8 +866,8 @@ load-module: function [
                 binary? code [code: to block! code]
             ]
 
-            really object! hdr
-            really block! code
+            ensure object! hdr
+            ensure block! code
 
             mod: catch/quit [
                 module/mixin hdr code (opt do-needs/no-user hdr)

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -197,7 +197,7 @@ make-scheme: function [
         scheme/actor: actor
     ]
 
-    unless maybe [object! handle!] :scheme/actor [
+    unless match [object! handle!] :scheme/actor [
         fail ["Scheme actor" :scheme/name "can't be" type of :scheme/actor]
     ]
 

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -118,7 +118,7 @@ elf-format: context [
             if endian = 'little [reverse bin]
             set name (to-integer/unsigned bin)
         ][
-            val: really integer! get name
+            val: ensure integer! get name
             bin: skip (tail of to-binary val) (negate num-bytes) ; big endian
             if endian = 'little [reverse bin]
             change begin bin
@@ -245,7 +245,7 @@ elf-format: context [
                 (mode: 'read) section-header-rule
                 (
                     name-start: skip string-section sh_name
-                    name-end: really binary! find name-start #{00}
+                    name-end: ensure binary! find name-start #{00}
                     section-name: to-string copy/part name-start name-end
                     if name = section-name [
                         return index ;-- sh_offset, sh_size, etc. are set


### PR DESCRIPTION
This addresses the question of what the "anti-default" should be called
by taking the name MAYBE:

    >> x: maybe 1 + 2
    == 3

    >> x: maybe blank
    == 3

    >> x: maybe ()
    == 3

    >> x: maybe* blank ;-- * means count _ as value
    == _

    >> x: maybe [1 + 2] ;-- not what you meant
    ** Error: Literal block! used w/MAYBE, use () if intentional

All in all, it's a very good name for what it does.  It's a tool for
*maybe* doing an assignment, if the right hand side is "something"...
where something usually means not-void and not-blank, but can be
fallen back upon to mean just not-void.

A parallel function called REALLY operates in much the same way, but
instead of not doing the assignment it will fail.

    >> x: really ()
    ** Script Error: really requires value argument to not be void

    >> x: really blank
    ** Error: REALLY received a BLANK! (use REALLY* if this is ok)

*(Since it always does the assignment else raises an error, it's actually
not enfix and has no need to quote the left to bypass any
assignments...so it can be used anywhere, not just to the right of a
SET-WORD! or SET-PATH!.)*

The names were too good for the purpose to pass up.  But this meant
having to re-shuffle the names for the arity-2 functions, which instead
of assuming blanks and voids are what you're filtering, allow you to
filter on typesets or by calling a function.

Those were given the names MATCH and ENSURE.

    >> match [integer! string!] 3
    == 3

    >> match [integer! string!] <tag>
    == _

    >> match :even? 3
    == _

    >> match :odd? 3
    == 3

    >> ensure [integer! string!] <tag>
    ** Error: ENSURE did not expect argument of type tag!

MATCH is a noun-like word which might be desired for variable names,
and has been used previously in the QuarterMaster web framework.  But
it seems to work reasonably well here.  And the revised words seem to
go along better with their arity.