### PR TITLE
Kill if?/find?/select?/while?/all?/any?/case?/switch?/parse?

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -66,7 +66,7 @@ for-each [name value] options [
                 ][
                     user-ext: make object! load ext-file
                     unless all [
-                        find? words-of user-ext 'extensions
+                        find words-of user-ext 'extensions
                         block? user-ext/extensions
                     ][
                         fail ["Malformated extension selection file, it needs to be 'EXTENSIONS: []'" (mold user-ext)]
@@ -1306,7 +1306,7 @@ cfg-tcc: _
 case [
     any [
         file? user-config/with-tcc
-        find? [yes on true #[true]] user-config/with-tcc
+        find [yes on true #[true]] user-config/with-tcc
     ][
         tcc-rootdir: either file? user-config/with-tcc [
             first split-path user-config/with-tcc
@@ -1348,7 +1348,7 @@ case [
             %tmp-embedded-header.c
         ]
     ]
-    find? [no off false #[false] _] user-config/with-tcc [
+    find [no off false #[false] _] user-config/with-tcc [
         ;pass
     ]
     true [
@@ -1510,7 +1510,7 @@ for-each [action name modules] user-config/extensions [
                     item/modules
                 ][
                     map-each m item/modules [
-                        if find? modules m/name [
+                        if find modules m/name [
                             m
                         ]
                     ]
@@ -1559,7 +1559,7 @@ add-project-flags: proc [
     /g debug
 ][
     assert [
-        find? [
+        find [
             dynamic-library-class
             object-library-class
             static-library-class
@@ -1620,7 +1620,7 @@ process-module: func [
                     gen-obj/dir s src-dir/extensions/%
                 ]
                 all [object? s
-                    find? [
+                    find [
                         object-library-class
                         object-file-class
                     ] s/class-name
@@ -1644,7 +1644,7 @@ process-module: func [
                         ]
                     ]
                     all [object? lib
-                        find? [
+                        find [
                             ext-dynamic-class
                             ext-static-class
                         ] lib/class-name
@@ -1838,7 +1838,7 @@ add-new-obj-folders: procedure [
 
         for-each obj lib [
             dir: first split-path obj/output
-            unless find? folders dir [
+            unless find folders dir [
                 append folders dir
             ]
         ]

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -237,11 +237,7 @@ proc: func [spec body] [
 ]
 
 
-; No specializations in R3-Alpha, cover simple cases
-;
-find?: func [series value] [
-    true? find :series :value
-]
+did: :to-logic
 
 ; Ren-C replaces the awkward term PAREN! with GROUP!  (Retaining PAREN!
 ; for compatibility as pointing to the same datatype).  Older Rebols

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -718,7 +718,7 @@ ld: make linker-class [
     ][
         switch/default dep/class-name [
             object-file-class [
-                ;if find? words-of dep 'depends [
+                ;if find words-of dep 'depends [
                     ;for-each ddep dep/depends [
                     ;    dump ddep
                     ;]
@@ -732,7 +732,7 @@ ld: make linker-class [
                     ]
                 ][
                     unspaced [
-                        if find? dep/flags 'static ["-static "]
+                        if find dep/flags 'static ["-static "]
                         "-l" dep/output
                     ]
                 ]
@@ -830,7 +830,7 @@ llvm-link: make linker-class [
     ][
         switch/default dep/class-name [
             object-file-class [
-                ;if find? words-of dep 'depends [
+                ;if find words-of dep 'depends [
                     ;for-each ddep dep/depends [
                     ;    dump ddep
                     ;]
@@ -924,7 +924,7 @@ link: make linker-class [
     ][
         switch/default dep/class-name [
             object-file-class [
-                ;if find? words-of dep 'depends [
+                ;if find words-of dep 'depends [
                     ;for-each ddep dep/depends [
                     ;    dump ddep
                     ;]
@@ -1073,7 +1073,7 @@ object-file-class: make object! [
         args
     ][
         assert [
-            find? [
+            find [
                 application-class
                 dynamic-library-class
                 static-library-class
@@ -1172,7 +1172,11 @@ generator-class: make object! [
         localize (func [v][either file? v [file-to-local v][v]])
     ][
         if object? cmd [
-            assert [find? [cmd-create-class cmd-delete-class cmd-strip-class] cmd/class-name]
+            assert [
+                find [
+                    cmd-create-class cmd-delete-class cmd-strip-class
+                ] cmd/class-name
+            ]
             cmd: gen-cmd cmd
         ]
         unless cmd [return _]
@@ -1202,12 +1206,12 @@ generator-class: make object! [
         <local>
         dep
     ][
-        if find? words-of solution 'output [
+        if find words-of solution 'output [
             setup-outputs solution
         ]
         flip-flag solution false
 
-        if find? words-of solution 'depends [
+        if find words-of solution 'depends [
             for-each dep solution/depends [
                 if dep/class-name = 'var-class [
                     append vars reduce [
@@ -1229,11 +1233,11 @@ generator-class: make object! [
         dep
     ][
         if all [
-            find? words-of project 'generated?
+            find words-of project 'generated?
             to != project/generated?
         ][
             project/generated?: to
-            if find? words-of project 'depends [
+            if find words-of project 'depends [
                 for-each dep project/depends [
                     flip-flag dep to
                 ]
@@ -1440,7 +1444,7 @@ makefile: make generator-class [
         for-each dep project/depends [
             unless object? dep [continue]
             ;dump dep
-            unless find? [ext-dynamic-class ext-static-class] dep/class-name [
+            unless find [ext-dynamic-class ext-static-class] dep/class-name [
                 either dep/generated? [
                     continue
                 ][
@@ -1592,7 +1596,7 @@ Execution: make generator-class [
 
         prepare project
 
-        unless find? [ext-dynamic-class ext-static-class] project/class-name [
+        unless find [ext-dynamic-class ext-static-class] project/class-name [
             either project/generated? [
                 leave
             ][
@@ -1731,7 +1735,7 @@ visual-studio: make generator-class [
         ;dump project
         depends: make block! 8
         for-each dep project/depends [
-            if find? [
+            if find [
                 object-library-class
                 dynamic-library-class
                 static-library-class
@@ -1838,7 +1842,7 @@ visual-studio: make generator-class [
     find-optimization?: func [
         optimization
     ][
-        not find? [0 _ no false off #[false]] optimization
+        not find [0 _ no false off #[false]] optimization
     ]
 
     generate-project: procedure [
@@ -1862,7 +1866,7 @@ visual-studio: make generator-class [
         project/generated?: true
         ;print mold project
 
-        either find? [
+        either find [
             dynamic-library-class
             static-library-class
             application-class
@@ -1920,7 +1924,7 @@ visual-studio: make generator-class [
             ]
             remove back tail-of lib ;move the trailing ";"
 
-            if find? [dynamic-library-class application-class] project/class-name [
+            if find [dynamic-library-class application-class] project/class-name [
                 for-each i project/searches [
                     if i: filter-flag/leading-char i "msc" "" [
                         append searches unspaced [file-to-local i ";"]
@@ -2024,7 +2028,7 @@ visual-studio: make generator-class [
   ] {
     </ClCompile>}
     case [
-        find? [dynamic-library-class application-class] project/class-name [
+        find [dynamic-library-class application-class] project/class-name [
             unspaced [ {
     <Link>
       <AdditionalOptions> /machine:} cpu { %(AdditionalOptions)</AdditionalOptions>
@@ -2044,7 +2048,7 @@ visual-studio: make generator-class [
     </Link>}
             ]
         ]
-        find? [static-library-class object-library-class] project/class-name [
+        find [static-library-class object-library-class] project/class-name [
             unspaced [ {
     <Lib>
       <AdditionalOptions> /machine:} cpu { %(AdditionalOptions)</AdditionalOptions>
@@ -2052,7 +2056,7 @@ visual-studio: make generator-class [
             ]
         ]
         all [
-            find? [entry-class] project/class-name
+            find [entry-class] project/class-name
             project/commands
         ][
             unspaced [ {
@@ -2064,7 +2068,7 @@ visual-studio: make generator-class [
         ]
     ]
     if all [
-        find? words-of project 'post-build-commands
+        find words-of project 'post-build-commands
         project/post-build-commands
     ][
         unspaced [ {
@@ -2167,7 +2171,7 @@ visual-studio: make generator-class [
   use [o refs][
     refs: make string! 1024
     for-each o project/depends [
-        if find? words-of o 'id [
+        if find words-of o 'id [
             unless o/id [o/id: take uuid-pool]
             append refs unspaced [ {    <ProjectReference Include="} o/name {.vcxproj" >
       <Project>} o/id {</Project>
@@ -2226,7 +2230,7 @@ visual-studio: make generator-class [
         ; Project section
         projects: make block! 8
         for-each dep solution/depends [
-            if find? [
+            if find [
                 dynamic-library-class
                 static-library-class
                 object-library-class

--- a/scripts/changes-file/changes-file.reb
+++ b/scripts/changes-file/changes-file.reb
@@ -138,7 +138,7 @@ notable?: function [
         cherry-pick (load-cherry-pick-map)
         related (make block! 0)
 ][
-    if find? related c/commit [return false]    ;; related commits are not notable
+    if find related c/commit [return false]    ;; related commits are not notable
 
     numbers: charset "1234567890"
 

--- a/src/extensions/locale/ext-locale-init.reb
+++ b/src/extensions/locale/ext-locale-init.reb
@@ -475,18 +475,17 @@ unless 'Windows = first system/platform [
         ]
 
         case [
-            find? [language language*] type [
+            find [language language*] type [
                 any [
-                    all [find? ["C" "POSIX"] lang "English"]
+                    all [find ["C" "POSIX"] lang "English"]
                     select iso-639 lang
                 ]
             ]
-            find? [territory territory*] type [
+            find [territory territory*] type [
                 all [territory select iso-3166 territory]
             ]
-            true [
-                fail ["Invalid locale type:" type]
-            ]
+        ] else [
+            fail ["Invalid locale type:" type]
         ]
     ]
 

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -82,9 +82,10 @@ suffix-of: func [
 
 dir?: func [
     {Returns TRUE if the file or url ends with a slash (or backslash).}
+    return: [logic!]
     target [file! url!]
 ][
-    find? "/\" last target
+    did find "/\" last target
 ]
 
 dirize: func [

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -91,7 +91,7 @@ maybe: enfix func [
     <local> gotten
 ][
     ; While DEFAULT requires a BLOCK!, MAYBE does not.  Catch mistakes such
-    ; as `x: maybe [...]` 
+    ; as `x: maybe [...]`
     ;
     if semiquoted? 'value [
         fail/where [
@@ -344,7 +344,7 @@ dig-function-meta-fields: function [value [function!]] [
             ; sensitive to it here.
             ;
             temp: select meta 'return-type
-            if all [not set? 'temp | fields | select? fields 'return-type] [
+            if all [not set? 'temp | fields | select fields 'return-type] [
                 temp: copy fields/return-type
             ]
             :temp
@@ -556,29 +556,10 @@ set*: redescribe [
 )
 
 
-; LOGIC VERSIONS OF CONTROL STRUCTURES
-;
-; Control structures evaluate to either void (if no branches taken) or the
-; last value of any evaluated blocks.  This applies to everything from IF
-; to CASE to WHILE.  The ? versions are tailored to return whether a branch
-; was taken at all, and always return either TRUE or FALSE.
-
-if?: redescribe [
-    {Variation of IF which returns TRUE if the branch runs, FALSE if not}
-](
-    chain [:if | :any-value?]
-)
-
 if*: redescribe [
     {Same as IF/ONLY (void, not blank, if branch evaluates to void)}
 ](
     specialize 'if [only: true]
-)
-
-unless?: redescribe [
-    {Variation of UNLESS which returns TRUE if the branch runs, FALSE if not}
-](
-    chain [:unless | :any-value?]
 )
 
 unless*: redescribe [
@@ -593,28 +574,10 @@ either*: redescribe [
     specialize 'either [only: true]
 )
 
-while?: redescribe [
-    {Variation of WHILE which returns TRUE if the body ever runs, FALSE if not}
-](
-    chain [:while | :any-value?]
-)
-
-case?: redescribe [
-    {Variation of CASE which returns TRUE if any cases run, FALSE if not}
-](
-    chain [:case | :any-value?]
-)
-
 case*: redescribe [
     {Same as CASE/ONLY (void, not blank, if branch evaluates to void)}
 ](
     specialize 'case [only: true]
-)
-
-switch?: redescribe [
-    {Variation of SWITCH which returns TRUE if any cases run, FALSE if not}
-](
-    chain [:switch | :any-value?]
 )
 
 switch*: redescribe [
@@ -633,18 +596,6 @@ catch?: redescribe [
     {Variation of CATCH which returns TRUE if a throw is caught, FALSE if not}
 ](
     specialize 'catch [?: true]
-)
-
-any?: redescribe [
-    {Shortcut OR, ignores voids. Unlike plain ANY, forces result to LOGIC!}
-](
-    chain [:any | :to-value | :to-logic]
-)
-
-all?: redescribe [
-    {Shortcut AND, ignores voids. Unlike plain ALL, forces result to LOGIC!}
-](
-    chain [:all | :to-value | :to-logic]
 )
 
 match: redescribe [
@@ -721,7 +672,7 @@ really: func [
         {Just make sure the value isn't void, pass through BLANK!}
 ][
     ; While DEFAULT requires a BLOCK!, REALLY does not.  Catch mistakes such
-    ; as `x: really [...]` 
+    ; as `x: really [...]`
     ;
     if semiquoted? 'value [
         fail/where [
@@ -741,22 +692,10 @@ really: func [
 really*: specialize 'really [only: true]
 
 
-find?: redescribe [
-    {Variant of FIND that returns TRUE if present and FALSE if not.}
-](
-    chain [:find | :something?]
-)
-
 select: redescribe [
     {Variant of SELECT* that returns BLANK when not found, instead of void}
 ](
     chain [:select* | :to-value]
-)
-
-select?: redescribe [
-    {Variant of SELECT that returns TRUE if a value was selected, else FALSE.}
-](
-    chain [:select | :any-value?]
 )
 
 pick: redescribe [
@@ -774,23 +713,6 @@ take: redescribe [
         specialize 'either-test-value [
             branch: [
                 fail "Can't TAKE from series end (see TAKE* to get void)"
-            ]
-        ]
-    ]
-)
-
-parse?: redescribe [
-    {Variant of PARSE that enforces a TRUE or FALSE result from the rules.}
-](
-    chain [
-        :parse
-            |
-        specialize 'either-test [
-            test: :logic?
-            branch: [
-                fail [
-                    "Rules passed to PARSE? returned non-LOGIC!:" (mold :x)
-                ]
             ]
         ]
     ]

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -145,12 +145,14 @@ confirm: function [
 
     unless with [choices: [["y" "yes"] ["n" "no"]]]
 
-    to-value case [
+    to-logic case [
         empty? choices [true]
-        string? choices [find?/match response choices]
-        2 > length of choices [find?/match response first choices]
-        find? first choices response [true]
-        find? second choices response [false]
+        string? choices [find/match response choices]
+        2 > length of choices [find/match response first choices]
+        find first choices response [true]
+        find second choices response [false]
+    ] else [
+         false
     ]
 ]
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -735,7 +735,7 @@ set 'r3-legacy* func [<local> if-flags] [
             apply 'lib-set [
                 target: either any-context? target [words of target] [target]
                 value: :value
-                only: any? [set_ANY only]
+                only: set_ANY or (only)
                 some: set_SOME
                 enfix: enfix
             ]
@@ -775,12 +775,12 @@ set 'r3-legacy* func [<local> if-flags] [
 
                 apply 'lib-get [
                     source: words of source
-                    opt: any? [any_GET opt_GET] ;-- will error if voids found
+                    opt: any_GET or (opt_GET) ;-- will error if voids found
                 ]
             ][
                 apply 'lib-get [
                     source: source
-                    opt: any? [any_GET opt_GET]
+                    opt: any_GET or (opt_GET)
                 ]
             ]
         ]
@@ -1092,7 +1092,7 @@ set 'r3-legacy* func [<local> if-flags] [
             return-value
         ][
             apply 'lib/quit [
-                with: any? [with | return]
+                with: with or (return)
                 value: case [with [value] return [return-value]]
             ]
         ])

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -112,7 +112,7 @@ save: function [
             append header-data reduce [(quote length:) (true)]
         ]
 
-        unless compress: find? (select header-data 'options) 'compress [
+        unless compress: did find (select header-data 'options) 'compress [
             method: _
         ]
 

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -241,7 +241,7 @@ reword: function [
     case_REWORD: case
     case: :lib/case
 
-    unless into [output: make (type of source) length of source]
+    output: default [make (type of source) length of source]
 
     prefix: _
     suffix: _
@@ -284,7 +284,7 @@ reword: function [
     ; to figure this out based on copying data out of the source series would
     ; need to do a lot of reverse-engineering of the types.
     ;
-    match: _
+    keyword-match: _
 
     ; Note that the enclosing rule has to account for `prefix` and `suffix`,
     ; this just matches the keywords themselves, setting `match` if one did.
@@ -317,7 +317,7 @@ reword: function [
                 ; match necessarily happened, as the enclosing rule may have
                 ; a `suffix` left to take into account.
                 ;
-                as group! compose [match: quote (keyword)]
+                as group! compose [keyword-match: quote (keyword)]
             ]
 
             keep [
@@ -330,8 +330,8 @@ reword: function [
     ; Note that `any-keyword-rule` will look something like:
     ;
     ; [
-    ;     "keyword1" (match: quote keyword1)
-    ;     | "keyword2" (match: quote keyword2)
+    ;     "keyword1" (keyword-match: quote keyword1)
+    ;     | "keyword2" (keyword-match: quote keyword2)
     ;     | fail
     ; ]
 
@@ -372,9 +372,9 @@ reword: function [
                         ;
                         output: insert/part output a b
 
-                        v: select values match
+                        v: select values keyword-match
                         output: insert output case [
-                            function? :v [v :match]
+                            function? :v [v :keyword-match]
                             block? :v [do :v]
                             true [:v]
                         ]
@@ -491,8 +491,11 @@ alter: func [
             append series :value true
         ]
     ]
-    unless? remove (find/(all [case_ALTER ['case]]) series :value) [
-        append series :value ;-- returns true if this branch runs, false if not
+    either remove (find/(all [case_ALTER ['case]]) series :value) [
+        append series :value
+        true
+    ][
+        false
     ]
 ]
 

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -713,7 +713,7 @@ sys/make-scheme [
         open?: func [
             port [port!]
         ][
-            all? [port/state open? port/state/connection]
+            port/state and (open? port/state/connection)
         ]
 
         close: func [

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -1332,7 +1332,7 @@ sys/make-scheme [
         ]
 
         open?: func [port [port!]] [
-            all? [port/state open? port/state/connection]
+            port/state and (open? port/state/connection)
         ]
 
         close: func [port [port!] <local> ctx] [

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -87,7 +87,7 @@ mixin?: func [
 ][
     ; Note: Unnamed modules DO NOT default to being mixins.
     if module? mod [mod: meta-of mod]  ; Get the header object
-    all? [
+    did all [
         find select mod 'options 'private
         ; If there are no exports, there's no difference
         block? select mod 'exports
@@ -760,7 +760,7 @@ load-module: function [
                 import [
                     ; /import overrides 'delay option
                 ]
-                not delay [delay: find? hdr/options 'delay]
+                not delay [delay: did find hdr/options 'delay]
             ]
             if hdr/checksum [modsum: copy hdr/checksum]
         ]

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -586,8 +586,8 @@ pe-format: context [
             word [any-word!]
         ][
             unless any [
-                find? words to word! word
-                find? def to set-word! word
+                find words to word! word
+                find def to set-word! word
             ][
                 append def reduce [to set-word! word]
             ]

--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -33,8 +33,7 @@
         ;; extra large (500K+)
         data: copy {}
         call/wait/output [%/usr/bin/git "log" {--pretty=format:'[commit: {%h} author: {%an} email: {%ae} date-string: {%ai} summary: {%s}]'}] data
-        and?
-            (length of data) > 500'000
-            find? data "summary: {Initial commit}]"  ;; bottom of log
+        length of data > 500'000 and (find data "summary: {Initial commit}]")
+        ;; bottom of log
     ] else [true] ;; test wasn't run but no way to skip :(
 ]

--- a/tests/context/set.test.reb
+++ b/tests/context/set.test.reb
@@ -10,11 +10,11 @@
 [
     a: 10
     b: 20
-    all? [blank = set [a b] blank | blank? a | blank? b]
+    did all [blank = set [a b] blank | blank? a | blank? b]
 ][
     a: 10
     b: 20
-    all? [
+    did all [
         [x y] = set/single [a b] [x y]
         a = [x y]
         b = [x y]
@@ -24,11 +24,11 @@
     b: 20
     c: 30
     set [a b c] [_ 99]
-    all? [a = _ | b = 99 | c = _]
+    did all [a = _ | b = 99 | c = _]
 ][
     a: 10
     b: 20
     c: 30
     set/some [a b c] [_ 99]
-    all? [a = 10 | b = 99 | c = 30]
+    did all [a = 10 | b = 99 | c = 30]
 ]

--- a/tests/control/catch.test.reb
+++ b/tests/control/catch.test.reb
@@ -87,7 +87,7 @@
 ;
 [
     x: _
-    all? [
+    did all [
         error? trap [do-all [
             x: 10
                 |
@@ -101,7 +101,7 @@
 
 [
     x: _
-    all? [
+    did all [
         30 = catch [do-all [
             x: 10
                 |

--- a/tests/control/dont.test.reb
+++ b/tests/control/dont.test.reb
@@ -9,7 +9,7 @@
 
 [
     pos: _
-    all? [
+    did all [
         don't []
         don't/next [] 'pos
         pos = []
@@ -18,7 +18,7 @@
 
 [
     success: true
-    all? [
+    did all [
         don't [success: false (success: false) :abs set 'success <bad>]
         success = true
     ]
@@ -26,7 +26,7 @@
     pos: _
     success: true
     code: [success: 1 + 2 (success: false) :abs set 'success <bad>]
-    all? [
+    did all [
         don't code
         don't/next code 'pos
         pos = [(success: false) :abs set 'success <bad>]

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -32,7 +32,7 @@
         return if i < 15 [30] else [4]
     ]
 
-    a: all? [
+    a: did all [
         30 = c 10
         4 = c 20
     ]

--- a/tests/control/for-each.test.reb
+++ b/tests/control/for-each.test.reb
@@ -79,18 +79,18 @@
     x: 10
     sum: 0
     for-each x [1 2 3] [sum: sum + x]
-    all? [x = 10 | sum = 6]
+    did all [x = 10 | sum = 6]
 ][
     x: 10
     sum: 0
     for-each 'x [1 2 3] [sum: sum + x]
-    all? [x = 3 | sum = 6]
+    did all [x = 3 | sum = 6]
 ][
     x: 10
     y: 20
     sum: 0
     for-each ['x y] [1 2 3 4] [sum: sum + x + y]
-    all? [x = 3 | y = 20 | sum = 10]
+    did all [x = 3 | y = 20 | sum = 10]
 ]
 
 ; Redundancy is checked for.  LIT-WORD! redundancy is legal because those
@@ -106,7 +106,7 @@
     obj1: make object! [x: 20]
     obj2: make object! [x: 30]
     sum: 0
-    all? [
+    did all [
         error? trap [for-each [x x] [1 2 3 4] [sum: sum + x]]
         error? trap [
             for-each (compose [ ;-- see above

--- a/tests/datatypes/block.test.reb
+++ b/tests/datatypes/block.test.reb
@@ -14,7 +14,7 @@
 
 [
     data: [a 10 b 20]
-    all? [
+    did all [
         10 = data/a
         10 = select data 'a
         10 = select* data 'a

--- a/tests/datatypes/date.test.reb
+++ b/tests/datatypes/date.test.reb
@@ -19,13 +19,13 @@
 
 ; extreme behaviour
 [
-    any? [
+    did any [
         error? try [date-d: 1/Jan/0000 - 1]
         date-d = load mold date-d
     ]
 ]
 [
-    any? [
+    did any [
         error? try [date-d: 31-Dec-16383 + 1]
         date-d = load mold date-d
     ]

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -309,7 +309,7 @@
 [
     a: func [b] [a: _ c: b]
     f: func [d] [a [d] do c]
-    all? [
+    did all [
         1 = f 1
         error? try [2 = f 2]
     ]

--- a/tests/datatypes/money.test.reb
+++ b/tests/datatypes/money.test.reb
@@ -12,14 +12,14 @@
 ; check, whether these are moldable
 [
     x: $999999999999999
-    any? [
+    did any [
         error? try [x: x + $1]
         not error? try [mold x]
     ]
 ]
 [
     x: -$999999999999999
-    any? [
+    did any [
         error? try [x: x - $1]
         not error? try [mold x]
     ]
@@ -27,7 +27,7 @@
 ; alternative form
 [$1.1 == $1,1]
 [
-    any? [
+    did any [
         error? try [x: $1234567890123456]
         not error? try [mold x]
     ]

--- a/tests/datatypes/symbol.test.reb
+++ b/tests/datatypes/symbol.test.reb
@@ -14,7 +14,7 @@
     block-1: reduce ['a _]
     block-2: reduce ['b block-1]
     block-1/2: block-2
-    all? [
+    did all [
         block-1/1 = block-1/1
         block-1/2 = block-1/2
     ]

--- a/tests/datatypes/time.test.reb
+++ b/tests/datatypes/time.test.reb
@@ -9,7 +9,7 @@
 
 ; small value
 [
-    any? [
+    did any [
         error? try [t: -596522:0:0 - 1:00]
         t = load mold t
     ]
@@ -17,7 +17,7 @@
 
 ; big value
 [
-    any? [
+    did any [
         error? try [t: 596522:0:0 + 1:00]
         t = load mold t
     ]

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -60,14 +60,14 @@
 
     3 = (value: 1 + 2 <| 30 + 40 x: value  () ())
 
-    all? [value = 3 | x = 3]
+    did all [value = 3 | x = 3]
 ][
     value: ()
     x: ()
 
     70 = (value: 1 + 2 |> 30 + 40 x: value () () ())
 
-    all? [value = 3 | x = 3]
+    did all [value = 3 | x = 3]
 ]
 
 [

--- a/tests/functions/adapt.test.reb
+++ b/tests/functions/adapt.test.reb
@@ -8,7 +8,7 @@
 ][
     capture: blank
     foo: adapt 'any [capture: block]
-    all? [
+    did all [
       foo [1 2 3]
       capture = [1 2 3]
     ]

--- a/tests/functions/enclose.test.reb
+++ b/tests/functions/enclose.test.reb
@@ -15,7 +15,7 @@
         do f
     ]
 
-    all? [
+    did all [
         blank? n-add 10 20
         25 = n-add 20 20
     ]

--- a/tests/functions/hijack.test.reb
+++ b/tests/functions/hijack.test.reb
@@ -6,7 +6,7 @@
 
     old-foo: copy :foo
 
-    all? [
+    did all [
         (old-foo 10) = 11
         hijack 'foo func [x] [(old-foo x) + 20]
         (old-foo 10) = 11
@@ -56,7 +56,7 @@
 
     step10: (two-30 10 20) ; 60
 
-    all? [
+    did all [
         step1 = 60
         step2 = 60
         step3 = 6000

--- a/tests/functions/invisible.test.reb
+++ b/tests/functions/invisible.test.reb
@@ -16,14 +16,14 @@
 ][
     pos: _
     val: do/next [1 comment "a" + comment "b" 2 * 3 fail "didn't stop"] 'pos
-    all? [
+    did all [
         val = 1
         pos = [+ comment "b" 2 * 3 fail "didn't stop"]
     ]
 ][
     pos: _
     val: do/next [1 comment "a" comment "b" + 2 * 3 fail "didn't stop"] 'pos
-    all? [
+    did all [
         val = 1
         pos = [+ 2 * 3 fail "didn't stop"] 'pos
     ]
@@ -57,14 +57,14 @@
 [
     unset 'x
     x: 1 + 2 * 3 elide (y: :x)
-    all? [
+    did all [
         x = 9
         not set? 'y
     ]
 ][
     unset 'x
     x: 1 + elide (y: 10) 2 * 3
-    all? [
+    did all [
         x = 9
         y = 10
     ]
@@ -79,7 +79,7 @@
     y: 1 elide [+ 2
     z: 30] + 7
 
-    all? [
+    did all [
         x = 10
         y = 8
         not set? 'z

--- a/tests/parse-tests.r
+++ b/tests/parse-tests.r
@@ -1,19 +1,19 @@
 ; Is PARSE working at all?
 
-[parse? "abc" ["abc"]]
+[did parse "abc" ["abc"]]
 
 ; Blank and empty block case handling
 
-[parse? [] []]
-[parse? [] [[[]]]]
-[parse? [] [_ _ _]]
-[not parse? [x] []]
-[not parse? [x] [_ _ _]]
-[not parse? [x] [[[]]]]
-[parse? [] [[[_ _ _]]]]
-[parse? [x] ['x _]]
-[parse? [x] [_ 'x]]
-[parse? [x] [[] 'x []]]
+[did parse [] []]
+[did parse [] [[[]]]]
+[did parse [] [_ _ _]]
+[not parse [x] []]
+[not parse [x] [_ _ _]]
+[not parse [x] [[[]]]]
+[parse [] [[[_ _ _]]]]
+[parse [x] ['x _]]
+[parse [x] [_ 'x]]
+[parse [x] [[] 'x []]]
 
 ; SET-WORD! (store current input position)
 
@@ -47,15 +47,15 @@
 
 ; TO/THRU integer!
 
-[parse? "abcd" [to 3 "cd"]]
-[parse? "abcd" [to 5]]
-[parse? "abcd" [to 128]]
+[did parse "abcd" [to 3 "cd"]]
+[did parse "abcd" [to 5]]
+[did parse "abcd" [to 128]]
 
-[#1965 | parse? "abcd" [thru 3 "d"]]
-[#1965 | parse? "abcd" [thru 4]]
-[#1965 | parse? "abcd" [thru 128]]
-[#1965 | parse? "abcd" ["ab" to 1 "abcd"]]
-[#1965 | parse? "abcd" ["ab" thru 1 "bcd"]]
+[#1965 | did parse "abcd" [thru 3 "d"]]
+[#1965 | did parse "abcd" [thru 4]]
+[#1965 | did parse "abcd" [thru 128]]
+[#1965 | did parse "abcd" ["ab" to 1 "abcd"]]
+[#1965 | did parse "abcd" ["ab" thru 1 "bcd"]]
 
 ; parse THRU tag!
 
@@ -74,12 +74,12 @@
     i == 1
 ]
 
-[#1959 | parse? "abcd" [thru "d"]]
-[#1959 | parse? "abcd" [to "d" skip]]
+[#1959 | did parse "abcd" [thru "d"]]
+[#1959 | did parse "abcd" [to "d" skip]]
 
-[#1959 | parse? "<abcd>" [thru <abcd>]]
-[#1959 | parse? [a b c d] [thru 'd]]
-[#1959 | parse? [a b c d] [to 'd skip]]
+[#1959 | did parse "<abcd>" [thru <abcd>]]
+[#1959 | did parse [a b c d] [thru 'd]]
+[#1959 | did parse [a b c d] [to 'd skip]]
 
 ; self-invoking rule
 
@@ -120,26 +120,26 @@
 
 ; NOT rule
 
-[#1246 | parse? "1" [not not "1" "1"]]
-[#1246 | parse? "1" [not [not "1"] "1"]]
-[#1246 | not parse? "" [not 0 "a"]]
-[#1246 | not parse? "" [not [0 "a"]]]
-[#1240 | parse? "" [not "a"]]
-[#1240 | parse? "" [not skip]]
-[#1240 | parse? "" [not fail]]
+[#1246 | did parse "1" [not not "1" "1"]]
+[#1246 | did parse "1" [not [not "1"] "1"]]
+[#1246 | not parse "" [not 0 "a"]]
+[#1246 | not parse "" [not [0 "a"]]]
+[#1240 | did parse "" [not "a"]]
+[#1240 | did parse "" [not skip]]
+[#1240 | did parse "" [not fail]]
 
 [#100 | 1 == eval does [parse [] [(return 1)] 2]]
 
 ; TO/THRU + bitset!/charset!
 
-[#1457 | parse? "a" compose [thru (charset "a")]]
-[#1457 | not parse? "a" compose [thru (charset "a") skip]]
-[#1457 | parse? "ba" compose [to (charset "a") skip]]
-[#1457 | not parse? "ba" compose [to (charset "a") "ba"]]
+[#1457 | did parse "a" compose [thru (charset "a")]]
+[#1457 | not parse "a" compose [thru (charset "a") skip]]
+[#1457 | did parse "ba" compose [to (charset "a") skip]]
+[#1457 | not parse "ba" compose [to (charset "a") "ba"]]
 
 ; self-modifying rule, not legal in Ren-C if it's during the parse
 
-[error? try [not parse? "abcd" rule: ["ab" (remove back tail of rule) "cd"]]]
+[error? try [not parse "abcd" rule: ["ab" (remove back tail of rule) "cd"]]]
 
 [
     https://github.com/metaeducation/ren-c/issues/377

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -227,7 +227,7 @@
 ; path evaluation order
 [
     a: 1x2
-    any? [
+    did any [
         error? try [b: a/(a: [3 4] 1)]
         b = 1
         b = 3

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -379,7 +379,7 @@ rebsource: context [
             ] else [
                 if any [
                     parse second split-path item ["tmp-" to end]
-                    not find? extensions extension-of item
+                    not find extensions extension-of item
                 ][
                     unset 'item
                 ]
@@ -439,6 +439,6 @@ rebsource: context [
         {Returns true if file should not be analysed.}
         file
     ][
-        find? whitelisted file
+        did find whitelisted file
     ]
 ]


### PR DESCRIPTION
When the ability to specialize and chain functions was introduced in
Ren-C, void-based protocols did not exist (such as those now used by
ELSE and THEN, as well as the /ONLY variations of conditionals).  To
tell whether a conditional had taken a branch, it was necessary for the
native to expose a refinement (called /?) that would return a LOGIC!.

Hence specialization and chaining were used to create a group of
functions that ended in ?.  Unlike most functions with that naming
convention that were simple tests taking one parameter, these would
take as many parameters as the function they specialized, but merely
come back with a LOGIC! answer instead of their usual result.

Most uses of these functions were somewhat gratuitous...not to clamp
values to LOGIC!, but to ostensibly inform the reader that the context
the call was in would only have a logic result used.  Yet the plain
version of the functions which returned a BLANK! would suffice.

Some of the lack of need for the functions came with reaching some
compromises on things like SELECT returning BLANK! when a value was
not found--even though that could be conflated with finding a value
that was actually a blank.  The compromise of having a "core" version
of (e.g. SELECT*) which would use void to signal missing values made
the variants like SELECT? less necessary.

Also, the introduction of a positive analogue to NOT, called DID,
looks relatively good without a disruptive ? for those cases that
really need it.