### PR TITLE
Fix uncased UNIQUE, PUT/CASE for ambiguous MAP! key casings

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -225,6 +225,19 @@ select: action [
 
 ]
 
+; !!! PUT was added by Red as the complement to SELECT, which offers a /CASE
+; refinement for adding keys to MAP!s case-sensitively.  The name may not
+; be ideal, but it's something you can't do with path access, so adopting it
+; for the time-being.  Only implemented for MAP!s at the moment
+;
+put: action [
+    {Replaces the value following a key, and returns the new value.}
+    return: [<opt> any-value!]
+    series [map!]
+    key [any-value!]
+    value [<opt> any-value!]
+    /case {Perform a case-sensitive search}
+]
 
 reflect: action [
     {Returns specific details about a datatype.}

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -207,6 +207,8 @@ Script: [
     void-object-block:  {Can't create block from object if it has void values}
 
     map-key-unlocked:   [{key must be LOCK-ed to add to MAP!} :arg1]
+    conflicting-key:    [:arg1 {key conflicts; use SELECT or PUT with /CASE}]
+
     tcc-not-supported-opt: [{Option} :arg1 {is not supported}]
     tcc-expect-word:     [{Option expecting a word:} :arg1]
     tcc-invalid-include: [{Include expects a block or a path:} :arg1]

--- a/tests/series/unique.test.reb
+++ b/tests/series/unique.test.reb
@@ -2,3 +2,19 @@
 ([1 2 3] = unique [1 2 2 3])
 ([[1 2] [2 3] [3 4]] = unique [[1 2] [2 3] [2 3] [3 4]])
 ([path/1 path/2 path/3] = unique [path/1 path/2 path/2 path/3])
+
+; case-insensitive default
+(
+    [aa "aa" #"a"] = unique [
+        aa AA aa aA Aa aa
+        "aa" "AA" "aa" "aA" "Aa" "aa"
+        #"a" #"A"
+    ]
+)
+(
+    [aa AA aA Aa "aa" "AA" "aA" "Aa" #"a" #"A"] == unique/case [
+        aa AA aa aA AA Aa aA Aa
+        "aa" "AA" "aa" "aA" "AA" "Aa" "aA" "Aa"
+        #"a" #"A" #"A" #"a"
+    ]
+)


### PR DESCRIPTION
The hashing code for MAP!s is shared with set operations.  A rather old
commit (Jan 24, 2016) for facilitating case-sensitivity in maps had a
side effect of breaking case-insensitive set operations:

https://github.com/metaeducation/ren-c/commit/20c8e506431c9b773e9c7ee14286f5eabc6167e5

They haven't worked right since Jan 2016.  But no one noticed.  :-)

Rather than fix that sole issue, this commit attempts to resolve the
longstanding puzzle the change was intending to address: being able to
use differently-cased versions of the same key in MAP!s.  The feature
has provoked prolonged debates, and raises some semantic questions.

Rather than invent two different data types (case sensitive maps and
non-case-sensitive), the plan thus far--shared by Red--is to make the
maps preserve the case of the keys put into them.  Then it would use
SELECT/CASE and a corresponding writing routine (e.g. Red's PUT/CASE)
to deal with those situations where more than one casing of a key
is present.

This brings in PUT/CASE, but also becomes more rigorous in dealing
with ambiguous situations.  Using PATH! or plain SELECT will error if
the key being asked about has more than one case form.  The way to get
past this is SELECT/CASE and PUT/CASE, which use only the exact
spelling of the key given.

Creation through MAKE MAP! assumes case insensitivity, so multiple
cased spellings of the same key may be used there.