### PR TITLE
END ignores values to end of block/group, simplify invisibles

### DIFF
--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -275,13 +275,17 @@ void Do_Core_Exit_Checks_Debug(REBFRM *f) {
     if (f->flags.bits & DO_FLAG_TO_END)
         assert(THROWN(f->out) || FRM_AT_END(f));
 
-    // Function execution should have written *some* actual output value.
-    // checking the VAL_TYPE() is enough to make sure it's not END or trash
+    // We'd like `do [1 + comment "foo"]` to act identically to `do [1 +]`
+    // (as opposed to `do [1 + ()]`).  Hence Do_Core() offers the distinction
+    // of END for a fully "invisible" evaluation, as opposed to void.  This
+    // distinction is only offered internally, at the moment.
     //
-    assert(VAL_TYPE(f->out) <= REB_MAX_VOID);
+    if (NOT_END(f->out)) {
+        assert(VAL_TYPE(f->out) <= REB_MAX_VOID);
 
-    if (NOT(THROWN(f->out)))
-        ASSERT_VALUE_MANAGED(f->out);
+        if (NOT(THROWN(f->out)))
+            ASSERT_VALUE_MANAGED(f->out);
+    }
 }
 
 #endif

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -776,7 +776,7 @@ inline static REBIXO DO_NEXT_MAY_THROW(
     SET_FRAME_VALUE(f, ARR_AT(array, index));
 
     if (FRM_AT_END(f)) {
-        Init_Void(out);
+        Init_Endish_Void(out);
         return END_FLAG;
     }
 
@@ -798,8 +798,12 @@ inline static REBIXO DO_NEXT_MAY_THROW(
     if (THROWN(out))
         return THROWN_FLAG;
 
-    if (FRM_AT_END(f))
+    if (FRM_AT_END(f)) {
+        if (IS_END(out))
+            Init_Endish_Void(out);
+
         return END_FLAG;
+    }
 
     assert(f->source.index > 1);
     return f->source.index - 1;
@@ -837,7 +841,7 @@ inline static REBIXO Do_Array_At_Core(
     }
 
     if (FRM_AT_END(f)) {
-        Init_Void(out);
+        Init_Endish_Void(out);
         return END_FLAG;
     }
 
@@ -854,7 +858,14 @@ inline static REBIXO Do_Array_At_Core(
     if (THROWN(f->out))
         return THROWN_FLAG;
 
-    return FRM_AT_END(f) ? END_FLAG : f->source.index;
+    if (FRM_AT_END(f)) {
+        if (IS_END(f->out))
+            Init_Endish_Void(f->out);
+
+        return END_FLAG;
+    }
+
+    return f->source.index;
 }
 
 

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -837,6 +837,14 @@ inline static void SET_END_Core(
 #define Init_Void(v) \
     VAL_RESET((v), REB_MAX_VOID, VALUE_FLAG_FALSEY) // see note above!
 
+// !!! A theory was that the "evaluated" flag would help a function that took
+// both <opt> and <end>, which are converted to voids, distinguish what kind
+// of void it is.  This may or may not be a good idea, but unevaluating it
+// here just to make a note of the concept, and tag it via the callsites.
+//
+#define Init_Endish_Void(v) \
+    VAL_RESET((v), REB_MAX_VOID, VALUE_FLAG_FALSEY | VALUE_FLAG_UNEVALUATED)
+
 #define IS_VOID_OR_FALSEY(v) \
     GET_VAL_FLAG((v), VALUE_FLAG_FALSEY)
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -75,6 +75,16 @@ elide: func [
     ; no body
 ]
 
+end: func [
+    {Inertly consumes all subsequent data, evaluating to previous result.}
+
+    return: []
+    :omit [<opt> any-value! <...>]
+][
+    until [tail? omit] [take omit]
+]
+
+
 ; Despite being very "noun-like", HEAD and TAIL have classically been "verbs"
 ; in Rebol.  Ren-C builds on the concept of REFLECT, so that REFLECT STR 'HEAD
 ; will get the head of a string.  An enfix left-soft-quoting operation is

--- a/tests/functions/invisible.test.reb
+++ b/tests/functions/invisible.test.reb
@@ -96,3 +96,13 @@
         not set? 'z
     ]
 ]
+
+[
+    () = do [end]
+][
+    3 = do [1 + 2 end 10 + 20 | 100 + 200]
+][
+    ok? trap [eval (proc [x [<end>]] []) end 1 2 3]
+][
+    error? trap [eval (proc [x [<opt>]] []) end 1 2 3]
+]


### PR DESCRIPTION
This adds a new usermode function which consumes items in a way
that makes it appear evaluation of a BLOCK!/GROUP! has ended:

    >> do [1 + 2 end 10 + 20 | 100 + 200]
    == 3

It does this by being a hard-quoted variadic, that just takes its
arguments without looking at them...and then it is also an "invisible".

Testing this exposed a difference between:

    >> do [1 +]
    ** + is missing its value2 argument

    >> do [1 + end]
    ** + does not accept void as its value2 argument

That was because the internals of Do_Core() would convert ENDs into
voids too early for argument fulfillment to tell the difference.  This
commit changes it so that the conversion to a void is done later by
those callers of the evaluator that need it.

The benefit applies to other invisibles, like COMMENT, in making sure
that they really have *no* different effect vs. not being there (as far as
the evaluator is concerned.)