### PR TITLE
Allow extension and core to have natives with the same name

### DIFF
--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -262,7 +262,7 @@ either num-native > 0 [
     ]
     for-each item native-list [
         if set-word? item [
-            e-last/emit-item ["N_" to word! item]
+            e-last/emit-item ["N_" u-m-name "_" to word! item]
         ]
     ]
     e-last/emit-end
@@ -321,11 +321,22 @@ for-next native-list [
         all [path? native-list/2 | 'native = first native-list/2]
     ][
         assert [set-word? native-list/1]
-        (emit-include-params-macro e-first
-            (to-word native-list/1) (native-list/3))
+        (emit-include-params-macro/ext e-first
+            (to-word native-list/1) (native-list/3)
+            u-m-name)
         e-first/emit newline
     ]
 ]
+
+;-------------------------------------------------------------
+;
+e-first/emit-lines [
+    ["// redefine REBNATIVE to avoid name conflict"]
+    ["#undef REBNATIVE"]
+    ["#define REBNATIVE(n) \"]
+]
+e-first/emit-line/indent
+    ["REB_R N_" u-m-name "_ ##n(REBFRM *frame_)"]
 
 ;--------------------------------------------------------------
 ; words

--- a/make/tools/native-emitters.r
+++ b/make/tools/native-emitters.r
@@ -62,12 +62,13 @@ emit-include-params-macro: procedure [
     e [object!] "where to emit (see %common-emitters.r)"
     word [word!] "name of the native"
     paramlist [block!] "paramlist of the native"
+    /ext ext-name
 ][
     ; start emitting what will be a multi line macro (backslash as last
     ; character on line is how macros span multiple lines in C).
     ;
     e/emit-line [
-        {#define} space "INCLUDE_PARAMS_OF_" (uppercase to-c-name word)
+        {#define} space either ext [unspaced [ext-name "_"]][""] "INCLUDE_PARAMS_OF_" (uppercase to-c-name word)
         space "\"
     ]
 

--- a/src/extensions/bmp/mod-bmp.c
+++ b/src/extensions/bmp/mod-bmp.c
@@ -300,7 +300,7 @@ static REBOOL Has_Valid_BITMAPFILEHEADER(const REBYTE *data, REBCNT len) {
 //
 REBNATIVE(identify_bmp_q)
 {
-    INCLUDE_PARAMS_OF_IDENTIFY_BMP_Q;
+    BMP_INCLUDE_PARAMS_OF_IDENTIFY_BMP_Q;
 
     const REBYTE *data = VAL_BIN_AT(ARG(data));
     REBCNT len = VAL_LEN_AT(ARG(data));
@@ -323,7 +323,7 @@ REBNATIVE(identify_bmp_q)
 //
 REBNATIVE(decode_bmp)
 {
-    INCLUDE_PARAMS_OF_DECODE_BMP;
+    BMP_INCLUDE_PARAMS_OF_DECODE_BMP;
 
     const REBYTE *data = VAL_BIN_AT(ARG(data));
     REBCNT len = VAL_LEN_AT(ARG(data));
@@ -565,7 +565,7 @@ bad_table_error:
 //
 REBNATIVE(encode_bmp)
 {
-    INCLUDE_PARAMS_OF_ENCODE_BMP;
+    BMP_INCLUDE_PARAMS_OF_ENCODE_BMP;
 
     REBINT i, y;
     REBYTE *cp, *v;

--- a/src/extensions/crypt/mod-crypt.c
+++ b/src/extensions/crypt/mod-crypt.c
@@ -125,7 +125,7 @@ static void cleanup_rc4_ctx(const REBVAL *v)
 //
 static REBNATIVE(rc4)
 {
-    INCLUDE_PARAMS_OF_RC4;
+    CRYPT_INCLUDE_PARAMS_OF_RC4;
 
     if (REF(stream)) {
         REBVAL *data = ARG(data);
@@ -192,7 +192,7 @@ static REBNATIVE(rc4)
 //
 static REBNATIVE(rsa)
 {
-    INCLUDE_PARAMS_OF_RSA;
+    CRYPT_INCLUDE_PARAMS_OF_RSA;
 
     REBOOL padding;
     if (REF(padding))
@@ -359,7 +359,7 @@ static REBNATIVE(rsa)
 //
 static REBNATIVE(dh_generate_key)
 {
-    INCLUDE_PARAMS_OF_DH_GENERATE_KEY;
+    CRYPT_INCLUDE_PARAMS_OF_DH_GENERATE_KEY;
 
     DH_CTX dh_ctx;
     memset(&dh_ctx, 0, sizeof(dh_ctx));
@@ -443,7 +443,7 @@ static REBNATIVE(dh_generate_key)
 //
 static REBNATIVE(dh_compute_key)
 {
-    INCLUDE_PARAMS_OF_DH_COMPUTE_KEY;
+    CRYPT_INCLUDE_PARAMS_OF_DH_COMPUTE_KEY;
 
     DH_CTX dh_ctx;
     memset(&dh_ctx, 0, sizeof(dh_ctx));
@@ -535,7 +535,7 @@ static void cleanup_aes_ctx(const REBVAL *v)
 //
 static REBNATIVE(aes)
 {
-    INCLUDE_PARAMS_OF_AES;
+    CRYPT_INCLUDE_PARAMS_OF_AES;
 
     if (REF(stream)) {
         if (VAL_HANDLE_CLEANER(ARG(ctx)) != cleanup_aes_ctx)
@@ -646,7 +646,7 @@ static REBNATIVE(aes)
 //
 REBNATIVE(sha256)
 {
-    INCLUDE_PARAMS_OF_SHA256;
+    CRYPT_INCLUDE_PARAMS_OF_SHA256;
 
     REBCNT index;
     REBCNT len;
@@ -784,7 +784,7 @@ static REBOOL Cloak(
 //
 static REBNATIVE(decloak)
 {
-    INCLUDE_PARAMS_OF_DECLOAK;
+    CRYPT_INCLUDE_PARAMS_OF_DECLOAK;
 
     if (NOT(Cloak(
         TRUE,
@@ -817,7 +817,7 @@ static REBNATIVE(decloak)
 //
 static REBNATIVE(encloak)
 {
-    INCLUDE_PARAMS_OF_ENCLOAK;
+    CRYPT_INCLUDE_PARAMS_OF_ENCLOAK;
 
     if (NOT(Cloak(
         FALSE,

--- a/src/extensions/debugger/mod-debugger.c
+++ b/src/extensions/debugger/mod-debugger.c
@@ -87,7 +87,7 @@ const REBVAL *HG_Host_Repl = NULL; // needs to be a GC-protecting reference
 //
 static REBNATIVE(init_debugger)
 {
-    INCLUDE_PARAMS_OF_INIT_DEBUGGER;
+    DEBUGGER_INCLUDE_PARAMS_OF_INIT_DEBUGGER;
 
     HG_Host_Repl = FUNC_VALUE(VAL_FUNC(ARG(console)));
     return R_VOID;
@@ -115,7 +115,7 @@ REBOOL Do_Breakpoint_Throws(
 //
 static REBNATIVE(breakpoint)
 //
-// !!! Need definition to test for N_breakpoint function
+// !!! Need definition to test for N_DEBUGGER_breakpoint function
 {
     if (Do_Breakpoint_Throws(
         D_OUT,
@@ -151,9 +151,9 @@ static REBNATIVE(breakpoint)
 //
 static REBNATIVE(pause)
 //
-// !!! Need definition to test for N_pause function
+// !!! Need definition to test for N_DEBUGGER_pause function
 {
-    INCLUDE_PARAMS_OF_PAUSE;
+    DEBUGGER_INCLUDE_PARAMS_OF_PAUSE;
 
     if (Do_Breakpoint_Throws(
         D_OUT,
@@ -235,8 +235,8 @@ REBFRM *Frame_For_Stack_Level(
         if (NOT(pending)) {
             if (first) {
                 if (
-                    FUNC_DISPATCHER(frame->phase) == &N_pause
-                    || FUNC_DISPATCHER(frame->phase) == N_breakpoint
+                    FUNC_DISPATCHER(frame->phase) == &N_DEBUGGER_pause
+                    || FUNC_DISPATCHER(frame->phase) == N_DEBUGGER_breakpoint
                 ) {
                     // this is considered the "0".  Return it only if 0
                     // requested specifically (you don't "count down to it")
@@ -326,7 +326,7 @@ static REBNATIVE(resume)
 // each host doesn't have to rewrite interpretation in the hook--they only
 // need to recognize a RESUME throw and pass the argument back.
 {
-    INCLUDE_PARAMS_OF_RESUME;
+    DEBUGGER_INCLUDE_PARAMS_OF_RESUME;
 
     if (REF(with) && REF(do)) {
         //
@@ -400,8 +400,8 @@ static REBNATIVE(resume)
                 continue;
 
             if (
-                FUNC_DISPATCHER(frame->phase) == &N_pause
-                || FUNC_DISPATCHER(frame->phase) == &N_breakpoint
+                FUNC_DISPATCHER(frame->phase) == &N_DEBUGGER_pause
+                || FUNC_DISPATCHER(frame->phase) == &N_DEBUGGER_breakpoint
             ) {
                 break;
             }
@@ -582,7 +582,7 @@ REBOOL Host_Breakpoint_Quitting_Hook(
         if (Do_Any_Array_At_Throws(instruction_out, code)) {
             if (
                 IS_FUNCTION(instruction_out)
-                && VAL_FUNC_DISPATCHER(instruction_out) == &N_resume
+                && VAL_FUNC_DISPATCHER(instruction_out) == &N_DEBUGGER_resume
             ){
                 // This means we're done with the embedded REPL.  We want
                 // to resume and may be returning a piece of code that
@@ -787,8 +787,8 @@ REBOOL Do_Breakpoint_Throws(
             if (
                 frame != FS_TOP
                 && (
-                    FUNC_DISPATCHER(frame->phase) == &N_pause
-                    || FUNC_DISPATCHER(frame->phase) == &N_breakpoint
+                    FUNC_DISPATCHER(frame->phase) == &N_DEBUGGER_pause
+                    || FUNC_DISPATCHER(frame->phase) == &N_DEBUGGER_breakpoint
                 )
             ) {
                 // We hit a breakpoint (that wasn't this call to
@@ -910,7 +910,7 @@ return_temp:
 //
 static REBNATIVE(backtrace_index)
 {
-    INCLUDE_PARAMS_OF_BACKTRACE_INDEX;
+    DEBUGGER_INCLUDE_PARAMS_OF_BACKTRACE_INDEX;
 
     REBCNT number;
 
@@ -962,7 +962,7 @@ void Shutdown_Debugger(void)
 //
 static REBNATIVE(backtrace)
 {
-    INCLUDE_PARAMS_OF_BACKTRACE;
+    DEBUGGER_INCLUDE_PARAMS_OF_BACKTRACE;
 
     Check_Security(Canon(SYM_DEBUG), POL_READ, 0);
 
@@ -1025,8 +1025,8 @@ static REBNATIVE(backtrace)
             if (
                 first
                 && (
-                    FUNC_DISPATCHER(f->phase) == &N_pause
-                    || FUNC_DISPATCHER(f->phase) == &N_breakpoint
+                    FUNC_DISPATCHER(f->phase) == &N_DEBUGGER_pause
+                    || FUNC_DISPATCHER(f->phase) == &N_DEBUGGER_breakpoint
                 )
             ) {
                 // Omitting breakpoints from the list entirely presents a
@@ -1202,7 +1202,7 @@ static REBNATIVE(debug)
 // stack level is being inspected in the REPL.
 //
 {
-    INCLUDE_PARAMS_OF_DEBUG;
+    DEBUGGER_INCLUDE_PARAMS_OF_DEBUG;
 
     REBVAL *value = ARG(value);
 

--- a/src/extensions/ffi/mod-ffi.c
+++ b/src/extensions/ffi/mod-ffi.c
@@ -126,7 +126,7 @@ REBNATIVE(make_routine)
 // !!! Would be nice if this could just take a filename and the lib management
 // was automatic, e.g. no LIBRARY! type.
 {
-    INCLUDE_PARAMS_OF_MAKE_ROUTINE;
+    FFI_INCLUDE_PARAMS_OF_MAKE_ROUTINE;
 
     ffi_abi abi;
     if (REF(abi))
@@ -193,7 +193,7 @@ REBNATIVE(make_routine_raw)
 // !!! Would be nice if this could just take a filename and the lib management
 // was automatic, e.g. no LIBRARY! type.
 {
-    INCLUDE_PARAMS_OF_MAKE_ROUTINE_RAW;
+    FFI_INCLUDE_PARAMS_OF_MAKE_ROUTINE_RAW;
 
     ffi_abi abi;
     if (REF(abi))
@@ -237,7 +237,7 @@ REBNATIVE(make_routine_raw)
 //
 REBNATIVE(wrap_callback)
 {
-    INCLUDE_PARAMS_OF_WRAP_CALLBACK;
+    FFI_INCLUDE_PARAMS_OF_WRAP_CALLBACK;
 
     ffi_abi abi;
     if (REF(abi))
@@ -303,7 +303,7 @@ REBNATIVE(wrap_callback)
 //  ]
 //
 REBNATIVE(addr_of) {
-    INCLUDE_PARAMS_OF_ADDR_OF;
+    FFI_INCLUDE_PARAMS_OF_ADDR_OF;
 
     REBVAL *v = ARG(value);
 
@@ -356,7 +356,7 @@ REBNATIVE(make_similar_struct)
 // re-use of the structure's field definitions, so it is a means of saving on
 // memory (?)  Code retained for examination.
 {
-    INCLUDE_PARAMS_OF_MAKE_SIMILAR_STRUCT;
+    FFI_INCLUDE_PARAMS_OF_MAKE_SIMILAR_STRUCT;
 
     REBVAL *spec = ARG(spec);
     REBVAL *body = ARG(body);
@@ -385,7 +385,7 @@ REBNATIVE(make_similar_struct)
 //
 REBNATIVE(destroy_struct_storage)
 {
-    INCLUDE_PARAMS_OF_DESTROY_STRUCT_STORAGE;
+    FFI_INCLUDE_PARAMS_OF_DESTROY_STRUCT_STORAGE;
 
     REBSER *data = ARG(struct)->payload.structure.data;
     if (NOT_SER_FLAG(data, SERIES_FLAG_ARRAY))
@@ -430,7 +430,7 @@ REBNATIVE(alloc_value_pointer)
 // !!! Would it be better to not bother with the initial value parameter and
 // just start the cell out void?
 {
-    INCLUDE_PARAMS_OF_ALLOC_VALUE_POINTER;
+    FFI_INCLUDE_PARAMS_OF_ALLOC_VALUE_POINTER;
 
     REBVAL *paired = Alloc_Pairing(NULL); // no owning frame
     Move_Value(paired, ARG(value));
@@ -463,7 +463,7 @@ REBNATIVE(alloc_value_pointer)
 //
 REBNATIVE(free_value_pointer)
 {
-    INCLUDE_PARAMS_OF_FREE_VALUE_POINTER;
+    FFI_INCLUDE_PARAMS_OF_FREE_VALUE_POINTER;
 
     REBVAL *paired = cast(REBVAL*, cast(REBUPT, VAL_INT64(ARG(pointer))));
 
@@ -517,7 +517,7 @@ REBNATIVE(get_at_pointer)
 // such mechanisms have been designed yet.  In the meantime, the interface
 // for GET-AT-POINTER should not deviate too far from GET.
 {
-    INCLUDE_PARAMS_OF_GET_AT_POINTER;
+    FFI_INCLUDE_PARAMS_OF_GET_AT_POINTER;
 
     REBVAL *paired = cast(REBVAL*, cast(REBUPT, VAL_INT64(ARG(source))));
     if (IS_VOID(paired) && NOT(REF(only)))
@@ -549,7 +549,7 @@ REBNATIVE(set_at_pointer)
 // !!! See notes on GET-AT-POINTER about keeping interface roughly compatible
 // with the SET native.
 {
-    INCLUDE_PARAMS_OF_SET_AT_POINTER;
+    FFI_INCLUDE_PARAMS_OF_SET_AT_POINTER;
 
     if (IS_VOID(ARG(value)) && NOT(REF(only)))
         fail (Error_No_Value(ARG(value)));

--- a/src/extensions/ffi/t-struct.c
+++ b/src/extensions/ffi/t-struct.c
@@ -1562,7 +1562,7 @@ REBTYPE(Struct)
         return R_OUT; }
 
     case SYM_REFLECT: {
-        INCLUDE_PARAMS_OF_REFLECT;
+        FFI_INCLUDE_PARAMS_OF_REFLECT;
 
         UNUSED(ARG(value));
         REBSYM property = VAL_WORD_SYM(ARG(property));

--- a/src/extensions/gif/mod-gif.c
+++ b/src/extensions/gif/mod-gif.c
@@ -230,7 +230,7 @@ static REBOOL Has_Valid_GIF_Header(REBYTE *data, REBCNT len) {
 //
 REBNATIVE(identify_gif_q)
 {
-    INCLUDE_PARAMS_OF_IDENTIFY_GIF_Q;
+    GIF_INCLUDE_PARAMS_OF_IDENTIFY_GIF_Q;
 
     REBYTE *data = VAL_BIN_AT(ARG(data));
     REBCNT len = VAL_LEN_AT(ARG(data));
@@ -254,7 +254,7 @@ REBNATIVE(identify_gif_q)
 //
 REBNATIVE(decode_gif)
 {
-    INCLUDE_PARAMS_OF_DECODE_GIF;
+    GIF_INCLUDE_PARAMS_OF_DECODE_GIF;
 
     REBYTE *data = VAL_BIN_AT(ARG(data));
     REBCNT len = VAL_LEN_AT(ARG(data));

--- a/src/extensions/jpg/mod-jpg.c
+++ b/src/extensions/jpg/mod-jpg.c
@@ -55,7 +55,7 @@ extern void jpeg_load(char *buffer, int nbytes, char *output);
 //
 REBNATIVE(identify_jpeg_q)
 {
-    INCLUDE_PARAMS_OF_IDENTIFY_JPEG_Q;
+    JPG_INCLUDE_PARAMS_OF_IDENTIFY_JPEG_Q;
 
     // Handle JPEG error throw:
     if (setjmp(jpeg_state)) {
@@ -82,7 +82,7 @@ REBNATIVE(identify_jpeg_q)
 //
 REBNATIVE(decode_jpeg)
 {
-    INCLUDE_PARAMS_OF_DECODE_JPEG;
+    JPG_INCLUDE_PARAMS_OF_DECODE_JPEG;
 
     // Handle JPEG error throw:
     if (setjmp(jpeg_state)) {

--- a/src/extensions/locale/mod-locale.c
+++ b/src/extensions/locale/mod-locale.c
@@ -61,7 +61,7 @@ REBNATIVE(locale)
 //
 {
 #ifdef TO_WINDOWS
-    INCLUDE_PARAMS_OF_LOCALE;
+    LOCALE_INCLUDE_PARAMS_OF_LOCALE;
     REBSTR *cat = VAL_WORD_CANON(ARG(category));
     LCTYPE type;
     if (cat == LOCALE_WORD_LANGUAGE) {
@@ -119,7 +119,7 @@ REBNATIVE(locale)
 //
 REBNATIVE(setlocale)
 {
-    INCLUDE_PARAMS_OF_SETLOCALE;
+    LOCALE_INCLUDE_PARAMS_OF_SETLOCALE;
 
     struct cat_pair {
         REBSTR *word;

--- a/src/extensions/odbc/mod-odbc.c
+++ b/src/extensions/odbc/mod-odbc.c
@@ -261,7 +261,7 @@ REBNATIVE(open_connection)
 // making new objects from inside the native code and naming the fields was
 // too hard and/or undocumented.  It shouldn't be difficult to change.
 {
-    INCLUDE_PARAMS_OF_OPEN_CONNECTION;
+    ODBC_INCLUDE_PARAMS_OF_OPEN_CONNECTION;
 
     SQLRETURN rc;
 
@@ -359,7 +359,7 @@ REBNATIVE(open_statement)
 // !!! Similar to previous routines, this takes an empty statement object in
 // to initialize.
 {
-    INCLUDE_PARAMS_OF_OPEN_STATEMENT;
+    ODBC_INCLUDE_PARAMS_OF_OPEN_STATEMENT;
 
     REBCTX *connection = VAL_CONTEXT(ARG(connection));
     SQLHDBC hdbc = cast(SQLHDBC, VAL_HANDLE_VOID_POINTER(
@@ -896,7 +896,7 @@ SQLRETURN ODBC_BindColumns(
 //
 REBNATIVE(insert_odbc)
 {
-    INCLUDE_PARAMS_OF_INSERT_ODBC;
+    ODBC_INCLUDE_PARAMS_OF_INSERT_ODBC;
 
     REBCTX *statement = VAL_CONTEXT(ARG(statement));
     SQLHSTMT hstmt = VAL_HANDLE_POINTER(
@@ -1277,7 +1277,7 @@ void ODBC_Column_To_Rebol_Value(
 //
 REBNATIVE(copy_odbc)
 {
-    INCLUDE_PARAMS_OF_COPY_ODBC;
+    ODBC_INCLUDE_PARAMS_OF_COPY_ODBC;
 
     REBCTX *statement = VAL_CONTEXT(ARG(statement));
 
@@ -1343,7 +1343,7 @@ REBNATIVE(copy_odbc)
 //
 REBNATIVE(update_odbc)
 {
-    INCLUDE_PARAMS_OF_UPDATE_ODBC;
+    ODBC_INCLUDE_PARAMS_OF_UPDATE_ODBC;
 
     REBCTX *connection = VAL_CONTEXT(ARG(connection));
 
@@ -1397,7 +1397,7 @@ REBNATIVE(update_odbc)
 //
 REBNATIVE(close_statement)
 {
-    INCLUDE_PARAMS_OF_CLOSE_STATEMENT;
+    ODBC_INCLUDE_PARAMS_OF_CLOSE_STATEMENT;
 
     REBCTX *statement = VAL_CONTEXT(ARG(statement));
 
@@ -1438,7 +1438,7 @@ REBNATIVE(close_statement)
 //
 REBNATIVE(close_connection)
 {
-    INCLUDE_PARAMS_OF_CLOSE_CONNECTION;
+    ODBC_INCLUDE_PARAMS_OF_CLOSE_CONNECTION;
 
     REBCTX *connection = VAL_CONTEXT(ARG(connection));
 

--- a/src/extensions/png/mod-lodepng.c
+++ b/src/extensions/png/mod-lodepng.c
@@ -173,7 +173,7 @@ static unsigned rebol_zlib_compress(
 //
 REBNATIVE(identify_png_q)
 {
-    INCLUDE_PARAMS_OF_IDENTIFY_PNG_Q;
+    LODEPNG_INCLUDE_PARAMS_OF_IDENTIFY_PNG_Q;
 
     LodePNGState state;
     lodepng_state_init(&state);
@@ -226,7 +226,7 @@ REBNATIVE(identify_png_q)
 //
 REBNATIVE(decode_png)
 {
-    INCLUDE_PARAMS_OF_DECODE_PNG;
+    LODEPNG_INCLUDE_PARAMS_OF_DECODE_PNG;
 
     LodePNGState state;
     lodepng_state_init(&state);
@@ -315,7 +315,7 @@ REBNATIVE(decode_png)
 //
 REBNATIVE(encode_png)
 {
-    INCLUDE_PARAMS_OF_ENCODE_PNG;
+    LODEPNG_INCLUDE_PARAMS_OF_ENCODE_PNG;
 
     REBVAL *image = ARG(image);
 

--- a/src/extensions/process/mod-process.c
+++ b/src/extensions/process/mod-process.c
@@ -232,7 +232,7 @@ int OS_Create_Process(
     char **err,
     u32 *err_len
 ) {
-    INCLUDE_PARAMS_OF_CALL;
+    PROCESS_INCLUDE_PARAMS_OF_CALL;
 
     UNUSED(ARG(command)); // turned into `call` and `argv/argc` by CALL
     UNUSED(REF(wait)); // covered by flag_wait
@@ -870,7 +870,7 @@ int OS_Create_Process(
     char **err,
     u32 *err_len
 ) {
-    INCLUDE_PARAMS_OF_CALL;
+    PROCESS_INCLUDE_PARAMS_OF_CALL;
 
     UNUSED(ARG(command)); // translated into call and argc/argv
     UNUSED(REF(wait)); // flag_wait controls this
@@ -1501,7 +1501,7 @@ REBNATIVE(call)
 // !!! Parameter usage may require WAIT mode even if not explicitly requested.
 // /WAIT should be default, with /ASYNC (or otherwise) as exception!
 {
-    INCLUDE_PARAMS_OF_CALL;
+    PROCESS_INCLUDE_PARAMS_OF_CALL;
 
     UNUSED(REF(shell)); // looked at via frame_ by OS_Create_Process
     UNUSED(REF(console)); // same
@@ -1813,7 +1813,7 @@ REBNATIVE(get_os_browsers)
 // of more "structural" result, it was just easy because it's how the string
 // comes back from the Windows registry.  Review.
 {
-    INCLUDE_PARAMS_OF_GET_OS_BROWSERS;
+    PROCESS_INCLUDE_PARAMS_OF_GET_OS_BROWSERS;
 
     REBDSP dsp_orig = DSP;
 
@@ -1919,7 +1919,7 @@ REBNATIVE(sleep)
 // on Sleep() vs. usleep()...and all the relevant includes have been
 // established here.
 {
-    INCLUDE_PARAMS_OF_SLEEP;
+    PROCESS_INCLUDE_PARAMS_OF_SLEEP;
 
     REBCNT msec = Milliseconds_From_Value(ARG(duration));
 
@@ -1953,7 +1953,7 @@ static void kill_process(REBINT pid, REBINT signal);
 //
 static REBNATIVE(terminate)
 {
-    INCLUDE_PARAMS_OF_TERMINATE;
+    PROCESS_INCLUDE_PARAMS_OF_TERMINATE;
 
 #ifdef TO_WINDOWS
     if (GetCurrentProcessId() == cast(DWORD, VAL_INT32(ARG(pid))))
@@ -2020,7 +2020,7 @@ static REBNATIVE(terminate)
 //
 static REBNATIVE(get_env)
 {
-    INCLUDE_PARAMS_OF_GET_ENV;
+    PROCESS_INCLUDE_PARAMS_OF_GET_ENV;
 
     REBVAL *variable = ARG(variable);
 
@@ -2099,7 +2099,7 @@ static REBNATIVE(get_env)
 //
 static REBNATIVE(set_env)
 {
-    INCLUDE_PARAMS_OF_SET_ENV;
+    PROCESS_INCLUDE_PARAMS_OF_SET_ENV;
 
     REBVAL *variable = ARG(variable);
     REBVAL *value = ARG(value);
@@ -2343,7 +2343,7 @@ static REBNATIVE(list_env)
 //
 static REBNATIVE(get_pid)
 {
-    INCLUDE_PARAMS_OF_GET_PID;
+    PROCESS_INCLUDE_PARAMS_OF_GET_PID;
 
     Init_Integer(D_OUT, getpid());
 
@@ -2364,7 +2364,7 @@ static REBNATIVE(get_pid)
 //
 static REBNATIVE(get_uid)
 {
-    INCLUDE_PARAMS_OF_GET_UID;
+    PROCESS_INCLUDE_PARAMS_OF_GET_UID;
 
     Init_Integer(D_OUT, getuid());
 
@@ -2385,7 +2385,7 @@ static REBNATIVE(get_uid)
 //
 static REBNATIVE(get_euid)
 {
-    INCLUDE_PARAMS_OF_GET_EUID;
+    PROCESS_INCLUDE_PARAMS_OF_GET_EUID;
 
     Init_Integer(D_OUT, geteuid());
 
@@ -2404,7 +2404,7 @@ static REBNATIVE(get_euid)
 //
 static REBNATIVE(get_gid)
 {
-    INCLUDE_PARAMS_OF_GET_UID;
+    PROCESS_INCLUDE_PARAMS_OF_GET_UID;
 
     Init_Integer(D_OUT, getgid());
 
@@ -2425,7 +2425,7 @@ static REBNATIVE(get_gid)
 //
 static REBNATIVE(get_egid)
 {
-    INCLUDE_PARAMS_OF_GET_EUID;
+    PROCESS_INCLUDE_PARAMS_OF_GET_EUID;
 
     Init_Integer(D_OUT, getegid());
 
@@ -2451,7 +2451,7 @@ static REBNATIVE(get_egid)
 //
 static REBNATIVE(set_uid)
 {
-    INCLUDE_PARAMS_OF_SET_UID;
+    PROCESS_INCLUDE_PARAMS_OF_SET_UID;
 
     if (setuid(VAL_INT32(ARG(uid))) < 0) {
         switch (errno) {
@@ -2489,7 +2489,7 @@ static REBNATIVE(set_uid)
 //
 static REBNATIVE(set_euid)
 {
-    INCLUDE_PARAMS_OF_SET_EUID;
+    PROCESS_INCLUDE_PARAMS_OF_SET_EUID;
 
     if (seteuid(VAL_INT32(ARG(euid))) < 0) {
         switch (errno) {
@@ -2527,7 +2527,7 @@ static REBNATIVE(set_euid)
 //
 static REBNATIVE(set_gid)
 {
-    INCLUDE_PARAMS_OF_SET_GID;
+    PROCESS_INCLUDE_PARAMS_OF_SET_GID;
 
     if (setgid(VAL_INT32(ARG(gid))) < 0) {
         switch (errno) {
@@ -2565,7 +2565,7 @@ static REBNATIVE(set_gid)
 //
 static REBNATIVE(set_egid)
 {
-    INCLUDE_PARAMS_OF_SET_EGID;
+    PROCESS_INCLUDE_PARAMS_OF_SET_EGID;
 
     if (setegid(VAL_INT32(ARG(egid))) < 0) {
         switch (errno) {
@@ -2626,7 +2626,7 @@ static void kill_process(REBINT pid, REBINT signal)
 //
 static REBNATIVE(send_signal)
 {
-    INCLUDE_PARAMS_OF_SEND_SIGNAL;
+    PROCESS_INCLUDE_PARAMS_OF_SEND_SIGNAL;
 
     kill_process(VAL_INT32(ARG(pid)), VAL_INT32(ARG(signal)));
 

--- a/src/extensions/uuid/mod-uuid.c
+++ b/src/extensions/uuid/mod-uuid.c
@@ -59,7 +59,7 @@
 //
 static REBNATIVE(generate)
 {
-    INCLUDE_PARAMS_OF_GENERATE;
+    UUID_INCLUDE_PARAMS_OF_GENERATE;
 
 #ifdef TO_WINDOWS
     UUID uuid;

--- a/src/extensions/view/mod-view.c
+++ b/src/extensions/view/mod-view.c
@@ -126,7 +126,7 @@ REBOOL osDialogOpen = FALSE;
 //
 REBNATIVE(request_file_p)
 {
-    INCLUDE_PARAMS_OF_REQUEST_FILE_P;
+    VIEW_INCLUDE_PARAMS_OF_REQUEST_FILE_P;
 
     // Files to return will be collected and returned on the stack
     //
@@ -565,7 +565,7 @@ REBNATIVE(request_dir_p)
 // The code that was there has been resurrected well enough to run, but is
 // currently disabled to avoid the OLE32 dependency.
 {
-    INCLUDE_PARAMS_OF_REQUEST_DIR_P;
+    VIEW_INCLUDE_PARAMS_OF_REQUEST_DIR_P;
 
     REBCTX *error = NULL;
 


### PR DESCRIPTION
There are two conflicts when an extension and core have natives with
same name: the parameter macmros INCLUDE_PARAMS_OF and the C function
name N_, because they share the same globale name space, and sys-core.h
is included by each module source. The conflicts are solved by prefixing
INCLUDE_PARAMS_OF with CORE_ or module name (e.g.
CRYPT_INCLUDE_PARAMS_OF) and redefining REBNATIVE in each module to
include the module name in the C functions (e.g. N_rc4 becomes
N_CRYPT_rc4)and keep the names of the core natives unchanged.