### PR TITLE
Make BAR! act as an invisible, instead of voiding

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -101,8 +101,7 @@ Script: [
 
     hijack-blank:       {Hijacked function was captured but no body given yet}
 
-    expression-barrier: {Expression barrier hit while processing arguments}
-    bar-hit-mid-case:   {Expression barrier hit in middle of CASE pairing}
+    no-quote-bar:       {Expression barrier BAR! can't be QUOTEd (use UNEVAL)}
     enfix-quote-late:   [:arg1 {can't left quote a forward quoted value}]
     evaluate-void:      {voids cannot be evaluated}
 

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -282,7 +282,7 @@ static REBARR *Startup_Datatypes(REBARR *boot_types, REBARR *boot_typespecs)
         // on lib...but it could still be technically possible, even in
         // a limited sense.)
         //
-        assert(value == Get_Type(cast(enum Reb_Kind, n)));
+        assert(value == Datatype_From_Kind(cast(enum Reb_Kind, n)));
         SET_VAL_FLAG(CTX_VAR(Lib_Context, n), CELL_FLAG_PROTECTED);
 
         Append_Value(catalog, KNOWN(word));

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1282,7 +1282,7 @@ REBCTX *Error_No_Catch_For_Throw(REBVAL *thrown)
 //
 REBCTX *Error_Invalid_Type(enum Reb_Kind kind)
 {
-    return Error_Invalid_Type_Raw(Get_Type(kind));
+    return Error_Invalid_Type_Raw(Datatype_From_Kind(kind));
 }
 
 
@@ -1319,7 +1319,7 @@ REBCTX *Error_Illegal_Action(enum Reb_Kind type, REBSYM action)
     DECLARE_LOCAL (action_word);
     Init_Word(action_word, Canon(action));
 
-    return Error_Cannot_Use_Raw(action_word, Get_Type(type));
+    return Error_Cannot_Use_Raw(action_word, Datatype_From_Kind(type));
 }
 
 
@@ -1331,7 +1331,7 @@ REBCTX *Error_Math_Args(enum Reb_Kind type, REBSYM action)
     DECLARE_LOCAL (action_word);
     Init_Word(action_word, Canon(action));
 
-    return Error_Not_Related_Raw(action_word, Get_Type(type));
+    return Error_Not_Related_Raw(action_word, Datatype_From_Kind(type));
 }
 
 
@@ -1344,8 +1344,8 @@ REBCTX *Error_Unexpected_Type(enum Reb_Kind expected, enum Reb_Kind actual)
     assert(actual < REB_MAX);
 
     return Error_Expect_Val_Raw(
-        Get_Type(expected),
-        Get_Type(actual)
+        Datatype_From_Kind(expected),
+        Datatype_From_Kind(actual)
     );
 }
 
@@ -1359,7 +1359,7 @@ REBCTX *Error_Unexpected_Type(enum Reb_Kind expected, enum Reb_Kind actual)
 REBCTX *Error_Arg_Type(
     REBFRM *f,
     const RELVAL *param,
-    enum Reb_Kind kind
+    enum Reb_Kind actual
 ) {
     assert(IS_TYPESET(param));
 
@@ -1369,25 +1369,17 @@ REBCTX *Error_Arg_Type(
     DECLARE_LOCAL (label);
     Get_Frame_Label_Or_Blank(label, f);
 
-    if (kind != REB_MAX_VOID) {
-        assert(kind != REB_0);
-        REBVAL *datatype = Get_Type(kind);
-        assert(IS_DATATYPE(datatype));
-
+    if (actual != REB_MAX_VOID)
         return Error_Expect_Arg_Raw(
             label,
-            datatype,
+            Datatype_From_Kind(actual),
             param_word
         );
-    }
 
     // Although REB_MAX_VOID is not a type, the typeset bits are used
-    // to check it.  Since Get_Type() will fail, use another error.
+    // to check it.  Since Datatype_From_Kind() will fail, use another error.
     //
-    return Error_Arg_Required_Raw(
-        label,
-        param_word
-    );
+    return Error_Arg_Required_Raw(label, param_word);
 }
 
 
@@ -1401,9 +1393,7 @@ REBCTX *Error_Bad_Return_Type(REBFRM *f, enum Reb_Kind kind) {
     if (kind == REB_MAX_VOID)
         return Error_Needs_Return_Value_Raw(label);
 
-    REBVAL *datatype = Get_Type(kind);
-    assert(IS_DATATYPE(datatype));
-    return Error_Bad_Return_Type_Raw(label, datatype);
+    return Error_Bad_Return_Type_Raw(label, Datatype_From_Kind(kind));
 }
 
 
@@ -1412,7 +1402,7 @@ REBCTX *Error_Bad_Return_Type(REBFRM *f, enum Reb_Kind kind) {
 //
 REBCTX *Error_Bad_Make(enum Reb_Kind type, const REBVAL *spec)
 {
-    return Error_Bad_Make_Arg_Raw(Get_Type(type), spec);
+    return Error_Bad_Make_Arg_Raw(Datatype_From_Kind(type), spec);
 }
 
 
@@ -1421,7 +1411,7 @@ REBCTX *Error_Bad_Make(enum Reb_Kind type, const REBVAL *spec)
 //
 REBCTX *Error_Cannot_Reflect(enum Reb_Kind type, const REBVAL *arg)
 {
-    return Error_Cannot_Use_Raw(arg, Get_Type(type));
+    return Error_Cannot_Use_Raw(arg, Datatype_From_Kind(type));
 }
 
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1568,7 +1568,7 @@ REB_R Type_Action_Dispatcher(REBFRM *f)
         case SYM_TYPE:
             if (kind == REB_MAX_VOID)
                 return R_BLANK;
-            Val_Init_Datatype(f->out, kind);
+            Init_Datatype(f->out, kind);
             return R_OUT;
 
         default:

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -61,8 +61,8 @@ REB_R PD_Unhooked(REBPVS *pvs, const REBVAL *picker, const REBVAL *opt_setval)
     UNUSED(picker);
     UNUSED(opt_setval);
 
-    REBVAL *type = Get_Type(VAL_TYPE(pvs->out)); // put in error message?
-    UNUSED(type);
+    const REBVAL *type = Datatype_From_Kind(VAL_TYPE(pvs->out));
+    UNUSED(type); // !!! put in error message?
 
     fail ("Datatype is provided by an extension which is not loaded.");
 }

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -1112,7 +1112,7 @@ REBNATIVE(does)
                     return R_OUT_IS_THROWN;
                 }
 
-                if (r == R_VOID)
+                if (r == R_END)
                     fail ("DOES hack needs argument");
 
                 Move_Value(arg, D_OUT);

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -204,13 +204,19 @@ void Do_Core_Expression_Checks_Debug(REBFRM *f) {
     // about the output cell is that it's not trash.  In the debug build,
     // give this more teeth by explicitly setting it to an unreadable blank,
     // but only if it wasn't an END marker (that's how we can tell no
-    // evaluations have been done yet, consider `(comment [...] + 2)`)
+    // evaluations have been done yet, consider `(comment [...] + 2)`) or
+    // have NODE_FLAG_MARKED by BAR! for (1 + 2 | comment "hi") to be 3.
 
     ASSERT_NOT_TRASH_IF_DEBUG(f->out);
 
   #if defined(DEBUG_UNREADABLE_BLANKS)
-    if (not IS_UNREADABLE_DEBUG(f->out) and NOT_END(f->out))
+    if (
+        not IS_UNREADABLE_DEBUG(f->out)
+        and NOT_END(f->out)
+        and not (f->flags.bits & DO_FLAG_BARRIER_HIT)
+    ){
         Init_Unreadable_Blank(f->out);
+    }
 
     // Once a throw is started, no new expressions may be evaluated until
     // that throw gets handled.

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -222,25 +222,28 @@ REBINT Int8u(const REBVAL *val)
 
 
 //
-//  Val_Init_Datatype: C
-//
-void Val_Init_Datatype(REBVAL *out, enum Reb_Kind kind)
-{
-    assert(kind > REB_0 and kind < REB_MAX);
-    Move_Value(out, CTX_VAR(Lib_Context, SYM_FROM_KIND(kind)));
-}
-
-
-//
-//  Get_Type: C
+//  Datatype_From_Kind: C
 //
 // Returns the specified datatype value from the system context.
 // The datatypes are all at the head of the context.
 //
-REBVAL *Get_Type(enum Reb_Kind kind)
+const REBVAL *Datatype_From_Kind(enum Reb_Kind kind)
 {
     assert(kind > REB_0 and kind < REB_MAX);
-    return CTX_VAR(Lib_Context, SYM_FROM_KIND(kind));
+    REBVAL *type = CTX_VAR(Lib_Context, SYM_FROM_KIND(kind));
+    assert(IS_DATATYPE(type));
+    return type;
+}
+
+
+//
+//  Init_Datatype: C
+//
+REBVAL *Init_Datatype(RELVAL *out, enum Reb_Kind kind)
+{
+    assert(kind > REB_0 and kind < REB_MAX);
+    Move_Value(out, Datatype_From_Kind(kind));
+    return KNOWN(out);
 }
 
 
@@ -629,12 +632,12 @@ int Clip_Int(int val, int mini, int maxi)
 //
 //  Add_Max: C
 //
-int64_t Add_Max(enum Reb_Kind type, int64_t n, int64_t m, int64_t maxi)
+int64_t Add_Max(enum Reb_Kind kind_or_0, int64_t n, int64_t m, int64_t maxi)
 {
     int64_t r = n + m;
     if (r < -maxi or r > maxi) {
-        if (type != REB_0)
-            fail (Error_Type_Limit_Raw(Get_Type(type)));
+        if (kind_or_0 != REB_0)
+            fail (Error_Type_Limit_Raw(Datatype_From_Kind(kind_or_0)));
         r = r > 0 ? maxi : -maxi;
     }
     return r;
@@ -648,7 +651,7 @@ int64_t Mul_Max(enum Reb_Kind type, int64_t n, int64_t m, int64_t maxi)
 {
     int64_t r = n * m;
     if (r < -maxi or r > maxi)
-        fail (Error_Type_Limit_Raw(Get_Type(type)));
+        fail (Error_Type_Limit_Raw(Datatype_From_Kind(type)));
     return cast(int, r); // !!! (?) review this cast
 }
 

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -70,8 +70,8 @@ void MAKE_Unhooked(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     UNUSED(out);
     UNUSED(arg);
 
-    REBVAL *type = Get_Type(kind);
-    UNUSED(type); // put in error message?
+    const REBVAL *type = Datatype_From_Kind(kind);
+    UNUSED(type); // !!! put in error message?
 
     fail ("Datatype is provided by an extension that's not currently loaded");
 }
@@ -192,7 +192,7 @@ REBNATIVE(make)
                 DS_DROP_TO(dsp_orig);
                 return R_OUT_IS_THROWN;
             }
-            if (r == R_VOID)
+            if (r == R_END)
                 break;
             assert(r == R_OUT);
 
@@ -229,8 +229,8 @@ void TO_Unhooked(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     UNUSED(out);
     UNUSED(arg);
 
-    REBVAL *type = Get_Type(kind);
-    UNUSED(type); // use in error message?
+    const REBVAL *type = Datatype_From_Kind(kind);
+    UNUSED(type); // !!! put in error message?
 
     fail ("Datatype does not have extension with a TO handler registered");
 }

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -525,10 +525,6 @@ static REB_R Case_Choose_Core(
     // available for scratch space in the rest of the routine.
 
     while (FRM_HAS_MORE(f)) {
-        if (IS_BAR(f->value)) { // interstitial BAR! legal, `case [1 2 | 3 4]`
-            Fetch_Next_In_Frame(f);
-            continue;
-        }
 
         // Perform a DO/NEXT's worth of evaluation on a "condition" to test
 
@@ -547,9 +543,6 @@ static REB_R Case_Choose_Core(
 
         if (FRM_AT_END(f)) // require conditions and branches in pairs
             fail (Error_Past_End_Raw());
-
-        if (IS_BAR(f->value)) // BAR! out of sync between condition and branch
-            fail (Error_Bar_Hit_Mid_Case_Raw());
 
         if (IS_CONDITIONAL_FALSE(cell)) {
             //

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1148,7 +1148,7 @@ REBNATIVE(quote)
     REBVAL *v = ARG(value);
 
     if (IS_BAR(v))
-        fail (Error_Expression_Barrier_Raw()); // use UNEVAL instead of QUOTE
+        fail (Error_No_Quote_Bar_Raw());
 
     if (REF(soft) and IS_QUOTABLY_SOFT(v)) {
         Move_Value(D_CELL, v);

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -492,8 +492,8 @@ void MF_Unhooked(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     UNUSED(mo);
     UNUSED(form);
 
-    REBVAL *type = Get_Type(VAL_TYPE(v));
-    UNUSED(type); // use in error message?
+    const REBVAL *type = Datatype_From_Kind(VAL_TYPE(v));
+    UNUSED(type); // !!! put in error message?
 
     fail ("Datatype does not have extension with a MOLD handler registered");
 }
@@ -625,18 +625,6 @@ REBOOL Form_Reduce_Throws(
     REBOOL pending = FALSE;
 
     while (FRM_HAS_MORE(f)) {
-        if (IS_BLANK(f->value)) { // opt-out
-            Fetch_Next_In_Frame(f);
-            continue;
-        }
-
-        if (IS_BAR(f->value)) { // newline
-            Append_Utf8_Codepoint(mo->series, '\n');
-            pending = FALSE;
-            Fetch_Next_In_Frame(f);
-            continue;
-        }
-
         if (Do_Next_In_Frame_Throws(out, f)) {
             Drop_Frame(f);
             return TRUE;
@@ -644,12 +632,6 @@ REBOOL Form_Reduce_Throws(
 
         if (IS_VOID(out) || IS_BLANK(out)) // opt-out
             continue;
-
-        if (IS_BAR(out)) { // newline
-            Append_Utf8_Codepoint(mo->series, '\n');
-            pending = FALSE;
-            continue;
-        }
 
         if (IS_CHAR(out)) {
             Append_Utf8_Codepoint(mo->series, VAL_CHAR(out));

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -268,7 +268,7 @@ REBTYPE(Char)
     }
 
     if (chr < 0 || chr > 0xffff) // DEBUG_UTF8_EVERYWHERE
-        fail (Error_Type_Limit_Raw(Get_Type(REB_CHAR)));
+        fail (Error_Type_Limit_Raw(Datatype_From_Kind(REB_CHAR)));
 
     Init_Char(D_OUT, cast(REBUNI, chr));
     return R_OUT;

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -323,7 +323,7 @@ static REBDAT Normalize_Date(REBINT day, REBINT month, REBINT year, REBINT tz)
     }
 
     if (year < 0 || year > MAX_YEAR)
-        fail (Error_Type_Limit_Raw(Get_Type(REB_DATE)));
+        fail (Error_Type_Limit_Raw(Datatype_From_Kind(REB_DATE)));
 
     dr.date.year = year;
     dr.date.month = month+1;

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -586,7 +586,7 @@ REBSER *Make_Image(REBCNT w, REBCNT h, REBOOL error)
 {
     if (w > 0xFFFF || h > 0xFFFF) {
         if (error)
-            fail (Error_Size_Limit_Raw(Get_Type(REB_IMAGE)));
+            fail (Error_Size_Limit_Raw(Datatype_From_Kind(REB_IMAGE)));
         return NULL;
     }
 

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -559,7 +559,7 @@ REBTYPE(Time)
             case SYM_MULTIPLY:
                 secs *= num;
                 if (secs < -MAX_TIME || secs > MAX_TIME)
-                    fail (Error_Type_Limit_Raw(Get_Type(REB_TIME)));
+                    fail (Error_Type_Limit_Raw(Datatype_From_Kind(REB_TIME)));
                 goto setTime;
 
             case SYM_DIVIDE:

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -294,14 +294,14 @@ REBARR *Typeset_To_Array(const REBVAL *tset)
             value = Alloc_Tail_Array(block);
             if (n == 0) {
                 //
-                // !!! A NONE! value is currently supported in typesets to
+                // !!! A BLANK! value is currently supported in typesets to
                 // indicate that they take optional values.  This may wind up
                 // as a feature of MAKE ACTION! only.
                 //
                 Init_Blank(value);
             }
             else
-                Val_Init_Datatype(value, cast(enum Reb_Kind, n));
+                Init_Datatype(value, cast(enum Reb_Kind, n));
         }
     }
     return block;

--- a/src/extensions/ffi/t-routine.c
+++ b/src/extensions/ffi/t-routine.c
@@ -638,7 +638,7 @@ REB_R Routine_Dispatcher(REBFRM *f)
 
             if (r == R_OUT_IS_THROWN)
                 return R_OUT_IS_THROWN;
-            if (r == R_VOID)
+            if (r == R_END)
                 break;
             assert(r == R_OUT);
 

--- a/src/include/sys-action.h
+++ b/src/include/sys-action.h
@@ -141,7 +141,11 @@ enum Reb_Result {
     // so it can be used by common routines that return REB_R values and need
     // an "escape" code.
     //
-    R_UNHANDLED
+    R_UNHANDLED,
+
+    // Used as a signal from Do_Vararg_Op_May_Throw
+    //
+    R_END
 };
 typedef enum Reb_Result REB_R;
 

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -379,13 +379,10 @@ inline static REBVAL *Derelativize(
             INIT_BINDING(out, specifier);
         }
     }
-    else if (specifier == SPECIFIED) { // no potential override
-        assert(v->extra.binding->header.bits & ARRAY_FLAG_VARLIST);
-        out->extra.binding = v->extra.binding;
-    }
-    else {
-        assert(v->extra.binding->header.bits & ARRAY_FLAG_VARLIST);
-
+    else if (
+        specifier != SPECIFIED
+        and (v->extra.binding->header.bits & ARRAY_FLAG_VARLIST)
+    ){
         REBNOD *f_binding;
         if (IS_CELL(specifier))
             f_binding = cast(REBFRM*, specifier)->binding;
@@ -408,6 +405,13 @@ inline static REBVAL *Derelativize(
         }
         else
             out->extra.binding = v->extra.binding;
+    }
+    else { // no potential override
+        assert(
+            (v->extra.binding->header.bits & ARRAY_FLAG_VARLIST)
+            or IS_VARARGS(v) // BLOCK! style varargs use binding to hold array
+        );
+        out->extra.binding = v->extra.binding;
     }
 
     out->payload = v->payload;

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -621,7 +621,10 @@ inline static REBOOL Do_Next_In_Frame_Throws(
     // The & on the following line is purposeful.  See Init_Endlike_Header.
     // DO_FLAG_NO_LOOKAHEAD may be set by an operation like ELIDE.
     //
-    (&f->flags)->bits = prior_flags;
+    // Since this routine is used by BLOCK!-style varargs, it must retain
+    // knowledge of if BAR! was hit.
+    //
+    (&f->flags)->bits = prior_flags | (f->flags.bits & DO_FLAG_BARRIER_HIT);
 
     return THROWN(out);
 }
@@ -717,6 +720,9 @@ inline static REBOOL Do_Next_In_Subframe_Throws(
     parent->value = child->value;
     parent->gotten = child->gotten;
     assert(parent->specifier == child->specifier); // !!! can't change?
+
+    if (child->flags.bits & DO_FLAG_BARRIER_HIT)
+        parent->flags.bits |= DO_FLAG_BARRIER_HIT;
 
     return THROWN(out);
 }

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -545,6 +545,8 @@ inline static void Drop_Action_Core(
     // the native code is no longer running?
     //
     f->flags.bits &= ~DO_FLAG_NATIVE_HOLD;
+    if (not (f->flags.bits & DO_FLAG_FULFILLING_ARG))
+        f->flags.bits &= ~DO_FLAG_BARRIER_HIT;
 
     if (drop_chunks) {
         if (f->varlist == NULL) {

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -121,7 +121,7 @@
     FLAGIT_LEFT(5)
 
 
-//=//// DO_FLAG_APPLYING ///.......////////////////////////////////////////=//
+//=//// DO_FLAG_APPLYING //////////////////////////////////////////////////=//
 //
 // Used to indicate that the Do_Core code is entering a situation where the
 // frame was already set up.
@@ -268,6 +268,20 @@
     FLAGIT_LEFT(16)
 
 
+//=//// DO_FLAG_BARRIER_HIT ///////////////////////////////////////////////=//
+//
+// If a variadic operation is not hard-quoting, all instances of a variadic
+// tied to the same frame need to see a BAR! as an end of the variadic input.
+// But evaluation cannot leave BAR!s in the input stream, because they are
+// "invisibles".  So a `do/next [1 + 2 | | |]` must run through all the bars
+// otherwise the next evaluation would be `[| | |]` and there'd be no way
+// to synthesize 3 from it.  This means after a variadic TAKE the signal
+// will be gone, so this flag is used.
+//
+#define DO_FLAG_BARRIER_HIT \
+    FLAGIT_LEFT(17)
+
+
 #if !defined(NDEBUG)
 
 //=//// DO_FLAG_FINAL_DEBUG ///////////////////////////////////////////////=//
@@ -280,7 +294,7 @@
 //
 
 #define DO_FLAG_FINAL_DEBUG \
-    FLAGIT_LEFT(17)
+    FLAGIT_LEFT(18)
 
 #endif
 
@@ -291,7 +305,7 @@
 // information in a platform aligned position of the frame.
 //
 #ifdef CPLUSPLUS_11
-    static_assert(17 < 32, "DO_FLAG_XXX too high");
+    static_assert(18 < 32, "DO_FLAG_XXX too high");
 #endif
 
 

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -575,10 +575,8 @@ help: procedure [
     print-newline
 
     print [
-        "DESCRIPTION:"
-            |
-        space4 (any [description | "(undocumented)"])
-            |
+        "DESCRIPTION:" LF
+        space4 (any [description | "(undocumented)"]) LF
         space4 (uppercase mold topic) {is} classification
     ]
 
@@ -724,8 +722,7 @@ what: procedure [
     for-each [word arg] sort/skip list 2 [
         append/dup clear vals #" " size
         print [
-            head of change vals word
-                |
+            head of change vals word LF
             :arg
         ]
     ]
@@ -771,10 +768,7 @@ require-commit: procedure [
     ; can look at the date of the running Rebol and know that a build that is
     ; older than that won't work.
     ;
-    if all [
-        date: select c 'date
-        rebol/build < date
-    ][
+    if did date: select c 'date and (rebol/build < date) [
         fail [
             "This script needs a build newer or equal to" date
             "so run `upgrade`"
@@ -784,16 +778,13 @@ require-commit: procedure [
     ; If there's a specific ID then assume that if the current build does not
     ; have that ID then there *could* be a problem.
     ;
-    if all [
-        id: select c 'id
-        id <> commit
-    ][
+    if did id: select c 'id and (id <> commit) [
         print [
-            "This script has only been tested again commit" id
-                |
+            "This script has only been tested again commit" id LF
+
             "If it doesn't run as expected"
-            "you can try seeing if this commit is still available"
-                |
+            "you can try seeing if this commit is still available" LF
+
             "by using the `do <dl-renc>` tool and look for"
             unspaced [
                 "r3-" copy/part id 7 "*"

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -1076,7 +1076,7 @@ pe-format: context [
         ]
         insert pos section-data
 
-        return ((head of exe-data) elide reset)
+        return (head of exe-data | elide reset)
     ]
 
     remove-section: function [
@@ -1133,7 +1133,7 @@ pe-format: context [
 
         remove/part skip exe-data target-sec/physical-offset target-sec/physical-size
 
-        return ((head of exe-data) elide reset)
+        return (head of exe-data | elide reset)
     ]
 
     update-embedding: specialize 'update-section [section-name: encap-section-name]
@@ -1144,7 +1144,7 @@ pe-format: context [
         ;print ["Geting embedded from" mold file]
         exe-data: read file
 
-        return ((find-section/data exe-data encap-section-name) elide reset)
+        return (find-section/data exe-data encap-section-name | elide reset)
     ]
 ]
 

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -210,17 +210,17 @@ start-console: procedure [
             new-skin: do load skin-file
 
             ;; if loaded skin returns console! object then use as prototype
-            if all [
+            all [
                 object? new-skin
-                select new-skin 'repl ;; quacks like REPL, say it's a console!
-            ][
+                did select new-skin 'repl ;; quacks like REPL, it's a console!
+            ] then [
                 proto-skin: new-skin
                 proto-skin/was-updated: true
-                proto-skin/name: any [proto-skin/name "updated"]
+                proto-skin/name: default ["updated"]
             ]
 
             proto-skin/is-loaded: true
-            proto-skin/name: any [proto-skin/name "loaded"]
+            proto-skin/name: default ["loaded"]
             append o/loaded skin-file
 
         ] func [error] [
@@ -229,7 +229,7 @@ start-console: procedure [
         ]
     ]
 
-    proto-skin/name: any [proto-skin/name | "default"]
+    proto-skin/name: default ["default"]
 
     system/console: proto-skin
 
@@ -265,8 +265,8 @@ start-console: procedure [
     loud-print [newline {Console skinning:} newline]
     if skin-error [
         loud-print [
-            {  Error loading console skin  -} skin-file | |
-            skin-error | |
+            {  Error loading console skin  -} skin-file LF LF
+            skin-error LF LF
             {  Fix error and restart CONSOLE}
         ]
     ] else [

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -243,6 +243,7 @@
         f 1
     ]
 )
+
 ; "error out" leaves a "running" function in a "clean" state
 (
     f: func [x] [
@@ -253,22 +254,45 @@
     ]
     f 1
 )
+
 ; Argument passing of "get arguments" ("get-args")
-(gf: func [:x] [:x] 10 == gf 10)
-(gf: func [:x] [:x] 'a == gf a)
-(gf: func [:x] [:x] (quote 'a) == gf 'a)
-(gf: func [:x] [:x] (quote :a) == gf :a)
-(gf: func [:x] [:x] (quote a:) == gf a:)
-(gf: func [:x] [:x] (quote (10 + 20)) == gf (10 + 20))
-(gf: func [:x] [:x] o: context [f: 10] (quote :o/f) == gf :o/f)
+[
+    (
+        getf: func [:x] [:x]
+        true
+    )
+
+    (10 == getf 10)
+    ('a == getf a)
+    (quote 'a == getf 'a)
+    (quote :a == getf :a)
+    (quote a: == getf a:)
+    (quote (10 + 20) == getf (10 + 20))
+    (
+        o: context [f: 10]
+        quote :o/f == getf :o/f
+    )
+]
+
 ; Argument passing of "literal arguments" ("lit-args")
-(lf: func ['x] [:x] 10 == lf 10)
-(lf: func ['x] [:x] 'a == lf a)
-(lf: func ['x] [:x] (quote 'a) == lf 'a)
-(lf: func ['x] [:x] a: 10 10 == lf :a)
-(lf: func ['x] [:x] (quote a:) == lf a:)
-(lf: func ['x] [:x] 30 == lf (10 + 20))
-(lf: func ['x] [:x] o: context [f: 10] 10 == lf :o/f)
+[
+    (
+        litf: func ['x] [:x]
+        true
+    )
+
+    (10 == litf 10)
+    ('a == litf a)
+    (quote 'a == litf 'a)
+    (a: 10 | 10 == litf :a)
+    (quote a: == litf a:)
+    (30 == litf (10 + 20))
+    (
+        o: context [f: 10]
+        10 == litf :o/f
+    )
+]
+
 ; basic test for recursive action! invocation
 (
     i: 0

--- a/tests/functions/invisible.test.reb
+++ b/tests/functions/invisible.test.reb
@@ -122,3 +122,131 @@
 (
     [3 11] = reduce [1 + 2 elide 3 + 4 5 + 6]
 )
+
+
+; BAR! is invisible, and acts as an expression barrier
+
+(
+    3 = (1 + 2 |)
+)(
+    3 = (1 + 2 | comment "invisible")
+)
+
+; Non-variadic
+[
+    (
+        left-normal: enfix right-normal:
+            <- func [return: [<opt> bar!] x [bar!]] [:x]
+        left-normal*: enfix right-normal*:
+            <- func [return: [<opt> bar!] x [bar! <end>]] [:x]
+
+        left-tight: enfix right-tight:
+            <- func [return: [<opt> bar!] #x [bar!]] [:x]
+        left-tight*: enfix right-tight*:
+            <- func [return: [<opt> bar!] #x [bar! <end>]] [:x]
+
+        left-soft: enfix right-soft:
+            <- func [return: [<opt> bar!] 'x [bar!]] [:x]
+        left-soft*: enfix right-soft*:
+            <- func [return: [<opt> bar!] 'x [bar! <end>]] [:x]
+
+        left-hard: enfix right-hard:
+            <- func [return: [<opt> bar!] :x [bar!]] [:x]
+        left-hard*: enfix right-hard*:
+            <- func [return: [<opt> bar!] :x [bar! <end>]] [:x]
+
+        true
+    )
+
+    ('no-arg = (trap [right-normal |])/id)
+    (void? do [right-normal* |])
+    (void? do [right-normal*])
+
+    ('no-arg = (trap [| left-normal])/id)
+    (void? do [| left-normal*])
+    (void? do [left-normal*])
+
+    ('no-arg = (trap [right-tight |])/id)
+    (void? do [right-tight* |])
+    (void? do [right-tight*])
+
+    ('no-arg = (trap [| left-tight])/id)
+    (void? do [| left-tight*])
+    (void? do [left-tight*])
+
+    ('no-arg = (trap [right-soft |])/id)
+    (void? do [right-soft* |])
+    (void? do [right-soft*])
+
+    ('no-arg = (trap [| left-soft])/id)
+    (void? do [| left-soft*])
+    (void? do [left-soft*])
+
+    ('| = do [right-hard |])
+    ('| = do [right-hard* |])
+    (void? do [right-hard*])
+
+    ('| = do [| left-hard])
+    ('| = do [| left-hard*])
+    (void? do [left-hard*])
+]
+
+
+; Variadic
+[
+    (
+        left-normal: enfix right-normal:
+            <- func [return: [<opt> bar!] x [bar! <...>]] [take x]
+        left-normal*: enfix right-normal*:
+            <- func [return: [<opt> bar!] x [bar! <...> <end>]] [take* x]
+
+        left-tight: enfix right-tight:
+            <- func [return: [<opt> bar!] #x [bar! <...>]] [take x]
+        left-tight*: enfix right-tight*:
+            <- func [return: [<opt> bar!] #x [bar! <...> <end>]] [take* x]
+
+        left-soft: enfix right-soft:
+            <- func [return: [<opt> bar!] 'x [bar! <...>]] [take x]
+        left-soft*: enfix right-soft*:
+            <- func [return: [<opt> bar!] 'x [bar! <...> <end>]] [take* x]
+
+        left-hard: enfix right-hard:
+            <- func [return: [<opt> bar!] :x [bar! <...>]] [take x]
+        left-hard*: enfix right-hard*:
+            <- func [return: [<opt> bar!] :x [bar! <...> <end>]] [take* x]
+
+        true
+    )
+
+    (error? trap [right-normal |])
+    (void? do [right-normal* |])
+    (void? do [right-normal*])
+
+    (error? trap [| left-normal])
+    (void? do [| left-normal*])
+    (void? do [left-normal*])
+
+    (error? trap [right-tight |])
+    (void? do [right-tight* |])
+    (void? do [right-tight*])
+
+    (error? trap [| left-tight])
+    (void? do [| left-tight*])
+    (void? do [left-tight*])
+
+    (error? trap [right-soft |])
+    (void? do [right-soft* |])
+    (void? do [right-soft*])
+
+    (error? trap [| left-soft])
+    (void? do [| left-soft*])
+    (void? do [left-soft*])
+
+    ('| = do [right-hard |])
+    ('| = do [right-hard* |])
+    (void? do [right-hard*])
+
+    ('| = do [| left-hard])
+    ('| = do [| left-hard*])
+    (void? do [left-hard*])
+]

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -217,31 +217,21 @@ make object! compose [
             ]
         ] also [
             summary: spaced [
-                    |
-                "system/version:" system/version
-                    |
-                "code-checksum:" code-checksum
-                    |
-                "test-checksum:" test-checksum
-                    |
+                "system/version:" system/version LF
+                "code-checksum:" code-checksum LF
+                "test-checksum:" test-checksum LF
                 "Total:" (
                     successes
                     + test-failures
                     + crashes
                     + dialect-failures
                     + skipped
-                )
-                    |
-                "Succeeded:" successes
-                    |
-                "Test-failures:" test-failures
-                    |
-                "Crashes:" crashes
-                    |
-                "Dialect-failures:" dialect-failures
-                    |
-                "Skipped:" skipped
-                    |
+                ) LF
+                "Succeeded:" successes LF
+                "Test-failures:" test-failures LF
+                "Crashes:" crashes LF
+                "Dialect-failures:" dialect-failures LF
+                "Skipped:" skipped LF
             ]
 
             log [summary]


### PR DESCRIPTION
When BAR! was first introduced, there was not a concept of "invisible"
evaluation.  So it had to produce some evaluative product.  It made
void, which also happened to be neutral in R3-Alpha's ANY and ALL,
so that this definition could work there too:

    |: does []
    all [foo | bar]

With the introduction of invisibles, the idea that a BAR! could block
evaluation visibility without interfering with the result stream at
all becomes appealing.  This allows, for instance:

    return (1 + 2 | elide "hi") ;-- returns 3

That's not what happens with a voiding |.

Changing | to act as an invisible-class element, while still acting
as a barrier, is a bit more involved than one might think due to the
interaction with variadics.  Semantics of variadics continue to get
nailed down as questions arise in their design, but if they are not
hard quoting they are supposed to stop at expression barriers.  This
does some basic implementing and testing of that.

One consequence of this is that it eliminates a previous feature--which
was already in the "questionable ideas" bin--of letting BAR! serve
as a line feed in UNSPACED and PRINT.