### PR TITLE
MY operator for prefix functions (complement to ME for enfix)

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -2432,10 +2432,19 @@ post_switch:;
 
     if (f->gotten == END)
         f->gotten = Get_Opt_Var_Else_End(f->value, f->specifier);
-    else
+    else {
+        // !!! a particularly egregious hack in EVAL-ENFIX lets us simulate
+        // enfix for a function whose value is not enfix.  This means the
+        // value in f->gotten isn't the fetched function, but the function
+        // plus a VALUE_FLAG_ENFIXED.  We discern this hacky case by noting
+        // if f->deferred is precisely equal to BLANK_VALUE.
+        //
         assert(
             f->gotten == Get_Opt_Var_Else_End(f->value, f->specifier)
+            || (f->prior && f->prior->deferred == BLANK_VALUE) // !!! for hack
+
         );
+    }
 
 //=//// NEW EXPRESSION IF UNBOUND, NON-FUNCTION, OR NON-ENFIX /////////////=//
 

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -89,6 +89,8 @@ REBNATIVE(eval)
 //          {Value to preload as the left hand-argument (won't reevaluate)}
 //      rest [varargs!]
 //          {The code stream to execute (head element must be enfixed)}
+//      /prefix
+//          {Variant used when rest is prefix (e.g. for MY operator vs. ME)}
 //  ]
 //
 REBNATIVE(eval_enfix)
@@ -125,6 +127,37 @@ REBNATIVE(eval_enfix)
         fail ("EVAL-ENFIX is not made to support MAKE VARARGS! [...] rest");
     }
 
+    if (FRM_AT_END(f) || VAL_TYPE(f->value) != REB_WORD) // no PATH! yet...
+        fail ("ME and MY only work if right hand side starts with WORD!");
+
+    if (f->gotten == END)
+        f->gotten = Get_Opt_Var_Else_End(f->value, f->specifier);
+    else 
+        assert(f->gotten == Get_Opt_Var_Else_End(f->value, f->specifier));
+
+    if (f->gotten == END || NOT(IS_FUNCTION(f->gotten)))
+        fail ("ME and MY only work if right hand WORD! is a FUNCTION!");
+
+    if (GET_VAL_FLAG(f->gotten, VALUE_FLAG_ENFIXED)) {
+        if (REF(prefix))
+            fail ("Use ME instead of MY with infix functions");
+
+        // Already set up to work using our tricky technique.
+    }
+    else {
+        if (NOT(REF(prefix)))
+            fail ("Use MY instead of ME with prefix functions");
+
+        // Here we do something devious.  We subvert the system by setting
+        // f->gotten to an enfixed version of the function even if it is
+        // not enfixed.  This lets us slip in a first argument to a function
+        // *as if* it were enfixed, e.g. `series: my next`.
+        //
+        Move_Value(D_CELL, f->gotten);
+        SET_VAL_FLAG(D_CELL, VALUE_FLAG_ENFIXED);
+        f->gotten = D_CELL;
+    }
+
     // Simulate as if the passed-in value was calculated into the output slot,
     // which is where enfix functions usually find their left hand values.
     //
@@ -139,7 +172,7 @@ REBNATIVE(eval_enfix)
     // the frame of EVAL-ENFIX that is invoking it.
     //
     assert(FS_TOP->deferred == NULL);
-    FS_TOP->deferred = D_OUT;
+    FS_TOP->deferred = m_cast(REBVAL*, BLANK_VALUE); // !!! signal our hack
 
     REBFLGS flags = DO_FLAG_FULFILLING_ARG | DO_FLAG_POST_SWITCH;
     if (Do_Next_In_Subframe_Throws(D_OUT, f, flags))

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -332,6 +332,18 @@ me: enfix func [
     set* var eval-enfix (get* var) rest
 ]
 
+my: enfix func [
+    {Update variable using it as the first argument to a prefix operator}
+
+    return: [<opt> any-value!]
+    :var [set-word! set-path!]
+        {Variable to assign (and use as the first prefix argument)}
+    :rest [<opt> any-value! <...>]
+        {Code to run with var as left (first element should be prefix)}
+][
+    set* var eval-enfix/prefix (get* var) rest
+]
+
 
 ; Lambdas are experimental quick function generators via a symbol
 ;

--- a/tests/series/append.test.reb
+++ b/tests/series/append.test.reb
@@ -6,4 +6,22 @@
     append p [b 2]
     not in o 'b
 ]
+
 [block? append copy [] ()]
+
+
+; Slipstream in some tests of MY (there don't seem to be a lot of tests here)
+;
+[
+    data: [1 2 3 4]
+    data: my next
+    data: my skip 2
+    data: my back
+
+    block: copy [a b c d]
+    block: my next
+    block: my insert data
+    block: my head
+
+    block = [a 3 4 b c d]
+]


### PR DESCRIPTION
This commit adds an implementation for MY that allows a SET-WORD!'s
existing value to be slipped in the first argument to a function
which overwrites it.  e.g.

    >> block: copy [a b c d]

    >> block: my next

    >> probe block
    [b c d]

    >> block: my append [1 2 3]

    >> probe block
    [a b c d 1 2 3]

Unfortunately the trickery involved does not work for PATH!s at this
time (e.g. append/only), only for WORD!s.  The reason is because it
is actually pretending the right hand argument is an enfix function
even though it is not, and running through the same machinery that
fills the first frame argument of enfix functions with a prior single
value while doing the rest of an evaluation normally.

(A less dodgy technique for doing the same thing should be possible to
design in the future--e.g. this is not something beyond the reasonable
capability of the evaluator to do "correctly".)