### PR TITLE
Add runtime stack growth direction detection option

### DIFF
--- a/make/configs/emscripten-node.r
+++ b/make/configs/emscripten-node.r
@@ -11,16 +11,16 @@ toolset: [
 
 optimize: "z"
 
-main: %../tests/test-node.js
+main: '../tests/test-node.js ;-- expects PATH!, but also expects .c (?)
 
 debug: true 
 
 ldflags: reduce [
-	unspaced["-O" optimize]
-	unspaced [{-s 'ASSERTIONS=} either debug [1] [0] {'}]
-	{-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]'}
-	{--post-js prep/include/reb-lib.js}
-	either all [main file? main 'file = exists? main] [spaced [{--post-js} main]] [""]
+    unspaced["-O" optimize]
+    unspaced [{-s 'ASSERTIONS=} either debug [1] [0] {'}]
+    {-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]'}
+    {--post-js prep/include/reb-lib.js}
+    either all [main file? main 'file = exists? main] [spaced [{--post-js} main]] [""]
 ]
 
 extensions: [

--- a/make/make.r
+++ b/make/make.r
@@ -178,7 +178,7 @@ gen-obj: func [
         ]
         output: to-obj-path to string! ;\
             either main [
-                join-of %main/ last s
+                join-of %main/ (last ensure path! s)
             ] [s]
         cflags: either empty? flags [_] [flags]
         definitions: (to-value :definitions)

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -61,7 +61,7 @@ systems: [
         ; was: "Amiga V2.0-3.1 68000"
 
     0.1.03 amiga/posix "ppc"
-        #BEN #LLC #F64 <NPS> <HID> /HID /DYN %M
+        #SGD #BEN #LLC #F64 <NPS> <HID> /HID /DYN %M
 
     Macintosh: 2
     ;-------------------------------------------------------------------------
@@ -75,25 +75,25 @@ systems: [
         ; was: "Macintosh, FAT PPC, 68K"
 
     0.2.04 osx-ppc/osx "osx-ppc"
-        #BEN #LLC #F64 <NCM> /HID /DYN %M ;originally targeted OS/X 10.2
+        #SGD #BEN #LLC #F64 <NCM> /HID /DYN %M ;originally targeted OS/X 10.2
 
     0.2.05 osx-x86/osx "osx-x86"
-        #LEN #LLC #NSER #F64 <NCM> <NPS> <ARC> /HID /ARC /DYN %M
+        #SGD #LEN #LLC #NSER #F64 <NCM> <NPS> <ARC> /HID /ARC /DYN %M
 
     0.2.40 osx-x64/osx _
-        #LEN #LLC #NSER #F64 <NCM> <NPS> /HID /DYN %M
+        #SGD #LEN #LLC #NSER #F64 <NCM> <NPS> /HID /DYN %M
 
     Windows: 3
     ;-------------------------------------------------------------------------
     0.3.01 windows-x86/windows "win32-x86"
-        #LEN #UNI #F64 #W32 #NSEC <WLOSS> /CON /S4M %W32 %M
+        #SGD #LEN #UNI #F64 #W32 #NSEC <WLOSS> /CON /S4M %W32 %M
         ; was: "Microsoft Windows XP/NT/2K/9X iX86"
 
     0.3.02 _ "dec-alpha"
         ; was: "Windows Alpha NT DEC Alpha"
 
     0.3.40 windows-x64/windows "win32-x64"
-        #LEN #UNI #F64 #W32 #LLP64 #NSEC <WLOSS> /CON /S4M %W32 %M
+        #SGD #LEN #UNI #F64 #W32 #LLP64 #NSEC <WLOSS> /CON /S4M %W32 %M
 
     Linux: 4
     ;-------------------------------------------------------------------------
@@ -101,13 +101,13 @@ systems: [
         ; was: "Linux Libc5 iX86 1.2.1.4.1 view-pro041.tar.gz"
 
     0.4.02 linux-x86/linux "libc6-2-3-x86"
-        #LEN #LLC #NSER #F64 <M32> <NSP> <UFS> /M32 %M %DL ;gliblc-2.3
+        #SGD #LEN #LLC #NSER #F64 <M32> <NSP> <UFS> /M32 %M %DL ;gliblc-2.3
 
     0.4.03 linux-x86/linux "libc6-2-5-x86"
-        #LEN #LLC #F64 <M32> <UFS> /M32 %M %DL ;gliblc-2.5
+        #SGD #LEN #LLC #F64 <M32> <UFS> /M32 %M %DL ;gliblc-2.5
 
     0.4.04 linux-x86/linux "libc6-2-11-x86"
-        #LEN #LLC #F64 #PIP2 <M32> <HID> /M32 /HID /DYN %M %DL ;glibc-2.11
+        #SGD #LEN #LLC #F64 #PIP2 <M32> <HID> /M32 /HID /DYN %M %DL ;glibc-2.11
 
     0.4.05 _ _
         ; was: "Linux 68K"
@@ -125,34 +125,34 @@ systems: [
         ; was: "Linux Cobalt Qube MIPS"
 
     0.4.10 linux-ppc/linux "libc6-ppc"
-        #BEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
+        #SGD #BEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
 
     0.4.11 linux-ppc64/linux "libc6-ppc64"
-        #BEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
+        #SGD #BEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
 
     0.4.20 linux-arm/linux "libc6-arm"
-        #LEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
 
     0.4.21 linux-arm/linux _
-        #LEN #LLC #F64 #PIP2 <HID> <PIE> /HID /DYN %M %DL ;android
+        #SGD #LEN #LLC #F64 #PIP2 <HID> <PIE> /HID /DYN %M %DL ;android
 
     0.4.22 linux-aarch64/linux "libc6-aarch64"
-        #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
 
     0.4.30 linux-mips/linux "libc6-mips"
-        #LEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
 
     0.4.31 linux-mips32be/linux "libc6-mips32be"
-        #BEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
+        #SGD #BEN #LLC #F64 #PIP2 <HID> /HID /DYN %M %DL
 
     0.4.40 linux-x64/linux "libc-x64"
-        #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
 
     0.4.60 linux-axp/linux "dec-alpha"
-        #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
 
     0.4.61 linux-ia64/linux "libc-ia64"
-        #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 #PIP2 #LP64 <HID> /HID /DYN %M %DL
 
     BeOS: 5
     ;-------------------------------------------------------------------------
@@ -163,7 +163,7 @@ systems: [
         ; was: "BeOS R5 iX86"
 
     0.5.75 haiku/posix "x86-32"
-        #LEN #LLC %NWK
+        #SGD #LEN #LLC %NWK
 
     BSDi: 6
     ;-------------------------------------------------------------------------
@@ -176,10 +176,10 @@ systems: [
         ; was: "Free BSD iX86"
 
     0.7.02 freebsd-x86/posix "elf-x86"
-        #LEN #LLC #F64 %M
+        #SGD #LEN #LLC #F64 %M
 
     0.7.40 freebsd-x64/posix _
-        #LEN #LLC #F64 #LP64 %M
+        #SGD #LEN #LLC #F64 #LP64 %M
 
     NetBSD: 8
     ;-------------------------------------------------------------------------
@@ -210,13 +210,13 @@ systems: [
         ; was: "OpenBSD 68K"
 
     0.9.04 openbsd-x86/posix "elf-x86"
-        #LEN #LLC #F64 %M
+        #SGD #LEN #LLC #F64 %M
 
     0.9.05 _ "sparc"
         ; was: "OpenBSD Sparc"
 
     0.9.40 openbsd-x64/posix "elf-x64"
-        #LEN #LLC #F64 #LP64 %M
+        #SGD #LEN #LLC #F64 #LP64 %M
 
     Sun: 10
     ;-------------------------------------------------------------------------
@@ -239,18 +239,18 @@ systems: [
     Android: 13
     ;-------------------------------------------------------------------------
     0.13.01 android-arm/android "arm"
-        #LEN #LLC #F64 <HID> <PIC> /HID /DYN %M %DL %LOG
+        #SGD #LEN #LLC #F64 <HID> <PIC> /HID /DYN %M %DL %LOG
 
     0.13.02 android5-arm/android _
-        #LEN #LLC #F64 <HID> <PIC> /HID /PIE /DYN %M %DL %LOG
+        #SGD #LEN #LLC #F64 <HID> <PIC> /HID /PIE /DYN %M %DL %LOG
 
     Syllable: 14
     ;-------------------------------------------------------------------------
     0.14.01 syllable-dtp/posix _
-        #LEN #LLC #F64 <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 <HID> /HID /DYN %M %DL
 
     0.14.02 syllable-svr/linux _
-        #LEN #LLC #F64 <M32> <HID> /HID /DYN %M %DL
+        #SGD #LEN #LLC #F64 <M32> <HID> /HID /DYN %M %DL
 
     WindowsCE: 15
     ;-------------------------------------------------------------------------
@@ -269,9 +269,9 @@ systems: [
     Emscripten: 16
     ;-------------------------------------------------------------------------
     0.16.01 emscripten-asm/emscripten "asm.js"
-        #LEN
+        #SG? #LEN
     0.16.02 emscripten-wasm/emscripten "webassembly"
-        #LEN /WASM
+        #SG? #LEN /WASM
 
     AIX: 17
     ;-------------------------------------------------------------------------
@@ -318,6 +318,13 @@ system-definitions: make object! [
 
     LLC: "HAS_LL_CONSTS"          ; supports e.g. 0xffffffffffffffffLL
     ;LL?: _                       ; might have LL consts, reb-config.h checks
+
+    ; See C_STACK_OVERFLOWING for an explanation of the dodgy technique used
+    ; to try and preempt a C stackoverflow crash with a trappable error. 
+    ;
+    SGD: "OS_STACK_GROWS_DOWN"    ; most widespread choice in C compilers
+    ;SGU: "OS_STACK_GROWS_UP"     ; rarer (Debian HPPA, some emscripten/wasm)
+    SG?: _                        ; try to detect growth direction at runtime
 
     W32: <msc:WIN32>              ; aes.c requires this
     UNI: "UNICODE"                ; win32 wants it

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -141,7 +141,6 @@ options: construct [] [  ; Options supplied to REBOL during startup
     module-paths: [%./]
     default-suffix: %.reb ; Used by IMPORT if no suffix is provided
     file-types: []
-    result-types: _
 
     ; Legacy Behaviors Options (paid attention to only by debug builds)
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -42,12 +42,6 @@
 //
 void Snap_State_Core(struct Reb_State *s)
 {
-    // See remarks in Set_Stack_Limit() for why this is needed as part of
-    // multithreading as in Ren Garden.  It's not ideal, but it works around
-    // a problem for the moment.
-    //
-    s->stack_limit = Stack_Limit;
-
     s->dsp = DSP;
     s->top_chunk = TG_Top_Chunk;
 
@@ -215,7 +209,6 @@ void Trapped_Helper(struct Reb_State *s)
     SET_SERIES_LEN(TG_Mold_Stack, s->mold_loop_tail);
 
     Saved_State = s->last_state;
-    Stack_Limit = s->stack_limit;
 }
 
 

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -1105,8 +1105,7 @@ static void Free_Unbiased_Series_Data(char *unbiased, REBCNT size_unpooled)
 //
 //  Expand_Series: C
 //
-// Expand a series at a particular index point by the number
-// number of units specified by delta.
+// Expand a series at a particular index point by `delta` units.
 //
 //     index - where space is expanded (but not cleared)
 //     delta - number of UNITS to expand (keeping terminator)

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -447,7 +447,7 @@ REBNATIVE(test)
     INCLUDE_PARAMS_OF_TEST;
     UNUSED(ARG(value));
 
-    REBVAL *temp = rebRun("trap [x: 10]", END);
+    REBVAL *temp = rebRun("print mold trap [foo: does [foo] foo]", END);
 
     Move_Value(D_OUT, temp);
     rebRelease(temp);

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -150,7 +150,10 @@ TVAR REBSER *TG_Mold_Stack; // Used to prevent infinite loop in cyclical molds
 // would represent a memory leak in the release build.
 TVAR REBSER *GC_Manuals;    // Manually memory managed (not by GC)
 
-TVAR REBUPT Stack_Limit;    // Limit address for CPU stack.
+#if !defined(OS_STACK_GROWS_UP) && !defined(OS_STACK_GROWS_DOWN)
+    TVAR REBOOL TG_Stack_Grows_Up; // Will be detected via questionable method
+#endif
+TVAR REBUPT TG_Stack_Limit;    // Limit address for CPU stack.
 
 #ifdef DEBUG_COUNT_TICKS
     //

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -530,22 +530,18 @@ inline static void Drop_Chunk_Of_Values(REBVAL *opt_head)
 // http://stackoverflow.com/questions/5013806/
 //
 
-#ifdef TO_EMSCRIPTEN
-    //
-    // !!! The Emscripten emulation of C, in particular, can't use this trick.
-    // Until there's some way of knowing how to stop stack overflows, just
-    // overflow... :-(
-    //
+
+#if defined(OS_STACK_GROWS_UP)
     #define C_STACK_OVERFLOWING(address_of_local_var) \
-        FALSE
+        (cast(REBUPT, (address_of_local_var)) >= TG_Stack_Limit)
+#elif defined(OS_STACK_GROWS_DOWN)
+    #define C_STACK_OVERFLOWING(address_of_local_var) \
+        (cast(REBUPT, (address_of_local_var)) <= TG_Stack_Limit)
 #else
-    #ifdef OS_STACK_GROWS_UP
-        #define C_STACK_OVERFLOWING(address_of_local_var) \
-            (cast(REBUPT, address_of_local_var) >= Stack_Limit)
-    #else
-        #define C_STACK_OVERFLOWING(address_of_local_var) \
-            (cast(REBUPT, address_of_local_var) <= Stack_Limit)
-    #endif
+    #define C_STACK_OVERFLOWING(address_of_local_var) \
+        (TG_Stack_Grows_Up \
+            ? cast(REBUPT, (address_of_local_var)) >= TG_Stack_Limit \
+            : cast(REBUPT, (address_of_local_var)) <= TG_Stack_Limit)
 #endif
 
 #define STACK_BOUNDS (4*1024*1000) // note: need a better way to set it !!

--- a/src/include/sys-state.h
+++ b/src/include/sys-state.h
@@ -44,8 +44,6 @@ struct Reb_State {
 
     struct Reb_State *last_state;
 
-    REBUPT stack_limit; // See Set_Stack_Limit() for why this is captured
-
     REBDSP dsp;
     struct Reb_Chunk *top_chunk;
     REBFRM *frame;

--- a/src/include/sys-trap.h
+++ b/src/include/sys-trap.h
@@ -165,6 +165,8 @@
 #define PUSH_TRAP(e,s) \
     do { \
         assert(Saved_State != NULL || (DSP == 0 && FS_TOP == NULL)); \
+        if (Saved_State == NULL) \
+            Set_Stack_Limit(s); \
         Snap_State_Core(s); \
         (s)->last_state = Saved_State; \
         Saved_State = (s); \

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -275,7 +275,11 @@ probe: func [
     value [<opt> any-value!]
         {Value to display.}
 ][
-    print mold :value
+    if set? 'value [
+        print mold :value
+    ] else [
+        print "!!! PROBE of void !!!!" ;-- MOLD won't take voids
+    ]
     :value
 ]
 
@@ -296,11 +300,6 @@ immediate!: make typeset! [
     ; Does not include internal datatypes
     blank! logic! any-scalar! date! any-word! datatype! typeset! event!
 ]
-
-system/options/result-types: make typeset! [
-    immediate! any-series! bitset! image! object! map! gob!
-]
-
 
 ok?: func [
     "Returns TRUE on all values that are not ERROR!"


### PR DESCRIPTION
R3-Alpha's method of doing stack overflow detection was based on a
non-standard C technique...which wasn't really its fault, because there
is no mention of a "stack" at all in the C standard.

In order to try and preempt common crashes, recursive routines would
conservatively test pointers of their local variables against a
"stack limit" calculated against a boundary location in memory.  While
some C compilers grow their stacks up and others down, down was most
common.  While this is not a perfect method, it's one of the few
available options in C programs that want to try not to crash in the
face of a C stack overflow.

R3-Alpha tried to detect the stack growth direction using a comparison
of addresses of local variables, which broke in some optimizers.  It
was removed due to the uncommonness of stacks growing up, in favor of
putting the direction in the build configuration.

However, Emscripten and webassembly don't have a firm commitment on
which direction the stack grows:

https://github.com/kripken/emscripten/issues/5410

So for now, this creates an option of a semi-reliable detection via
a routine that is recursive in an optimizer-unfriendly way.  A build
configuration can specify this detection, or that the stack grows
up or down.