### PR TITLE
Enable ELIDE, COMMENT, etc. in CASE interstitials

### DIFF
--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -152,7 +152,7 @@ load-header: function [
             return either required ['no-header] [reduce [_ tmp tail of tmp]]
         ]
 
-        true [
+        elide (
             ; get 'rebol keyword
             ;
             set* [key: rest:] transcode/only data
@@ -160,7 +160,7 @@ load-header: function [
             ; get header block
             ;
             set* [hdr: rest:] transcode/next/relax rest
-        ]
+        )
 
         not block? :hdr [
             ; header block is incomplete

--- a/tests/control/case.test.reb
+++ b/tests/control/case.test.reb
@@ -41,31 +41,32 @@
 )
 
 (
-    flag: false
-    did all [
-        3 = case [
-            true reduce [elide (flag: true) 'add 1 2]
-        ]
-        flag = true ;-- the REDUCE ran, and BLOCK! was then executed
-    ]
+    3 = case [true (reduce ['add 1 2])]
 )
 (
-    flag: false
-    did all [
-        void? case [
-            false reduce [elide (flag: true) 'add 1 2]
-        ]
-        flag = true ;-- the REDUCE ran, but BLOCK! was then ignored
-    ]
+    void? case [false (reduce ['add 1 2])]
 )
 
 (
     error? trap [
         case [
-            true add 1 2 ;-- "branch" is 3, but must be BLOCK! or FUNCTION!
+            true add 1 2 ;-- branch slots must be BLOCK!, FUNCTION!, softquote
         ]
     ]
 )
+
+; Invisibles should be legal to mix with CASE.
+
+(
+    flag: false
+    result: case [
+        1 < 2 [1020]
+        elide (flag: true)
+        true [fail "shouldn't get here"]
+    ]
+    (not flag) and (result = 1020)
+)
+
 
 
 ; RETURN, THROW, BREAK will stop case evaluation


### PR DESCRIPTION
This commit switches CASE to use soft-quoting semantics on its branch
values.  The limiting aspect of this is you can no longer say, e.g.

    3 = case [
       true reduce ['add 1 2]
    ]

If you wanted to say that, you would have to write:

    3 = case [
       true (reduce ['add 1 2])
    ]

There are significant benefits to modifying CASE to this rule.  First,
if a condition is false, it is possible to skip over the branch slot
as it is only one element in size.  This is to say that the following
would not print, and return void:

    void? case [
        false (print "won't print" ['add 1 2])
    ]

While pinning down the semantics of CASE has been a longstanding goal
of Ren-C, the actual motivating scenario was to not "double-evaluate"
branches in the general case, so that ELIDE/DUMP/COMMENT and other
invisibles could be used *between* cases, e.g.:

    flag: false
    result: case [
        1 < 2 [1020]
        elide (flag: true)
        true [fail "shouldn't get here"]
    ]
    (not flag) and (result = 1020)

That is given as an example, because it would have been a problem
in the previous implementation...as flag would be set to TRUE when
the [1020] block was "evaluated".  Now it works as one likely
intends, to only run the elided expression after the previous
condition fails.