### PR TITLE
Head *and* Tail NEW-LINE positions, APPEND/LINE (+INSERT,CHANGE)

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -276,6 +276,9 @@ take*: action [
     /last {Take it from the tail end}
 ]
 
+; !!! INSERT, APPEND, CHANGE expect to have compatible frames...same params
+; at the same position, with same types!
+;
 insert: action [
     {Inserts element(s); for series, returns just past the insert.}
     series [any-series! port! map! gob! object! bitset! port!] {At position (modified)}
@@ -285,8 +288,12 @@ insert: action [
     /only {Only insert a block as a single value (not the contents of the block)}
     /dup {Duplicates the insert a specified number of times}
     count [any-number! pair!]
+    /line {Data should be its own line (use as formatting cue if ANY-ARRAY!)}
 ]
 
+; !!! INSERT, APPEND, CHANGE expect to have compatible frames...same params
+; at the same position, with same types!
+;
 append: action [
     {Inserts element(s) at tail; for series, returns head.}
     series [any-series! port! map! gob! object! module! bitset!]
@@ -297,17 +304,12 @@ append: action [
     /only {Only insert a block as a single value (not the contents of the block)}
     /dup {Duplicates the insert a specified number of times}
     count [any-number! pair!]
+    /line {Data should be its own line (use as formatting cue if ANY-ARRAY!)}
 ]
 
-remove: action [
-    {Removes element(s); returns same position.}
-    series [any-series! map! gob! port! bitset! blank!] {At position (modified)}
-    /part {Removes multiple elements or to a given position}
-    limit [any-number! any-series! pair! char!]
-    /map {Remove key from map}
-    key
-]
-
+; !!! INSERT, APPEND, CHANGE expect to have compatible frames...same params
+; at the same position, with same types!
+;
 change: action [
     {Replaces element(s); returns just past the change.}
     series [any-series! gob! port! struct!]{At position (modified)}
@@ -317,6 +319,16 @@ change: action [
     /only {Only change a block as a single value (not the contents of the block)}
     /dup {Duplicates the change a specified number of times}
     count [any-number! pair!]
+    /line {Data should be its own line (use as formatting cue if ANY-ARRAY!)}
+]
+
+remove: action [
+    {Removes element(s); returns same position.}
+    series [any-series! map! gob! port! bitset! blank!] {At position (modified)}
+    /part {Removes multiple elements or to a given position}
+    limit [any-number! any-series! pair! char!]
+    /map {Remove key from map}
+    key
 ]
 
 clear: action [

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -69,7 +69,9 @@ void Collapsify_Array(REBARR *array, REBSPC *specifier, REBCNT limit)
             enum Reb_Kind kind = VAL_TYPE(item);
             Init_Any_Array_At(item, kind, copy, 0); // at 0 now
             assert(IS_SPECIFIC(item));
-            assert(NOT_VAL_FLAG(item, VALUE_FLAG_LINE)); // should be cleared
+            assert(
+                NOT_VAL_FLAG(item, VALUE_FLAG_NEWLINE_BEFORE) // gets cleared
+            );
         }
     }
 }
@@ -150,14 +152,6 @@ REBVAL *Init_Near_For_Frame(RELVAL *out, REBFRM *f)
         }
         else
             Derelativize(DS_TOP, item, f->specifier);
-
-        if (count == 0) {
-            //
-            // Get rid of any newline marker on the first element,
-            // that would visually disrupt a backtrace for no reason.
-            //
-            CLEAR_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
-        }
 
         if (count == FRM_INDEX(f) - start - 1) {
             //

--- a/src/core/s-ops.c
+++ b/src/core/s-ops.c
@@ -417,7 +417,7 @@ REBARR *Split_Lines(const REBVAL *str)
                     AS_REBUNI(up) - AS_REBUNI(start) - 1
                 )
             );
-            SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+            SET_VAL_FLAG(DS_TOP, VALUE_FLAG_NEWLINE_BEFORE);
             ++i;
             start = up;
             if (c == CR) {
@@ -446,8 +446,8 @@ REBARR *Split_Lines(const REBVAL *str)
                 AS_REBUNI(up) - AS_REBUNI(start) // no -1, wasn't terminated
             )
         );
