### PR TITLE
Fix DEHEX behavior w.r.t. UTF-8, add corresponding ENHEX

### DIFF
--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -187,7 +187,7 @@ const REBYTE Lex_Map[256] =
     /* 7B {   */    LEX_DELIMIT|LEX_DELIMIT_LEFT_BRACE,
     /* 7C |   */    LEX_SPECIAL|LEX_SPECIAL_BAR,
     /* 7D }   */    LEX_DELIMIT|LEX_DELIMIT_RIGHT_BRACE,
-    /* 7E ~   */    LEX_WORD,  //LEX_SPECIAL|LEX_SPECIAL_TILDE,
+    /* 7E ~   */    LEX_WORD, // !!! once belonged to LEX_SPECIAL
     /* 7F DEL */    LEX_DEFAULT,
 
     /* Odd Control Chars */
@@ -798,7 +798,11 @@ static REBCNT Prescan_Token(SCAN_STATE *ss)
             break;
 
         case LEX_CLASS_WORD:
-            // !!! Comment said "flags word char (for nums)"...meaning?
+            //
+            // If something is in LEX_CLASS_SPECIAL it gets set in the flags
+            // that are returned.  But if any member of LEX_CLASS_WORD is
+            // found, then a flag will be set indicating that also.
+            //
             SET_LEX_FLAG(flags, LEX_SPECIAL_WORD);
             while (IS_LEX_WORD_OR_NUMBER(*cp)) cp++;
             break;
@@ -2730,7 +2734,6 @@ const REBYTE *Scan_Issue(REBVAL *out, const REBYTE *cp, REBCNT len)
                 || LEX_SPECIAL_PERIOD == c
                 || LEX_SPECIAL_PLUS == c
                 || LEX_SPECIAL_MINUS == c
-                || LEX_SPECIAL_TILDE == c
                 || LEX_SPECIAL_BAR == c
                 || LEX_SPECIAL_BLANK == c
                 || LEX_SPECIAL_COLON == c

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -138,9 +138,12 @@ enum LEX_CLASS_ENUM {
 #define IS_LEX_NOT_DELIMIT(c)           (Lex_Map[(REBYTE)c] >= LEX_SPECIAL)
 #define IS_LEX_WORD_OR_NUMBER(c)        (Lex_Map[(REBYTE)c] >= LEX_WORD)
 
-/*
-**  Special Chars (encoded in the LEX_VALUE field)
-*/
+//
+//  Special Chars (encoded in the LEX_VALUE field)
+//
+// !!! This used to have "LEX_SPECIAL_TILDE" for "7E ~ - complement number",
+// but that was removed at some point and it was made a legal word character.
+//
 enum LEX_SPECIAL_ENUM {             /* The order is important! */
     LEX_SPECIAL_AT,                 /* 40 @ - email */
     LEX_SPECIAL_PERCENT,            /* 25 % - file name */
@@ -151,7 +154,6 @@ enum LEX_SPECIAL_ENUM {             /* The order is important! */
     LEX_SPECIAL_GREATER,            /* 3E > - compare or end tag */
     LEX_SPECIAL_PLUS,               /* 2B + - positive number */
     LEX_SPECIAL_MINUS,              /* 2D - - date, negative number */
-    LEX_SPECIAL_TILDE,              /* 7E ~ - complement number */
     LEX_SPECIAL_BAR,                /* 7C | - expression barrier */
     LEX_SPECIAL_BLANK,              /* 5F _ - blank */
 
@@ -160,7 +162,14 @@ enum LEX_SPECIAL_ENUM {             /* The order is important! */
     LEX_SPECIAL_COMMA,              /* 2C , - decimal number */
     LEX_SPECIAL_POUND,              /* 23 # - hex number */
     LEX_SPECIAL_DOLLAR,             /* 24 $ - money */
-    LEX_SPECIAL_WORD,               /* SPECIAL - used for word chars (for nums) */
+
+    // LEX_SPECIAL_WORD is not a LEX_VALUE() of anything in LEX_CLASS_SPECIAL,
+    // it is used to set a flag by Prescan_Token().
+    //
+    // !!! Comment said "for nums"
+    //
+    LEX_SPECIAL_WORD,
+
     LEX_SPECIAL_MAX
 };
 

--- a/tests/pending-tests.r
+++ b/tests/pending-tests.r
@@ -547,15 +547,6 @@
 
 [[<b> "hello" </b>] == decode 'markup "<b>hello</b>"]
 
-; bug#1986
-["aβc" = dehex "a%ce%b2c"]
-
-; bug#1986
-[(to-string #{61CEB262}) = dehex "a%ce%b2c"]
-
-; bug#1986
-[#{61CEB262} = to-binary dehex "a%ce%b2c"]
-
 ; system/clipboard.r
 ; empty clipboard
 [

--- a/tests/string/dehex.test.reb
+++ b/tests/string/dehex.test.reb
@@ -1,9 +1,34 @@
 ; functions/string/dehex.r
-["a%b" = dehex "a%b"]
-["a%~b" = dehex "a%~b"]
+
+; DEHEX no longer tolerates non %xx or %XX patterns with % in source data
+;
+[error? trap ["a%b" = dehex "a%b"]]
+[error? trap ["a%~b" = dehex "a%~b"]]
+
 ["a^@b" = dehex "a%00b"]
 ["a b" = dehex "a%20b"]
 ["a%b" = dehex "a%25b"]
 ["a+b" = dehex "a%2bb"]
 ["a+b" = dehex "a%2Bb"]
 ["abc" = dehex "a%62c"]
+
+; #1986
+["aβc" = dehex "a%ce%b2c"]
+[(to-string #{61CEB263}) = dehex "a%CE%b2c"]
+[#{61CEB263} = to-binary dehex "a%CE%B2c"]
+
+; Per RFC 3896 2.1, all percent encodings should normalize to uppercase
+;
+["a%CE%B2c" = enhex "aβc"]
+
+; For what must be encoded, see https://stackoverflow.com/a/7109208/
+[
+    no-encode: unspaced [
+        "ABCDEFGHIJKLKMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        "-._~:/?#[]@!$&'()*+,;="
+    ]
+    did all [
+        no-encode == enhex no-encode
+        no-encode == dehex no-encode
+    ]
+]


### PR DESCRIPTION
R3-Alpha did not follow RFC 3896, which states that percent-encoded
URLs should be interpreting the percent encoded data as UTF-8.  This
was a longstanding bug report:

https://github.com/rebol/rebol-issues/issues/1986

A test was added that would fail, since the issue had not been fixed.
This test (along with many others) was put aside for later review
when the tests were changed to require all tests pass.

As part of an effort to fully triage those "put aside" tests (in one
way or another), this just goes ahead and fixes the issue.  It also
adds a corresponding ENHEX native which follows the RFC for producing
hex bytes for characters that need it.  Per that RFC, all hex byte
characters are canonized to uppercase in production (though both
upper and lower are tolerated by dehex).

One change in behavior is that a % sign in the source material *must*
be followed by two hex digits, either upper or lower case.  Other
appearances of % will be treated as an error.