### PR TITLE
Introduce CSCAPE templating routine for simplifying bootstrap

### DIFF
--- a/make/tools/common.r
+++ b/make/tools/common.r
@@ -23,7 +23,18 @@ REBOL [
 ; disabled if you *are* running Ren-C (e.g. the tests)
 
 
-;; Repostory meta data.
+; Simple "divider-style" thing for remarks.  At a certain verbosity level,
+; it could dump those remarks out...perhaps based on how many == there are.
+; (This is a good reason for retaking ==, as that looks like a divider.)
+;
+===: func [:remarks [any-value! <...>]] [
+    until [
+        equal? '=== take remarks
+    ]
+]
+
+
+;; Repository meta data.
 ;; - Good for keeping fixed paths out of scripts.
 ;;
 

--- a/make/tools/make-boot-ext-header.r
+++ b/make/tools/make-boot-ext-header.r
@@ -26,22 +26,24 @@ mkdir/deep output-dir/include
 
 extensions: either any-string? :args/EXTENSIONS [split args/EXTENSIONS #":"][[]]
 
-e-ext: (make-emitter
+e: (make-emitter
     "Boot Modules" output-dir/include/tmp-boot-extensions.h)
 
 remove-each ext extensions [empty? ext] ;SPLIT in r3-a111 gives an empty "" at the end
 
 for-each ext extensions [
-    e-ext/emit-line ["DECLARE_EXT_INIT(" ext ");"]
-    e-ext/emit-line ["DECLARE_EXT_QUIT(" ext ");"]
+    e/emit 'ext {
+        DECLARE_EXT_INIT(${Ext});
+        DECLARE_EXT_QUIT(${Ext});
+    }
 ]
+e/emit-line []
 
-e-ext/emit-line []
-e-ext/emit-line ["static CFUNC *Boot_Extensions [] = {"]
+e/emit ["static CFUNC *Boot_Extensions [] = {"]
 for-each ext extensions [
-    e-ext/emit-line/indent ["cast(CFUNC *, EXT_INIT(" ext ")),"]
-    e-ext/emit-line/indent ["cast(CFUNC *, EXT_QUIT(" ext ")),"]
+    e/emit-line/indent ["cast(CFUNC *, EXT_INIT(" ext ")),"]
+    e/emit-line/indent ["cast(CFUNC *, EXT_QUIT(" ext ")),"]
 ]
-e-ext/emit-end
+e/emit-end
 
-e-ext/write-emitted
+e/write-emitted

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -130,277 +130,250 @@ build: context [features: [help-strings]]
 ;build: platform-data/builds/:product
 
 
-boot-types: load %types.r
+type-table: load %types.r
 
 e-dispatch: make-emitter "Dispatchers" core/tmp-dispatchers.c
 e-dispatch/emit newline
 
-e-dispatch/emit-line {#include "sys-core.h"}
+
+e-dispatch/emit [{#include "sys-core.h"}]
 e-dispatch/emit newline
 
+
 e-dispatch/emit {
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  VALUE DISPATCHERS (auto-generated, edit in %make-boot.r)
-//
-///////////////////////////////////////////////////////////////////////////=//
+    /*
+    ** VALUE DISPATCHERS: e.g. for `append value x` or `select value y`
+    */
+
+    REBACT Value_Dispatch[REB_MAX] = ^{
 }
-e-dispatch/emit newline
-e-dispatch/emit-line "REBACT Value_Dispatch[REB_MAX] = {"
-for-each-record type boot-types [
-    switch/default type/class [
-        0 [ ; REB_0 should not ever be dispatched, bad news
-            e-dispatch/emit-item "NULL"
-        ]
-        * [ ; Extension types just fail until registered
-            e-dispatch/emit-item "T_Unhooked"
-        ]
-    ][ ; All other types should have handlers
-        e-dispatch/emit-item ["T_" propercase-of ensure word! type/class]
+for-each-record t type-table [
+    switch/default t/class [
+        0 [e-dispatch/emit-item "NULL"] ;-- never dispatch on REB_0
+        * [e-dispatch/emit-item "T_Unhooked"] ;-- extensions replace this
+    ][
+        e-dispatch/emit-item ["T_" propercase-of ensure word! t/class]
     ]
-    e-dispatch/emit-annotation ensure [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] t/name
 ]
 e-dispatch/emit-end
 
 
 e-dispatch/emit {
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  PATH DISPATCHERS (auto-generated, edit in %make-boot.r)
-//
-///////////////////////////////////////////////////////////////////////////=//
+    /*
+    ** PATH DISPATCHERS: for `a/b`, `:a/b`, `a/b:`, `pick a b`, `poke a b`
+    */
+
+    REBPEF Path_Dispatch[REB_MAX] = ^{
 }
-e-dispatch/emit newline
-e-dispatch/emit-line "REBPEF Path_Dispatch[REB_MAX] = {"
-for-each-record type boot-types [
-    switch/default type/path [
+for-each-record t type-table [
+    switch/default t/path [
         - [e-dispatch/emit-item "PD_Fail"]
-        + [e-dispatch/emit-item [
-            "PD_" propercase-of ensure word! type/class]
-        ]
+        + [e-dispatch/emit-item ["PD_" propercase-of ensure word! t/class]]
         * [e-dispatch/emit-item "PD_Unhooked"]
     ][
-        ; !!! Today's PORT! path dispatches through context even though that
-        ; isn't its technical "class" for responding to actions.
+        ; !!! Today's PORT! path dispatches through context even though
+        ; that isn't its technical "class" for responding to actions.
         ;
-        e-dispatch/emit-item ["PD_" propercase-of ensure word! type/path]
+        e-dispatch/emit-item ["PD_" propercase-of ensure word! t/path]
     ]
-    e-dispatch/emit-annotation ensure [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] t/name
 ]
 e-dispatch/emit-end
 
 
 e-dispatch/emit {
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  MAKE DISPATCHERS (auto-generated, edit in %make-boot.r)
-//
-///////////////////////////////////////////////////////////////////////////=//
+    /*
+    ** MAKE DISPATCHERS: for `make datatype def`
+    */
+
+    MAKE_FUNC Make_Dispatch[REB_MAX] = ^{
 }
-e-dispatch/emit newline
-e-dispatch/emit-line "MAKE_FUNC Make_Dispatch[REB_MAX] = {"
-for-each-record type boot-types [
-    switch/default type/make [
+for-each-record t type-table [
+    switch/default t/make [
         - [e-dispatch/emit-item "MAKE_Fail"]
-        + [e-dispatch/emit-item [
-            "MAKE_" propercase-of ensure word! type/class]
-        ]
+        + [e-dispatch/emit-item ["MAKE_" propercase-of ensure word! t/class]]
         * [e-dispatch/emit-item "MAKE_Unhooked"]
     ][
         fail "MAKE in %types.r should be, -, +, or *"
     ]
-    e-dispatch/emit-annotation ensure [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] t/name
 ]
 e-dispatch/emit-end
 
 
 e-dispatch/emit {
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  TO DISPATCHERS (auto-generated, edit in %make-boot.r)
-//
-///////////////////////////////////////////////////////////////////////////=//
+    /*
+    ** TO DISPATCHERS: for `to datatype value`
+    */
+
+    TO_FUNC To_Dispatch[REB_MAX] = ^{
 }
-e-dispatch/emit newline
-e-dispatch/emit-line "TO_FUNC To_Dispatch[REB_MAX] = {"
-for-each-record type boot-types [
-    switch/default type/make [
+for-each-record t type-table [
+    switch/default t/make [
         - [e-dispatch/emit-item "TO_Fail"]
-        + [e-dispatch/emit-item [
-            "TO_" propercase-of ensure word! type/class
-        ]]
+        + [e-dispatch/emit-item ["TO_" propercase-of ensure word! t/class]]
         * [e-dispatch/emit-item "TO_Unhooked"]
     ][
         fail "TO in %types.r should be -, +, or *"
     ]
-    e-dispatch/emit-annotation ensure [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] t/name
 ]
 e-dispatch/emit-end
 
 
 e-dispatch/emit {
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  MOLD DISPATCHERS (auto-generated, edit in %make-boot.r)
-//
-///////////////////////////////////////////////////////////////////////////=//
+    /*
+    ** MOLD DISPATCHERS: for `mold value`
+    */
+
+    MOLD_FUNC Mold_Or_Form_Dispatch[REB_MAX] = ^{
 }
-e-dispatch/emit newline
-e-dispatch/emit-line "MOLD_FUNC Mold_Or_Form_Dispatch[REB_MAX] = {"
-for-each-record type boot-types [
-    switch/default type/mold [
+for-each-record t type-table [
+    switch/default t/mold [
         - [e-dispatch/emit-item "MF_Fail"]
-        + [e-dispatch/emit-item [
-            "MF_" propercase-of ensure word! type/class
-        ]]
+        + [e-dispatch/emit-item ["MF_" propercase-of ensure word! t/class]]
         * [e-dispatch/emit-item "MF_Unhooked"]
     ][
         ; ERROR! may be a context, but it has its own special forming
         ; beyond the class (falls through to ANY-CONTEXT! for mold), and
         ; BINARY! has a different handler than strings
         ;
-        e-dispatch/emit-item ["MF_" propercase-of ensure word! type/mold]
+        e-dispatch/emit-item ["MF_" propercase-of ensure word! t/mold]
     ]
-    e-dispatch/emit-annotation ensure [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] t/name
 ]
 e-dispatch/emit-end
 
 
 e-dispatch/emit {
-//=////////////////////////////////////////////////////////////////////////=//
-//
-//  COMPARISON DISPATCHERS (auto-generated, edit in %make-boot.r)
-//
-///////////////////////////////////////////////////////////////////////////=//
+    /*
+    ** COMPARISON DISPATCHERS, to support GREATER?, EQUAL?, LESSER?...
+    */
+
+    REBCTF Compare_Types[REB_MAX] = ^{
 }
-e-dispatch/emit newline
-e-dispatch/emit-line "REBCTF Compare_Types[REB_MAX] = {"
-for-each-record type boot-types [
-    switch/default type/class [
+for-each-record t type-table [
+    switch/default t/class [
         0 [e-dispatch/emit-item "NULL"]
         * [e-dispatch/emit-item "CT_Unhooked"]
     ][
-        e-dispatch/emit-item ["CT_" propercase-of ensure word! type/class]
+        e-dispatch/emit-item ["CT_" propercase-of ensure word! t/class]
     ]
-    e-dispatch/emit-annotation ensure [word! integer!] type/name
+    e-dispatch/emit-annotation ensure [word! integer!] t/name
 ]
 e-dispatch/emit-end
+
 
 e-dispatch/write-emitted
 
 
+
 ;----------------------------------------------------------------------------
 ;
-; Bootdefs.h - Boot include file
+; %reb-types.h - Datatype Definitions
 ;
 ;----------------------------------------------------------------------------
 
 e-types: make-emitter "Datatype Definitions" inc/reb-types.h
 
+
 e-types/emit {
-/***********************************************************************
-**
-*/  enum Reb_Kind
-/*
-**      Internal datatype numbers. These change. Do not export.
-**
-***********************************************************************/
+    /*
+    ** INTERNAL DATATYPE CONSTANTS, e.g. REB_BLOCK or REB_TAG
+    **
+    ** Do not export these values via libRebol, as the numbers can change.
+    ** Their ordering is for supporting certain optimizations, such as being
+    ** able to quickly check if a type IS_BINDABLE().  When types are added,
+    ** or removed, the numbers must shuffle around to preserve invariants.
+    **
+    ** Note: REB_0 is reserved for internal purposes...0 is not a "type".
+    ** But to make it easier to build the dispatch tables (which must have
+    ** an entry for index 0) it appears in %types.r
+    */
+
+    enum Reb_Kind ^{
 }
-e-types/emit-line "{"
 
-datatypes: copy []
 n: 0
-
-for-each-record type boot-types [
-    append datatypes type/name
-
-    either type/name = 0 [
+for-each-record t type-table [
+    either t/name = 0 [
         e-types/emit-item/assign "REB_0" 0
     ][
-        e-types/emit-item/assign/upper ["REB_" ensure word! type/name] n
+        ensure word! t/name
+        e-types/emit-item/upper ["REB_" t/name]
+        e-types/emit-annotation n
     ]
-    e-types/emit-annotation n
-
     n: n + 1
 ]
 
 e-types/emit-item/assign "REB_MAX" n
-e-types/emit-annotation n
 e-types/emit-end
 
+
 e-types/emit {
-/***********************************************************************
-**
-**  REBOL Type Check Macros
-**
-***********************************************************************/
+    /*
+    ** SINGLE TYPE CHECK MACROS, e.g. IS_BLOCK() or IS_TAG()
+    **
+    ** These routines are based on VAL_TYPE(), which does much more checking
+    ** than VAL_TYPE_RAW() in the debug build.  In some commonly called
+    ** routines, it may be worth it to use the less checked version.
+    **
+    ** Note: There's no IS_0() test for REB_0.  Usages alias it and test
+    ** against the alias for clarity, e.g. `VAL_TYPE(v) == REB_0_PARTIAL`
+    */
 }
+e-types/emit newline
 
-new-types: copy []
+boot-types: copy []
 n: 0
-for-each-record type boot-types [
-    ;
-    ; Type #0 is reserved for special purposes
-    ;
+for-each-record t type-table [
     if n != 0 [
-        ;
-        ; Emit the IS_INTEGER() / etc. test for the datatype.  Use DID()
-        ; so that `REBOOL b = IS_INTEGER(value);` passes the tests in the
-        ; build guaranteeing all REBOOL are 1 or 0, despite the fact that
-        ; there are other values that C considers "truthy".
-        ;
-        e-types/emit-line [
-            {#define IS_} (uppercase to-c-name type/name) "(v)" space
-            "DID(VAL_TYPE(v)==REB_" (uppercase to-c-name type/name) ")"
-        ]
+        e-types/emit 't {
+            #define IS_${T/NAME}(v) \
+                DID(VAL_TYPE(v) == REB_${T/NAME}) /* $(n) */
+        }
+        e-types/emit newline
 
-        append new-types to-word adjoin form type/name "!"
+        append boot-types to-word adjoin form t/name "!"
     ]
-
     n: n + 1
 ]
 
-; Emit the macros that embed specific knowledge of the type ordering.  These
-; are best kept in the header of %types.r, so anyone changing the order is
-; reminded of the importance of adjusting them.
-;
 types-header: first load/header %types.r
 e-types/emit trim/auto copy ensure string! types-header/macros
 
 
 e-types/emit {
-/***********************************************************************
-**
-**  REBOL Typeset Defines
-**
-***********************************************************************/
+    /*
+    ** TYPESET DEFINITIONS (e.g. TS_ANY_ARRAY or TS_ANY_STRING)
+    **
+    ** Note: User-facing typesets, such as ANY-VALUE!, do not include void
+    ** (absence of a value), nor do they include the internal "REB_0" type.
+    */
 
-// User-facing typesets, such as ANY-VALUE!, do not include void (absence of
-// a value) nor the internal "REB_0" type
-//
-#define TS_VALUE ((FLAGIT_KIND(REB_MAX_VOID) - 1) - FLAGIT_KIND(REB_0))
+    #define TS_VALUE ((FLAGIT_KIND(REB_MAX_VOID) - 1) - FLAGIT_KIND(REB_0))
 }
-
 typeset-sets: copy []
 
-for-each-record type boot-types [
-    for-each ts compose [(type/typesets)] [
+for-each-record t type-table [
+    for-each ts compose [(t/typesets)] [
         spot: any [
             to-value select typeset-sets ts
             first back insert tail-of typeset-sets reduce [ts copy []]
         ]
-        append spot type/name
+        append spot t/name
     ]
 ]
 remove/part typeset-sets 2 ; the - markers
 
 for-each [ts types] typeset-sets [
-    e-types/emit ["#define" space uppercase to-c-name ["TS_" ts] space "("]
+    e-types/emit 'ts "#define TS_${TS} ("
     for-each t types [
-        e-types/emit ["FLAGIT_KIND(" uppercase to-c-name ["REB_" t] ")|"]
+        e-types/emit 't "FLAGIT_KIND(REB_${T})|"
     ]
     e-types/unemit #"|" ;-- remove the last | added
-    e-types/emit [")" newline]
+    e-types/emit unspaced [")" newline]
 ]
 
 e-types/write-emitted
@@ -414,69 +387,75 @@ e-types/write-emitted
 
 e-bootdefs: make-emitter "Boot Definitions" inc/tmp-bootdefs.h
 
-e-bootdefs/emit-line [{#define REBOL_VER} space (version/1)]
-e-bootdefs/emit-line [{#define REBOL_REV} space (version/2)]
-e-bootdefs/emit-line [{#define REBOL_UPD} space (version/3)]
-e-bootdefs/emit-line [{#define REBOL_SYS} space (version/4)]
-e-bootdefs/emit-line [{#define REBOL_VAR} space (version/5)]
-
-;-- Generate Canonical Words (must follow datatypes above!) ------------------
 
 e-bootdefs/emit {
-/***********************************************************************
-**
-*/  enum REBOL_Symbols
-/*
-**      REBOL static canonical words (symbols) used with the code.
-**
-***********************************************************************/
+    /*
+    ** VERSION INFORMATION
+    **
+    ** !!! While using 5 byte-sized integers to denote a Rebol version might
+    ** not be ideal, it's a standard that's been around a long time.
+    */
+
+    #define REBOL_VER $(version/1)
+    #define REBOL_REV $(version/2)
+    #define REBOL_UPD $(version/3)
+    #define REBOL_SYS $(version/4)
+    #define REBOL_VAR $(version/5)
 }
-e-bootdefs/emit-line "{"
+e-bootdefs/emit-line []
+
+
+e-bootdefs/emit {
+    /*
+    ** CONSTANTS FOR BUILT-IN SYMBOLS: e.g. SYM_THRU or SYM_INTEGER_X
+    **
+    ** ANY-WORD! uses internings of UTF-8 character strings.  An arbitrary
+    ** number of these are created at runtime, and can be garbage collected
+    ** when no longer in use.  But a pre-determined set of internings are
+    ** assigned small integer "SYM" compile-time-constants, to be used in
+    ** switch() for efficiency in the core.
+    **
+    ** Datatypes are given symbol numbers at the start of the list, so that
+    ** their SYM_XXX values will be identical to their REB_XXX values.
+    **
+    ** Note: SYM_0 is not a symbol of the string "0".  It's the "SYM" constant
+    ** that is returned for any interning that *does not have* a compile-time
+    ** constant assigned to it.  Since VAL_WORD_SYM() will return SYM_0 for
+    ** all user (and extension) defined words, don't try to check equality
+    ** with `VAL_WORD_SYM(word1) == VAL_WORD_SYM(word2)`.
+    */
+
+    enum REBOL_Symbols ^{
+}
+
 e-bootdefs/emit-item/assign "SYM_0" 0
 
-n: 0
-boot-words: copy []
+n: 1
+boot-words: copy [] ;-- MAP! in R3-Alpha is unreliable
 add-word: func [
-    ; LEAVE is not available in R3-Alpha compatibility PROC
-    ; RETURN () is not legal in R3-Alpha compatibility FUNC (no RETURN: [...])
-    ; Make it a FUNC and just RETURN blank to appease both
-
     word
     /skip-if-duplicate
-    /type
 ][
-    ;
-    ; Horribly inefficient linear search, but MAP! in R3-Alpha is unreliable
-    ; and implemented differently, and we want this code to work in it too.
-    ;
     if find boot-words word [
         if skip-if-duplicate [return blank]
         fail ["Duplicate word specified" word]
     ]
 
-    ; Although TO-C-NAME is used on the SYM_XXX string as a whole, in order
-    ; to get names like SYM_ELLIPSIS the escaping has to be done on the
-    ; individual word first in this case, as opposed to something more generic
-    ; which would also turn SYM_.a. into "SYM__DOTA_DOT" (or similar) 
-    ;
-    e-bootdefs/emit-item/upper ["SYM_" (to-c-name word)]
+    e-bootdefs/emit-item/upper [
+        comment [to-cname ("SYM_" word)] ;-- `...` would be SYM__DOT_DOT_DOT
+        "SYM_" (to-c-name word) ;-- `...` is recognized to make SYM_ELLIPSIS
+    ]
     e-bootdefs/emit-annotation spaced [n "-" word]
     n: n + 1
 
-    ; The types make a SYM_XXX entry, but they're kept in a separate block
-    ; in the boot object (see `boot-types` in `sections`)
-    ;
-    ; !!! Update--temporarily to make word numbering easier, they are
-    ; duplicated.  Consider a better way longer term.
-    ;
-    append boot-words word ;-- was `unless type [...]`
+    append boot-words word
     return blank
 ]
 
-for-each-record type boot-types [
-    if n = 0 [n: n + 1 | continue]
-
-    add-word/type to-word unspaced [to-string type/name "!"]
+for-each-record t type-table [
+    if t/name != 0 [
+        add-word to-word unspaced [ensure word! t/name "!"]
+    ]
 ]
 
 wordlist: load %words.r
@@ -879,15 +858,13 @@ e-bootblock/emit newline
 
 boot-typespecs: make block! 100
 specs: load %typespec.r
-for-each type datatypes [
-    if type = 0 [continue]
-    verify [spec: select specs type]
-    append/only boot-typespecs spec
+for-each-record t type-table [
+    if t/name <> 0 [
+        append/only boot-typespecs really select specs to-word t/name
+    ]
 ]
 
 ;-- Create main code section (compressed):
-
-boot-types: new-types
 
 write-if-changed boot/tmp-boot-block.r mold reduce sections
 data: mold/flat reduce sections

--- a/make/tools/make-os-ext.r
+++ b/make/tools/make-os-ext.r
@@ -177,7 +177,7 @@ e-lib/emit-lines [
     [{#define HOST_LIB_SIZE} space proto-count]
 ]
 
-e-lib/emit reduce [
+e-lib/emit unspaced [
 {
 // !!! SEE **WARNING** BEFORE EDITING
 

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -125,25 +125,20 @@ if true = attempt [void? :some-undefined-thing] [
         fail "Don't use UNTIL-NOT when you want R3-Alpha compatibility"
     ]
 
-    case [
-        () = :really [
-            ;-- Ren-Cs up to around Jan 27, 2018
+    either () = :really [
+        ;-- Ren-Cs up to around Jan 27, 2018
 
-            assert [find words-of :ensure 'test]
-            really: func [cell [<opt> any-value!]] [
-                if any [void? :cell blank? :cell] [
-                    fail/where [
-                        "REALLY expects argument to be SOMETHING?"
-                    ] 'cell
-                ]
-                :cell
+        assert [find words-of :ensure 'test]
+        really: func [cell [<opt> any-value!]] [
+            if any [void? :cell blank? :cell] [
+                fail/where [
+                    "REALLY expects argument to be SOMETHING?"
+                ] 'cell
             ]
+            :cell
         ]
-
-        true [
-            assert [find words-of :ensure 'test]
-            assert [1 = length-of words-of :really]
-        ]
+    ][
+        assert [find words-of :ensure 'test]
     ]
 
     did: func [cell [<opt> any-value!]] [

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -110,6 +110,11 @@ if true = attempt [void? :some-undefined-thing] [
         fail "Do not use THEN in scripts which want compatibility w/R3-Alpha"
     ]
 
+    ; UNTIL was deprecated under its old meaning, but ultimately reverted
+    ; so put it back...
+    ;
+    until: :loop-until
+
     ; WHILE-NOT can't be written correctly in usermode R3-Alpha (RETURN won't
     ; work definitionally)
     ;
@@ -120,18 +125,25 @@ if true = attempt [void? :some-undefined-thing] [
         fail "Don't use UNTIL-NOT when you want R3-Alpha compatibility"
     ]
 
-    ; The once-arity-2 primitive known as ENSURE was renamed to REALLY, to
-    ; better parallel MAYBE and free up ENSURE to simply mean "make sure it's
-    ; a value".  Then it was changed back, when MAYBE and REALLY were moved
-    ; to be single arity and MATCH was introduced.  Try and smooth that over.
-    ;
-    either all [
-        () <> :really
-        find words-of :really 'test
-    ][
-        ensure: :really ;-- Ren-Cs up to around Jan 27, 2018
-    ][
-        assert [find words-of :ensure 'test]
+    case [
+        () = :really [
+            ;-- Ren-Cs up to around Jan 27, 2018
+
+            assert [find words-of :ensure 'test]
+            really: func [cell [<opt> any-value!]] [
+                if any [void? :cell blank? :cell] [
+                    fail/where [
+                        "REALLY expects argument to be SOMETHING?"
+                    ] 'cell
+                ]
+                :cell
+            ]
+        ]
+
+        true [
+            assert [find words-of :ensure 'test]
+            assert [1 = length-of words-of :really]
+        ]
     ]
 
     did: func [cell [<opt> any-value!]] [

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -175,14 +175,19 @@ static inline void Abort_Function(REBFRM *f) {
     DS_DROP_TO(f->dsp_orig); // any unprocessed refinements or chains on stack
 }
 
-static inline void Link_Vararg_Param_To_Frame(REBFRM *f, REBOOL make) {
-    assert(GET_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC));
+static inline void Link_Vararg_Param_To_Frame(
+    REBFRM *f_state,
+    const RELVAL *param,
+    REBVAL *arg,
+    REBOOL make
+){
+    assert(GET_VAL_FLAG(param, TYPESET_FLAG_VARIADIC));
 
-    // Store the offset so that both the f->arg and f->param locations can
+    // Store the offset so that both the arg and param locations can
     // be quickly recovered, while using only a single slot in the REBVAL.
     //
-    f->arg->payload.varargs.param_offset = f->arg - f->args_head;
-    f->arg->payload.varargs.facade = FUNC_FACADE(f->phase);
+    arg->payload.varargs.param_offset = arg - f_state->args_head;
+    arg->payload.varargs.facade = FUNC_FACADE(f_state->phase);
 
     // The data feed doesn't necessarily come from the frame
     // that has the parameter and the argument.  A varlist may be
@@ -190,16 +195,16 @@ static inline void Link_Vararg_Param_To_Frame(REBFRM *f, REBOOL make) {
     // an ordinary array.
     //
     if (make) {
-        RESET_VAL_HEADER(f->arg, REB_VARARGS);
+        RESET_VAL_HEADER(arg, REB_VARARGS);
 
         // !!! Doesn't use INIT_BINDING() because that conservatively reifies,
         // and not only do we know we don't have to here, it would assert
         // trying to reify a fulfilling frame.
         //
-        f->arg->extra.binding = NOD(f);
+        arg->extra.binding = NOD(f_state);
     }
     else
-        assert(VAL_TYPE(f->arg) == REB_VARARGS);
+        assert(VAL_TYPE(arg) == REB_VARARGS);
 }
 
 
@@ -234,6 +239,101 @@ inline static REBOOL In_Typecheck_Mode(REBFRM *f) {
 
 inline static REBOOL In_Unspecialized_Mode(REBFRM *f) {
     return DID(f->special == f->param);
+}
+
+
+// Typechecking has to be broken out into a subroutine because it is not
+// always the case that one is typechecking the current argument.  See the
+// documentation on REB_0_DEFERRED for why.
+//
+inline static void Check_Arg(
+    REBFRM *f_state, // name helps avoid accidental references to f->arg, etc.
+    const RELVAL *param,
+    REBVAL *arg,
+    REBVAL *refine
+){
+    if (IS_END(arg)) {
+        //
+        // This can happen, e.g. with `do [1 + comment "foo"]`.  It should act
+        // no differently from `do [1 +]`, so argument fulfillment may have
+        // to signal END (e.g. Do_Core() may fill a slot with END)
+        //
+        if (NOT_VAL_FLAG(param, TYPESET_FLAG_ENDABLE))
+            fail (Error_No_Arg(f_state, param));
+
+        Init_Endish_Void(arg);
+        return;
+    }
+
+    ASSERT_VALUE_MANAGED(arg);
+
+    // refine may point to the applicable refinement slot for the current
+    // arg being fulfilled, or it might just be a signal of information about
+    // the mode (see comments on `Reb_Frame.refine`)
+    //
+    assert(
+        refine == ORDINARY_ARG ||
+        refine == LOOKBACK_ARG ||
+        refine == ARG_TO_UNUSED_REFINEMENT ||
+        refine == ARG_TO_REVOKED_REFINEMENT ||
+        (IS_LOGIC(refine) && IS_TRUTHY(refine)) // used
+    );
+
+    if (IS_VOID(arg)) {
+        if (IS_LOGIC(refine)) {
+            //
+            // We can only revoke the refinement if this is the 1st
+            // refinement arg.  If it's a later arg, then the first
+            // didn't trigger revocation, or refine wouldn't be logic.
+            //
+            if (refine + 1 != arg)
+                fail (Error_Bad_Refine_Revoke(param, arg));
+
+            Init_Logic(refine, FALSE); // can't re-enable...
+            refine = ARG_TO_REVOKED_REFINEMENT;
+            return; // don't type check for optionality
+        }
+
+        if (IS_FALSEY(refine)) {
+            //
+            // FALSE -> refinement already revoked, void is okay
+            // BLANK! -> refinement was never in use, so also okay
+            //
+            return;
+        }
+
+        // fall through to check arg for if <opt> is ok
+        //
+        assert(refine == ORDINARY_ARG || refine == LOOKBACK_ARG);
+    }
+    else {
+        // If the argument is set, then the refinement shouldn't be
+        // in a revoked or unused state.
+        //
+        if (IS_FALSEY(refine))
+            fail (Error_Bad_Refine_Revoke(param, arg));
+    }
+
+    if (NOT_VAL_FLAG(param, TYPESET_FLAG_VARIADIC)) {
+        if (NOT(TYPE_CHECK(param, VAL_TYPE(arg))))
+            fail (Error_Arg_Type(f_state, param, VAL_TYPE(arg)));
+
+        return;
+    }
+
+    // Varargs are odd, because the type checking doesn't actually check the
+    // types inside the parameter--it always has to be a VARARGS!.
+    //
+    if (!IS_VARARGS(arg))
+        fail (Error_Not_Varargs(f_state, param, VAL_TYPE(arg)));
+
+    // While "checking" the variadic argument we actually re-stamp it with
+    // this parameter and frame's signature.  It reuses whatever the original
+    // data feed was (this frame, another frame, or just an array from MAKE
+    // VARARGS!)
+    //
+    const REBOOL make = FALSE; // reuse feed in arg
+    Link_Vararg_Param_To_Frame(f_state, param, arg, make);
 }
 
 
@@ -307,7 +407,6 @@ void Do_Core(REBFRM * const f)
         //
         assert(f->prior->deferred != NULL);
 
-        f->deferred = NULL;
         assert(NOT_END(f->out));
         f->flags.bits &= ~DO_FLAG_POST_SWITCH; // !!! unnecessary?
         goto post_switch;
@@ -326,7 +425,6 @@ void Do_Core(REBFRM * const f)
     if (f->flags.bits & DO_FLAG_APPLYING) {
         evaluating = NOT(f->flags.bits & DO_FLAG_EXPLICIT_EVALUATE);
 
-        f->deferred = NULL;
         assert(f->refine == ORDINARY_ARG); // APPLY infix not (yet?) supported
         goto process_function;
     }
@@ -375,8 +473,6 @@ reevaluate:;
 
     UPDATE_TICK_DEBUG(current);
     // v-- This is the TICK_BREAKPOINT or C-DEBUG-BREAK landing spot --v
-
-    f->deferred = NULL;
 
     if (NOT(evaluating) == NOT_VAL_FLAG(current, VALUE_FLAG_EVAL_FLIP)) {
         //
@@ -622,7 +718,6 @@ reevaluate:;
         Do_Process_Function_Checks_Debug(f);
       #endif
 
-        assert(f->deferred == NULL);
         assert(DSP >= f->dsp_orig); // REFINEMENT!s pushed by path processing
         assert(f->refine == LOOKBACK_ARG || f->refine == ORDINARY_ARG);
 
@@ -998,7 +1093,7 @@ reevaluate:;
             if (GET_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC)) {
                 const REBOOL make = TRUE;
                 Prep_Stack_Cell(f->arg);
-                Link_Vararg_Param_To_Frame(f, make);
+                Link_Vararg_Param_To_Frame(f, f->param, f->arg, make);
                 goto continue_arg_loop; // new value, type guaranteed correct
             }
 
@@ -1011,27 +1106,20 @@ reevaluate:;
 
     //=//// START BY HANDLING ANY DEFERRED ENFIX PROCESSING //////////////=//
 
-            // With an expression like `if 10 and 20` we may have filled IF's
-            // first arg slot with 10 then returned, hoping `if 10` could
-            // form a complete expression, and take care of the enfix after
-            // the function call is finished (at the end of the switch).
+            // `if 10 and 20` starts by filling the first arg slot with 10,
+            // because AND has a "non-tight" (normal) left hand argument.
+            // Were `if 10` a complete expression, it would allow that.
             //
-            // But if we looped back to here, it would mean we're now trying
-            // to consume another argument at the callsite.  That means we
-            // won't be getting to the end of the switch before handling
-            // this deferred enfix.  In the case of `if 10 and 20`, we'd be
-            // trying to fill the `body` slot with `and 20`...which will fail,
-            // saying AND has no left hand argument.
-            //
-            // Rather than raise an error, we kept a `f->deferred` field that
-            // points at the previously filled f->arg slot.  We go back and
-            // re-enter a sub-frame for the argument via DO_FLAG_POST_SWITCH.
-            // Continuing the example, this gives the IF's `condition` slot a
-            // second chance to be fulfilled--this time using the 10 as the
-            // AND's left-hand argument.
+            // But now we're consuming another argument at  the callsite, so
+            // by definition `if 10` wasn't finished.  We kept a `f->deferred`
+            // field that points at the previously filled f->arg slot.  So we
+            // can re-enter a sub-frame and give the IF's `condition` slot a
+            // second chance to run the enfix processing it put off before,
+            // this time using the 10 as the AND's left-hand argument.
             //
             if (f->deferred != NULL) {
-                //
+                assert(VAL_TYPE(&f->cell) == REB_0_DEFERRED);
+
                 // The GC's understanding of how far to protect parameters is
                 // based on how far f->param has gotten.  Yet we've advanced
                 // f->param and f->arg, with END in arg, but are rewinding
@@ -1061,9 +1149,19 @@ reevaluate:;
                     goto finished;
                 }
 
-                // Don't clear until after the call (not being NULL is how the
-                // subframe knows not to defer again.)
+                // This frame's cell shouldn't have been disturbed by the
+                // subframe processing, so it can still provide context for
+                // typechecking the argument (it wasn't previously checked).
                 //
+                assert(VAL_TYPE(&f->cell) == REB_0_DEFERRED);
+                Check_Arg(
+                    f,
+                    f->cell.payload.deferred.param,
+                    f->deferred,
+                    f->cell.payload.deferred.refine
+                );
+
+                Init_Unreadable_Blank(&f->cell);
                 f->deferred = NULL;
 
                 // Compensate for the param and arg change earlier.
@@ -1194,94 +1292,11 @@ reevaluate:;
 
         check_arg:;
 
-            if (IS_END(f->arg)) {
-                //
-                // This can happen, e.g. with `do [1 + comment "foo"]`.  The
-                // theory being that it should behave no differently than
-                // `do [1 +]`, so Do_Core() has to be able to return END.
-                //
-                if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_ENDABLE))
-                    fail (Error_No_Arg(f, f->param));
-
-                Init_Endish_Void(f->arg);
-                goto continue_arg_loop;
-            }
-
-            ASSERT_VALUE_MANAGED(f->arg);
             assert(pclass != PARAM_CLASS_REFINEMENT);
             assert(pclass != PARAM_CLASS_LOCAL);
 
-            // f->refine may point to the applicable refinement slot for the
-            // current arg being fulfilled, or it might just be a signal of
-            // information about the mode (see `Reb_Frame.refine` in %sys-do.h)
-            //
-            assert(
-                f->refine == ORDINARY_ARG ||
-                f->refine == LOOKBACK_ARG ||
-                f->refine == ARG_TO_UNUSED_REFINEMENT ||
-                f->refine == ARG_TO_REVOKED_REFINEMENT ||
-                (IS_LOGIC(f->refine) && IS_TRUTHY(f->refine)) // used
-            );
-
-            if (IS_VOID(f->arg)) {
-                if (IS_LOGIC(f->refine)) {
-                    //
-                    // We can only revoke the refinement if this is the 1st
-                    // refinement arg.  If it's a later arg, then the first
-                    // didn't trigger revocation, or refine wouldn't be logic.
-                    //
-                    if (f->refine + 1 != f->arg)
-                        fail (Error_Bad_Refine_Revoke(f->param, f->arg));
-
-                    Init_Logic(f->refine, FALSE); // can't re-enable...
-                    f->refine = ARG_TO_REVOKED_REFINEMENT;
-                    goto continue_arg_loop; // don't type check for optionality
-                }
-                else if (IS_FALSEY(f->refine)) {
-                    //
-                    // FALSE means the refinement has already been revoked so
-                    // the void is okay.  BLANK! means the refinement was
-                    // never in use in the first place.  Don't type check.
-                    //
-                    goto continue_arg_loop;
-                }
-                else {
-                    // fall through to check arg for if <opt> is ok
-                    //
-                    assert(
-                        f->refine == ORDINARY_ARG
-                        || f->refine == LOOKBACK_ARG
-                    );
-                }
-            }
-            else {
-                // If the argument is set, then the refinement shouldn't be
-                // in a revoked or unused state.
-                //
-                if (IS_FALSEY(f->refine))
-                    fail (Error_Bad_Refine_Revoke(f->param, f->arg));
-            }
-
-            if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_VARIADIC)) {
-                if (NOT(TYPE_CHECK(f->param, VAL_TYPE(f->arg))))
-                    fail (Error_Arg_Type(f, f->param, VAL_TYPE(f->arg)));
-            }
-            else {
-                // Varargs are odd, because the type checking doesn't
-                // actually check the types inside the parameter--it always
-                // has to be a VARARGS!.
-                //
-                if (!IS_VARARGS(f->arg))
-                    fail (Error_Not_Varargs(f, f->param, VAL_TYPE(f->arg)));
-
-                // While "checking" the variadic argument we actually re-stamp
-                // it with this parameter and frame's signature.  It reuses
-                // whatever the original data feed was (this frame, another
-                // frame, or just an array from MAKE VARARGS!)
-                //
-                const REBOOL make = FALSE; // reuse feed in f->arg
-                Link_Vararg_Param_To_Frame(f, make);
-            }
+            if (f->deferred == NULL)
+                Check_Arg(f, f->param, f->arg, f->refine);
 
         continue_arg_loop:;
 
@@ -1334,12 +1349,31 @@ reevaluate:;
         if (In_Typecheck_Mode(f)) {
             if (f->varlist != NULL)
                 assert(NOT_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE));
+
+            assert(IS_POINTER_TRASH_DEBUG(f->deferred));
         }
         else { // was fulfilling...
             if (f->varlist != NULL) {
                 assert(GET_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE));
                 CLEAR_SER_INFO(f->varlist, SERIES_INFO_INACCESSIBLE);
             }
+
+            if (f->deferred != NULL) {
+                //
+                // We deferred typechecking, but still need to do it...
+                // f->cell holds the necessary context for typechecking
+                //
+                assert(VAL_TYPE(&f->cell) == REB_0_DEFERRED);
+                Check_Arg(
+                    f,
+                    f->cell.payload.deferred.param,
+                    f->deferred,
+                    f->cell.payload.deferred.refine
+                );
+                Init_Unreadable_Blank(&f->cell);
+            }
+
+            TRASH_POINTER_IF_DEBUG(f->deferred);
         }
 
     //==////////////////////////////////////////////////////////////////==//
@@ -1532,7 +1566,6 @@ reevaluate:;
             f->special = f->arg;
             f->refine = ORDINARY_ARG; // no gathering, but need for assert
             deny(GET_FUN_FLAG(f->phase, FUNC_FLAG_INVISIBLE));
-            f->deferred = NULL; // frame filling decisions already made
             SET_END(f->out);
             goto process_function;
 
@@ -1543,7 +1576,6 @@ reevaluate:;
             // value of what f->phase is, for instance.
             //
             deny(GET_FUN_FLAG(f->phase, FUNC_FLAG_INVISIBLE));
-            f->deferred = NULL; // frame filling decisions already made
             SET_END(f->out);
             goto redo_unchecked;
 
@@ -2269,6 +2301,8 @@ reevaluate:;
 
 post_switch:;
 
+    assert(IS_POINTER_TRASH_DEBUG(f->deferred));
+
     f->eval_type = VAL_TYPE(f->value);
 
 //=//// IF NOT A WORD!, IT DEFINITELY STARTS A NEW EXPRESSION /////////////=//
@@ -2441,12 +2475,19 @@ post_switch:;
         && (f->flags.bits & DO_FLAG_FULFILLING_ARG)
         && f->prior->deferred == NULL
         && NOT_VAL_FLAG(f->prior->param, TYPESET_FLAG_ENDABLE)
-        /* && f->deferred == NULL */ // !!! see notes above...
     ){
         assert(NOT(f->flags.bits & DO_FLAG_TO_END));
         assert(Is_Function_Frame_Fulfilling(f->prior));
 
-        f->prior->deferred = f->out; // see remarks on deferred in REBFRM
+        // Must be true if fulfilling an argument that is *not* a deferral
+        //
+        assert(f->out == f->prior->arg);
+
+        f->prior->deferred = f->prior->arg; // see deferred comments in REBFRM
+        
+        RESET_VAL_HEADER(&f->prior->cell, REB_0_DEFERRED);
+        f->prior->cell.payload.deferred.param = f->prior->param;
+        f->prior->cell.payload.deferred.refine = f->prior->refine;
 
         // Leave the enfix operator pending in the frame, and it's up to the
         // parent frame to decide whether to use DO_FLAG_POST_SWITCH to jump
@@ -2456,8 +2497,6 @@ post_switch:;
         //
         goto finished;
     }
-
-    f->deferred = NULL;
 
     // This is a case for an evaluative lookback argument we don't want to
     // defer, e.g. a #tight argument or a normal one which is not being

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -270,6 +270,11 @@ void Do_Process_Function_Checks_Debug(REBFRM *f) {
         ASSERT_NOT_TRASH_IF_DEBUG(f->out);
     }
 
+    if (f->special == f->arg)
+        assert(IS_POINTER_TRASH_DEBUG(f->deferred));
+    else
+        assert(f->deferred == NULL);
+
     // DECLARE_FRAME() starts out f->cell as valid GC-visible bits, and as
     // it's used for various temporary purposes it should remain valid.  But
     // its contents could be anything, based on that temporary purpose.  Help

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1168,8 +1168,12 @@ static void Mark_Frame_Stack_Deep(void)
         // Frame temporary cell should always contain initialized bits, as
         // DECLARE_FRAME sets it up and no one is supposed to trash it.
         //
-        if (NOT_END(&f->cell))
-            Queue_Mark_Opt_Value_Deep(&f->cell);
+        if (NOT_END(&f->cell)) {
+            if (VAL_TYPE_RAW(&f->cell) == REB_0_DEFERRED)
+                assert(f->deferred != NULL);
+            else
+                Queue_Mark_Opt_Value_Deep(&f->cell);
+        }
 
         if (NOT(Is_Function_Frame(f))) {
             //

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -377,7 +377,7 @@ REBNATIVE(value_q)
 {
     INCLUDE_PARAMS_OF_VALUE_Q;
 
-    return R_FROM_BOOL(NOT(IS_VOID(ARG(cell))));
+    return R_FROM_BOOL(ANY_VALUE(ARG(cell)));
 }
 
 
@@ -1074,11 +1074,11 @@ REBNATIVE(aliases_q)
 inline static REBOOL Is_Set(const REBVAL *location)
 {
     if (ANY_WORD(location))
-        return IS_ANY_VALUE(Get_Opt_Var_May_Fail(location, SPECIFIED));
+        return ANY_VALUE(Get_Opt_Var_May_Fail(location, SPECIFIED));
 
     DECLARE_LOCAL (temp); // result may be generated
     Get_Path_Core(temp, location, SPECIFIED);
-    return IS_ANY_VALUE(temp);
+    return ANY_VALUE(temp);
 }
 
 

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -185,7 +185,7 @@ REBNATIVE(eval_enfix)
     // this frame...so when it asserts about "f->prior->deferred" it means
     // the frame of EVAL-ENFIX that is invoking it.
     //
-    assert(FS_TOP->deferred == NULL);
+    assert(IS_POINTER_TRASH_DEBUG(FS_TOP->deferred));
     FS_TOP->deferred = m_cast(REBVAL*, BLANK_VALUE); // !!! signal our hack
 
     REBFLGS flags = DO_FLAG_FULFILLING_ARG | DO_FLAG_POST_SWITCH;
@@ -666,6 +666,7 @@ REBNATIVE(apply)
     f->param = FUNC_FACADE_HEAD(f->phase); // reset
 
     f->special = f->arg; // now signal only type-check the existing data
+    TRASH_POINTER_IF_DEBUG(f->deferred); // invariant for checking mode
 
     (*PG_Do)(f);
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -164,6 +164,8 @@ inline static void Push_Frame_Core(REBFRM *f)
     //
     f->phase = NULL;
 
+    TRASH_POINTER_IF_DEBUG(f->deferred);
+
     TRASH_POINTER_IF_DEBUG(f->opt_label);
   #if defined(DEBUG_FRAME_LABELS)
     TRASH_POINTER_IF_DEBUG(f->label_utf8);

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -491,6 +491,8 @@ inline static void Push_Function(
     else
         f->special = const_KNOWN(f->param);
 
+    f->deferred = NULL;
+
     // A REBFRM* for a function call may-or-may-not need an associated REBCTX*
     // dynamically allocated.  Whether it does or not depends on if bindings
     // to the args or locals wind up "leaking" into slots that have a lifetime

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -693,6 +693,12 @@ struct Reb_Frame {
     // that cell is re-dispatched with DO_FLAG_POST_SWITCH to give the
     // impression that the AND had "tightly" taken the argument all along.
     //
+    // !!! Since the deferral process pokes a REB_0_DEFERRED into the frame's
+    // cell to save the argument positioning, it could use the VAL_TYPE_RAW()
+    // of that cell to cue that deferment is in progress, and store the
+    // pointer to the deferred argument in the cell's `extra`.  That would
+    // mean one less field in the frame.  Impacts of that should be studied.
+    //
     REBVAL *deferred;
 
    #if defined(DEBUG_COUNT_TICKS)

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -576,6 +576,19 @@ struct Reb_Partial {
 };
 
 
+// Enfix processing for "non-tight" (normal) arguments may have to revisit
+// an argument slot to fill it in.  But it may be that the argument gathering
+// loop then finishes, indicating no need for re-entry.  At which point, the
+// slot will need to be type checked.  Remember the state of the enumeration
+// at the moment of deferral in the frame's cell in order to return to it.
+//
+#define REB_0_DEFERRED REB_0
+struct Reb_Deferred {
+    const RELVAL *param;
+    REBVAL *refine;
+};
+
+
 // Handles hold a pointer and a size...which allows them to stand-in for
 // a binary REBSER.
 //
@@ -789,6 +802,7 @@ union Reb_Value_Payload {
     //
     struct Reb_Reference reference; // used with REB_0_REFERENCE
     struct Reb_Partial partial; // used with REB_0_PARTIAL
+    struct Reb_Deferred deferred; // used with REB_0_DEFERRED
 };
 
 struct Reb_Cell

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -304,7 +304,11 @@ inline static REBYTE *SER_AT_RAW(REBYTE w, REBSER *s, REBCNT i) {
         // caller passing in the wrong width (freeing sets width to 0).  But
         // give some debug tracking either way.
         //
-        printf("SER_AT_RAW asked %d on width=%d\n", w, SER_WIDE(s));
+        REBYTE wide = SER_WIDE(s);
+        if (wide == 0)
+            printf("SER_AT_RAW asked on freed series\n");
+        else
+            printf("SER_AT_RAW asked %d on width=%d\n", w, SER_WIDE(s));
         panic (s);
     }
 #endif

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -234,10 +234,10 @@ reword: function [
         ]
 
         block? delimiters [
-            unless parse delimiters [
+            parse delimiters [
                 set prefix delimiter-types
                 set suffix opt delimiter-types
-            ][
+            ] or [
                 fail ["Invalid /ESCAPE delimiter block" delimiters]
             ]
         ]
@@ -246,9 +246,10 @@ reword: function [
     ]
 
     ; MAKE MAP! will create a map with no duplicates from the input if it
-    ; is a BLOCK!.  This might be better with stricter checking, in case
-    ; later keys overwrite earlier ones and obscure the invalidity of the
-    ; earlier keys (or perhaps MAKE MAP! itself should disallow duplicates)
+    ; is a BLOCK! (though differing cases of the same key will be preserved).
+    ; This might be better with stricter checking, in case later keys
+    ; overwrite earlier ones and obscure the invalidity of the earlier keys
+    ; (or perhaps MAKE MAP! itself should disallow duplicates)
     ;
     if block? values [
         values: make map! values
@@ -349,7 +350,7 @@ reword: function [
                         ;
                         output: insert/part output a b
 
-                        v: select values keyword-match
+                        v: select/(all [case_REWORD 'case]) values keyword-match
                         output: insert output case [
                             function? :v [v :keyword-match]
                             block? :v [do :v]

--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -37,15 +37,21 @@
     length of data = 80'000
 )
 
-;; git log crash (inconsistent)
-;; fixed by https://github.com/metaeducation/ren-c/commit/c2221bffa2815dd074dc00080e1a29816ad7f5e2
+;; extra large CALL/OUTPUT (500K+), test only run if can find git binary
 (
-    ;; only going to run if can find git binary
-    if exists? %/usr/bin/git [
-        ;; extra large (500K+)
+    not exists? %/usr/bin/git or [
         data: copy {}
-        call/wait/output [%/usr/bin/git "log" {--pretty=format:'[commit: {%h} author: {%an} email: {%ae} date-string: {%ai} summary: {%s}]'}] data
+        call/wait/output compose [
+            %/usr/bin/git "log" (spaced [
+                "--pretty=format:'["
+                    "commit: {%h}"
+                    "author: {%an}"
+                    "email: {%ae}"
+                    "date-string: {%ai}"
+                    "summary: {%s}"
+                "]'"
+            ])
+        ] data
         length of data > 500'000 and (find data "summary: {Initial commit}]")
-        ;; bottom of log
-    ] else [true] ;; test wasn't run but no way to skip :(
+    ]
 )

--- a/tests/control/either.test.reb
+++ b/tests/control/either.test.reb
@@ -72,3 +72,17 @@
     blk: [either false [] blk]
     error? trap blk
 )
+(
+    ; This exercises "deferred typechecking"; even though it passes through a
+    ; step where there is a void in the condition slot, that's not the final
+    ; situation since the equality operation will be run later, so the test
+    ; has to wait.
+    ;
+    either () = () [true] [false]
+)
+(
+    ; complement to the above, need to type check the final product
+    ;
+    infix-voider: enfix func [return: [<opt>] x y] []
+    'no-value = (trap [either 1 infix-voider 2 [false] [false]])/id
+)


### PR DESCRIPTION
R3-Alpha's "make prep" step centered around generating a large number
of derived .C and .H files.  The input to this generation process was
several Rebol tables, as well as scanning over the C source code of
the interpreter itself.

The make prep code was somewhat ad-hoc, and used Rebol JOIN and other
string operations to build up lines of C.  During the development of
Ren-C, the demands on this process became greater...so the already
somewhat difficult-to-follow code became more complicated than it
already was.

To begin taming the complexity, this introduces a new way to merge
Rebol variables into a template of C code.  A templating routine
called CSCAPE (for C escape, pronounced "sea-scape") is integrated
into the emitter.  Rebol escapes identified by ${...} are LOADed
and evaluated, and their result has TO-C-NAME run on them.  If $(...)
is used instead, then the result is run through UNSPACED (if a block)
or FORM (for all other types).

An added twist is the usage of capitalization in the expression, which
affects the result.  Use of all uppercase characters means the result
will be run through UPPERCASE, all lowercase means it will run through
LOWERCASE, and mixed casing (or if no letters are present) means it
will be left alone.  Hence:

    mod: {Super-Crypto+}
    n: 10

    >> cscape {int EXT_${MOD}_NUM = $(n);}
    == {int EXT_SUPER_CRYPTO_A_NUM = 10;}

    >> cscape {const char *s = "${Mod}";}
    == {const char *s = "Super_Crypto_A";}

This permits *significant* simplification in the emit process.  As a
first step, this integrates CSCAPE into the basic emit command, and
uses it in a few places to demonstrate it.