### PR TITLE
Default left enfix normal to "greedy", add <- operator

### DIFF
--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -968,7 +968,8 @@ REBNATIVE(semiquoted_q)
 //  {Function for returning the same value that it got in (identity function)}
 //
 //      return: [<opt> any-value!]
-//      value [<opt> any-value!]
+//      value [<opt> <end> any-value!]
+//          {Accepting <end> means it also limits enfix reach to the left}
 //      /quote
 //          {Make it seem that the return result was quoted}
 //  ]
@@ -979,6 +980,9 @@ REBNATIVE(identity)
 // https://stackoverflow.com/q/3136338
 //
 // !!! Quoting version is currently specialized as SEMIQUOTE, for convenience.
+//
+// This is assigned to <- for convenience, but cannot be used under that name
+// in bootstrap.  It uses the <end>-ability to stop left reach.
 {
     INCLUDE_PARAMS_OF_IDENTITY;
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -251,10 +251,10 @@ eval proc [
 print: proc [
     "Textually output value (evaluating elements if a block), adds newline"
 
-     value [any-value!]
-          "Value or BLOCK! literal (BLANK! means print nothing)"
-     /eval
-          "Allow value to be a block and evaluated (even if not literal)"
+    value [any-value!]
+        "Value or BLOCK! literal (BLANK! means print nothing)"
+    /eval
+        "Allow value to be a block and evaluated (even if not literal)"
     <local> eval_PRINT ;quote_PRINT
 ][
     eval_PRINT: eval
@@ -262,7 +262,7 @@ print: proc [
 
     if blank? :value [leave]
 
-    write-stdout case [
+    write-stdout identity case [
         not block? value [
             form :value
         ]
@@ -271,7 +271,9 @@ print: proc [
             spaced value
         ]
     ] else [
-        fail "PRINT called on non-literal block without /EVAL switch"
+        fail/where
+            "PRINT called on non-literal block without /EVAL switch"
+            'value
     ]
 
     write-stdout newline

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -404,10 +404,12 @@ my: enfix func [
 ]
 
 
-; Lambdas are experimental quick function generators via a symbol
+; Lambdas are experimental quick function generators via a symbol.  The
+; identity is used to shake up enfix ordering.
 ;
 set/enfix (r3-alpha-quote "->") :lambda
-set/enfix (r3-alpha-quote "<-") (specialize :lambda [only: true])
+set (r3-alpha-quote "<-") :identity ;-- not enfix, just affects enfix
+
 
 
 ; These constructs used to be enfix to complete their left hand side.  Yet

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -625,7 +625,7 @@ split: function [
         size: dlm   ; alias for readability
 
         res: collect [
-            parse series case [
+            parse series identity case [
                 all [integer? size | into] [
                     if size < 1 [cause-error 'Script 'invalid-arg size]
                     count: size - 1

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -91,7 +91,11 @@ console!: make object! [
         ; We don't want to use PRINT here because it would put the cursor on
         ; a new line.
         ;
-        write-stdout block? prompt then [unspaced prompt] else [form prompt]
+        write-stdout identity block? prompt then [
+            unspaced prompt
+        ] else [
+            form prompt
+        ]
         write-stdout space
     ]
 

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -30,15 +30,20 @@
 )
 
 (
-    ; Don't want `return if ... else ...` to act as `(return if ...) else ...`
     ; https://github.com/metaeducation/ren-c/issues/510
 
     c: func [i] [
         return if i < 15 [30] else [4]
     ]
 
-    a: did all [
+    d: func [i] [
+        return <- if i < 15 [30] else [4]
+    ]
+
+    did all [
         30 = c 10
-        4 = c 20
+        () = c 20
+        30 = d 10
+        4 = d 20
     ]
 )


### PR DESCRIPTION
The previous rule for left enfix normal finished one complete operation
such that:

    return if 1 > 2 ["a"] else ["b"]

...would have ELSE only complete the IF statement before running, not
the return statement.  However, this rule isn't necessarily favorable
in other enfix situations with THEN, OR, AND, etc.

This implements a proposed change to the rules which completes the
entire left by default, but offers an operator to use instead of a
GROUP! with <-:

    return <- if 1 > 2 ["a"] else ["b"]