### PR TITLE
Introduce ME operator, kill off ++, --, **, and //

### DIFF
--- a/make/default-config.r
+++ b/make/default-config.r
@@ -36,8 +36,13 @@ toolset: [
 debug: no
 
 ; one of 'no', 1, 2 or 4
+;
 optimize: 2
-standard: 'c ;one of: 'c, 'gnu89, 'gnu99, 'c99, 'c11, 'c++, 'c++98, 'c++0x, 'c++11, 'c++14 or 'c++17
+
+; one of [c gnu89 gnu99 c99 c11 c++ c++98 c++0x c++11 c++14 c++17]
+;
+standard: 'c
+
 rigorous: no
 
 static: no

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -722,7 +722,7 @@ for-each [id val] id-list [
         parse val [
             any [
                 get-word! (
-                    n-args: n-args + 1 ; don't use ++, not R3-Alpha compatible
+                    n-args: n-args + 1 ; don't use ME, not R3-Alpha compatible
                 )
                 | skip
             ]
@@ -755,7 +755,7 @@ for-each [id val] id-list [
             e-errfuncs/emit-line compose [ {const REBVAL *arg} (i + 1)
                 either i < (n-args - 1) [","] [""]
             ]
-            i: i + 1 ; don't use ++, not R3-Alpha compatible 
+            i: i + 1 ; don't use ME, not R3-Alpha compatible 
         ]
         e-errfuncs/emit-line [")"]
         e-errfuncs/emit-line [ "^{" ]
@@ -764,7 +764,7 @@ for-each [id val] id-list [
         i: 0
         while [i < n-args] [
             append args compose [ {, arg} (i + 1)]
-            i: i + 1 ; don't use ++, not R3-Alpha comptible
+            i: i + 1 ; don't use ME, not R3-Alpha comptible
         ]
 
         e-errfuncs/emit-line/indent [

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -325,7 +325,10 @@ void Do_Core(REBFRM * const f)
     if (f->flags.bits & DO_FLAG_POST_SWITCH) {
         evaluating = NOT(f->flags.bits & DO_FLAG_EXPLICIT_EVALUATE);
 
+        // !!! Note EVAL-ENFIX does a crude workaround to preserve this check.
+        //
         assert(f->prior->deferred != NULL);
+
         f->deferred = NULL;
         assert(NOT_END(f->out));
         f->flags.bits &= ~DO_FLAG_POST_SWITCH; // !!! unnecessary?

--- a/src/extensions/uuid/make-libuuid.reb
+++ b/src/extensions/uuid/make-libuuid.reb
@@ -60,10 +60,14 @@ fix-randutils.c: func [
         any [
             comment-out-includes
 
-            ;randutils.c:137:12: error: invalid conversion from ‘void*’ to ‘unsigned char*’
+            ; randutils.c:137:12: error:
+            ; invalid conversion from ‘void*’ to ‘unsigned char*’
+            ;
             | change {cp = buf} {cp = (unsigned char*)buf}
 
-            ; Fix "error: invalid suffix on literal; C++11 requires a space between literal and identifier"
+            ; Fix "error: invalid suffix on literal;
+            ; C++11 requires a space between literal and identifier"
+            ;
             | change {"PRIu64"} {" PRIu64 "}
 
             | skip

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -48,18 +48,15 @@ r3-alpha-quote: func [:spelling [word! string!]] [
 ]
 
 
-; Make top-level words for things not added by %b-init.c (e.g. /, //)
+; Make top-level words (note: / is added by %b-init.c as an "odd word")
 ;
-+: -: *: **: _
++: -: *: _
 
 for-each [math-op function-name] [
     +       add
     -       subtract
     *       multiply
     /       divide ;-- !!! may become pathing operator (which also divides)
-
-    **      power ;-- !!! more a separator? https://forum.rebol.info/t/474/4
-    //      remainder ;-- !!! new comment? https://forum.rebol.info/t/275
 ][
     ; Ren-C's infix math obeys the "tight" parameter convention of R3-Alpha.
     ; But since the prefix functions themselves have normal parameters, this
@@ -315,6 +312,25 @@ nand: enfix func [
 ; There's no way to do a shortcut XOR...both sides have to be tested.
 ;
 xor: enfix :xor?
+
+
+; The -- and ++ operators were deemed too "C-like", so ME was created to allow
+; `some-var: me + 1` or `some-var: me / 2` in a generic way.
+;
+; !!! This depends on a fairly lame hack called EVAL-ENFIX at the moment, but
+; that evaluator exposure should be generalized more cleverly.
+;
+me: enfix func [
+    {Update variable using it as the left hand argument to an enfix operator}
+
+    return: [<opt> any-value!]
+    :var [set-word! set-path!]
+        {Variable to assign (and use as the left hand enfix argument)}
+    :rest [<opt> any-value! <...>]
+        {Code to run with var as left (first element should be enfixed)}
+][
+    set* var eval-enfix (get* var) rest
+]
 
 
 ; Lambdas are experimental quick function generators via a symbol

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -52,14 +52,14 @@ clean-path: function [
 
     parse reverse file [
         some [
-            "../" (count: ++ 1)
+            "../" (count: me + 1)
             | "./"
             | #"/" (
                 if any [not file? file | #"/" <> last out] [append out #"/"]
             )
             | copy f [to #"/" | to end] (
                 either count > 0 [
-                    count: -- 1
+                    count: me - 1
                 ][
                     unless find ["" "." ".."] as string! f [append out f]
                 ]

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -14,36 +14,6 @@ REBOL [
 pi: 3.14159265358979323846
 
 
-; ++ and -- were previously used to take a quoted word and increment
-; it.  They were ordinary prefix operations
-
-++: enfix func [
-    {Set variable to the result of incrementing itself using the + operator}
-
-    return: [any-value!]
-        "The new state of the variable"
-    'var [set-word! set-path!]
-        "Variable to update"
-    n
-        "Amount to increment by"
-][
-    set var (get var) + n
-]
-
---: enfix func [
-    {Set variable to the result of decrementing itself using the - operator}
-
-    return: [any-value!]
-        "The new state of the variable"
-    'var [set-word! set-path!]
-        "Variable to update"
-    n
-        "Amount to decrement or skip backwards by"
-][
-    set var (get var) - n
-]
-
-
 mod: function [
     "Compute a nonnegative remainder of A divided by B."
     a [any-number! money! time!]

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -97,7 +97,7 @@ secure: function [
         n: 1
         for-each act [read write execute] [
             join blk [pick acts 1 + pol/:n act]
-            n: ++ 1
+            n: me + 1
         ]
         blk
     ])

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -743,6 +743,6 @@ find-all: function [
         | (set series orig | false) ;-- reset series and break loop
     ]][
         do body
-        series: ++ 1
+        series: next series
     ]
 ]

--- a/tests/atronix/ms-drives.r
+++ b/tests/atronix/ms-drives.r
@@ -11,6 +11,6 @@ while [i < 26] [
     unless zero? maps and (shift 1 i) [
         print unspaced [to char! (to integer! #"A") + i ":"]
     ]
-    i: ++ 1
+    i: i + 1
 ]
 close msvcrt

--- a/tests/atronix/test-libs.r
+++ b/tests/atronix/test-libs.r
@@ -138,7 +138,7 @@ forever [
         a9/j: 490 + i
 
         read-s10 a a1 a2 a3 a4 a5 a6 a7 a8 a9
-        i: ++ 1
+        i: i + 1
     ]
 
     print ["a9:" mold a9]
@@ -160,7 +160,7 @@ forever [
         print ["i = " i]
         s: return-s i
         print ["s:" mold s]
-        i: ++ 1
+        i: i + 1
     ]
     print now
     wait [2]

--- a/tests/datatypes/closure.test.reb
+++ b/tests/datatypes/closure.test.reb
@@ -191,7 +191,7 @@
 ; basic test for recursive closure! invocation
 [
     i: 0
-    countdown: clos [n] [if n > 0 [i: ++ 1 | countdown n - 1]]
+    countdown: clos [n] [if n > 0 [i: i + 1 | countdown n - 1]]
     countdown 10
     i = 10
 ]

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -272,7 +272,7 @@
 ; basic test for recursive function! invocation
 [
     i: 0
-    countdown: proc [n] [if n > 0 [i: ++ 1 | countdown n - 1]]
+    countdown: proc [n] [if n > 0 [i: i + 1 | countdown n - 1]]
     countdown 10
     i = 10
 ]

--- a/tests/math/add.test.reb
+++ b/tests/math/add.test.reb
@@ -221,3 +221,10 @@
 [0.0.255 = add 0.0.255 0.0.0]
 [0.0.255 = add 0.0.255 0.0.1]
 [0.0.255 = add 0.0.255 0.0.255]
+
+; Slipstream a test of ME in here, as the replacement for "++"
+[
+    some-var: 20
+    some-var: me + 1 * 10
+    some-var = 210
+]

--- a/tests/misc/fib.r
+++ b/tests/misc/fib.r
@@ -42,7 +42,7 @@ fib: func [
         t: i1
         i1: i0 + i1
         i0: t
-        n: -- 1
+        n: n - 1
     ]
     i1
 ]


### PR DESCRIPTION
Debates about whether to take `//` or `--` for comment based on their
"line-y" looks triggered the question of how these symbol-based items
might be given to purposes besides rarely-used math operations.  It
seems much more Rebol-like to have a test dialect be able to do the
likes of the following when saying the following tests relate to issue
#1020

    -- #1020 --
    [x > 1]
    [x < 2]

Freeing up the "drawing-ish" operator repetitions for users to assign
for such uses makes more sense than hardcoding them for rarely (or
even barely) used math operators, that don't look good.  So the idea
of a generic ME operator came up, where:

    >> some-var: 20

    >> some-var: me + 1 * 10

    >> print some-var
    210

Being able to write `some-var: me + 10` isn't as "simple" <ahem> as:

* making ME a backwards quote operator that fetches some-var
* quoting its next argument (e.g. +) for word looking up to a function
* making the next argument variadic, and normal-enfix TAKE-ing it
* APPLYing the quoted function on those two values
* setting the left set-word (e.g. some-var:) to the result

The problem with that strategy is that the parameter conventions of +
matter.  Removing it from the evaluator and taking matters into one's
own hands means one must reproduce the evaluator's logic--and that
means it will probably be done poorly.  It's clearly not as sensible as
having some way of slipping the value of some-var into the flow of
normal evaluation.

This commit uses a small trick to implement this specific feature, but
it should be generalized in the future.  However, it is good enough
that ++ and -- can be retaken, and it takes // out (which didn't match
that pattern anyway, and makes for a poor WORD!) so that it may be
repurposed as a comment.  ** is eliminated just for good measure.