### PR TITLE
Make APPLY and MY work with PATH!

### DIFF
--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -92,7 +92,7 @@ REBOOL Next_Path_Throws(REBPVS *pvs)
     assert(pvs->refine == &pvs->cell);
 
     if (IS_GET_WORD(pvs->value)) { // e.g. object/:field
-        Copy_Opt_Var_May_Fail(
+        Move_Opt_Var_May_Fail(
             SINK(&pvs->cell), pvs->value, pvs->specifier
         );
     }
@@ -491,7 +491,7 @@ return_thrown:
 void Get_Simple_Value_Into(REBVAL *out, const RELVAL *val, REBSPC *specifier)
 {
     if (IS_WORD(val) || IS_GET_WORD(val))
-        Copy_Opt_Var_May_Fail(out, val, specifier);
+        Move_Opt_Var_May_Fail(out, val, specifier);
     else if (IS_PATH(val) || IS_GET_PATH(val))
         Get_Path_Core(out, val, specifier);
     else

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -523,7 +523,7 @@ REBNATIVE(get)
             Init_Void(dest); // may be turned to blank after loop, or error
         }
         else if (ANY_WORD(source)) {
-            Copy_Opt_Var_May_Fail(dest, source, specifier);
+            Move_Opt_Var_May_Fail(dest, source, specifier);
         }
         else if (ANY_PATH(source)) {
             //

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -447,7 +447,7 @@ REBNATIVE(chain)
 //  {Create a variant of a function that preprocesses its arguments}
 //
 //      return: [function!]
-//      adaptee [function! any-word! any-path!]
+//      adaptee [function! word! path!]
 //          {Function or specifying word (preserves word name for debug info)}
 //      prelude [block!]
 //          {Code to run in constructed frame before adapted function runs}
@@ -460,7 +460,17 @@ REBNATIVE(adapt)
     REBVAL *adaptee = ARG(adaptee);
 
     REBSTR *opt_adaptee_name;
-    Get_If_Word_Or_Path_Arg(D_OUT, &opt_adaptee_name, adaptee);
+    const REBOOL push_refinements = FALSE;
+    if (Get_If_Word_Or_Path_Throws(
+        D_OUT,
+        &opt_adaptee_name,
+        adaptee,
+        SPECIFIED,
+        push_refinements
+    )){
+        return R_OUT_IS_THROWN;
+    }
+
     if (NOT(IS_FUNCTION(D_OUT)))
         fail (Error_Invalid(adaptee));
     Move_Value(adaptee, D_OUT); // Frees D_OUT, and GC safe (in ARG slot)
@@ -561,9 +571,9 @@ REBNATIVE(adapt)
 //  {Wrap code around a FUNCTION! with access to its FRAME! and return value}
 //
 //      return: [function!]
-//      inner [function! any-word! any-path!]
+//      inner [function! word! path!]
 //          {Function that a FRAME! will be built for (and optionally called)}
-//      outer [function! any-word! any-path!]
+//      outer [function! word! path!]
 //          {Gets a FRAME! for INNER before invocation, can DO it (or not)}
 //  ]
 //
@@ -573,14 +583,33 @@ REBNATIVE(enclose)
 
     REBVAL *inner = ARG(inner);
     REBSTR *opt_inner_name;
-    Get_If_Word_Or_Path_Arg(D_OUT, &opt_inner_name, inner);
+    const REBOOL push_refinements = FALSE;
+    if (Get_If_Word_Or_Path_Throws(
+        D_OUT,
+        &opt_inner_name,
+        inner,
+        SPECIFIED,
+        push_refinements
+    )){
+        return R_OUT_IS_THROWN;
+    }
+
     if (NOT(IS_FUNCTION(D_OUT)))
         fail (Error_Invalid(inner));
     Move_Value(inner, D_OUT); // Frees D_OUT, and GC safe (in ARG slot)
 
     REBVAL *outer = ARG(outer);
     REBSTR *opt_outer_name;
-    Get_If_Word_Or_Path_Arg(D_OUT, &opt_outer_name, outer);
+    if (Get_If_Word_Or_Path_Throws(
+        D_OUT,
+        &opt_outer_name,
+        outer,
+        SPECIFIED,
+        push_refinements
+    )){
+        return R_OUT_IS_THROWN;
+    }
+
     if (NOT(IS_FUNCTION(D_OUT)))
         fail (Error_Invalid(outer));
     Move_Value(outer, D_OUT); // Frees D_OUT, and GC safe (in ARG slot)
@@ -654,9 +683,9 @@ REBNATIVE(enclose)
 //
 //      return: [function! blank!]
 //          {The hijacked function value, blank if self-hijack (no-op).}
-//      victim [function! any-word! any-path!]
+//      victim [function! word! path!]
 //          {Function value whose references are to be affected.}
-//      hijacker [function! any-word! any-path!]
+//      hijacker [function! word! path!]
 //          {The function to run in its place.}
 //  ]
 //
@@ -677,14 +706,33 @@ REBNATIVE(hijack)
 
     REBVAL *victim = ARG(victim);
     REBSTR *opt_victim_name;
-    Get_If_Word_Or_Path_Arg(D_OUT, &opt_victim_name, victim);
+    const REBOOL push_refinements = FALSE;
+    if (Get_If_Word_Or_Path_Throws(
+        D_OUT,
+        &opt_victim_name,
+        victim,
+        SPECIFIED,
+        push_refinements
+    )){
+        return R_OUT_IS_THROWN;
+    }
+
     if (!IS_FUNCTION(D_OUT))
         fail ("Victim of HIJACK must be a FUNCTION!");
     Move_Value(victim, D_OUT); // Frees D_OUT, and GC safe (in ARG slot)
 
     REBVAL *hijacker = ARG(hijacker);
     REBSTR *opt_hijacker_name;
-    Get_If_Word_Or_Path_Arg(D_OUT, &opt_hijacker_name, hijacker);
+    if (Get_If_Word_Or_Path_Throws(
+        D_OUT,
+        &opt_hijacker_name,
+        hijacker,
+        SPECIFIED,
+        push_refinements
+    )){
+        return R_OUT_IS_THROWN;
+    }
+
     if (!IS_FUNCTION(D_OUT))
         fail ("Hijacker in HIJACK must be a FUNCTION!");
     Move_Value(hijacker, D_OUT); // Frees D_OUT, and GC safe (in ARG slot)

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -295,20 +295,29 @@ REB_R Do_Vararg_Op_May_Throw(
         // overwritten by an arbitrary evaluation.
         //
         switch (pclass) {
-        case PARAM_CLASS_NORMAL:
-            if (Do_Next_In_Subframe_Throws(out, f, DO_FLAG_FULFILLING_ARG))
-                return R_OUT_IS_THROWN;
-            break;
-
-        case PARAM_CLASS_TIGHT:
+        case PARAM_CLASS_NORMAL: {
+            DECLARE_FRAME (child);
             if (Do_Next_In_Subframe_Throws(
                 out,
                 f,
-                DO_FLAG_FULFILLING_ARG | DO_FLAG_NO_LOOKAHEAD
+                DO_FLAG_FULFILLING_ARG,
+                child
             )){
                 return R_OUT_IS_THROWN;
             }
-            break;
+            break; }
+
+        case PARAM_CLASS_TIGHT: {
+            DECLARE_FRAME (child);
+            if (Do_Next_In_Subframe_Throws(
+                out,
+                f,
+                DO_FLAG_FULFILLING_ARG | DO_FLAG_NO_LOOKAHEAD,
+                child
+            )){
+                return R_OUT_IS_THROWN;
+            }
+            break; }
 
         case PARAM_CLASS_HARD_QUOTE:
             Quote_Next_In_Frame(out, f);

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -226,7 +226,7 @@ static REBOOL Subparse_Throws(
 
     // !!! By calling the subparse native here directly from its C function
     // vs. going through the evaluator, we don't get the opportunity to do
-    // things like HIJACK it.  Consider code in Apply_Def_Or_Exemplar().
+    // things like HIJACK it.  Consider APPLY-ing it.
     //
     REB_R r = N_subparse(f);
     assert(NOT_END(out));
@@ -375,7 +375,7 @@ static const RELVAL *Get_Parse_Value(
         if (VAL_CMD(rule))
             return rule;
 
-        Copy_Opt_Var_May_Fail(cell, rule, specifier);
+        Move_Opt_Var_May_Fail(cell, rule, specifier);
         if (IS_VOID(cell))
             fail (Error_No_Value_Core(rule, specifier));
 
@@ -769,7 +769,7 @@ static REBIXO To_Thru_Block_Rule(
                         fail (Error_Parse_Rule());
                 }
                 else {
-                    Copy_Opt_Var_May_Fail(cell, rule, P_RULE_SPECIFIER);
+                    Move_Opt_Var_May_Fail(cell, rule, P_RULE_SPECIFIER);
                     rule = cell;
                 }
             }
@@ -1647,7 +1647,7 @@ REBNATIVE(subparse)
                 // :word - change the index for the series to a new position
                 if (IS_GET_WORD(P_RULE)) {
                     DECLARE_LOCAL (temp);
-                    Copy_Opt_Var_May_Fail(temp, P_RULE, P_RULE_SPECIFIER);
+                    Move_Opt_Var_May_Fail(temp, P_RULE, P_RULE_SPECIFIER);
                     if (!ANY_SERIES(temp)) { // #1263
                         DECLARE_LOCAL (non_series);
                         Derelativize(non_series, P_RULE, P_RULE_SPECIFIER);
@@ -1676,7 +1676,7 @@ REBNATIVE(subparse)
 
                 // word - some other variable
                 if (IS_WORD(P_RULE)) {
-                    Copy_Opt_Var_May_Fail(save, P_RULE, P_RULE_SPECIFIER);
+                    Move_Opt_Var_May_Fail(save, P_RULE, P_RULE_SPECIFIER);
                     rule = save;
                     if (IS_VOID(rule))
                         fail (Error_No_Value_Core(P_RULE, P_RULE_SPECIFIER));

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -711,7 +711,7 @@ static inline const REBVAL *Get_Opt_Var_Else_End(
     );
 }
 
-inline static void Copy_Opt_Var_May_Fail(
+inline static void Move_Opt_Var_May_Fail(
     REBVAL *out,
     const RELVAL *any_word,
     REBSPC *specifier

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -772,7 +772,8 @@ struct Reb_Frame {
     REBFRM name##struct; \
     REBFRM * const name = &name##struct; \
     Prep_Stack_Cell(&name->cell); \
-    Init_Unreadable_Blank(&name->cell);
+    Init_Unreadable_Blank(&name->cell); \
+    name->dsp_orig = DSP;
 
 
 // Hookable "Rebol DO Function" and "Rebol APPLY Function".  See PG_Do and

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -66,7 +66,6 @@
 (error? make error! [type: 'script id: 'too-long])
 (error? make error! [type: 'script id: 'invalid-chars])
 (error? make error! [type: 'script id: 'invalid-compare])
-(error? make error! [type: 'script id: 'verify-void])
 (error? make error! [type: 'script id: 'invalid-part])
 (error? make error! [type: 'script id: 'no-return])
 (error? make error! [type: 'script id: 'block-lines])

--- a/tests/series/append.test.reb
+++ b/tests/series/append.test.reb
@@ -24,3 +24,8 @@
 
     block = [a 3 4 b c d]
 )
+(
+    block: copy [a b c]
+    block: my append/part/dup [d e f] 2 3
+    [a b c d e d e d e] = block
+)


### PR DESCRIPTION
This makes APPLY and MY speak the protocol for pushing refinements to
the stack for Do_Core() to process them, by factoring out code that
was introduced for SPECIALIZE.

    >> some-block: copy [a b c]

    >> some-block: my append/dup/part [d e f] 3 2
    == [a b c d e d e d e]

One difficult aspect was that the baseline of the stack needs to be
known, yet Do_Core() may be called on a stack that is constantly
building itself up.  (e.g. REDUCE which pushes a frame and then does
several consecutive evaluations with that frame pushed).  Previously
the DSP was captured on each Do_Core() entry, but this modifies it
so that it gets captured in DECLARE_FRAME(), allowing one to put it
at a separate point from Push_Frame() or a Do_Core() entry.