### PR TITLE
First cut demo of intermixing UTF-8 with REBVAL* in rebDo()

### DIFF
--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -2356,13 +2356,12 @@ reevaluate:;
 //==//////////////////////////////////////////////////////////////////////==//
 
     case REB_MAX_VOID:
-        if (NOT(evaluating)) {
-            Init_Void(f->out);
+        if (NOT(evaluating) == NOT_VAL_FLAG(current, VALUE_FLAG_EVAL_FLIP)) {
+            Init_Void(f->out); // it's inert, treat as okay
         }
         else {
             // must be EVAL, so the value must be living in the frame cell
             //
-            assert(current == &f->cell);
             fail (Error_Evaluate_Void_Raw());
         }
         break;

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -245,9 +245,10 @@ typedef struct rebol_scan_state {
 #define ANY_CR_LF_END(c) (!(c) || (c) == CR || (c) == LF)
 
 enum {
-    SCAN_NEXT = 1 << 0, // load/next feature
-    SCAN_ONLY = 1 << 1, // only single value (no blocks)
-    SCAN_RELAX = 1 << 2 // no error throw
+    SCAN_FLAG_NEXT = 1 << 0, // load/next feature
+    SCAN_FLAG_ONLY = 1 << 1, // only single value (no blocks)
+    SCAN_FLAG_RELAX = 1 << 2, // no error throw
+    SCAN_FLAG_VOIDS_LEGAL = 1 << 3 // void splice ok--for top level of rebDo()
 };
 
 


### PR DESCRIPTION
This is a *very rough* proof of concept, showing for the first time
a functional form of intermixing REBVAL* API pointers and UTF-8
text to a parameterized rebDo.  This pattern permits flexible
combinations of text runs with spliced content, e.g.

   rebDo("print [", value1, "+ (2 *", value2, ")]", END);

One central trick is the usage of platform-independent byte ordering
macros, which are able to make the pattern of valid UTF-8 strings
distinct from the pattern of Rebol values (also distinct from
Rebol series, END markers, freed cells, etc).

There are numerous issues to resolve: one is how binding will be
handled (both for the string runs and for the spliced values).  But
also the semantics of evaluation, regarding whether WORD! or FUNCTION!
values will need to be live by default and QUOTEd or rebQuote()d...
or if they will be inert and brought to life via EVAL/rebEval().

However, this shows the general direction of what is possible and
tests the methods for how various problems might be attacked.