### PR TITLE
Automatically lock series backing map keys when inserted

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -206,7 +206,6 @@ Script: [
     void-vararg-array:  {Can't MAKE ANY-ARRAY! from VARARGS! that allow <opt>}
     void-object-block:  {Can't create block from object if it has void values}
 
-    map-key-unlocked:   [{key must be LOCK-ed to add to MAP!} :arg1]
     conflicting-key:    [:arg1 {key conflicts; use SELECT or PUT with /CASE}]
 
     tcc-not-supported-opt: [{Option} :arg1 {is not supported}]
@@ -262,6 +261,7 @@ Access: [
     series-protected:   {series read-only due to PROTECT (see UNPROTECT)}
     series-frozen:      {series is source or permanently locked, can't modify}
     series-held:        {series has temporary read-only hold for iteration}
+    series-auto-locked: {series was implicitly locked (e.g. as key for MAP!)}
 
     hidden:             {not allowed - would expose or modify hidden values}
 

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1667,7 +1667,8 @@ REBVAL *RL_rebLock(REBVAL *p1, const REBVAL *p2)
     assert(IS_END(p2)); // Not yet variadic...
     UNUSED(p2);
 
-    Ensure_Value_Immutable(p1);
+    REBSER *locker = NULL;
+    Ensure_Value_Immutable(p1, locker);
     return p1;
 }
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -614,11 +614,8 @@ REBOOL Make_Error_Object_Throws(
 
         Init_String(&vars->message, Copy_Sequence_At_Position(arg));
     }
-    else {
-        // No other argument types are handled by this routine at this time.
-
-        fail (Error_Invalid_Error_Raw(arg));
-    }
+    else
+        fail (Error_Invalid(arg));
 
     // Validate the error contents, and reconcile message template and ID
     // information with any data in the object.  Do this for the IS_STRING
@@ -737,7 +734,7 @@ REBOOL Make_Error_Object_Throws(
                 //
                 //     make error! [type: 'script id: 'set-self]
 
-                fail (Error_Invalid_Error_Raw(arg));
+                fail (Error_Invalid_Error_Raw(CTX_VALUE(error)));
             }
             assert(IS_INTEGER(&vars->code));
         }
@@ -759,7 +756,7 @@ REBOOL Make_Error_Object_Throws(
         // not already there.
 
         if (NOT(IS_BLANK(&vars->code)))
-            fail (Error_Invalid_Error_Raw(arg));
+            fail (Error_Invalid_Error_Raw(CTX_VALUE(error)));
 
         // !!! Because we will experience crashes in the molding logic,
         // we put some level of requirement besides "code # not 0".
@@ -774,7 +771,7 @@ REBOOL Make_Error_Object_Throws(
                 || IS_BLANK(&vars->message)
             )
         ) {
-            fail (Error_Invalid_Error_Raw(arg));
+            fail (Error_Invalid_Error_Raw(CTX_VALUE(error)));
         }
     }
 

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -998,8 +998,12 @@ REBNATIVE(does)
             NULL // no specialization exemplar (or inherited exemplar)
         );
 
+        // Block_Dispatcher() *may* copy at an indeterminate time, so to keep
+        // things invariant we have to lock it.
+        //
         RELVAL *body = FUNC_BODY(fun);
-        Ensure_Value_Immutable(specializee); // Block_Dispatcher() *may* copy
+        REBSER *locker = NULL;
+        Ensure_Value_Immutable(specializee, locker);
         Move_Value(body, specializee);
 
         Move_Value(D_OUT, FUNC_VALUE(fun));

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -337,11 +337,8 @@ REBCNT Find_Map_Entry(
     // a SET must always be done with an immutable key...because if it were
     // changed, there'd be no notification to rehash the map.
     //
-    if (!Is_Value_Immutable(key)) {
-        DECLARE_LOCAL (unlocked);
-        Derelativize(unlocked, key, key_specifier);
-        fail (Error_Map_Key_Unlocked_Raw(unlocked));
-    }
+    REBSER *locker = SER(MAP_PAIRLIST(map));
+    Ensure_Value_Immutable(key, locker);
 
     // Must set the value:
     if (n) {  // re-set it:

--- a/src/extensions/locale/ext-locale-init.reb
+++ b/src/extensions/locale/ext-locale-init.reb
@@ -11,7 +11,7 @@ unless 'Windows = first system/platform [
 
     ;DO NOT EDIT this table
     ;It's updated by iso3166.r
-    iso-3166-table: make map! lock [
+    iso-3166-table: make map! [
     "AF" "Afghanistan"
     "AX" "Åland Islands"
     "AL" "Albania"
@@ -265,7 +265,7 @@ unless 'Windows = first system/platform [
 
     ;DO NOT EDIT this table
     ;It's updated by iso639.r
-    iso-639-table: make map! lock [
+    iso-639-table: make map! [
     "aa" "Afar"
     "ab" "Abkhazian"
     "af" "Afrikaans"

--- a/src/extensions/locale/iso3166.r
+++ b/src/extensions/locale/iso3166.r
@@ -38,8 +38,10 @@ iso-3166-table: make map! 512
 parse cnt [
     some [
         copy name to ";"
-        ";" copy code-2 to "^/"
-        (append iso-3166-table pair: reduce [lock to string! code-2 to string! capitalize name]
+        ";" copy code-2 to "^/" (
+            append iso-3166-table pair: compose [
+                (to string! code-2) (to string! capitalize name)
+            ]
         )
 
         "^/"

--- a/src/extensions/locale/iso639.r
+++ b/src/extensions/locale/iso639.r
@@ -39,7 +39,9 @@ parse cnt [
         ;
         "|" copy name to "|" (
             if code-2 [
-                append iso-639-table reduce [lock to string! code-2 to string! name]
+                append iso-639-table compose [
+                    (to string! code-2) (to string! name)
+                ]
             ]
         )
 

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -527,7 +527,7 @@ inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
 }
 
 // Gives the appropriate kind of error message for the reason the series is
-// read only (frozen, running, protected).
+// read only (frozen, running, protected, locked to be a map key...)
 //
 // !!! Should probably report if more than one form of locking is in effect,
 // but if only one error is to be reported then this is probably the right
@@ -535,6 +535,9 @@ inline static REBOOL Is_Series_Read_Only(REBSER *s) { // may be temporary...
 //
 inline static void FAIL_IF_READ_ONLY_SERIES(REBSER *s) {
     if (Is_Series_Read_Only(s)) {
+        if (GET_SER_INFO(s, SERIES_INFO_AUTO_LOCKED))
+            fail (Error_Series_Auto_Locked_Raw());
+
         if (GET_SER_INFO(s, SERIES_INFO_HOLD))
             fail (Error_Series_Held_Raw());
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -1165,19 +1165,6 @@ set 'r3-legacy* func [<local>] [
             ]
         ])
 
-        append: (adapt 'append [
-            if map? series [
-                if block? :value [
-                    ;
-                    ; MAP! in Ren-C must have locked keys, but R3-Alpha did
-                    ; not have a LOCK.  When they append blocks, lock the
-                    ; key elements for them.
-                    ;
-                    for-each [k v] value [lock k]
-                ]
-            ]
-        ])
-
         ; because reduce has been changed but lib/reduce is not in legacy
         ; mode, this means the repend and join function semantics are
         ; different.  This snapshots their implementation.

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -250,13 +250,8 @@ reword: function [
     ; later keys overwrite earlier ones and obscure the invalidity of the
     ; earlier keys (or perhaps MAKE MAP! itself should disallow duplicates)
     ;
-    ; !!! To be used as keys, any series in the block will have to be LOCK'd.
-    ; This could either be done with copies of the keys in the block, or
-    ; locking them directly.  For now, the whole block is locked before the
-    ; MAKE MAP! call.
-    ;
     if block? values [
-        values: make map! lock values
+        values: make map! values
     ]
 
     ; The keyword matching rule is a series of [OR'd | clauses], where each

--- a/tests/datatypes/map.test.reb
+++ b/tests/datatypes/map.test.reb
@@ -42,7 +42,7 @@
 ; Creation through MAKE MAP! assumes case insensitivity.
 [
     (
-        m: make map! lock [AA 10 aa 20 <BB> 30 <bb> 40 #"C" 50 #"c" 60]
+        m: make map! [AA 10 aa 20 <BB> 30 <bb> 40 #"C" 50 #"c" 60]
         true
     )
 
@@ -61,12 +61,12 @@
     ('conflicting-key = (trap [m/(#"c")])/id)
 
     ('conflicting-key = (trap [put m 'Aa 70])/id)
-    ('conflicting-key = (trap [m/(lock <Bb>): 80])/id)
+    ('conflicting-key = (trap [m/(<Bb>): 80])/id)
     ('conflicting-key = (trap [m/(#"C"): 90])/id)
 
     (
         put/case m 'Aa 100
-        put/case m lock <Bb> 110
+        put/case m <Bb> 110
         put/case m #"C" 120
         true
     )


### PR DESCRIPTION
R3-Alpha's MAP! would give wrong answers if a key used in a map were
changed after the insertion.  Ren-C safeguarded against this by
only allowing keys that had been LOCK'd immutably, with a promise
that they would remain immutable (as there is no UNLOCK).  This also
allowed ANY-ARRAY!s or OBJECT!s to be used as map keys.

For efficiency, the key passed in was not automatically copied before
locking, as that could have surprising memory usage and performance
consequences.  Instead, an already locked key would be used directly,
and a key that hadn't been locked would give an error...which would
allow the person doing the insertion to decide if they felt they
needed a separate mutable copy (shallow or deep)...and they could
either make a copy and lock it, or just lock what they had.

This commit switches the situation so that the map just locks any
unlocked keys it is passed, and puts a notice on them that they were
locked in order to be map keys.  So when a later modification is
attempted, the user will get feedback of the reason for the locking.
(The feedback is primitive and could be made more informative in the
future.)

The advantage of this is that casual users of maps may not even notice
the locking, if they weren't intending on modifying keys in the first
place.  The trouble comes up with cases like this:

    m: make map! []
    s: copy ""
    repeat n 10 [
       append s "a" ;-- says s was locked for map, 2nd time thru loop
       m/(s): n
    ]

The user would instead have to do `m/(copy s): n`.  It seems that on
balance, it's better to bias it this direction.