### PR TITLE
Error on ambiguous deferments of variadics

### DIFF
--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -531,6 +531,16 @@ inline static void Drop_Function_Core(
     REBFRM *f,
     REBOOL drop_chunks
 ){
+    if (f->flags.bits & DO_FLAG_AMBIGUOUS_DEFER) {
+        //
+        // This failure will call back into Drop_Function_Core, which may
+        // not be the best design...but for the moment we go with it.  So
+        // the flag has to be cleared to prevent an infinite loop.
+        //
+        f->flags.bits &= ~DO_FLAG_AMBIGUOUS_DEFER;
+        fail ("Ambiguous variadic deferment");
+    }
+
     assert(
         f->opt_label == NULL
         || GET_SER_FLAG(f->opt_label, SERIES_FLAG_UTF8_STRING)

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -77,8 +77,17 @@
 ]
 
 [
-    2 = (1 |> 2 | 3 + 4 | 5 + 6)
+    11 = (1 |> 2 | 3 + 4 | 5 + 6)
 ][
-    1 = (1 <| 2 | 3 + 4 | 5 + 6)
+    1 = (3 + 4 | 5 + 6 | 1 <| 2)
 ]
 
+[
+    error? trap [(|> 1 + 1 true = false) = 2] ;-- ambiguous deferment
+][
+    (|> 1 + 1 (true = false)) = 2 ;-- ok
+][
+    (|> 1 + 1 false) = 2 ;-- ok
+][
+    did |> not true = false
+]


### PR DESCRIPTION
One of the tradeoffs of using Ren-C's "one expression's worth of
evaluation on the left" for "normal" enfix is that it means there is
special treatment of the last parameter of things.

    >> fun-arity-2: func [a b] [dump [a b] return "string"]

    >> fun-arity-2 1 = 1 2 = 2
    a: => true
    b: => 2
    ** Error: cannot compare INTEGER! and STRING!

So above, what's happening is that the first `=` sign realizes that
it cannot get a complete function call out of (fun-arity-2 1), so
it goes ahead and interprets its left argument as simply (1).  But
the second `=` realizes that `fun-arity-2 1 = 1 2` is a complete
expression, so it uses that.  The function is called, and evaluates
to a string, which is then compared with 2.

It's quirky, but learnable...and it offers great power to a number of
expressive tricks (including allowing for ELSE).  Parentheses can be
used in situations where there's any question about what's happening:

    fun-arity-2 (1 = 1) (2 = 2)

But one issue with "treating the last argument differently" is what the
semantics will be with a variadic function.  By contract, a variadic
takes as much or as little out of the frame as it wants...consuming
an argument at a time.  Imagine changing the above function to
a variadic implementation:

    >> fun-variadic-2: func [v [any-value! <...>]] [
        dump [(take v) (take v)]
        return "string"
    ]

It would seem inconsistent if that function didn't behave the same
as FUN-ARITY-2 in terms of how the arguments were handled.  Yet without
changing variadics to make them more complex (e.g. "announcing" in
advance how many arguments they plan to take), there seems to be no
way to accomplish that.

This commit tries the next-best thing.  If a variadic TAKE is done,
it runs the evaluation without taking a deferment (e.g. it would read
`fun-variadic-2 1 = 1 2 = 2` as `fun-variadic-2 (1 = 1) (2 = 2)`.)
But it makes a note if a left normal enfix operator was used in a
variadic argument slot, and if another argument isn't taken after
that before the function ends then it will give an error.

This "wait-and-see" approach helps prevent a variadic function from
behaving differently than its fixed-arity counterparts, but means it
will force some kind of parenthesization on some scenarios it would
not be required for the fixed arity case.

Note this doesn't affect left-enfix-tight operations (e.g. math ops),
just left-enfix-normal (e.g. comparison ops)