### PR TITLE
TRIM and CHARSET tests, bug fixes.

### DIFF
--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -166,6 +166,28 @@ append-of: redescribe [
 )
 
 
+; CHARSET was moved from "Mezzanine" because it is called by TRIM which is
+; in "Base" - see TRIM.
+;
+charset: function [
+    "Makes a bitset of chars for the parse function."
+    chars [string! block! binary! char! integer!]
+    /length "Preallocate this many bits"
+    len [integer!] "Must be > 0"
+][
+    ;-- CHARSET function historically has a refinement called /LENGTH, that
+    ;-- is used to preallocate bits.  Yet the LENGTH? function has been
+    ;-- changed to use just the word LENGTH.  We could change this to
+    ;-- /CAPACITY SIZE or something similar, but keep it working for now.
+    ;--
+    length_CHARSET: length      ; refinement passed in
+    unset 'length               ; helps avoid overlooking the ambiguity
+
+    init: either length_CHARSET [len][[]]
+    append make bitset! init chars
+]
+
+
 ; TRIM is used by PORT! implementations, which currently rely on "Base" and
 ; not "Mezzanine", so this can't be in %mezz-series at the moment.  Review.
 ;

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -90,24 +90,6 @@ remold: func [
 ]
 
 
-charset: function [
-    "Makes a bitset of chars for the parse function."
-    chars [string! block! binary! char! integer!]
-    /length "Preallocate this many bits"
-    len [integer!] "Must be > 0"
-][
-    ;-- CHARSET function historically has a refinement called /LENGTH, that
-    ;-- is used to preallocate bits.  Yet the LENGTH? function has been
-    ;-- changed to use just the word LENGTH.  We could change this to
-    ;-- /CAPACITY SIZE or something similar, but keep it working for now.
-    ;--
-    length_CHARSET: length      ; refinement passed in
-    unset 'length               ; helps avoid overlooking the ambiguity
-
-    either length_CHARSET [append make bitset! len chars] [make bitset! chars]
-]
-
-
 array: func [
     "Makes and initializes a series of a given size."
     size [integer! block!] "Size or block of sizes for each dimension"

--- a/tests/series/charset.test.reb
+++ b/tests/series/charset.test.reb
@@ -1,0 +1,6 @@
+[equal? charset #"*" charset 42]
+[equal? charset #"*" charset {*}]
+[equal? charset #"*" charset #{2A}]
+[equal? charset #"*" charset [42]]
+[equal? charset #"*" charset [{*}]]
+[equal? charset #"*" charset [#{2A}]]

--- a/tests/series/trim.test.reb
+++ b/tests/series/trim.test.reb
@@ -10,11 +10,27 @@
 [#{BFD3} = trim #{0000BFD30000}]
 [#{10200304} = trim/with #{AEAEAE10200304BDBDBD} #{AEBD}]
 
+; Incompatible refinement errors.
+[error? try [trim/auto/head {}]]
+[error? try [trim/auto/tail {}]]
+[error? try [trim/auto/lines {}]]
+[error? try [trim/auto/all {}]]
+[error? try [trim/all/head {}]]
+[error? try [trim/all/tail {}]]
+[error? try [trim/all/lines {}]]
+[error? try [trim/auto/with {} {*}]]
+[error? try [trim/head/with {} {*}]]
+[error? try [trim/tail/with {} {*}]]
+[error? try [trim/lines/with {} {*}]]
+
 ["a  ^/  b  " = trim/head "  a  ^/  b  "]
 ["  a  ^/  b" = trim/tail "  a  ^/  b  "]
 ["foo^/^/bar^/" = trim "  foo  ^/ ^/  bar  ^/  ^/  "]
 ["foobar" = trim/all "  foo  ^/ ^/  bar  ^/  ^/  "]
 ["foo bar" = trim/lines "  foo  ^/ ^/  bar  ^/  ^/  "]
+["x^/" = trim/auto "^/  ^/x^/"]
+["x^/" = trim/auto "  ^/x^/"]
+["x^/y^/ z^/" = trim/auto "  x^/ y^/   z^/"]
 
 [[a b] = trim [a b]]
 [[a b] = trim [a b _]]


### PR DESCRIPTION
This adds bug fixes, modifications and tests for TRIM and CHARSET.

The argument to TRIM/WITH was used simply for creating a BITSET! which is the purpose of CHARSET. Maybe originally this was a choice of convenience so that a console user did not have to call CHARSET themselves.

To reduce duplication, the work of creating a BITSET! within TRIM is delegated to CHARSET, which means moving CHARSET from mezz-series.r to base-series.r

In keeping with the idea of convenience, BITSET! becomes an allowed argument type for /WITH.