### PR TITLE
BLANK! triggers ELSE (vs. just void), EITHER acts as in R3-Alpha

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -129,7 +129,7 @@ gen-obj: func [
 
     if block? s [
         for-each flag next s [
-            append flags opt switch/default flag [
+            append flags opt switch*/default flag [
                 <no-uninitialized> [
                     [
                         <gnu:-Wno-uninitialized>
@@ -975,7 +975,7 @@ switch user-config/optimize [
 
 cfg-cplusplus: false
 ;standard
-append app-config/cflags opt switch/default user-config/standard [
+append app-config/cflags opt switch*/default user-config/standard [
     c [
         _
     ]
@@ -1048,7 +1048,7 @@ append app-config/cflags opt switch/default user-config/standard [
 ; Example. Mingw32 does not have access to windows console api prior to vista.
 ;
 cfg-pre-vista: false
-append app-config/definitions opt switch/default user-config/pre-vista [
+append app-config/definitions opt switch*/default user-config/pre-vista [
     #[true] yes on true [
         cfg-pre-vista: true
         compose [
@@ -1064,7 +1064,7 @@ append app-config/definitions opt switch/default user-config/pre-vista [
 ]
 
 cfg-rigorous: false
-append app-config/cflags opt switch/default user-config/rigorous [
+append app-config/cflags opt switch*/default user-config/rigorous [
     #[true] yes on true [
         cfg-rigorous: true
         compose [
@@ -1284,7 +1284,7 @@ append app-config/cflags opt switch/default user-config/rigorous [
     fail ["RIGOROUS must be yes, no, or logic! not" (user-config/rigorous)]
 ]
 
-append app-config/ldflags opt switch/default user-config/static [
+append app-config/ldflags opt switch*/default user-config/static [
     _ no off false #[false] [
         ;pass
         _

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -514,7 +514,7 @@ opt: func [
     {Turns blanks to voids, all other value types pass through.}
     value [<opt> any-value!]
 ][
-    either* blank? :value [()] [:value]
+    either blank? :value [()] [:value]
 ]
 
 to-value: func [

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1155,11 +1155,13 @@ inline static REBOOL Eval_Value_Core_Throws(
 //     >> case [false "a" false "b"] then func [x] [print x] else [print "*"]
 //     *
 //
-// Also, Ren-C does something called "blankification", unless the /ONLY
-// refinement is used.  This is the process by which a void-producing branch
-// is forced to be a BLANK! instead, allowing void to be reserved for the
-// result when no branch ran.  This gives a uniform way of determining
-// whether a branch ran or not (utilized by ELSE, THEN, etc.)
+// Also, Ren-C does something called "barification", unless the /ONLY
+// refinement is used.  This is the process by which a void or BLANK! branch
+// result is forced to be BAR! instead, allowing void to be reserved for the
+// result when no branch ran, and BLANK! to be reserved by constructs like
+// ANY and ALL to signal failure that can be used in a condition.  This gives
+// a uniform way of determining whether a branch ran or not (utilized by ELSE,
+// THEN, etc.)
 //
 // Note: Tolerance of non-BLOCK! and non-FUNCTION! branches to act as literal
 // values was proven to cause more harm than good.
@@ -1187,8 +1189,8 @@ inline static REBOOL Run_Branch_Throws(
             return TRUE;
     }
 
-    if (NOT(only) && IS_VOID(out))
-        Init_Blank(out); // "blankification", see comment above
+    if (NOT(only) && (IS_VOID(out) || IS_BLANK(out)))
+        Init_Bar(out); // "barification", see comment above
 
     return FALSE;
 }

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -923,11 +923,11 @@ inline static void VAL_SET_TYPE_BITS(RELVAL *v, enum Reb_Kind kind) {
 
 // Although a BLOCK! value is true, some constructs are safer by not allowing
 // literal blocks.  e.g. `if [x] [print "this is not safe"`.  The evaluated
-// bit can let these instances be distinguished.  Note that making *all*
-// evaluations safe would be limiting, e.g. `foo: any [false-thing []]`.
+// bit can let these instances be distinguished.  If someone finds this
+// limiting, they can put it in a GROUP!, e.g. `if ([x]) ...`
 //
-inline static REBOOL IS_CONDITIONAL_TRUE(const REBVAL *v, REBOOL only) {
-    if (NOT(only) && IS_BLOCK(v)) {
+inline static REBOOL IS_CONDITIONAL_TRUE(const REBVAL *v) {
+    if (IS_BLOCK(v)) {
         if (GET_VAL_FLAG(v, VALUE_FLAG_UNEVALUATED))
             fail (Error_Block_Conditional_Raw(v));
             
@@ -936,8 +936,8 @@ inline static REBOOL IS_CONDITIONAL_TRUE(const REBVAL *v, REBOOL only) {
     return IS_TRUTHY(v);
 }
 
-inline static REBOOL IS_CONDITIONAL_FALSE(const REBVAL *v, REBOOL only) {
-    if (NOT(only) && IS_BLOCK(v)) {
+inline static REBOOL IS_CONDITIONAL_FALSE(const REBVAL *v) {
+    if (IS_BLOCK(v)) {
         if (GET_VAL_FLAG(v, VALUE_FLAG_UNEVALUATED))
             fail (Error_Block_Conditional_Raw(v));
             

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -570,12 +570,6 @@ unless*: redescribe [
     specialize 'unless [only: true]
 )
 
-either*: redescribe [
-    {Same as EITHER/ONLY (void, not blank, if branch evaluates to void)}
-](
-    specialize 'either [only: true]
-)
-
 case*: redescribe [
     {Same as CASE/ONLY (void, not blank, if branch evaluates to void)}
 ](
@@ -608,8 +602,8 @@ match: redescribe [
         ; return blank on test failure (can't be plain _ due to "evaluative
         ; bit" rules...should this be changed so exemplars clear the bit?)
         ;
-        branch: []
-        only: false ;-- no /ONLY, hence void branch returns BLANK!
+        branch: [_]
+        only: true ;-- we want to deliberately return BLANK! from the branch
     ][
         if void? :value [ ; !!! TBD: filter this via REDESCRIBE when possible
             fail "Cannot use MATCH on void values (try using EITHER-TEST)"

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -406,7 +406,7 @@ try: func [
         "On exception, evaluate code"
     code [block! function!]
 ][
-    either* except [trap/with block :code] [trap block]
+    either except [trap/with block :code] [trap block]
 ]
 
 
@@ -456,7 +456,7 @@ r3-alpha-apply: function [
     using-args: true
 
     until [tail? block] [
-        arg: either* only [
+        arg: either only [
             block/1
             elide (block: next block)
         ][
@@ -777,7 +777,7 @@ set 'r3-legacy* func [<local> if-flags] [
             any_GET: any
             any: :lib/any
 
-            either* any-context? source [
+            either any-context? source [
                 ;
                 ; In R3-Alpha, this was vars of the context put into a BLOCK!:
                 ;

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -198,7 +198,7 @@ load-header: function [
         ]
 
         sum: hdr/checksum [
-            ; blank saved to simplify later code
+            ; !!! "blank saved to simplify later code" -- what?
             blank ;[print sum]
         ]
 
@@ -344,10 +344,10 @@ load: function [
             line: 1
 
             sftype: file-type? source
-            ftype: case [
+            ftype: case* [
                 all [:ftype = 'unbound | :sftype = 'extension] [sftype]
                 type [ftype]
-            ] else [
+            ] else* [
                 sftype
             ]
             data: read-decode source ftype

--- a/tests/control/case.test.reb
+++ b/tests/control/case.test.reb
@@ -16,7 +16,7 @@
     #2246
     void? case* [true []]
 ][
-    blank? case [true []]
+    '| = case [true []]
 ]
 
 ; case results

--- a/tests/control/either.test.reb
+++ b/tests/control/either.test.reb
@@ -10,11 +10,8 @@
 [1 = either true [1] [2]]
 [2 = either false [1] [2]]
 
-[void? either* true [] [1]]
-[void? either* false [1] []]
-
-[blank? either true [] [1]]
-[blank? either false [1] []]
+[void? either true [] [1]]
+[void? either false [1] []]
 
 [error? either true [try [1 / 0]] []]
 [error? either false [] [try [1 / 0]]]

--- a/tests/control/if.test.reb
+++ b/tests/control/if.test.reb
@@ -12,7 +12,7 @@
 [1 = if true [1]]
 
 [void? if* true []]
-[blank? if true []]
+['| = if true []]
 
 [error? if true [try [1 / 0]]]
 ; RETURN stops the evaluation
@@ -81,7 +81,7 @@
 
 ; recursive behaviour
 
-[blank? if true [if false [1]]]
+['| = if true [if false [1]]]
 [void? if* true [if* false [1]]]
 [1 = if true [if true [1]]]
 

--- a/tests/control/switch.test.reb
+++ b/tests/control/switch.test.reb
@@ -13,7 +13,7 @@
 ]
 
 [void? switch* 1 [1 []]]
-[blank? switch 1 [1 []]]
+['| = switch 1 [1 []]]
 
 [
     cases: reduce [1 head of insert copy [] try [1 / 0]]

--- a/tests/control/unless.test.reb
+++ b/tests/control/unless.test.reb
@@ -14,7 +14,7 @@
 [void? unless* true [1]]
 [void? unless* false []]
 [void? unless true [1]]
-[blank? unless false []]
+['| = unless false []]
 
 [error? unless false [try [1 / 0]]]
 

--- a/tests/control/while.test.reb
+++ b/tests/control/while.test.reb
@@ -17,8 +17,11 @@
     while [false] [success: false]
     success
 ]
-; Test break and continue
-[cycle?: true blank? while [cycle?] [break cycle?: false]]
+; Test break and continue (breaks force loop result to false)
+[
+    cycle?: true
+    false = while [cycle?] [break cycle?: false]
+]
 ; Test reactions to break and continue in the condition
 [
     was-stopped: true

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -40,8 +40,8 @@
        b: take args
        either tail? args [b] ["not at end"]
     ]
-    x: make varargs! [_]
-    blank? apply :f [args: x]
+    x: make varargs! [1020]
+    1020 = apply :f [args: x]
 ]
 
 [

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -452,8 +452,6 @@
 
 ['group! == apply/only :type? [() true]]
 
-;-- CC#2246
-[blank? case [true []]]
 
 ; #1906
 [


### PR DESCRIPTION
ELSE was designed to examine the evaluated value on its left, and pass
it through if it was non-void...otherwise evaluate the branch it was
provided.  When combined with a convention of conditional constructs
only returning void if they didn't run any branches, this could give
the "illusion" of a conventional language's behavior running ELSE
clauses.  (The illusion was enhanced with other enfix operators such
as ALSO and THEN.)

But since BLANK! was considered a value to be passed through vs. one
that the ELSE would branch on, it meant it could not be used with
constructs that returned BLANK! to indicate a "miss".  There are lots
of those now, like ALL, ANY, SELECT, PICK, FIND, etc...and users would
likely be using the convention in the future to make many more.

This commit tweaks the balance so that ELSE will trigger off of a
blank, as well as a void.  Then when a conditional takes a branch, if
that branch evaluates to *either a void or a blank*, it will modify the
result to be a BAR!.  This means:

    >> if true [1020]
    == 1020

    >> if true [print "Hi"]
    == |

    >> if true [_]
    == |

BAR! is chosen specifically for its "jarring" status as a value that
is uncommon, and doesn't gloss over the potential misunderstanding
(the way a #[false] might, since it is falsey *like* a blank while
clearly not being one).  It also is light to look at in the console
as an expression result.

The casualty of this decision is that constructs like CASE or SWITCH
cannot deliberately return BLANK! values unless variants e.g. `CASE*`
or `SWITCH*` are used (which instruct them to not alter the branch
results).  The option already existed for the purposes of passing
through voids unchanged, but this adds blanks to it.

It's a change, but not as scary as it first appears.  Other parts of
Rebol, such as APPEND, ask you to tack on an /ONLY if you want to mean
"verbatim".  And so this simply means that if you're writing a
conditional expression with branches that are returning a NOTHING?
(e.g. a void or a BLANK!), and that's what you meant, you use a
refinement or a one-character shorthand to say so.

There are mitigating factors for this.  For instance, one reason that
a conditional might like to return a blank deliberately would be to
run some code but try and signal to remove its effect, e.g.

    print [
       "stuff"
       if condition [
           do-some-diagnostics
           drink-some-tea
           blank
       ]
       "more stuff"
    ]

If the desire is to never inject content, that can be achieved now
with `elide (if condition [...])`, which is a bit clearer than trying to say
`(if* condition [... ()])` or `(if/only condition [... void])`

Those wishing to deliberately return blanks in a conditional sense
might find rewriting their IF clauses as ALL clauses works for them,
as a "miss" on ALL will return a blank.

As an additional mitigation, EITHER is removed from acting like this
group of functions...and returns the result of its branch evaluations
literally.  This gives an anchor for many common cases, in such a way
that code can work across Rebols.  It does so at the cost of not making
it always legal to change EITHER into IF ... ELSE.