### PR TITLE
Resurrect `<r3-legacy>` emulation, via more usermode code

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -145,22 +145,9 @@ options: construct [] [  ; Options supplied to REBOL during startup
 
     ; Legacy Behaviors Options (paid attention to only by debug builds)
 
-    exit-functions-only: false
     forever-64-bit-ints: false
-    print-forms-everything: false
     break-with-overrides: false
-    dont-exit-natives: false
-    paren-instead-of-group: false
-    get-will-get-anything: false
-    no-reduce-nested-print: false
     unlocked-source: false
-
-    ; These option will only apply if the function which is currently executing
-    ; was created after legacy mode was enabled, and if refinements-blank is
-    ; set (because that's what marks functions as "legacy" or not")
-    ;
-    no-switch-evals: false
-    no-switch-fallthrough: false
 ]
 
 script: construct [] [

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -38,16 +38,6 @@ datatypes
 ; !!! Kept for functionality of #[none] in the loader for <r3-legacy>
 none
 
-; For the moment, TO-WORD of a datatype is willing to canonize a datatype
-; as a word.  Long term, that specialization is not desirable because it
-; is effectively building keywords deep into the system.  Better would be
-; if datatypes could be communicated e.g. by #[()] for "groups" or "parens".
-;
-; Hardcoding in the GROUP! symbol is necessary for a legacy switch to be
-; willing to convert a "group!" into the word GROUP!
-;
-paren!
-
 ; The PICK* action was killed in favor of a native that uses the same logic
 ; as path processing.  Code still remains for processing PICK*, and ports or
 ; other mechanics may wind up using it...or path dispatch itself may be

--- a/src/core/t-datatype.c
+++ b/src/core/t-datatype.c
@@ -72,12 +72,6 @@ void TO_Datatype(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg) {
 void MF_Datatype(REB_MOLD *mo, const RELVAL *v, REBOOL form)
 {
     REBSTR *name = Canon(VAL_TYPE_SYM(v));
-#if !defined(NDEBUG)
-    if (LEGACY(OPTIONS_PAREN_INSTEAD_OF_GROUP)) {
-        if (VAL_TYPE_KIND(v) == REB_GROUP)
-            name = Canon(SYM_PAREN_X); // e_Xclamation point (PAREN!)
-    }
-#endif
     if (form)
         Emit(mo, "N", name);
     else


### PR DESCRIPTION
The `do <r3-legacy>` compatibility mode had atrophied somewhat from
lack of use, and several of the code paths inside the interpreter's C
code were removed to tighten things up.

This brings back a less-bend-over-backward compatibility mode, that is
not geared toward emulating obscure quirks of R3-Alpha.  Rather it acts
in the interest of aiming to enable a stylization of code as a "lowest
common denominator" which could run in R3-Alpha/Rebol2/Red, or this
`<r3-legacy>` mode of Ren-C.

To accomplish this, it does things like provide augmented FUNC and
FUNCTION generators that use FRAME! reflection to translate LOGIC!
false refinements into BLANK! values, and void arguments to unused
refinements into BLANK!s.  These function generators also provide a
definitional EXIT, in the spirit of the usermode form of definitional
returns...rather than try to directly simulate Red/Rebol2/R3-Alpha's
"climb the stack and exit the first non-native function" behavior
(which was bad).

This change was enough to run the Draem blog code from 2014, with
minor modifications, most all of which were related to the little-used
/ONLY feature for "don't run blocks" on conditionals, and the ability
to use non-blocks in conditional slots.  Explained here:

https://github.com/hostilefork/draem/commit/e9720a56ffaab9eec69a70ece76e66a43245b597