### PR TITLE
Repurpose ALSO, kill after, add THEN, swap ELIDE/COMMENT behavior

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -398,7 +398,7 @@ inline static REBOOL Reb_Do_Api_Core_Fails(
         va_end(*vaptr);
 
         if (Detect_Rebol_Pointer(second) != DETECTED_AS_END)
-            fail ("rebDo(utf8, END) is the only string DO supported ATM."); 
+            fail ("rebDo(utf8, END) is the only string DO supported ATM.");
 
         const REBYTE *utf8 = cast(const REBYTE*, p);
         REBARR *array = Scan_UTF8_Managed(

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1607,6 +1607,7 @@ reevaluate:;
             f->special = f->args_head;
             f->refine = ORDINARY_ARG; // no gathering, but need for assert
             assert(NOT(GET_FUN_FLAG(f->phase, FUNC_FLAG_INVISIBLE)));
+            f->deferred = NULL; // frame filling decisions already made
             SET_END(f->out);
             goto process_function;
 
@@ -1617,6 +1618,7 @@ reevaluate:;
             // value of what f->phase is, for instance.
             //
             assert(NOT(GET_FUN_FLAG(f->phase, FUNC_FLAG_INVISIBLE)));
+            f->deferred = NULL; // frame filling decisions already made
             SET_END(f->out);
             goto redo_unchecked;
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -281,14 +281,12 @@ test_failed:
 REBNATIVE(either_test_void)
 //
 // Native optimization of `specialize 'either-test-value [test: :void?]`
-// Worth it to write because this is the functionality enfixed as THEN.
+// Worth it to write because this is the functionality enfixed as ALSO.
 {
     INCLUDE_PARAMS_OF_EITHER_TEST_VOID;
 
-    if (IS_VOID(ARG(value))) {
-        Move_Value(D_OUT, ARG(value));
-        return R_OUT;
-    }
+    if (IS_VOID(ARG(value)))
+        return R_VOID;
 
     if (Run_Branch_Throws(D_OUT, ARG(value), ARG(branch), REF(only)))
         return R_OUT_IS_THROWN;

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -652,31 +652,3 @@ REBNATIVE(apply)
         NOD(ARG(def))
     );
 }
-
-
-//
-//  after: native [
-//
-//  {Returns the first value, but always evaluate the second branch after it.}
-//
-//      return: [<opt> any-value!]
-//          {Will be the same value as `returned`}
-//      returned [<opt> any-value!]
-//          {Value to return}
-//      code [block! function!]
-//          {Code that will always execute, with the result discarded}
-//  ]
-//
-REBNATIVE(after)
-//
-// The enfix form of this function is called ALSO (see as well: THEN, ELSE)
-{
-    INCLUDE_PARAMS_OF_AFTER;
-
-    const REBOOL only = FALSE;
-    if (Run_Branch_Throws(D_CELL, ARG(returned), ARG(code), only))
-        return R_OUT_IS_THROWN;
-
-    Move_Value(D_OUT, ARG(returned));
-    return R_OUT;
-}

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -115,7 +115,9 @@ was: func [
         {Used to take the assigned value}
     :look [set-word! set-path! <...>]
 ][
-    (get* first look) also-do [take evaluation]
+    get* first look ;-- returned value
+
+    elide take evaluation
 ]
 
 
@@ -822,7 +824,7 @@ lambda: function [
     f: either only [:func] [:function]
 
     f (
-        :args then [to block! args] !! []
+        :args also [to block! args] !! []
     )(
         if block? first body [
             take body
@@ -852,7 +854,9 @@ right-bar: func [
     expressions [<opt> any-value! <...>]
         {Any number of expression.}
 ][
-    if* not tail? expressions [take* expressions] also-do [do expressions]
+    if* not tail? expressions [take* expressions] ;-- return result
+
+    elide do expressions
 ]
 
 
@@ -864,15 +868,15 @@ once-bar: func [
     :lookahead [any-value! <...>]
     look:
 ][
-    take right also-do [
-        unless any [
-            tail? right
-                |
-            '|| = look: take lookahead ;-- hack...recognize selfs
-        ][
-            fail [
-                "|| expected single expression, found residual of" :look
-            ]
+    take right ;-- returned value
+
+    elide unless any [
+        tail? right
+            |
+        '|| = look: take lookahead ;-- hack...recognize selfs
+    ][
+        fail [
+            "|| expected single expression, found residual of" :look
         ]
     ]
 ]

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -157,10 +157,11 @@ for-each [comparison-op function-name] [
 
 ; !!! Originally in Rebol2 and R3-Alpha, ?? was used to dump variables.  In
 ; the spirit of not wanting to take ? for something like HELP, that function
-; has been defined as DUMP (and extended with significant new features).
+; has been defined as DUMP (and extended with significant new features).  The
+; console makes D at the start of input a shortcut for this.
 ;
 ; Instead, ?? is used to make an infix operator, that takes a condition on the
-; left and a value on the right--like an IF that won't run blocks/functions.
+; left and a value on the right--like a THEN that won't run blocks/functions.
 ; As a complement, !! is then taken as a parallel to ELSE, which will also not
 ; run blocks or functions.  This is a similar to these operators from Perl6:
 ;
@@ -193,7 +194,23 @@ for-each [comparison-op function-name] [
 ]
 
 
-; THEN and ELSE are "non-TIGHTened" enfix functions which either pass through
+; THEN is an enfixed form of IF, which gives a branch running parallel for ??.
+; Since it has a longer name it may not seem useful--but it can occasionally
+; be useful in balancing the look of an expression, e.g. compare:
+;
+;    if (some long) and (complicated expression) [a + b] else [c + d]
+;
+;    (some long) and (complicated expression) then [a + b] else [c + d]
+;
+
+then: enfix :if
+
+then*: enfix specialize :if [ ;-- THEN/ONLY is a path, can't dispatch infix
+    only: true
+]
+
+
+; ALSO and ELSE are "non-TIGHTened" enfix functions which either pass through
 ; an argument or run a branch, based on void-ness of the argument.  They take
 ; advantage of the pattern of conditionals such as `if condition [...]` to
 ; only return void if the branch does not run, and never return void if it
@@ -203,17 +220,17 @@ for-each [comparison-op function-name] [
 ; native.  But due to their common use they are hand-optimized into their own
 ; specialized natives: EITHER-TEST-VOID and EITHER-TEST-VALUE.
 
-then: enfix redescribe [
+also: enfix redescribe [
     "Evaluate the branch if the left hand side expression is not void"
 ](
     comment [specialize 'either-test [test: :void?]]
     :either-test-void
 )
 
-then*: enfix redescribe [
-    "Would be the same as THEN/ONLY, if infix functions dispatched from paths"
+also*: enfix redescribe [
+    "Would be the same as ALSO/ONLY, if infix functions dispatched from paths"
 ](
-    specialize 'then [only: true]
+    specialize 'also [only: true]
 )
 
 else: enfix redescribe [
@@ -228,8 +245,6 @@ else*: enfix redescribe [
 ](
     specialize 'else [only: true]
 )
-
-also-do: enfix :after ;-- temporarily %mezz-legacy.r defines ALSO as error
 
 
 ; SHORT-CIRCUIT BOOLEAN OPERATORS

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -28,7 +28,9 @@ first+: func [
     'word [word!] "Word must refer to a series"
     <local> prior
 ][
-    (first prior: get word) also-do [set word next prior]
+    first prior: get word ;-- returned value
+
+    elide (set word next prior)
 ]
 
 second: redescribe [

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -101,7 +101,7 @@ assert-debug: function [
 
         fail [
             "Assertion condition returned"
-             (case [
+             (choose [
                 (not set? 'bad-result) "void"
                     |
                 (blank? bad-result) "blank"

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -243,7 +243,9 @@ in-dir: function [
 
     ; You don't want the block to be done if the change-dir fails, for safety.
 
-    do block also-do [change-dir old-dir]
+    do block ;-- return result
+
+    elide (change-dir old-dir)
 ]
 
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -284,13 +284,19 @@ op?: func [dummy:] [
     ] 'dummy
 ]
 
-also: func [dummy:] [
-    fail/where [
-        {ALSO has been reformulated from a prefix form to an enfix form}
-        {The new form is temporarily available as ALSO-DO, or you may enfix}
-        {the AFTER function to get that behavior.}
-        {See: https://trello.com/c/Y03HJTY4}
-    ] 'dummy
+hijack 'also adapt copy :also [
+    if (block? :branch) and (not semiquoted? 'branch) [
+        fail/where [
+            {ALSO serves a different and important purpose in Ren-C, it is a}
+            {complement to the ELSE function.  If you wish to do additional}
+            {evaluations and "comment out" their results, see ELIDE and <|.}
+            {If you mean to use a block expression, use ALSO [do make-block]}
+            {just for now, during the compatibility period.}
+            {See: https://trello.com/c/Y03HJTY4}
+        ] 'branch
+    ]
+
+    ;-- fall through to normal ALSO implementation
 ]
 
 clos: closure: func [dummy:] [
@@ -443,7 +449,8 @@ r3-alpha-apply: function [
 
     until [tail? block] [
         arg: either* only [
-            block/1 also-do [block: next block]
+            block/1
+            elide (block: next block)
         ][
             do/next block 'block
         ]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -259,8 +259,7 @@ reword: function [
             ]
         ]
     ] else [
-        assert [match delimiter-types prefix]
-        prefix: delimiters
+        prefix: ensure delimiter-types delimiters
     ]
 
     ; MAKE MAP! will create a map with no duplicates from the input if it

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -1133,7 +1133,9 @@ pe-format: context [
 
         remove/part skip exe-data target-sec/physical-offset target-sec/physical-size
 
-        (head of exe-data) also-do [reset]
+        head of exe-data ;-- return value
+
+        elide (reset)
     ]
 
     update-embedding: specialize 'update-section [section-name: encap-section-name]
@@ -1143,7 +1145,9 @@ pe-format: context [
     ][
         ;print ["Geting embedded from" mold file]
         exe-data: read file
-        (find-section/data exe-data encap-section-name) also-do [reset]
+        find-section/data exe-data encap-section-name ;--return value
+
+        elide (reset)
     ]
 ]
 
@@ -1184,7 +1188,7 @@ generic-format: context [
 
         while [0 != modulo (length of executable) 4096] [
             append executable #{00}
-        ] then [
+        ] also [
             print [{Executable padded to} length of executable {bytes long.}]
         ] else [
             print {No padding of executable length required.}

--- a/tests/control/apply.test.reb
+++ b/tests/control/apply.test.reb
@@ -30,16 +30,22 @@
 [[[1]] == head of r3-alpha-apply :insert [copy [] [1] blank blank true]]
 [function! == r3-alpha-apply (specialize 'of [property: 'type]) [:print]]
 [get-word! == r3-alpha-apply/only (specialize 'of [property: 'type]) [:print]]
-; bug#1760
-[1 == eval does [r3-alpha-apply does [] [return 1] 2]]
-; bug#1760
-[1 == eval does [r3-alpha-apply func [a] [a] [return 1] 2]]
-; bug#1760
-[1 == eval does [r3-alpha-apply does [] [return 1]]]
-[1 == eval does [r3-alpha-apply func [a] [a] [return 1]]]
-[1 == eval does [r3-alpha-apply :after [return 1 2]]]
-; bug#1760
-[1 == eval does [r3-alpha-apply :after [2 return 1]]]
+
+;-- #1760 --
+
+[
+    1 == eval does [r3-alpha-apply does [] [return 1] 2]
+][
+    1 == eval does [r3-alpha-apply func [a] [a] [return 1] 2]
+][
+    1 == eval does [r3-alpha-apply does [] [return 1]]
+][
+    1 == eval does [r3-alpha-apply func [a] [a] [return 1]]
+][
+    1 == eval does [r3-alpha-apply func [a b] [a] [return 1 2]]
+][
+    1 == eval does [r3-alpha-apply func [a b] [a] [2 return 1]]
+]
 
 ; EVAL/ONLY
 [

--- a/tests/functions/redo.test.reb
+++ b/tests/functions/redo.test.reb
@@ -111,14 +111,26 @@
 ;  ADAPTs are compatible with functions they adapt
 ;  SPECIALIZEs are compatible with functions they specialize...etc.)
 ;
-; If LOG is set to PRINT the following will output:
+; If LOG is set to DUMP the following will output:
 ;
-;        C: n = 11 delta = 0
-;        S: n = 11 delta = 10
-;     BASE: n = 11 delta = 10
-;        C: n = 1 delta = 10
-;        S: n = 1 delta = 10
-;     BASE: n = 10 delta = 10
+;     --- C ---
+;     n: => 11
+;     delta: => 0
+;     --- S ---
+;     n: => 11
+;     delta: => 10
+;     --- BASE ---
+;     n: => 11
+;     delta: => 10
+;     --- C ---
+;     n: => 1
+;     delta: => 10
+;     --- S ---
+;     n: => 1
+;     delta: => 10
+;     --- BASE ---
+;     n: => 10
+;     delta: => 10
 ;
 ; C is called and captures its frame into F.  Then it uses REDO/OTHER to
 ; reuse the frame to call S.  S gets the variables and args that its knows
@@ -148,10 +160,13 @@
 ; the chained functions will get that result.  The string is translated to
 ; a tag and signals success.
 [
-    log: :comment ;-- change to :PRINT to see what's going on
+    log: (
+        func ['x] [] ;-- no-op
+        :dump ;-- un-elide to get output
+    )
 
     base: func [n delta /captured-frame f [frame!]] [
-        log [{BASE: n =} n {delta =} delta]
+        log [{BASE} n delta]
 
         n: n - delta
         if n < 0 [return "base less than zero"]
@@ -162,7 +177,7 @@
 
     c: chain [
         adapt 'base [
-           log [{   C: n =} n {delta =} delta]
+           log [{C} n delta]
 
            f: context of 'n
            captured-frame: true
@@ -181,7 +196,7 @@
     ]
 
     s: specialize adapt 'base [
-        log [{   S: n =} n {delta =} delta]
+        log [{S} n delta]
 
         if n = 1 [n: 10]
     ][

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -215,7 +215,7 @@ make object! compose [
                 ]
                 process-tests test-sources :process-vector
             ]
-        ] then [
+        ] also [
             summary: spaced [
                     |
                 "system/version:" system/version


### PR DESCRIPTION
The ELIDE routine was originally designed as an attempt to create a
"truly invisible" comment.  If given a BLOCK!, it would act like
COMMENT, and if given a GROUP!, it would execute code.  Both could
be done without interfering with the flow of surrounding evaluation.

The reason COMMENT was not done this way is because the definition of
a truly invisible operator wound up being a little weird.  It would
have to be--in effect--an enfix tight operation which was able to
"beam" the state after its parameters were gathered back to be its
return result.  This meant when ELIDE executed code, the moment of
execution made it appear fairly erratic...when most operations that
wanted to be "invisible" would prefer to sacrifice true invisibility
in order to execute code at a more reasonable moment.

As it turned out, ELIDE's moment of execution was *so unlikely to be useful*
that its ability to execute code was mostly unusable.  It was really only useful
when making a truly invisible comment...a role that seemingly would
be left better to COMMENT.  That would free up ELIDE to be a more tame
invisible operator that would appear to run in sequence.

Making ELIDE more accessible to the average user meant those writing
invisibles could copy from it, and not worry about COMMENT's more
unusual definition...which was really only useful for commenting.  This
flipped the educational bias of the invisibles--and with a usable
ELIDE, the ALSO function was no longer necessary.  One could just
elide any calculation in a more freeform way:

    also a b => a elide b

This meant that AFTER and ALSO could be killed, but the desirable name
ALSO could be used more effectively.  It was taken to mean what the
not-widely-known-about THEN operator had meant, allowing THEN to be
an infix form of IF.  That created parity of THEN/ELSE with ??/!!.