### PR TITLE
Retake UNLESS with left-hand-side defaulting operator

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -56,7 +56,7 @@ for-each [name value] options [
                     exists? ext-file: to file! tools-dir/(value)
                 ][
                     user-ext: make object! load ext-file
-                    unless all [
+                    if not all [
                         find words-of user-ext 'extensions
                         block? user-ext/extensions
                     ][
@@ -65,7 +65,7 @@ for-each [name value] options [
                     user-config/extensions: user-ext/extensions
                 ][
                     user-ext: load value
-                    unless block? user-ext [
+                    if not block? user-ext [
                         fail [
                             "Selected extensions must be a block, not"
                             (type-of user-ext)
@@ -232,7 +232,7 @@ parse-ext-build-spec: function [
     spec [block!]
 ][
     ext-body: copy []
-    unless parse spec [
+    if not parse spec [
         any [
             quote options: into [
                 any [
@@ -464,7 +464,7 @@ set-exec-path: proc [
     path
 ][
     if path [
-        unless file? path [
+        if not file? path [
             fail "Tool path has to be a file!"
         ]
         tool/exec-file: path
@@ -498,7 +498,9 @@ parse user-config/toolset [
                 set-exec-path rebmake/default-strip strip-exec
             ]
         )
-        | pos: (unless tail? pos [fail ["failed to parset toolset at:" mold pos]])
+        | pos: (
+            if not tail? pos [fail ["failed to parset toolset at:" mold pos]]
+        )
     ]
 ]
 
@@ -517,7 +519,7 @@ switch/default rebmake/default-compiler/name [
         ]
     ]
     clang [
-        unless find [ld llvm-link] rebmake/default-linker/name [
+        if not find [ld llvm-link] rebmake/default-linker/name [
             fail ["Incompatible compiler (CLANG) and linker: " rebmake/default-linker/name]
         ]
     ]
@@ -1172,7 +1174,7 @@ for-each [action name modules] user-config/extensions [
                     ]
                 ]
             ]
-            unless item [
+            if not item [
                 fail [{Unrecognized extension name:} name]
             ]
 
@@ -1306,7 +1308,8 @@ process-module: func [
                 ]
             ]
         ]
-        libraries: to-value if mod/libraries [
+        libraries: all [
+            mod/libraries
             map-each lib mod/libraries [
                 case [
                     file? lib [
@@ -1323,7 +1326,10 @@ process-module: func [
                         lib
                     ]
                     true [
-                        dump lib
+                        dump [
+                            "unrecognized module library" lib
+                            "in module" mod
+                        ]
                         fail "unrecognized module library"
                     ]
                 ]
@@ -1543,7 +1549,7 @@ add-new-obj-folders: procedure [
 
         for-each obj lib [
             dir: first split-path obj/output
-            unless find folders dir [
+            if not find folders dir [
                 append folders dir
             ]
         ]

--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -183,7 +183,7 @@ make-emitter: function [
 
 
         emit-line: proc [data /indent] [
-            unless any [tail? buf-emit | newline = last buf-emit] [
+            if not any [tail? buf-emit | newline = last buf-emit] [
                 probe skip (tail-of buf-emit) -100
                 fail "EMIT-LINE should always start a new line"
             ]

--- a/make/tools/common.r
+++ b/make/tools/common.r
@@ -144,12 +144,12 @@ to-c-name: function [
             break
         ]
 
-        unless find c-chars char [
+        if not find c-chars char [
             fail ["Non-alphanumeric or hyphen in" string "in to-c-name"]
         ]
     ]
 
-    unless scope [word: 'global] ; default to assuming global need
+    if not scope [word: 'global] ; default to assuming global need
 
     ; Easiest rule is just "never start a global identifier with underscore",
     ; but we check the C rules.  Since currently this routine is sometimes
@@ -235,12 +235,12 @@ for-each-record: procedure [
     body [block!]
         {Block to evaluate each time}
 ][
-    unless block? first table [
+    if not block? first table [
         fail {Table of records does not start with a header block}
     ]
 
     headings: map-each word first table [
-        unless word? word [
+        if not word? word [
             fail [{Heading} word {is not a word}]
         ]
         to-set-word word
@@ -294,13 +294,13 @@ find-record-unique: function [
     value
         {Value that the looked up key must be uniquely equal to}
 ][
-    unless find first table key [
+    if not find first table key [
         fail [key {not found in table headers:} (first table)]
     ]
 
     result: _
     for-each-record rec table [
-        unless value = select rec key [continue]
+        if value <> select rec key [continue]
 
         if result [
             fail [{More than one table record matches} key {=} value]
@@ -322,7 +322,7 @@ parse-args: function [
     ret: make block! 4
     standalone: make block! 4
     args: any [args copy []]
-    unless block? args [args: split args [some " "]]
+    if not block? args [args: split args [some " "]]
     forall args [
         name: _
         value: args/1
@@ -409,11 +409,11 @@ write-if-changed: procedure [
         content: spaced content
     ]
 
-    unless binary? content [
+    if not binary? content [
         content: to binary! content
     ]
 
-    unless all [
+    if not all [
         exists? dest
         content = read dest
     ][

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -102,7 +102,7 @@ sections: [
 ; be able to bootstrap under the conditions of the A111 rebol.com R3-Alpha
 ; as well as function either from the command line or the REPL.
 ;
-unless args: any [
+if not args: any [
     either string? :system/script/args [
         either block? load system/script/args [
             load system/script/args
@@ -638,7 +638,7 @@ boot-errors: load %errors.r
 id-list: make block! 200
 
 for-each [category info] boot-errors [
-    unless all [
+    if not all [
         (quote code:) == info/1
         integer? info/2
         (quote type:) == info/3
@@ -651,7 +651,7 @@ for-each [category info] boot-errors [
 
     new-section: true
     for-each [key val] skip info 4 [
-        unless set-word? key [
+        if not set-word? key [
             fail ["Non SET-WORD! key in %errors.r:" key]
         ]
 

--- a/make/tools/make-embedded-header.r
+++ b/make/tools/make-embedded-header.r
@@ -34,7 +34,7 @@ remove-macro: proc [
     macro [any-string!]
     <local> pos-m inc eol
 ][
-    unless binary? macro [macro: to binary! macro]
+    if not binary? macro [macro: to binary! macro]
     pos-m: find inp macro
     if pos-m [
         inc: find/reverse pos-m to binary! "#define"

--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -127,7 +127,7 @@ native-list-rule: [
                 'native/body/export 2 block!
             ]
         ](
-            unless blank? n-name [
+            if not blank? n-name [
                 ;dump n-name
                 append native-specs make native-spec compose/only [
                     name: (to lit-word! n-name)
@@ -160,14 +160,14 @@ native-list-rule: [
     ]
 ]
 
-unless parse native-list native-list-rule [
+if not parse native-list native-list-rule [
     fail [
         "failed to parse" mold native-list ":"
         "current word-list:" mold word-list
     ]
 ]
 
-unless blank? n-name [
+if not blank? n-name [
     ;dump n-name
     append native-specs make native-spec compose/only [
         name: (to lit-word! n-name)
@@ -185,7 +185,7 @@ error-list: copy []
 num-native: 0
 for-each native native-specs [
     ;dump native
-    unless blank? native/platforms [
+    if not blank? native/platforms [
         supported?: false
         for-each plat native/platforms [
             case [
@@ -206,7 +206,7 @@ for-each native native-specs [
                 ]
             ]
         ]
-        unless supported? [continue]
+        if not supported? [continue]
     ]
 
     num-native: num-native + 1
@@ -214,8 +214,8 @@ for-each native native-specs [
     if find to block! first native/spec 'export [
         append export-list to word! native/name
     ]
-    unless blank? native/errors [append error-list native/errors]
-    unless blank? native/words [append word-list native/words]
+    if not blank? native/errors [append error-list native/errors]
+    if not blank? native/words [append word-list native/words]
     append native-list reduce [to set-word! native/name]
     append native-list native/spec
 ]
@@ -228,12 +228,12 @@ spec: compose/deep/only [
         exports: (export-list)
     ]
 ]
-unless empty? word-list [
+if not empty? word-list [
     append spec compose/only [
         words: (word-list)
     ]
 ]
-unless empty? error-list [
+if not empty? error-list [
     append spec compose/only [
         errors: (error-list)
     ]
@@ -396,7 +396,7 @@ if not empty? error-list [
     e1/emit ["enum Ext_${Mod}_Errors {"]
     error-collected: copy []
     for-each [key val] error-list [
-        unless set-word? key [
+        if not set-word? key [
             fail ["key (" mold key ") must be a set-word!"]
         ]
         if find error-collected key [

--- a/make/tools/make-os-ext.r
+++ b/make/tools/make-os-ext.r
@@ -36,7 +36,7 @@ mkdir/deep output-dir/include
 file-base: has load %../../make/tools/file-base.r
 
 ; Collect OS-specific host files:
-unless (
+if not (
     os-specific-objs: select file-base to word! unspaced ["os-" config/os-base]
 )[
     fail [

--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -76,7 +76,7 @@ emit-proto: proc [proto] [
     ; use Rebol syntax...the new idea is to always use Rebol syntax.)
 
     api-name: spelling-of header/1
-    unless proto-parser/proto.id = unspaced ["RL_" api-name] [
+    if not proto-parser/proto.id = unspaced ["RL_" api-name] [
         fail [
             "Name in comment header (" api-name ") isn't function name"
             "minus RL_ prefix for" proto-parser/proto.id

--- a/make/tools/make-zlib.r
+++ b/make/tools/make-zlib.r
@@ -100,7 +100,7 @@ disable-user-includes: procedure [
 
     if inline [
         ; If we inline a header, it should happen once and only once for each
-        unless empty? headers [
+        if not empty? headers [
             fail [{Not all headers inlined by make-zlib:} (mold headers)]
         ]
     ]

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -280,7 +280,7 @@ set?: func [
     "Returns whether a bound word has a value (fails if unbound)"
     any-word [any-word!]
 ][
-    unless bound? any-word [
+    if not bound? any-word [
         fail [any-word "is not bound in set?"]
     ]
     value? any-word ;-- the "old" meaning of value...
@@ -452,7 +452,7 @@ fail: func [
         string? reason [do make error! reason]
         block? reason [
             for-each item reason [
-                unless any [
+                if not any [
                     any-scalar? :item
                     string? :item
                     group? :item
@@ -744,7 +744,7 @@ make-action: func [
                     "Default value not paired with argument:" (mold other/1)
                 ]
             ]
-            unless defaulters [
+            if not defaulters [
                 defaulters: copy []
             ]
             append defaulters compose/deep [
@@ -760,7 +760,7 @@ make-action: func [
             append locals var
             append exclusions var
             if other [
-                unless defaulters [
+                if not defaulters [
                     defaulters: copy []
                 ]
                 append defaulters compose/deep [
@@ -771,7 +771,7 @@ make-action: func [
         (unset 'var) ;-- don't consider further GROUP!s or variables
     |
         <in> (
-            unless new-body [
+            if not new-body [
                 append exclusions 'self
                 new-body: copy/deep body
             ]
@@ -793,10 +793,10 @@ make-action: func [
         ]
     |
         <static> (
-            unless statics [
+            if not statics [
                 statics: copy []
             ]
-            unless new-body [
+            if not new-body [
                 append exclusions 'self
                 new-body: copy/deep body
             ]

--- a/make/tools/read-deep.reb
+++ b/make/tools/read-deep.reb
@@ -58,7 +58,7 @@ read-deep: function [
         append result :path ; Possible void.
     ]
 
-    unless full [
+    if not full [
         remove result ; No need for root in result.
         len: length of root
         for i 1 length of result 1 [

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -47,7 +47,7 @@ map-files-to-local: func [
     <local>
     f
 ][
-    unless block? files [files: reduce [files]]
+    if not block? files [files: reduce [files]]
     map-each f files [
         file-to-local f
     ]
@@ -73,7 +73,7 @@ filter-flag: function [
 ][
     if not tag? flag [return flag] ;-- no filtering
 
-    unless parse to string! flag [
+    if not parse to string! flag [
         copy header: to ":"
         ":" copy option: to end
     ][
@@ -1229,12 +1229,12 @@ generator-class: make object! [
             ]
             cmd: gen-cmd cmd
         ]
-        unless cmd [return _]
+        if not cmd [return _]
 
         stop: false
         while [not stop][
             stop: true
-            unless parse cmd [
+            if not parse cmd [
                 while [
                     change [
                         [
@@ -1298,7 +1298,7 @@ generator-class: make object! [
     setup-output: procedure [
         project [object!]
     ][
-        unless suffix: find reduce [
+        if not suffix: find reduce [
             'application-class target-platform/exe-suffix
             'dynamic-library-class target-platform/dll-suffix
             'static-library-class target-platform/archive-suffix
@@ -1458,7 +1458,7 @@ makefile: make generator-class [
                                     ][
                                         gen-cmd cmd
                                     ]
-                                ]) [unless empty? cmd [cmd]] "^/^-"
+                                ]) [if not empty? cmd [cmd]] "^/^-"
                             ][
                                 either string? entry/commands [
                                     entry/commands
@@ -1493,9 +1493,9 @@ makefile: make generator-class [
         ;project/generated?: true
 
         for-each dep project/depends [
-            unless object? dep [continue]
+            if not object? dep [continue]
             ;dump dep
-            unless find [ext-dynamic-class ext-static-class] dep/class-name [
+            if not find [ext-dynamic-class ext-static-class] dep/class-name [
                 either dep/generated? [
                     continue
                 ][
@@ -1517,7 +1517,9 @@ makefile: make generator-class [
                     ]
                     append buf gen-rule make entry-class [
                         target: dep/output
-                        depends: join-of objs map-each ddep dep/depends [unless ddep/class-name = 'object-library-class [ddep]]
+                        depends: join-of objs map-each ddep dep/depends [
+                            if ddep/class-name <> 'object-library-class [ddep]
+                        ]
                         commands: append reduce [dep/command] opt dep/post-build-commands
                     ]
                     emit buf dep
@@ -1526,7 +1528,7 @@ makefile: make generator-class [
                     ;assert [dep/class-name != 'object-library-class] ;No nested object-library-class allowed
                     for-each obj dep/depends [
                         assert [obj/class-name = 'object-file-class]
-                        unless obj/generated? [
+                        if not obj/generated? [
                             obj/generated?: true
                             append buf gen-rule obj/gen-entries/(all [project/class-name = 'dynamic-library-class 'PIC]) dep
                         ]
@@ -1643,11 +1645,11 @@ Execution: make generator-class [
         suffix
     ][
         ;dump project
-        unless object? project [leave]
+        if not object? project [leave]
 
         prepare project
 
-        unless find [ext-dynamic-class ext-static-class] project/class-name [
+        if not find [ext-dynamic-class ext-static-class] project/class-name [
             either project/generated? [
                 leave
             ][
@@ -1679,7 +1681,7 @@ Execution: make generator-class [
             object-library-class [
                 for-each obj project/depends [
                     assert [obj/class-name = 'object-file-class]
-                    unless obj/generated? [
+                    if not obj/generated? [
                         obj/generated?: true
                         run-target obj/gen-entries/(all [p-project/class-name = 'dynamic-library-class 'PIC]) project
                     ]
@@ -1797,10 +1799,10 @@ visual-studio: make generator-class [
             ]
         ]
 
-        unless empty? depends [
+        if not empty? depends [
             append buf {^-ProjectSection(ProjectDependencies) = postProject^/}
             for-each dep depends [
-                unless dep/id [dep/id: take uuid-pool]
+                if not dep/id [dep/id: take uuid-pool]
                 append buf unspaced [
                     tab tab dep/id " = " dep/id newline
                 ]
@@ -1935,7 +1937,7 @@ visual-studio: make generator-class [
         project-dir: unspaced [project-name ".dir\" build-type "\"]
 
         searches: make string! 1024
-        unless project/class-name = 'entry-class [
+        if project/class-name <> 'entry-class [
             inc: make string! 1024
             for-each i project/includes [
                 if i: filter-flag i "msc" [
@@ -1960,7 +1962,7 @@ visual-studio: make generator-class [
                         if ext: filter-flag i/output "msc" [
                             append lib unspaced [
                                 ext
-                                unless ends-with? ext ".lib" [".lib"]
+                                if not ends-with? ext ".lib" [".lib"]
                                 ";"
                             ]
                         ]
@@ -2048,12 +2050,12 @@ visual-studio: make generator-class [
     </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>}
-    unless project/class-name = 'entry-class [
+    if project/class-name <> 'entry-class [
         unspaced [ {
       <AdditionalIncludeDirectories>} inc {</AdditionalIncludeDirectories>
       <AssemblerListingLocation>} build-type {/</AssemblerListingLocation>}
       ;RuntimeCheck is not compatible with optimization
-      unless find-optimization? project/optimization [ {
+      if not find-optimization? project/optimization [ {
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>}
       ]
       if compile-as [
@@ -2162,7 +2164,7 @@ visual-studio: make generator-class [
                                 append o-inc unspaced [file-to-local i ";"]
                             ]
                         ]
-                        unless empty? o-inc [
+                        if not empty? o-inc [
                             unspaced [
                                 {        <AdditionalIncludeDirectories>} o-inc "%(AdditionalIncludeDirectories)"
                                 {</AdditionalIncludeDirectories>^/}
@@ -2176,7 +2178,7 @@ visual-studio: make generator-class [
                                 append o-def unspaced [file-to-local i ";"]
                             ]
                         ]
-                        unless empty? o-def [
+                        if not empty? o-def [
                             unspaced [
                                 {        <PreprocessorDefinitions>}
                                 o-def "%(PreprocessorDefinitions)"
@@ -2196,7 +2198,7 @@ visual-studio: make generator-class [
                         collected: map-each i o/cflags [
                             opt filter-flag i "msc"
                         ]
-                        unless empty? collected [
+                        if not empty? collected [
                             unspaced [
                                 {        <AdditionalOptions>}
                                 spaced compose [
@@ -2226,14 +2228,14 @@ visual-studio: make generator-class [
     refs: make string! 1024
     for-each o project/depends [
         if find words-of o 'id [
-            unless o/id [o/id: take uuid-pool]
+            if not o/id [o/id: take uuid-pool]
             append refs unspaced [ {    <ProjectReference Include="} o/name {.vcxproj" >
       <Project>} o/id {</Project>
     </ProjectReference>^/}
             ]
         ]
     ]
-    unless empty? refs [
+    if not empty? refs [
         unspaced [ {
   <ItemGroup>
 } refs

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -521,7 +521,7 @@ use [
                     unknown_flags: copy any [build-flags: get in s word []]
                 )
                 words-of context
-            unless empty? unknown-flags [
+            if not empty? unknown-flags [
                 print mold unknown-flags
                 fail ["Unknown" word "used in %systems.r specification"]
             ]
@@ -563,7 +563,7 @@ config-system: function [
         ]
     ]
 
-    unless tuple? version [
+    if not tuple? version [
         fail [
             "Expected OS_ID tuple like 0.3.1, not:" version
         ]

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -7,7 +7,7 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // Copyright 2012 REBOL Technologies
-// Copyright 2012-2017 Rebol Open Source Contributors
+// Copyright 2012-2018 Rebol Open Source Contributors
 // REBOL is a trademark of REBOL Technologies
 //
 // See README.md and CREDITS.md for more information

--- a/src/core/t-event.c
+++ b/src/core/t-event.c
@@ -205,6 +205,9 @@ void Set_Event_Vars(REBVAL *evt, RELVAL *blk, REBSPC *specifier)
         Derelativize(var, blk, specifier);
         ++blk;
 
+        if (not IS_SET_WORD(var))
+            fail (Error_Invalid(var));
+
         if (IS_END(blk))
             Init_Blank(val);
         else

--- a/src/extensions/ffi/make-spec.r
+++ b/src/extensions/ffi/make-spec.r
@@ -65,7 +65,7 @@ options: [
                             any [user-config/pkg-config {pkg-config}]
                             var
                             %libffi
-                        unless empty? x [
+                        if not empty? x [
                             set (in cfg-ffi var) x
                         ]
                     ]

--- a/src/extensions/locale/ext-locale-init.reb
+++ b/src/extensions/locale/ext-locale-init.reb
@@ -6,7 +6,7 @@ REBOL [
     license: {Apache 2.0}
 ]
 
-unless 'Windows = first system/platform [
+if 'Windows <> first system/platform [
     ; Windows has locale implemented as a native
 
     ;DO NOT EDIT this table
@@ -458,19 +458,16 @@ unless 'Windows = first system/platform [
         iso-639 (iso-639-table)
         iso-3166 (iso-3166-table)
     ][
-        env-lang: get-env "LANG"
-        unless env-lang [
-            return _
-        ]
+        env-lang: get-env "LANG" or [return _]
         territory: _
 
         letter: charset [#"a" - #"z" #"A" - #"Z"]
-        unless parse env-lang [
+        parse env-lang [
             copy lang: [some letter]
             opt [#"_" copy territory: [some letter]]
             to end
-        ][
-            print ["Malformated env LANG:" env-lang]
+        ] or [
+            print ["Malformatted LANG environment variable:" env-lang]
             return _
         ]
 

--- a/src/extensions/locale/iso3166.r
+++ b/src/extensions/locale/iso3166.r
@@ -51,14 +51,14 @@ parse cnt [
 init-code: to string! read init
 space: charset " ^-^M^/"
 iso-3166-table-cnt: find mold iso-3166-table #"["
-unless parse init-code [
+parse init-code [
     thru "iso-3166-table:"
     to #"["
     change [
          #"[" thru #"]"
     ] iso-3166-table-cnt
     to end
-][
+] or [
     fail "Failed to update iso-3166-table"
 ]
 

--- a/src/extensions/locale/iso639.r
+++ b/src/extensions/locale/iso639.r
@@ -56,14 +56,14 @@ parse cnt [
 init-code: to string! read init
 space: charset " ^-^M^/"
 iso-639-table-cnt: find mold iso-639-table #"["
-unless parse init-code [
+parse init-code [
     thru "iso-639-table:"
     to #"["
     change [
          #"[" thru #"]"
     ] iso-639-table-cnt
     to end
-][
+] or [
     fail "Failed to update iso-639-table"
 ]
 

--- a/src/extensions/odbc/make-spec.r
+++ b/src/extensions/odbc/make-spec.r
@@ -35,7 +35,7 @@ modules: [
             ]
         ][
             ; On some systems (32-bit Ubuntu 12.04), odbc requires ltdl
-            append-of [%odbc] unless find [no false off _ #[false]] user-config/odbc-requires-ltdl [%ltdl]
+            append-of [%odbc] if not find [no false off _ #[false]] user-config/odbc-requires-ltdl [%ltdl]
         ]
     ]
 ]

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -109,12 +109,6 @@ uneval: func [
 ]
 
 
-; Some find UNLESS confusing, so IF-NOT is a synonym.  NOT binds with the IF.
-; So `if-not x and (y)` => `if not (x and (y))` vs `if (not x) and (y)`
-;
-if-not: :unless
-
-
 ; Despite being very "noun-like", HEAD and TAIL have classically been "verbs"
 ; in Rebol.  Ren-C builds on the concept of REFLECT, so that REFLECT STR 'HEAD
 ; will get the head of a string.  An enfix left-soft-quoting operation is

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -169,25 +169,23 @@ for-each [comparison-op function-name] [
 ; hence these are not meant as a generic substitute for IF and ELSE.
 ;
 ??: enfix func [
-    {If left is conditionally true, return value on the right (as-is)}
+    {If TO-LOGIC of the left is true, return right value, otherwise null}
 
     return: [<opt> any-value!]
-        {Void if the condition is FALSEY?, else value}
-    condition [any-value!]
-    value [any-value!]
+    left [any-value!]
+    right [any-value!]
 ][
-    if/only :condition [:value]
+    if/opt :left [:right]
 ]
 
 !!: enfix func [
-    {If left isn't void, return it, else return value on the right (as-is)}
+    {If left isn't null, return it, else return value on the right}
 
     return: [<opt> any-value!]
-        {Left if it isn't void, else right}
     left [<opt> any-value!]
     right [any-value!]
 ][
-    either-test-value/only :left [:right]
+    either-test-value/opt :left [:right]
 ]
 
 ; !!! By naming this ?! it somewhat suggests `?? () !!`, e.g. a shortening and
@@ -196,14 +194,13 @@ for-each [comparison-op function-name] [
 ; favoring one over the other enough to make it canon.
 ;
 !?: ?!: enfix func [
-    {If left is conditionally false, return value on the right (as-is)}
+    {If TO LOGIC! of the left is false, return right value, otherwise null}
 
     return: [<opt> any-value!]
-        {Void if the condition is FALSEY?, else value}
-    condition [any-value!]
-    value [any-value!]
+    left [any-value!]
+    right [any-value!]
 ][
-    unless/only :condition [:value]
+    if-not/opt :left [:right]
 ]
 
 
@@ -220,19 +217,19 @@ for-each [comparison-op function-name] [
 ; flexible when you wish to run a block of code from a variable.  (It also
 ; looks like less an odd name when paired with ELSE.)
 ;
-; NAY is the somewhat weird name for enfixed UNLESS, until someone thinks of
-; a better name for it.  (ELSE is not an option)
+; NAY is the somewhat weird name for enfixed IF-NOT, until someone thinks of
+; a better name for it.  (ELSE is not an option)  It may be unnecessary.
 
 then: enfix :if
 
-then*: enfix specialize :if [ ;-- THEN/ONLY is a path, can't run infix
-    only: true
+then*: enfix specialize :if [ ;-- THEN/OPT is a path, can't run infix
+    opt: true
 ]
 
-nay: enfix :unless
+nay: enfix :if-not
 
-nay*: enfix specialize :unless [ ;-- UNLESS/ONLY is a path, can't run infix
-    only: true
+nay*: enfix specialize :if-not [ ;-- NAY/OPT is a path, can't run infix
+    opt: true
 ]
 
 
@@ -241,35 +238,31 @@ nay*: enfix specialize :unless [ ;-- UNLESS/ONLY is a path, can't run infix
 ; advantage of the pattern of conditionals such as `if condition [...]` to
 ; only return null if the branch does not run, and never return null if it
 ; does run (null branch evaluations are forced to a BLANK!)
-;
-; These could be implemented as specializations of the generic EITHER-TEST
-; native.  But due to their common use they are optimized into their own
-; natives: EITHER-TEST-NULL and EITHER-TEST-VALUE.
 
 also: enfix redescribe [
     "Evaluate the branch if the left hand side expression is not null"
 ](
     comment [specialize 'either-test [test: :null?]]
-    :either-test-null
+    :either-test-null ;-- So common as to warrant hand-specialized native
 )
 
 also*: enfix redescribe [
-    "Would be the same as ALSO/ONLY, if infix functions dispatched from paths"
+    "Would be the same as ALSO/OPT, if infix functions dispatched from paths"
 ](
-    specialize 'also [only: true]
+    specialize 'also [opt: true]
 )
 
 else: enfix redescribe [
     "Evaluate the branch if the left hand side expression is void"
 ](
     comment [specialize 'either-test [test: :value?]]
-    :either-test-value
+    :either-test-value ;-- So common as to warrant hand-specialized native
 )
 
 else*: enfix redescribe [
-    "Would be the same as ELSE/ONLY, if infix functions dispatched from paths"
+    "Would be the same as ELSE/OPT, if infix functions dispatched from paths"
 ](
-    specialize 'else [only: true]
+    specialize 'else [opt: true]
 )
 
 

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -19,7 +19,7 @@ launch: func [
 ][
     if file? script [script: file-to-local clean-path script]
     args: reduce [file-to-local system/options/boot script]
-    unless unset? 'arg [append args arg]
+    if set? 'arg [append args arg]
     either wait [call/wait args] [call args]
 ]
 

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -113,7 +113,7 @@ speed?: function [
             ]
             calc: [(length of tmp) * 40 / secs / 1024 / 1024]
         ][
-            unless no-io [
+            if not no-io [
                 write file: %tmp-junk.txt "" ; force security request before timer
                 tmp: make string! 32000 * 5
                 insert/dup tmp "test^/" 32000

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -475,7 +475,7 @@ help: procedure [
         value: get :topic
     ]
 
-    unless action? :value [
+    if not action? :value [
         print spaced collect [
             keep [
                 (uppercase mold topic) "is" (type-name :value) "of value:"
@@ -544,7 +544,7 @@ help: procedure [
     adaptee: match action! try select meta 'adaptee
     chainees: match block! try select meta 'chainees
 
-    classification: case [
+    classification: {a function} unless case [
         :specializee [
             either original-name [
                 spaced [{a specialization of} original-name]
@@ -564,8 +564,6 @@ help: procedure [
         :chainees [
             {a chained function}
         ]
-    ] else [
-        {a function}
     ]
 
     print-newline
@@ -611,13 +609,13 @@ help: procedure [
         ]
     ]
 
-    unless empty? args [
+    if not empty? args [
         print-newline
         print "ARGUMENTS:"
         print-args args
     ]
 
-    unless empty? refinements [
+    if not empty? refinements [
         print-newline
         print "REFINEMENTS:"
         print-args/indent-words refinements

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -68,10 +68,10 @@ sign-of: func [
     "Returns sign of number as 1, 0, or -1 (to use as multiplier)."
     number [any-number! money! time!]
 ][
-    case [
+    0 unless case [
         positive? number [1]
         negative? number [-1]
-    ] else [0]
+    ]
 ]
 
 extreme-of: func [
@@ -237,12 +237,14 @@ math: function [
     clear nested-expr-val
     res: either parse expr expression [expr-val] [blank]
 
-    either only [res] [
+    either only [
+        res
+    ][
         ret: reduce res
-        unless all [
+        all [
             1 = length of ret
             any-number? ret/1
-        ][
+        ] or [
             fail [
                 unspaced ["Cannot be REDUCED to a number(" mold ret ")"]
                 ":" mold res

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -108,8 +108,8 @@ save: function [
             append header-data compose [length: (true)]
         ]
 
-        compress: did find (to-value select header-data 'options) 'compress
-        unless compress [
+        compress: did find try (select header-data 'options) 'compress
+        if not compress [
             method: _
         ]
 

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -25,7 +25,7 @@ secure: function [
 
     assert-policy (
         func [tst kind arg] [
-            unless tst [cause-error 'access 'security-error reduce [kind arg]]
+            if not tst [cause-error 'access 'security-error reduce [kind arg]]
         ]
     )
 
@@ -181,7 +181,7 @@ secure: function [
 ]
 
 
-unless system/options/secure == 'allow [
+if system/options/secure <> 'allow [
     ; Remove all other access to the policies:
     protect/hide in system/state 'policies
 ]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -57,7 +57,7 @@ join-all: function [
 ][
     forever [
         if tail? block [return ()]
-        unless null? base: do/next block 'block [break]
+        if not null? base: do/next block 'block [break]
     ]
 
     ; !!! It isn't especially compelling that  `join-of 3 "hello"` gives you
@@ -93,7 +93,7 @@ array: func [
 ][
     if block? size [
         if tail? rest: next size [rest: _]
-        unless integer? size: first size [
+        if not integer? size: first size [
             cause-error 'script 'expect-arg reduce ['array 'size type of :size]
         ]
     ]
@@ -150,23 +150,23 @@ replace: function [
     ; Note that if a FORM actually happens inside of FIND, it could wind up
     ; happening repeatedly in the /ALL case if that happens.
 
-    len: case [
+    len: 1 unless case [
         ; leave bitset patterns as-is regardless of target type, len = 1
         bitset? :pattern [1]
 
         any-string? target [
-            unless string? :pattern [pattern: form :pattern]
+            if not string? :pattern [pattern: form :pattern]
             length of :pattern
         ]
 
         binary? target [
             ; Target is binary, pattern is not, make pattern a binary
-            unless binary? :pattern [pattern: to-binary :pattern]
+            if not binary? :pattern [pattern: to-binary :pattern]
             length of :pattern
         ]
 
         any-block? :pattern [length of :pattern]
-    ] else [1]
+    ]
 
     while [pos: find/(all [case_REPLACE 'case]) target :pattern] [
         ; apply replacement if function, or drops pos if not
@@ -175,7 +175,7 @@ replace: function [
 
         target: change/part pos :value len
 
-        unless all_REPLACE [break]
+        if not all_REPLACE [break]
     ]
 
     either tail_REPLACE [target] [save-target]
@@ -262,7 +262,7 @@ reword: function [
     ;
     any-keyword-rule: collect [
         for-each [keyword value] values [
-            unless match keyword-types keyword [
+            if not match keyword-types keyword [
                 fail ["Invalid keyword type:" keyword]
             ]
 
@@ -372,7 +372,7 @@ reword: function [
         (output: insert output a)
     ]
 
-    unless parse/(all [case_REWORD 'case]) source rule [
+    parse/(all [case_REWORD 'case]) source rule or [
         fail "Unexpected error in REWORD's parse rule, should not happen."
     ]
 
@@ -392,7 +392,7 @@ move: func [
     size [integer!] "Size of each record"
     /to "Move to an index relative to the head of the series" ;; TO redefined
 ][
-    unless limit [limit: 1]
+    limit: default [1]
     if skip [
         if 1 > size [cause-error 'script 'out-of-range size]
         offset: either to [offset - 1 * size + 1] [offset * size]
@@ -427,7 +427,7 @@ extract: func [
     ][
         divide index of series negate width  ; Backward loop, use position
     ]
-    unless index [pos: 1]
+    if not index [pos: 1]
     if block? pos [
         parse pos [some [any-number! | logic!]] or [
             cause-error 'Script 'invalid-arg reduce [pos]
@@ -535,9 +535,9 @@ format: function [
     values
     /pad p
 ][
-    p: default [#" "]
-    unless block? :rules [rules: reduce [:rules]]
-    unless block? :values [values: reduce [:values]]
+    p: default [space]
+    if not block? :rules [rules: reduce [:rules]]
+    if not block? :values [values: reduce [:values]]
 
     ; Compute size of output (for better mem usage):
     val: 0

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -140,7 +140,7 @@ parse-asn: function [
 
             size [
                 size: d and+ 127
-                unless zero? (d and+ 128) [
+                if not zero? (d and+ 128) [
                     ; long form
                     ln: size
                     size: to-integer/unsigned copy/part next data size
@@ -613,7 +613,7 @@ parse-messages: function [
     ]
     debug [ctx/seq-num-r ctx/seq-num-w "READ <--" proto/type]
 
-    unless proto/type = 'handshake [
+    if proto/type <> 'handshake [
         if proto/type = 'alert [
             if proto/messages/1 > 1 [
                 ; fatal alert level
@@ -929,7 +929,7 @@ parse-response: function [
         "messages:" length of proto/messages
     ]
 
-    unless tail? skip msg proto/size + 5 [
+    if not tail? skip msg proto/size + 5 [
         fail "invalid length of response fragment"
     ]
 
@@ -1022,9 +1022,13 @@ do-commands: function [
     ctx/resp: copy []
     write ctx/connection ctx/msg
 
-    unless no-wait [
-        unless port? wait [ctx/connection 30] [fail "port timeout"]
+    any [
+        no-wait
+        port? wait [ctx/connection 30]
+    ] or [
+        fail "port timeout"
     ]
+
     ctx/resp
 ]
 
@@ -1178,8 +1182,8 @@ tls-awake: function [event [event!]] [
                     application [
                         for-each msg proto/messages [
                             if msg/type = 'app-data [
-                                unless tls-port/data [
-                                    tls-port/data: clear tls-port/state/port-data
+                                tls-port/data: default [
+                                    clear tls-port/state/port-data
                                 ]
                                 append tls-port/data msg/content
                                 application?: true
@@ -1257,7 +1261,7 @@ sys/make-scheme [
         open: func [port [port!] <local> conn] [
             if port/state [return port]
 
-            unless port/spec/host [
+            if not port/spec/host [
                 fail make-tls-error "Missing host address"
             ]
 
@@ -1343,7 +1347,7 @@ sys/make-scheme [
         ]
 
         close: func [port [port!] <local> ctx] [
-            unless port/state [return port]
+            if not port/state [return port]
 
             close port/state/connection
 

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -33,7 +33,7 @@ register-codec*: func [
     encode [action! blank!]
     <local> codec
 ][
-    unless block? suffixes [suffixes: reduce [suffixes]]
+    if not block? suffixes [suffixes: reduce [suffixes]]
 
     codec: construct [] compose/only [
         name: quote (name)
@@ -84,11 +84,11 @@ decode: function [
     data [binary!]
         {The data to decode}
 ][
-    unless all [
-        cod: select system/codecs type
+    all [
+        cod: try select system/codecs type
         f: :cod/decode
         (data: f data)
-    ][
+    ] or [
         cause-error 'access 'no-codec type
     ]
     data
@@ -107,11 +107,11 @@ encode: function [
         {Special encoding options}
     opts [block!]
 ][
-    unless all [
-        cod: select system/codecs type
+    all [
+        cod: try select system/codecs type
         f: :cod/encode
         (data: f data)
-    ][
+    ] or [
         cause-error 'access 'no-codec type
     ]
     data

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -245,7 +245,7 @@ start-console: procedure [
     ; the WHY function on the first error delivery.
     ;
     proto-skin/print-error: adapt :proto-skin/print-error [
-        unless system/state/last-error [
+        if not system/state/last-error [
             system/console/print-info "Note: use WHY for error information"
         ]
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -44,7 +44,7 @@ boot-print: procedure [
     eval_BOOT_PRINT: eval
     eval: :lib/eval
 
-    unless system/options/quiet [
+    if not system/options/quiet [
         print/(all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
     ]
 ]
@@ -352,7 +352,7 @@ host-start: function [
         return: [blank! file!]
             {Blank if not found}
     ][
-        unless get-env: attempt [:system/modules/Process/get-env] [
+        get-env: attempt [:system/modules/Process/get-env] or [
             loud-print [
                 "Interpreter not built with GET-ENV, can't detect HOME dir" LF
                 "(Build with Process extension enabled to address this)"
@@ -731,7 +731,7 @@ comment [
         ]
     ]
 
-    unless blank? boot-embedded [
+    if not blank? boot-embedded [
         case [
             binary? boot-embedded [ ; single script
                 code: load/header/type boot-embedded 'unbound
@@ -747,7 +747,7 @@ comment [
                 o/encap: boot-embedded
 
                 main: select boot-embedded %main.reb
-                unless binary? main [
+                if not binary? main [
                     die "Could not find %main.reb in encapped zip file"
                 ]
                 code: load/header/type main 'unbound

--- a/src/os/unzip.reb
+++ b/src/os/unzip.reb
@@ -360,8 +360,9 @@ ctx-zip: context [
                     (if not zero? flags/1 and+ 1 [return false])
                 copy method-number: 2 skip (
                     method-number: get-ishort method-number
-                    method: select [0 store 8 deflate] method-number
-                    unless method [method: method-number]
+                    method: select [0 store 8 deflate] method-number else [
+                        method-number
+                    ]
                 )
                 copy time: 2 skip (time: get-msdos-time time)
                 copy date: 2 skip (
@@ -396,7 +397,7 @@ ctx-zip: context [
                             throw copy/part data compressed-size
                         ]
 
-                        unless method = 'deflate [
+                        if method <> 'deflate [
                             info ["^- -> failed [method " method "]^/"]
                             throw blank
                         ]

--- a/tests/atronix/ms-drives.r
+++ b/tests/atronix/ms-drives.r
@@ -8,7 +8,7 @@ getdrives: make-routine msvcrt "_getdrives" compose/deep [
 maps: getdrives
 i: 0
 while [i < 26] [
-    unless zero? maps and (shift 1 i) [
+    if-not zero? maps and (shift 1 i) [
         print unspaced [to char! (to integer! #"A") + i ":"]
     ]
     i: i + 1

--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -39,7 +39,7 @@
 
 ;; extra large CALL/OUTPUT (500K+), test only run if can find git binary
 (
-    not exists? %/usr/bin/git or [
+    (not exists? %/usr/bin/git) or [
         data: copy {}
         call/wait/output compose [
             %/usr/bin/git "log" (spaced [
@@ -52,6 +52,6 @@
                 "]'"
             ])
         ] data
-        length of data > 500'000 and (find data "summary: {Initial commit}]")
+        length of data > 500'000 and (find data "summary: {Initial commit}")
     ]
 )

--- a/tests/comparison/equalq.test.reb
+++ b/tests/comparison/equalq.test.reb
@@ -541,7 +541,7 @@
     equal?
         test a-value b-value
         to-logic for-each [w v] a-value [
-            unless test :v select b-value w [break]
+            if not test :v select b-value w [break]
         ]
 )]
 ; object! structural equivalence verified
@@ -563,7 +563,7 @@
     equal?
         test a-value b-value
         to-logic for-each [w v] a-value [
-            unless test :v select b-value w [break]
+            if not test :v select b-value w [break]
         ]
 )
 ; unset! comparison fails

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -10,12 +10,12 @@
 )
 (
     success: <bad>
-    unless 1 > 2 [success: true] else [success: false]
+    if-not 1 > 2 [success: true] else [success: false]
     success
 )
 (
     success: <bad>
-    unless 1 < 2 [success: false] else [success: true]
+    if-not 1 < 2 [success: false] else [success: true]
     success
 )
 (

--- a/tests/control/if.test.reb
+++ b/tests/control/if.test.reb
@@ -90,3 +90,38 @@
     blk: [if true blk]
     error? trap blk
 )
+
+; IF-NOT is for performance minded cases, or cases where one doesn't want to
+; deal with the fact that equality completes left, e.g.:
+;
+;     if not x > 10 [...] => if (not x) > 10 [...]
+;     if-not x > 10 [...] => if not (x > 10) [...]
+;
+
+(
+    success: false
+    if-not false [success: true]
+    success
+)
+(
+    success: true
+    if-not true [success: false]
+    success
+)
+(1 = if-not false [1])
+
+(null? if-not* true [1])
+(null? if-not* false [])
+(null? if-not true [1])
+(blank? if-not false [])
+
+(error? if-not false [trap [1 / 0]])
+
+; RETURN stops the evaluation
+(
+    f1: func [] [
+        if-not false [return 1 2]
+        2
+    ]
+    1 = f1
+)

--- a/tests/control/unless.test.reb
+++ b/tests/control/unless.test.reb
@@ -1,28 +1,39 @@
-; functions/control/unless.r
-(
-    success: false
-    unless false [success: true]
-    success
-)
-(
-    success: true
-    unless true [success: false]
-    success
-)
-(1 = unless false [1])
+; In historical Rebol, UNLESS was a synonym for IF NOT.  This somewhat
+; unambitious use of the word has been replaced in Ren-C with an enfix
+; operator that allows one to put the default for an evaluation before the
+; cases which may produce a result.
+;
+;     >> x: {default} unless case [1 > 2 [{nope}] 3 > 4 [{not this either}]]
+;     >> print x
+;     default
+;
+; !!! Temporarily, the lib context contains a hybridized variadic UNLESS
+; which detects if it thinks the usage is expecting the "old unless" style.
+; This makes it a bit strange, but allows it to alert people used to the
+; old habits about the new behavior.
 
-(null? unless* true [1])
-(null? unless* false [])
-(null? unless true [1])
-(blank? unless false [])
-
-(error? unless false [trap [1 / 0]])
-
-; RETURN stops the evaluation
-(
-    f1: func [] [
-        unless false [return 1 2]
-        2
-    ]
-    1 = f1
-)
+(comment [
+    (
+        20 = (10 unless 20)
+    )(
+        10 = (10 unless _)
+    )(
+        10 = (10 unless ())
+    )(
+        _ = (10 unless* _) ;-- /TRY option considers blank a purposeful value
+    )(
+        x: 10 + 20 unless case [
+            false [<no>]
+            false [<nope>]
+            false [<nada>]
+        ]
+        x = 30
+    )(
+        x: 10 + 20 unless case [
+            false [<no>]
+            true [<yip!>]
+            false [<nada>]
+        ]
+        x = <yip!>
+    )
+] true)

--- a/tests/control/while.test.reb
+++ b/tests/control/while.test.reb
@@ -32,7 +32,7 @@
     first-time: true
     was-continued: false
     while [true] [
-        unless first-time [
+        if not first-time [
             was-continued: true
             break
         ]
@@ -74,8 +74,8 @@
 (  ; bug#1519
     cycle?: true
     f1: does [
-        unless 1 > 2 [
-            while [if cycle? [unwind :unless] cycle?] [cycle?: false 2]
+        if-not 1 > 2 [
+            while [if cycle? [unwind :if-not] cycle?] [cycle?: false 2]
         ]
     ]
     null? f1

--- a/tests/misc/shttpd.r
+++ b/tests/misc/shttpd.r
@@ -65,7 +65,7 @@ awake-client: function [event] [
                 read port
             ]
         ]
-        wrote [unless send-chunk port [close port]]
+        wrote [if not send-chunk port [close port]]
         close [close port]
     ]
 ]

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -83,9 +83,9 @@ rebsource: context [
         ][
             collect [
                 for-each source list/source-files [
-                    unless find whitelisted source [
-                        keep opt analyse/file source
-                    ]
+                    if find whitelisted source [continue]
+
+                    keep opt analyse/file source
                 ]
             ]
         ]
@@ -188,15 +188,14 @@ rebsource: context [
                             ;
                             ; ... ? (not a native)
                             ;
-                            unless (
-                                any [
-                                    equal? proto-parser/proto.id (
-                                        form to word! proto-parser/data/1)
-                                    equal? proto-parser/proto.id (
-                                        join-of "RL_"
-                                        form to word! proto-parser/data/1)
-                                ]
-                            ) [
+                            not any [
+                                proto-parser/proto.id =
+                                    <- (form to word! proto-parser/data/1)
+                                proto-parser/proto.id =
+                                    <- unspaced [
+                                        "RL_" to word! proto-parser/data/1
+                                    ]
+                            ] then [
                                 line: text-line-of proto-parser/parse.position
                                 emit analysis [
                                     id-mismatch

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -46,7 +46,7 @@ make object! compose [
     ][
         log [source]
 
-        unless empty? exclude flags allowed-flags [
+        if not empty? exclude flags allowed-flags [
             set 'skipped (skipped + 1)
             log [{ "skipped"^/}]
             leave
@@ -58,24 +58,25 @@ make object! compose [
             leave
         ]
 
-        error? set* 'test-block catch-any test-block 'exception
-
-        test-block: case [
-            exception [spaced ["failed," exceptions/:exception]]
-            not logic? :test-block ["failed, not a logic value"]
-            test-block ["succeeded"]
-        ] else [
-            "failed"
-        ]
-
+        set* 'test-block catch-any test-block 'exception
         recycle
 
-        either test-block = "succeeded" [
-            set 'successes (successes + 1)
-            log [{ "} test-block {"^/}]
-        ][
+        case [
+            exception [
+                spaced ["failed," exceptions/:exception]
+            ]
+            not logic? :test-block [
+                "failed, not a logic value"
+            ]
+            not test-block [
+                "failed"
+            ]
+        ] also message -> [
             set 'test-failures (test-failures + 1)
-            log reduce [{ "} test-block {"^/}]
+            log reduce [space {"} message {"} newline]
+        ] else [
+            set 'successes (successes + 1)
+            log reduce [space {"succeeded"} newline]
         ]
     ]
 

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -485,7 +485,7 @@ make object! [
 
         rule: [any token]
 
-        unless parse test-sources rule [
+        parse test-sources rule or [
             append collected-tests reduce [
                 'dialect
                 spaced [


### PR DESCRIPTION
While ELSE is helpful for putting defaults at the end of a list of
options, sometimes that default is what you want to emphasize at
the outset...with the other options being "overrides".  It is also
the case that the default can sometimes be a very simple option, so
nicer to have up front.

    x: case [
        ... [
             ...lots of lines of code...
        ]
        ... [
            ...lots of lines of code...
        ]
        ... (scrolls off page)
    ] else [
        {default}
    ]

This retakes the historical UNLESS term for an operation that switches
the ordering:

    x: {default} unless case [
        ... [
             ...lots of lines of code...
        ]
        ... [
            ...lots of lines of code...
        ]
        ... (scrolls off page)
    ]

It also makes an interim exposure of this UNLESS use a variadic-based
implementation to make it smart enough to notice old-style usages,
and give an error and instructions how to update.  Or to not update,
just using `UNLESS: :IF-NOT` in that code...and not having the
new feature.

The rationale for this change comes from many different areas:

* It's hard to think of a better word for what the new abstraction
  does besides UNLESS.  It's basically perfect.

* UNLESS has been a sort of divisive distraction in Rebol for some
  time...leading people to take sides on a somewhat frivolous issue.
  More people are vocally against it than for it, and many people
  say they don't see a point to using it over IF NOT.  Its very
  existence seems an endorsement, which leads to the risk of people
  converting one form to the other idly.

* The new usage is -genuinely useful-, immediately applicable to all
  kinds of code.  By making it cool instead of trivial, it refocuses
  attention on the merits of the language.

* The ability to detect old usages isn't foolproof, but very good, and
  could be improved further if someone identified any other patterns
  that were common in their code.

* Most usages of old UNLESS can be rewritten in Ren-C more clearly via
  other new abstractions:

---

    unless some-variable [some-variable: ...]
    -->
    some-variable: default [...] ;-- what's usually intended
    some-variable: me or [...] ;-- what actually happened

    unless parse data rules [...]
    -->
    parse data rules or [...]

    foo: alpha beta gamma
    unless foo [foo: sigma phi rho]
    -->
    foo: any [
        alpha beta gamma
        sigma phi rho
    ]