-        SET_VAL_FLAG(DS_TOP, VALUE_FLAG_LINE);
+        SET_VAL_FLAG(DS_TOP, VALUE_FLAG_NEWLINE_BEFORE);
     }
 
-    return Pop_Stack_Values(dsp_orig);
+    return Pop_Stack_Values_Core(dsp_orig, ARRAY_FLAG_TAIL_NEWLINE);
 }

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -658,17 +658,9 @@ void MF_Array(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     else
         all = GET_MOLD_FLAG(mo, MOLD_FLAG_ALL);
 
-    REBOOL over;
-    if (VAL_INDEX(v) >= VAL_LEN_HEAD(v)) {
-        //
-        // If out of range, do not cause error to avoid error looping.
-        //
-        over = TRUE; // Force it into []
-    }
-    else
-        over = FALSE;
+    assert(VAL_INDEX(v) <= VAL_LEN_HEAD(v));
 
-    if (all || (over && !IS_BLOCK(v) && !IS_GROUP(v))) {
+    if (all) {
         SET_MOLD_FLAG(mo, MOLD_FLAG_ALL);
         Pre_Mold(mo, v); // #[block! part
 
@@ -711,10 +703,7 @@ void MF_Array(REB_MOLD *mo, const RELVAL *v, REBOOL form)
             sep = NULL;
         }
 
-        if (over)
-            Append_Unencoded(mo->series, sep ? sep : "[]");
-        else
-            Mold_Array_At(mo, VAL_ARRAY(v), VAL_INDEX(v), sep);
+        Mold_Array_At(mo, VAL_ARRAY(v), VAL_INDEX(v), sep);
 
         if (VAL_TYPE(v) == REB_SET_PATH)
             Append_Utf8_Codepoint(mo->series, ':');
@@ -881,6 +870,8 @@ REBTYPE(Array)
             flags |= AM_ONLY;
         if (REF(part))
             flags |= AM_PART;
+        if (REF(line))
+            flags |= AM_LINE;
 
         index = Modify_Array(
             verb,

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -1090,6 +1090,9 @@ REBTYPE(Gob)
         if (!IS_GOB(arg))
             fail (Error_Unexpected_Type(REB_GOB, VAL_TYPE(arg)));
 
+        if (REF(line))
+            fail (Error_Bad_Refines_Raw());
+
         if (!GOB_PANE(gob) || index >= tail)
             fail (Error_Past_End_Raw());
         if (
@@ -1117,6 +1120,9 @@ REBTYPE(Gob)
 
         UNUSED(PAR(series));
         UNUSED(PAR(value));
+
+        if (REF(line))
+            fail (Error_Bad_Refines_Raw());
 
         if (REF(part) || REF(only) || REF(dup)) {
             UNUSED(PAR(limit));

--- a/src/core/t-image.c
+++ b/src/core/t-image.c
@@ -622,6 +622,9 @@ REBVAL *Modify_Image(REBFRM *frame_, REBCNT action)
 {
     INCLUDE_PARAMS_OF_INSERT; // currently must have same frame as CHANGE
 
+    if (REF(line))
+        fail (Error_Bad_Refines_Raw());
+
     REBVAL  *value = ARG(series); // !!! confusing, very old (unused?) code!
     REBVAL  *arg   = ARG(value);
     REBVAL  *len   = ARG(limit); // void if no /PART

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -825,7 +825,10 @@ REBTYPE(Map)
         if (REF(only))
             fail (Error_Bad_Refines_Raw());
 
-        if (!IS_BLOCK(arg))
+        if (REF(line))
+            fail (Error_Bad_Refines_Raw());
+
+        if (not IS_BLOCK(arg))
             fail (Error_Invalid(val));
         Move_Value(D_OUT, val);
         if (REF(dup)) {

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -131,6 +131,8 @@ REB_R Retrigger_Append_As_Write(REBFRM *frame_) {
         UNUSED(ARG(count));
         fail (Error_Bad_Refines_Raw());
     }
+    if (REF(line))
+        fail (Error_Bad_Refines_Raw());
 
     REBARR *a = Make_Array(2);
     Move_Value(Alloc_Tail_Array(a), &PG_Write_Action);

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1228,8 +1228,13 @@ REBTYPE(String)
         REBFLGS flags = 0;
         if (REF(part))
             flags |= AM_PART;
+        if (REF(line))
+            flags |= AM_LINE;
 
-        if (IS_BINARY(v))
+        if (IS_BINARY(v)) {
+            if (REF(line))
+                fail ("APPEND+INSERT+CHANGE cannot use /LINE with BINARY!");
+
             VAL_INDEX(v) = Modify_Binary(
                 v,
                 verb,
@@ -1238,7 +1243,11 @@ REBTYPE(String)
                 len,
                 REF(dup) ? Int32(ARG(count)) : 1
             );
-        else
+        }
+        else {
+            if (REF(line))
+                flags |= AM_LINE;
+
             VAL_INDEX(v) = Modify_String(
                 v,
                 verb,
@@ -1247,7 +1256,7 @@ REBTYPE(String)
                 len,
                 REF(dup) ? Int32(ARG(count)) : 1
             );
-
+        }
         break; }
 
     //-- Search:

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -268,12 +268,21 @@ inline static REBARR *Make_Array_For_Copy(
     REBFLGS flags,
     REBARR *original
 ){
+    if (original and GET_SER_FLAG(original, ARRAY_FLAG_TAIL_NEWLINE)) {
+        //
+        // All of the newline bits for cells get copied, so it only makes
+        // sense that the bit for newline on the tail would be copied too.
+        //
+        flags |= ARRAY_FLAG_TAIL_NEWLINE;
+    }
+
     if (
         (flags & ARRAY_FLAG_FILE_LINE)
-        and original != NULL
-        and GET_SER_FLAG(original, ARRAY_FLAG_FILE_LINE)
+        and (original and GET_SER_FLAG(original, ARRAY_FLAG_FILE_LINE))
     ){
-        REBARR *a = Make_Array_Core(capacity, 0);
+        flags &= ~ARRAY_FLAG_FILE_LINE;
+
+        REBARR *a = Make_Array_Core(capacity, flags);
         LINK(a).file = LINK(original).file;
         MISC(a).line = MISC(original).line;
         SET_SER_FLAG(a, ARRAY_FLAG_FILE_LINE);
@@ -316,7 +325,7 @@ inline static REBARR *Alloc_Singular_Array_Core(REBFLGS flags) {
 
 
 #define Append_Value(a,v) \
-    (Move_Value(Alloc_Tail_Array(a), (v)), NOOP)
+    Move_Value(Alloc_Tail_Array(a), (v))
 
 #define Append_Value_Core(a,v,s) \
     Derelativize(Alloc_Tail_Array(a), (v), (s))

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -473,7 +473,8 @@ enum {
 // Move these things:
 enum act_modify_mask {
     AM_PART = 1 << 0,
-    AM_ONLY = 1 << 1
+    AM_ONLY = 1 << 1,
+    AM_LINE = 1 << 2
 };
 enum act_find_mask {
     AM_FIND_ONLY = 1 << 0,

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -272,6 +272,19 @@
     FLAGIT_LEFT(GENERAL_ARRAY_BIT + 5)
 
 
+//=//// ARRAY_FLAG_TAIL_NEWLINE ///////////////////////////////////////////=//
+//
+// The mechanics of how Rebol tracks newlines is that there is only one bit
+// per value to track the property.  Yet since newlines are conceptually
+// "between" values, that's one bit too few to represent all possibilities.
+//
+// Ren-C carries a bit for indicating when there's a newline intended at the
+// tail of an array.
+//
+#define ARRAY_FLAG_TAIL_NEWLINE \
+    FLAGIT_LEFT(GENERAL_ARRAY_BIT + 6)
+
+
 // ^-- STOP ARRAY FLAGS AT FLAGIT_LEFT(31) --^
 //
 // Arrays can use all the way up to the 32-bit limit on the flags (since

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -129,13 +129,14 @@
 
 //=////////////////////////////////////////////////////////////////////////=//
 //
-//  VALUE_FLAG_LINE
+//  VALUE_FLAG_NEWLINE_BEFORE
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
-// This is a line marker bit, such that when the value is molded it will put a
-// newline before the value.  (The details are a little more subtle than that,
-// because an ANY-PATH! could not be LOADed back if this were allowed.)
+// When the array containing a value with this flag set is molding, that will
+// output a new line *before* molding the value.  This flag works in tandem
+// with a flag on the array itself which manages whether there should be a
+// newline output before the closing array delimiter: ARRAY_FLAG_TAIL_NEWLINE.
 //
 // The bit is set initially by what the scanner detects, and then left to the
 // user's control after that.
@@ -143,7 +144,10 @@
 // !!! The native `new-line` is used set this, which has a somewhat poor
 // name considering its similarity to `newline` the line feed char.
 //
-#define VALUE_FLAG_LINE \
+// !!! Currently, ANY-PATH! rendering just ignores this bit.  Some way of
+// representing paths with newlines in them may be needed.
+//
+#define VALUE_FLAG_NEWLINE_BEFORE \
     FLAGIT_LEFT(GENERAL_CELL_BIT + 2)
 
 

--- a/tests/convert/mold.test.reb
+++ b/tests/convert/mold.test.reb
@@ -45,3 +45,71 @@
 [#84
     (equal? mold/all make bitset! "^(00)" "#[bitset! #{80}]")
 ]
+
+
+;-- NEW-LINE markers
+
+[
+    (did block: copy [a b c])
+
+    (
+        mold block = {[a b c]}
+    )(
+        new-line block true
+        mold block = {[^/    a b c]}
+    )(
+        new-line tail block true
+        mold block = {[^/    a b c^/]}
+    )(
+        mold tail block = {[^/]}
+    )
+]
+
+(
+    block: [
+        a b c]
+    mold block = {[^/    a b c]}
+)
+
+(
+    block: [a b c
+    ]
+    mold block = {[a b c^/]}
+)
+
+(
+    block: [a b
+        c
+    ]
+    mold block = {[a b^/    c^/]}
+)
+
+(
+    block: copy [a b c]
+    new-line block true
+    new-line tail block true
+    append block [d e f]
+    mold block = {[^/    a b c^/    d e f]}
+)
+
+(
+    block: copy [a b c]
+    new-line block true
+    new-line tail block true
+    append/line block [d e f]
+    mold block = {[^/    a b c^/    d e f^/]}
+)
+
+(
+    block: copy []
+    append/line block [d e f]
+    mold block = {[^/    d e f^/]}
+)
+
+(
+    block: copy [a b c]
+    new-line block true
+    new-line tail block true
+    append/line block [d e f]
+    mold block = {[^/    a b c^/    d e f^/]}
+)

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -410,8 +410,7 @@ rebsource: context [
     ] proto-parser c.lexical/grammar
 
     emit: function [log body] [
-        insert position: tail of log new-line/all compose/only body false
-        new-line position true
+        append/line log (new-line/all compose/only body false)
     ]
 
     extension-of: function [


### PR DESCRIPTION
Historically each value cell in a Rebol array offered a place to put
a "new line marker".  This new line marker would indicate that a
new-line should be output *before* that value was molded.

Yet an N-element array has N + 1 "in-between" positions where a newline
might be indicated.  This approach meant that there was no way to
say that the tail of an array had a new line on it...meaning that one
could not write:

    data: copy [
        a b c
    ]
    new-line (tail data) true
    append data 10

...and get back:

    [
        a b c
        10
    ]

Because there was no memory in C of the fact that a new-line was at
the tail.  The only reason it appears there is a new line is that
there was some logic in mold that said if any new lines were output
during a mold, then the close brace would be on its own line.  You
could not preserve the absence, e.g. with:

    data: copy [
        a b c]

The scanner would lose the distinction, and wind up molding that out
with the close bracket on its own line.

This commit gets the extra "+ 1" bit from the array itself, denoting
if the tail of the array has a new-line bit.  When arrays are merged
then the product takes the union of the new-line bits for the ends:
if a new-line exists on either the head or tail of an insertion it
will update the relevant bits in the target array cells or the array's
tail newline bit.

To make it easier to work with these features, this also adds a /LINE
refinement to APPEND.  This will ensure a newline bit is put on the
tail of the inserted material.  As an added heurstic for /LINE, any
array that does not have a newline bit on its head will be changed to
have one, so one need not write:

    x: copy []
    new-line x true ;-- not needed, will happen implicitly
    append/line x [line one]
    append/line x [line two]