### PR TITLE
Derived Binding, so objects share "method" FUNCTION!s vs copying

### DIFF
--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -873,16 +873,12 @@ int RL_rebEvent(REBEVT *evt)
 //
 
 inline static REBFRM *Extract_Live_Rebfrm_May_Fail(const REBVAL *frame) {
-    if (!IS_FRAME(frame))
+    if (NOT(IS_FRAME(frame)))
         fail ("Not a FRAME!");
 
-    REBCTX *frame_ctx = VAL_CONTEXT(frame);
-    REBFRM *f = CTX_FRAME_IF_ON_STACK(frame_ctx);
-    if (f == NULL)
-        fail ("FRAME! is no longer on stack.");
+    REBFRM *f = CTX_FRAME_MAY_FAIL(VAL_CONTEXT(frame));
 
-    assert(Is_Function_Frame(f));
-    assert(NOT(Is_Function_Frame_Fulfilling(f)));
+    assert(Is_Function_Frame(f) && NOT(Is_Function_Frame_Fulfilling(f)));
     return f;
 }
 

--- a/src/core/c-value.c
+++ b/src/core/c-value.c
@@ -81,7 +81,7 @@ ATTRIBUTE_NO_RETURN void Panic_Value_Debug(const RELVAL *v) {
     printf("Kind=%d\n", cast(int, VAL_TYPE_RAW(v)));
     fflush(stdout);
 
-    if (containing != NULL && NOT(containing->header.bits & NODE_FLAG_CELL)) {
+    if (containing != NULL && NOT_CELL(containing)) {
         printf("Containing series for value pointer found, panicking it:\n");
         Panic_Series_Debug(SER(containing));
     }

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -217,9 +217,7 @@ REBNATIVE(near_of)
 {
     INCLUDE_PARAMS_OF_NEAR_OF;
 
-    REBFRM *f = CTX_FRAME_IF_ON_STACK(VAL_CONTEXT(ARG(frame)));
-    if (f == NULL)
-        fail (Error_Frame_Not_On_Stack_Raw());
+    REBFRM *f = CTX_FRAME_MAY_FAIL(VAL_CONTEXT(ARG(frame)));
 
     Init_Near_For_Frame(D_OUT, f);
     return R_OUT;
@@ -239,9 +237,7 @@ REBNATIVE(label_of)
 {
     INCLUDE_PARAMS_OF_LABEL_OF;
 
-    REBFRM *f = CTX_FRAME_IF_ON_STACK(VAL_CONTEXT(ARG(frame)));
-    if (f == NULL)
-        fail (Error_Frame_Not_On_Stack_Raw());
+    REBFRM *f = CTX_FRAME_MAY_FAIL(VAL_CONTEXT(ARG(frame)));
 
     if (f->opt_label == NULL)
         return R_BLANK;
@@ -310,9 +306,7 @@ REBNATIVE(running_q)
 
     REBCTX *frame_ctx = VAL_CONTEXT(ARG(frame));
 
-    REBFRM *f = CTX_FRAME_IF_ON_STACK(frame_ctx);
-    if (f == NULL)
-        return R_FALSE;
+    REBFRM *f = CTX_FRAME_MAY_FAIL(frame_ctx);
 
     if (Is_Function_Frame_Fulfilling(f))
         return R_FALSE;
@@ -335,9 +329,7 @@ REBNATIVE(pending_q)
 
     REBCTX *frame_ctx = VAL_CONTEXT(ARG(frame));
 
-    REBFRM *f = CTX_FRAME_IF_ON_STACK(frame_ctx);
-    if (f == NULL)
-        return R_FALSE;
+    REBFRM *f = CTX_FRAME_MAY_FAIL(frame_ctx);
 
     if (Is_Function_Frame_Fulfilling(f))
         return R_TRUE;

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -229,8 +229,17 @@ void Clonify_Values_Len_Managed(
         }
         else if (
             types & FLAGIT_KIND(VAL_TYPE(v)) & FLAGIT_KIND(REB_FUNCTION)
-        ) {
-            Clonify_Function(KNOWN(v)); // functions never "relative"
+        ){
+            // !!! While Ren-C has abandoned the concept of copying the body
+            // of functions (they are black boxes which may not *have* a
+            // body), it would still theoretically be possible to do what
+            // COPY does and make a function with a new and independently
+            // hijackable identity.  Assume for now it's better that the
+            // HIJACK of a method for one object will hijack it for all
+            // objects, and one must filter in the hijacking's body if one
+            // wants to take more specific action.
+            //
+            assert(FALSE);
         }
         else {
             // The value is not on our radar as needing to be processed,

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -174,13 +174,7 @@ REBNATIVE(make)
         }
         else {
             REBCTX *context = CTX(arg->extra.binding);
-            REBFRM *param_frame = CTX_FRAME_IF_ON_STACK(context);
-
-            // If the VARARGS! has a call frame, then ensure that the call
-            // frame where the VARARGS! originated is still on the stack.
-            //
-            if (param_frame == NULL)
-                fail (Error_Varargs_No_Stack_Raw());
+            REBFRM *param_frame = CTX_FRAME_MAY_FAIL(context);
 
             REBVAL *param = FUNC_FACADE_HEAD(param_frame->phase)
                 + arg->payload.varargs.param_offset;

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -263,7 +263,7 @@ inline static void Queue_Mark_Binding_Deep(const RELVAL *v) {
     REBNOD *binding = v->extra.binding;
 
 #if !defined(NDEBUG)
-    if (binding->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(binding)) {
         // assert(GET_VAL_FLAG(v, VALUE_FLAG_STACK));
 
         REBFRM *f = cast(REBFRM*, binding);
@@ -297,7 +297,7 @@ inline static void Queue_Mark_Binding_Deep(const RELVAL *v) {
     }
 #endif
 
-    if (NOT(binding->header.bits & NODE_FLAG_CELL))
+    if (NOT_CELL(binding))
         Queue_Mark_Array_Subclass_Deep(ARR(binding));
 }
 
@@ -792,7 +792,7 @@ static void Propagate_All_GC_Marks(void)
             // to Queue_Mark_Context_Deep.
 
             REBNOD *keysource = LINK(a).keysource;
-            if (keysource->header.bits & NODE_FLAG_CELL) {
+            if (IS_CELL(keysource)) {
                 //
                 // Must be a FRAME! and it must be on the stack running.  If
                 // it has stopped running, then the keylist must be set to
@@ -812,10 +812,16 @@ static void Propagate_All_GC_Marks(void)
                     // has to be a FUNCTION!.
                     //
                     assert(IS_FUNCTION(ARR_HEAD(keylist)));
+
+                    // Frames use paramlists as their "keylist", there is no
+                    // place to put an ancestor link.
                 }
                 else {
                     assert(NOT_SER_FLAG(keylist, ARRAY_FLAG_PARAMLIST));
                     ASSERT_UNREADABLE_IF_DEBUG(ARR_HEAD(keylist));
+
+                    REBARR *ancestor = LINK(keylist).ancestor;
+                    Queue_Mark_Array_Subclass_Deep(ancestor); // maybe keylist
                 }
                 Queue_Mark_Array_Subclass_Deep(keylist);
             }
@@ -1093,7 +1099,7 @@ static void Mark_Guarded_Nodes(void)
     REBCNT n = SER_LEN(GC_Guarded);
     for (; n > 0; --n, ++np) {
         REBNOD *node = *np;
-        if (node->header.bits & NODE_FLAG_CELL) { // a value cell
+        if (IS_CELL(node)) { // a value cell
             if (NOT(node->header.bits & NODE_FLAG_END))
                 Queue_Mark_Opt_Value_Deep(cast(REBVAL*, node));
         }
@@ -1161,7 +1167,7 @@ static void Mark_Frame_Stack_Deep(void)
                 Mark_Rebser_Only(cast(REBSER*, Singular_From_Cell(f->value)));
         }
 
-        if (NOT(f->specifier->header.bits & NODE_FLAG_CELL)) {
+        if (NOT_CELL(f->specifier)) {
             assert(
                 f->specifier == SPECIFIED
                 || (f->specifier->header.bits & ARRAY_FLAG_VARLIST)
@@ -1643,7 +1649,7 @@ REBCNT Recycle(void)
 void Guard_Node_Core(const REBNOD *node)
 {
 #if !defined(NDEBUG)
-    if (node->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(node)) {
         //
         // It is a value.  Cheap check: require that it already contain valid
         // data when the guard call is made (even if GC isn't necessarily

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -311,6 +311,11 @@ REBCTX *Context_For_Frame_May_Reify_Managed(REBFRM *f)
     VAL_RESET_HEADER(rootvar, REB_FRAME);
     rootvar->payload.any_context.varlist = f->varlist;
     rootvar->payload.any_context.phase = f->phase;
+
+    // The binding on the rootvar is important...this is how Get_Var_Core()
+    // can know what the binding in the FUNCTION! value that spawned the
+    // frame, even after the frame is expired.
+    //
     INIT_BINDING(rootvar, f->binding);
 
     // A reification of a frame for native code should not allow changing

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -348,7 +348,7 @@ REBOOL Get_Context_Of(REBVAL *out, const REBVAL *v)
             return FALSE;
 
         REBCTX *c;
-        if (n->header.bits & NODE_FLAG_CELL) {
+        if (IS_CELL(n)) {
             REBFRM *f = cast(REBFRM*, n);
             c = Context_For_Frame_May_Reify_Managed(f);
         }

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -148,9 +148,7 @@ REBNATIVE(set_location_of_error)
     else
         context = VAL_CONTEXT(ARG(location));
 
-    REBFRM *where = CTX_FRAME_IF_ON_STACK(context);
-    if (where == NULL)
-        fail (Error_Frame_Not_On_Stack_Raw());
+    REBFRM *where = CTX_FRAME_MAY_FAIL(context);
 
     REBCTX *error = VAL_CONTEXT(ARG(error));
     Set_Location_Of_Error(error, where);

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -221,13 +221,11 @@ REBNATIVE(return)
     // in the specific FUNCTION! value that was invoked.
     //
     REBFRM *target_frame;
-    if (f->binding->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(f->binding)) {
         target_frame = cast(REBFRM*, f->binding);
     }
     else if (f->binding->header.bits & ARRAY_FLAG_VARLIST) {
-        target_frame = CTX_FRAME_IF_ON_STACK(CTX(f->binding));
-        if (target_frame == NULL)
-            fail (Error_Frame_Not_On_Stack_Raw());
+        target_frame = CTX_FRAME_MAY_FAIL(CTX(f->binding));
     }
     else {
         assert(f->binding == UNBOUND);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -208,12 +208,7 @@ REBTYPE(Function)
             // !!! always "deep", allow it?
         }
 
-        // !!! The R3-Alpha theory was that functions could modify "their
-        // bodies" while running, effectively accruing state that one might
-        // want to snapshot.  See notes on Clonify_Function about why that
-        // idea is a bad one.
-        //
-        // Instead we create another handle which executes the same function
+        // Copying functions creates another handle which executes the same
         // code, yet has a distinct identity.  This means it would not be
         // HIJACK'd if the function that it was copied from was.
 

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -173,7 +173,7 @@ REB_R Do_Vararg_Op_May_Throw(
         // parameter.
         //
         assert(
-            NOT(vararg->extra.binding->header.bits & NODE_FLAG_CELL)
+            NOT_CELL(vararg->extra.binding)
             && NOT(vararg->extra.binding->header.bits & ARRAY_FLAG_VARLIST)
         );
         pclass = PARAM_CLASS_NORMAL;
@@ -620,7 +620,7 @@ void MF_Varargs(REB_MOLD *mo, const RELVAL *v, REBOOL form) {
 
     REBFRM *f;
 
-    if (VAL_BINDING(v)->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(VAL_BINDING(v))) {
         f = cast(REBFRM*, VAL_BINDING(v));
         goto have_f;
     }

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -399,11 +399,10 @@ inline static REBARR* Copy_Array_At_Extra_Deep_Managed(
     ROOT_EMPTY_STRING
 
 inline static REBSPC* AS_SPECIFIER(void *p) {
-    assert(p != NULL);
     REBSPC *specifier = cast(REBSPC*, p);
 
 #if !defined(NDEBUG)
-    if (specifier->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(specifier)) {
         REBFRM *f = cast(REBFRM*, specifier);
         assert(f->eval_type == REB_FUNCTION);
     }

--- a/src/include/sys-context.h
+++ b/src/include/sys-context.h
@@ -93,7 +93,7 @@ inline static REBCTX *CTX(void *p) {
 // possible--even in an unoptimized build.  Use VAL_TYPE_RAW, plain C cast.
 //
 inline static REBARR *CTX_KEYLIST(REBCTX *c) {
-    if (NOT(LINK(CTX_VARLIST(c)).keysource->header.bits & NODE_FLAG_CELL)) {
+    if (NOT_CELL(LINK(CTX_VARLIST(c)).keysource)) {
         //
         // Ordinarily, we want to use the keylist pointer that is stored in
         // the link field of the varlist.
@@ -173,6 +173,13 @@ inline static REBFRM *CTX_FRAME_IF_ON_STACK(REBCTX *c) {
     //
     assert(f->eval_type == REB_FUNCTION && f->phase != NULL);
 
+    return f;
+}
+
+inline static REBFRM *CTX_FRAME_MAY_FAIL(REBCTX *c) {
+    REBFRM *f = CTX_FRAME_IF_ON_STACK(c);
+    if (f == NULL)
+        fail (Error_Frame_Not_On_Stack_Raw());
     return f;
 }
 

--- a/src/include/sys-node.h
+++ b/src/include/sys-node.h
@@ -38,10 +38,30 @@
 inline static REBNOD *NOD(void *p) {
     assert(p != NULL);
 
-    REBNOD *n = cast(REBNOD*, p);
+    REBNOD *node = cast(REBNOD*, p);
     assert(
-        (n->header.bits & NODE_FLAG_NODE)
-        && NOT(n->header.bits & NODE_FLAG_FREE)
+        (node->header.bits & NODE_FLAG_NODE)
+        && NOT(node->header.bits & NODE_FLAG_FREE)
     );
-    return n;
+    return node;
 }
+
+#ifdef NDEBUG
+    inline static REBOOL IS_CELL(REBNOD *node) {
+        return LOGICAL(node->header.bits & NODE_FLAG_CELL);
+    }
+
+    inline static REBOOL NOT_CELL(REBNOD *node) {
+        return NOT(node->header.bits & NODE_FLAG_CELL);
+    }
+#else
+    // We want to get a compile-time check on whether the argument is a
+    // REBNOD (and not, say, a REBSER or REBVAL).  But we don't want to pay
+    // for the function call in debug builds, so only check in release builds.
+    //
+    #define IS_CELL(node) \
+        LOGICAL((node)->header.bits & NODE_FLAG_CELL)
+
+    #define NOT_CELL(node) \
+        NOT((node)->header.bits & NODE_FLAG_CELL)
+#endif

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -579,16 +579,24 @@ union Reb_Series_Link {
     // frame...but that prevented the ability to SET-META on a frame.  While
     // that feature may not be essential, it seems awkward to not allow it
     // since it's allowed for other ANY-CONTEXT!s.  Also, it turns out that
-    // FRAME! values have to get their keylist via the specifically applicable
-    // ->phase field anyway, and it's a faster test to check this for
-    // NODE_FLAG_CELL than to separately extract the CTX_TYPE() and treat
-    // frames differently.)
+    // heap-based FRAME! values--such as those that come from MAKE FRAME!--
+    // have to get their keylist via the specifically applicable ->phase field
+    // anyway, and it's a faster test to check this for NODE_FLAG_CELL than to
+    // separately extract the CTX_TYPE() and treat frames differently.)
     //
     // It is done as a base-class REBNOD* as opposed to a union in order to
     // not run afoul of C's rules, by which you cannot assign one member of
     // a union and then read from another.
     //
     REBNOD *keysource;
+
+    // On the keylist of an object, this points at a keylist which has the
+    // same number of keys or fewer, which represents an object which this
+    // object is derived from.  Note that when new object instances are
+    // created which do not require expanding the object, their keylist will
+    // be the same as the object they are derived from.
+    //
+    REBARR *ancestor;
 
     // The facade is a REBARR which is a proxy for the paramlist of the
     // underlying frame which is pushed when a function is called.  For

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -295,7 +295,7 @@ inline static void INIT_VAL_PARAM_CLASS(RELVAL *v, enum Reb_Param_Class c) {
     ((TS_ARRAY | TS_CONTEXT) & ~TS_NOT_COPIED)
 
 #define TS_CLONE \
-    ((TS_SERIES | FLAGIT_KIND(REB_FUNCTION)) & ~TS_NOT_COPIED)
+    (TS_SERIES & ~TS_NOT_COPIED) // currently same as TS_NOT_COPIED
 
 #define TS_ANY_WORD \
     (FLAGIT_KIND(REB_WORD) \

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1692,7 +1692,7 @@ inline static void INIT_BINDING(RELVAL *v, void *p) {
     REBNOD *binding = NOD(p);
 
 #if !defined(NDEBUG)
-    if (binding->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(binding)) {
         //
         // !!! This is a good assert but it is limiting the applications of
         // trying to do evaluations into API cells.  Review.
@@ -1762,7 +1762,7 @@ inline static REBVAL *Move_Value(RELVAL *out, const REBVAL *v)
     #if !defined(NDEBUG)
         if (Is_Bindable(v)) {
             if (NOT(v->header.bits & VALUE_FLAG_STACK))
-                assert(NOT(v->extra.binding->header.bits & NODE_FLAG_CELL));
+                assert(NOT_CELL(v->extra.binding));
         }
     #endif
         out->extra = v->extra;
@@ -1773,7 +1773,7 @@ inline static REBVAL *Move_Value(RELVAL *out, const REBVAL *v)
     // binding of some kind.  Check to see if the target stack level will
     // outlive the stack level of the non-reified material in the binding. 
 
-    assert(v->extra.binding->header.bits & NODE_FLAG_CELL);
+    assert(IS_CELL(v->extra.binding));
     REBFRM *f = cast(REBFRM*, v->extra.binding);
 
     REBCNT bind_depth = 1; // !!! need to determine v's binding stack level

--- a/src/include/sys-varargs.h
+++ b/src/include/sys-varargs.h
@@ -61,7 +61,7 @@ inline static REBOOL Is_Block_Style_Varargs(
     assert(IS_VARARGS(vararg));
 
     if (
-        (vararg->extra.binding->header.bits & NODE_FLAG_CELL)
+        IS_CELL(vararg->extra.binding)
         || (vararg->extra.binding->header.bits & ARRAY_FLAG_VARLIST)
     ){
         TRASH_POINTER_IF_DEBUG(*shared_out);
@@ -90,7 +90,7 @@ inline static REBOOL Is_Frame_Style_Varargs_May_Fail(
     assert(IS_VARARGS(vararg));
 
     if (
-        NOT(vararg->extra.binding->header.bits & NODE_FLAG_CELL)
+        NOT_CELL(vararg->extra.binding)
         && NOT(vararg->extra.binding->header.bits & ARRAY_FLAG_VARLIST)
     ){
         TRASH_POINTER_IF_DEBUG(*f);
@@ -100,14 +100,10 @@ inline static REBOOL Is_Frame_Style_Varargs_May_Fail(
     // "Ordinary" case... use the original frame implied by the VARARGS!
     // (so long as it is still live on the stack)
 
-    if (vararg->extra.binding->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(vararg->extra.binding))
         *f = cast(REBFRM*, vararg->extra.binding);
-    }
-    else {
-        *f = CTX_FRAME_IF_ON_STACK(CTX(vararg->extra.binding));
-        if (*f == NULL)
-            fail (Error_Varargs_No_Stack_Raw());
-    }
+    else
+        *f = CTX_FRAME_MAY_FAIL(CTX(vararg->extra.binding));
 
     return TRUE;
 }

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -89,10 +89,9 @@ inline static void INIT_WORD_CONTEXT(RELVAL *v, REBCTX *context) {
 inline static REBCTX *VAL_WORD_CONTEXT(const REBVAL *v) {
     assert(IS_WORD_BOUND(v));
     REBNOD *binding = VAL_BINDING(v);
-    if (binding->header.bits & NODE_FLAG_CELL) {
+    if (IS_CELL(binding)) {
         //
-        // Bound specifically to a REBFRM* that isn't reified.  Force
-        // a reification, for now.
+        // Bound directly to un-reified REBFRM*.  Force reification, for now.
         //
         REBFRM *f = cast(REBFRM*, binding);
         return Context_For_Frame_May_Reify_Managed(f);

--- a/tests/datatypes/object.test.reb
+++ b/tests/datatypes/object.test.reb
@@ -64,14 +64,6 @@
     p: make o [a: 3]
     1 == do p/c
 ]
-; multiple inheritance
-; bug#1863
-[
-    o1: make object! [a: 1 f: does [a]]
-    o2: make object! [a: 2]
-    o3: make o1 o2
-    2 == o3/f
-]
 ; appending to objects
 ; bug#1979
 [

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -651,21 +651,20 @@
 ; bug#1675
 [files: read %fixtures mold files block? files]
 
-; empty string rule
-; bug#1880
-; NOTE: It would seem that considering this a match violates the "parse
-; must make progress" rule.
-[parse "12" ["" to end]]
+; !!! Considering empty strings a match would violate the "parse rules must
+; advance input" rule.  Yet this seems like it should work (?)
+[
+    #1880
+    parse "12" ["" to end]
+]
 
-; bug#2214
-[not parse "abcd" rule: ["ab" (clear rule) "cd"]]
-
-; !!! The general issue of tying up Rebol with more notions of equality
-; without getting the existing ones right is suspect.  Ren-C simplified matters
-; and left EQUIV? as a synonym for EQUAL? at the present time, with the option
-; that it may be a form of equality that returns in the future.
-;
-; With EQUIV? as a synonym for EQUAL, the following test (whatever it was
-; supposed to test) started to fail.
-;
-[not equiv? 'a use [a] ['a]]
+; !!! Multiple inheritance was removed from Ren-C.  It was not well defined,
+; and won't work with derived binding unless more work is done...and that work
+; would involve defining exactly what it is supposed to do in the first place.
+[
+    #1863
+    o1: make object! [a: 1 f: does [a]]
+    o2: make object! [a: 2]
+    o3: make o1 o2
+    2 == o3/f
+]


### PR DESCRIPTION
In R3-Alpha, if you wrote:

    o1: make object! [a: 10 b: does [loop 10 [print a]]]
    o2: make o1 [a: 20]

...historically what had to happen was that the B function had to have
its body structure deep copied, so that all the A references in the B
function which had bindings to O1 could be replaced with new A
references with bindings to O2.

This was because the invisible "binding" property that an ANY-WORD!
could have was part and parcel of the cell, resident in the bit pattern
of the array.  You couldn't have a single block of data with words in
it that could be interpreted at one moment as pointing to one object,
and interpreted at another moment as pointing to another object.

This led to a problem where if you have 10 methods in an object, with
an average of let's say 10 blocks/arrays in each, with an average of
10 elements per block... then each new instance of that object would
cost 10 * 10 * 10 * 4x(sizeof(void*)).  That's not counting overhead
for the data...that's just what it would cost on each instance to
duplicate the methods.  Not only would it cost the memory, but it
would cost the time taken to duplicate and rebind the blocks...which
would be paid for regardless of whether that method was ever called.

(It copied strings and binaries in function bodies too, so it's worse
than even that.)

This commit removes the need for the copies.  Here's how it works:

FUNCTION! value cells have 4 platform-pointer-sized elements. First is
the header (as with all REBVAL cells, plus sneaky things that pretend
to be cells for only one pointer of size...enough to signal an END).
Then there's a pointer to the "paramlist", array w/cells linking
parameter names and embedding typesets. Then a pointer to the body,
which is a so-called "singular" array--it fits in a series node, but
holds the value directly inside it. What goes in that cell varies by
dispatcher...which is the C function that interprets the body's
contents to execute whatever code is appropriate for the function type.

Slot #4 is used to point to some form of "binding", particular to that
instance of a function cell. This mechanism was originally designed for
RETURN; so that a single archetypal return paramlist and body could be
reused by varied cells that only poked a different value into this
binding (in particular, which FRAME! that particular RETURN was
supposed to return from).

This so-called "derived binding" expands the concept, where the 4th
pointer can also point at one object (at the moment, only one) for
which any words in the function body bound to a less derived version of
that object will be forwarded.  The end result gives something largely
indistinguishable from the behavior in R3-Alpha, with significantly
less per-instance tax on memory or the GC.

There is a small tradeoff, in that a bound method of this kind pays a
small amount of additional runtime cost when looking up words in its
body.  But it only applies to "methods" made in this way, and there
could be several optimizations (for instance, keeping track of a bit on
objects of whether they've ever been used as a base class for any other
objects, and not checking for a derivation match if not, even if
running the body of a method).