### PR TITLE
Make GET return null if variable is not set, /ONLY => /OPT

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -182,8 +182,8 @@ gen-obj: func [
                 join-of %main/ (last ensure path! s)
             ] [s]
         cflags: either empty? flags [_] [flags]
-        definitions: (get 'definitions)
-        includes: (get 'includes)
+        definitions: (try get 'definitions)
+        includes: (try get 'includes)
     ]
 ]
 

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -31,7 +31,7 @@ do %systems.r
 change-dir %../../src/boot/
 
 args: parse-args system/options/args
-config: config-system get 'args/OS_ID
+config: config-system try get 'args/OS_ID
 
 first-rebol-commit: "19d4f969b4f5c1536f24b023991ec11ee6d5adfb"
 
@@ -119,7 +119,7 @@ if not args: any [
     fail "No platform specified."
 ]
 
-product: to-word any [get 'args/PRODUCT | "core"]
+product: to-word any [try get 'args/PRODUCT | "core"]
 
 platform-data: context [type: 'windows]
 build: context [features: [help-strings]]

--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -37,7 +37,7 @@ do %native-emitters.r ; for emit-include-params-macro
 
 args: parse-args system/options/args
 
-config: config-system get 'args/OS_ID
+config: config-system try get 'args/OS_ID
 
 mod: ensure string! args/MODULE
 m-name: mod

--- a/make/tools/make-os-ext.r
+++ b/make/tools/make-os-ext.r
@@ -29,7 +29,7 @@ do %systems.r
 change-dir %../../src/os/
 
 args: parse-args system/options/args
-config: config-system get 'args/OS_ID
+config: config-system try get 'args/OS_ID
 output-dir: system/options/path/prep
 mkdir/deep output-dir/include
 

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -372,12 +372,12 @@ set: func [
 
     value [<opt> any-value!]
         "Value or block of values"
-    /only
+    /opt
         "Value is optional, and if no value is provided then unset the word"
     /pad
         {For objects, set remaining words to NONE if block is too short}
 ][
-    apply :lib-set [target :value only pad]
+    apply :lib-set [target :value opt pad]
 ]
 
 
@@ -651,7 +651,7 @@ delimit: func [x delimiter] [
                 x: next x
                 continue
             ]
-            set/only 'item do/next x 'x
+            set/opt 'item do/next x 'x
             case [
                 any [blank? :item | null? :item] [
                     ;-- append nothing

--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -195,7 +195,7 @@ find: action [
     return: {position found, else blank (void if series is itself blank)}
         [<opt> any-series! blank! bar!]
     series [any-series! any-context! map! gob! bitset! typeset! blank!]
-    value [<opt> any-value!]
+    value [any-value!]
     /part {Limits the search to a given length or position}
     limit [any-number! any-series! pair!]
     /only {Treats a series value as only a single value}

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -141,7 +141,9 @@ options: construct [] [  ; Options supplied to REBOL during startup
     decimal-digits: 15 ; Max number of decimal digits to print.
     module-paths: [%./]
     default-suffix: %.reb ; Used by IMPORT if no suffix is provided
-    file-types: []
+    file-types: copy [
+        %.reb %.r3 %.r rebol
+    ]
 
     ; Legacy Behaviors Options (paid attention to only by debug builds)
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -376,7 +376,7 @@ void Shutdown_Boot_Extensions(CFUNC **funcs, REBCNT n)
 //          [action!]
 //      spec "spec of the native"
 //          [block!]
-//      impl "a handle returned from RX_Init_ of the extension"
+//      cfuncs "a handle returned from RX_Init_ of the extension"
 //          [handle!]
 //      index "Index of the native"
 //          [integer!]
@@ -389,14 +389,14 @@ REBNATIVE(load_native)
 {
     INCLUDE_PARAMS_OF_LOAD_NATIVE;
 
-    if (VAL_HANDLE_CLEANER(ARG(impl)) != cleanup_module_handler)
+    if (VAL_HANDLE_CLEANER(ARG(cfuncs)) != cleanup_module_handler)
         fail ("HANDLE! passed to LOAD-NATIVE did not come from RX_Init");
 
     REBI64 index = VAL_INT64(ARG(index));
-    if (index < 0 or cast(uintptr_t, index) >= VAL_HANDLE_LEN(ARG(impl)))
+    if (index < 0 or cast(uintptr_t, index) >= VAL_HANDLE_LEN(ARG(cfuncs)))
         fail ("Index of native is outside range specified by RX_Init");
 
-    REBNAT dispatcher = VAL_HANDLE_POINTER(REBNAT, ARG(impl))[index];
+    REBNAT dispatcher = VAL_HANDLE_POINTER(REBNAT, ARG(cfuncs))[index];
     REBACT *native = Make_Action(
         Make_Paramlist_Managed_May_Fail(
             ARG(spec),

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -381,7 +381,7 @@ me: enfix func [
     :rest [any-value! <...>]
         {Code to run with var as left (first element should be enfixed)}
 ][
-    set* var eval-enfix (get* var) rest
+    set* var eval-enfix (get var) rest
 ]
 
 my: enfix func [
@@ -393,7 +393,7 @@ my: enfix func [
     :rest [any-value! <...>]
         {Code to run with var as left (first element should be prefix)}
 ][
-    set* var eval-enfix/prefix (get* var) rest
+    set* var eval-enfix/prefix (get var) rest
 ]
 
 

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -201,20 +201,18 @@ spec-of: function [
     ]
 
     return collect [
-        keep compose [
-            (opt match string! any [
-                to-value select meta 'description
-                to-value select original-meta 'description
-            ])
+        keep/line match string! any [
+            try select meta 'description
+            try select original-meta 'description
         ]
 
-        return-type: match block! any [
-            to-value select meta 'return-type
-            to-value select original-meta 'return-type
+        return-type: try match block! any [
+            try select meta 'return-type
+            try select original-meta 'return-type
         ]
-        return-note: match string! any [
-            to-value select meta 'return-note
-            to-value select original-meta 'return-note
+        return-note: try match string! any [
+            try select meta 'return-note
+            try select original-meta 'return-note
         ]
         if return-type or (return-note) [
             keep compose/only [
@@ -524,18 +522,18 @@ help: procedure [
     ;
     fields: dig-action-meta-fields :value
 
-    description: fields/description
+    description: :fields/description
     return-type: :fields/return-type
-    return-note: fields/return-note
-    types: fields/parameter-types
-    notes: fields/parameter-notes
+    return-note: :fields/return-note
+    types: :fields/parameter-types
+    notes: :fields/parameter-notes
 
     ; For reporting what kind of function this is, don't dig at all--just
     ; look at the meta information of the function being asked about
     ;
     meta: meta-of :value
     all [
-        original-name: match word! any [
+        original-name: try match word! any [
             try select meta 'specializee-name
             try select meta 'adaptee-name
         ]
@@ -547,7 +545,7 @@ help: procedure [
     chainees: match block! try select meta 'chainees
 
     classification: {a function} unless case [
-        :specializee [
+        set? 'specializee [
             either original-name [
                 spaced [{a specialization of} original-name]
             ][
@@ -555,7 +553,7 @@ help: procedure [
             ]
         ]
 
-        :adaptee [
+        set? 'adaptee [
             either original-name [
                 spaced [{an adaptation of} original-name]
             ][
@@ -563,7 +561,7 @@ help: procedure [
             ]
         ]
 
-        :chainees [
+        set? 'chainees [
             {a chained function}
         ]
     ]
@@ -582,13 +580,13 @@ help: procedure [
             type: match [block! any-word!] try select types to-word param
 
             ;-- parameter name and type line
-            if type and (not refinement? param) [
+            if set? 'type and (not refinement? param) [
                 print unspaced [space4 param space "[" type "]"]
             ] else [
                 print unspaced [space4 param]
             ]
 
-            if note [
+            if set? 'note [
                 print unspaced [space4 space4 note]
             ]
         ]
@@ -602,7 +600,7 @@ help: procedure [
         ;
         print-newline
         print ["RETURNS:" (if set? 'return-type [mold return-type])]
-        either return-note [
+        either set? 'return-note [
             print unspaced [space4 return-note]
         ][
             if unset? 'return-type [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -799,41 +799,23 @@ set 'r3-legacy* func [<local>] [
             ]
         ])
 
-        ; This version of get supports the legacy /ANY switch.
-        ;
-        ; R3-Alpha's GET allowed any type, so GET 3 would fall through to
-        ; just returning 3.  This behavior is not in Rebol2, nor is it
-        ; in Red...which only support ANY-WORD!, OBJECT!, or NONE!
-        ; Hence it is not carried forward in legacy at this time.
-        ;
         get: (function [
+            {GET no longer supports OBJECT!, getting unset vars gives null}
             return: [<opt> any-value!]
-            source [blank! any-word! any-path! any-context! block!]
-            /any
+            source {Legacy handles Rebol2 types, not *any* type like R3-Alpha}
+                [blank! any-word! any-path! any-context! block!]
+            /any {Name for /ANY in Ren-C is /OPT}
         ][
             any_GET: any
             any: :lib/any
 
-            either* any-context? source [
-                ;
-                ; In R3-Alpha, this was vars of the context put into a BLOCK!:
-                ;
-                ;     >> get make object! [[a b][a: 10 b: 20]]
-                ;     == [10 20]
-                ;
-                ; Presumes order, has strange semantics.  Written as native
-                ; code but is expressible more flexibily in usermode getting
-                ; the WORDS-OF block, covering things like hidden fields etc.
+            if blank? source [return _] ;-- Rebol2 allows blank, returns blank
 
-                apply 'get [
-                    source: words of source
-                    only: any_GET
+            return apply 'get [
+                source: source unless any-context? source [
+                    words of source
                 ]
-            ][
-                apply 'get [
-                    source: source
-                    only: any_GET
-                ]
+                only: any_GET
             ]
         ])
 

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -56,6 +56,7 @@ save: function [
         not header ; User wants to save value as script, not data file
         did match [file! url!] where
         type: file-type? where
+        type <> 'rebol ;-- handled by this routine, not by WRITE+ENCODE
     ] then [
         ; We have a codec.  Will check for valid type.
         return write where encode type :value

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -64,8 +64,11 @@ make-port*: function [
     port/scheme: scheme
 
     ; Defaults:
-    port/actor: get in scheme 'actor ; avoid evaluation
-    port/awake: any [get in port/spec 'awake | :scheme/awake]
+    port/actor: try get in scheme 'actor ; avoid evaluation
+    port/awake: any [
+        try get in port/spec 'awake
+        try get 'scheme/awake
+    ]
     port/spec/ref: default [spec]
     port/spec/title: default [scheme/title]
     port: to port! port

--- a/tests/comparison/equalq.test.reb
+++ b/tests/comparison/equalq.test.reb
@@ -594,7 +594,7 @@
 ; Evaluates (trap [1 / 0]) to get error! value.
 (
     a-value: blank
-    set/only 'a-value (trap [1 / 0])
+    set 'a-value (trap [1 / 0])
     equal? a-value a-value
 )
 ; error! structural equivalence

--- a/tests/control/apply.test.reb
+++ b/tests/control/apply.test.reb
@@ -69,7 +69,7 @@
         return: [<opt> any-value!]
         x [<opt> any-value!]
     ][
-        get/only 'x
+        get 'x
     ][
         ()
     ]
@@ -79,7 +79,7 @@
         return: [<opt> any-value!]
         'x [<opt> any-value!]
     ][
-        get/only 'x
+        get 'x
     ][
         ()
     ]
@@ -89,7 +89,7 @@
         return: [<opt> any-value!]
         x [<opt> any-value!]
     ][
-        return get/only 'x
+        return get 'x
     ][
         ()
     ]
@@ -99,26 +99,26 @@
         return: [<opt> any-value!]
         'x [<opt> any-value!]
     ][
-        return get/only 'x
+        return get 'x
     ][
         ()
     ]
 )
 (
     error? r3-alpha-apply func ['x [<opt> any-value!]] [
-        return get/only 'x
+        return get 'x
     ][
         make error! ""
     ]
 )
 (
     error? r3-alpha-apply/only func [x [<opt> any-value!]] [
-        return get/only 'x
+        return get 'x
     ] head of insert copy [] make error! ""
 )
 (
     error? r3-alpha-apply/only func ['x [<opt> any-value!]] [
-        return get/only 'x
+        return get 'x
     ] head of insert copy [] make error! ""
 )
 (use [x] [x: 1 strict-equal? 1 r3-alpha-apply func ['x] [:x] [:x]])
@@ -133,7 +133,7 @@
     use [x] [
         unset 'x
         strict-equal? first [:x] r3-alpha-apply/only func ['x [<opt> any-value!]] [
-            return get/only 'x
+            return get 'x
         ] [:x]
     ]
 )
@@ -145,7 +145,7 @@
     use [x] [
         unset 'x
         strict-equal? 'x r3-alpha-apply/only func ['x [<opt> any-value!]] [
-            return get/only 'x
+            return get 'x
         ] [x]
     ]
 )

--- a/tests/control/break.test.reb
+++ b/tests/control/break.test.reb
@@ -13,7 +13,7 @@
     (a: 1 | loop 1 [set 'a break] :a = 1)
 ]
 [#1515
-    (a: 1 | loop 1 [set/only 'a break] | :a = 1)
+    (a: 1 | loop 1 [set/opt 'a break] | :a = 1)
 ]
 
 ; the "result" of break should not be passable to functions

--- a/tests/control/continue.test.reb
+++ b/tests/control/continue.test.reb
@@ -4,7 +4,7 @@
     (a: 1 loop 1 [a: continue] :a =? 1)
 ]
 (a: 1 loop 1 [set 'a continue] :a =? 1)
-(a: 1 loop 1 [set/only 'a continue] :a =? 1)
+(a: 1 loop 1 [set/opt 'a continue] :a =? 1)
 [#1509 ; the "result" of continue should not be passable to functions
     (a: 1 loop 1 [a: error? continue] :a =? 1)
 ]

--- a/tests/control/leave.test.reb
+++ b/tests/control/leave.test.reb
@@ -13,7 +13,7 @@
     (a: 1 eval proc [] [a: leave] :a =? 1)
 ]
 (a: 1 eval proc [] [set 'a leave] :a =? 1)
-(a: 1 eval proc [] [set/only 'a leave] :a =? 1)
+(a: 1 eval proc [] [set/opt 'a leave] :a =? 1)
 [#1509 ; the "result" of exit should not be passable to functions
     (a: 1 eval proc [] [a: error? leave] :a =? 1)
 ]

--- a/tests/control/loop.test.reb
+++ b/tests/control/loop.test.reb
@@ -58,7 +58,7 @@
                 use [break] [
                     break: 1
                     f 2
-                    1 = get/only 'break
+                    1 = get 'break
                 ]
             ][
                 false

--- a/tests/control/return.test.reb
+++ b/tests/control/return.test.reb
@@ -22,7 +22,7 @@
     (a: 1 eval func [] [a: return 2] :a =? 1)
 ]
 (a: 1 eval func [] [set 'a return 2] :a =? 1)
-(a: 1 eval func [] [set/only 'a return 2] :a =? 1)
+(a: 1 eval func [] [set/opt 'a return 2] :a =? 1)
 [#1509 ; the "result" of return should not be passable to functions
     (a: 1 eval func [] [a: error? return 2] :a =? 1)
 ]

--- a/tests/control/throw.test.reb
+++ b/tests/control/throw.test.reb
@@ -4,10 +4,10 @@
     (a: 1 catch [a: throw 2] :a =? 1)
 ]
 (a: 1 catch [set 'a throw 2] :a =? 1)
-(a: 1 catch [set/only 'a throw 2] :a =? 1)
+(a: 1 catch [set/opt 'a throw 2] :a =? 1)
 (a: 1 catch/name [a: throw/name 2 'b] 'b :a =? 1)
 (a: 1 catch/name [set 'a throw/name 2 'b] 'b :a =? 1)
-(a: 1 catch/name [set/only 'a throw/name 2 'b] 'b :a =? 1)
+(a: 1 catch/name [set/opt 'a throw/name 2 'b] 'b :a =? 1)
 [#1509 ; the "result" of throw should not be passable to functions
     (a: 1 catch [a: error? throw 2] :a =? 1)
 ]

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -16,7 +16,7 @@
 ;
 (a: 1 error? trap [a: 1 / 0] :a =? 1)
 (a: 1 error? trap [set 'a 1 / 0] :a =? 1)
-(a: 1 error? trap [set/only 'a 1 / 0] :a =? 1)
+(a: 1 error? trap [set/opt 'a 1 / 0] :a =? 1)
 
 [#2190
     (127 = catch/quit [attempt [catch/quit [1 / 0]] quit/with 127])

--- a/tests/datatypes/module.test.reb
+++ b/tests/datatypes/module.test.reb
@@ -45,7 +45,7 @@
 (1 = load "1")
 ([1] = load "[1]")
 ([1 2 3] = load "1 2 3")
-([1 2 3] = load/type "1 2 3" blank)
+([1 2 3] = load/type "1 2 3" ())
 ([1 2 3] = load "rebol [] 1 2 3")
 (
     d: load/header "rebol [] 1 2 3"

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -8,7 +8,7 @@
 ]
 
 (error? trap [a: () a])
-(not error? trap [set/only 'a ()])
+(not error? trap [set/opt 'a ()])
 
 (
     a-value: 10


### PR DESCRIPTION
In R3-Alpha, Rebol2, and Red, getting a variable that is unset is
an error.  Ren-C experimented with the idea that GET would be more
tolerant, and return a blank on failure.

The new model going forward in Ren-C has been to very purposefully use
null results as a kind of "soft" failure.  Most routines reject null
inputs, but if given a blank input will return void.  This makes each
step in an evaluation chain a place that one can elect to put a
TO-VALUE (now, also taking the old name TRY) or not.  Failing to put
in a TRY means one's attention is raised to the failed operation.

So this makes GET return void, while GET/TRY can be used to ask for
blankification.  For ordinary parameters this is the same as TRY GET,
but since blocks cannot hold nulls it's necessary to be a refinement
for block cases:

    >> get [a b] ['asasdfdf 'jklasdf]
    ** error, can't put nulls in block

    >> get/try [a b] ['asasdfdf 'jklasdf]
    == [_ _]

The change causes a significant ripple in code dependent on GET
returning blank, though little such code should exist in the wild outside
of Ren-C (as R3-Alpha/Rebol2/Red didn't allow GET of unset things)

This also settles on the name /OPT for the refinement to SET that
allows you to pass it NULL.  This solves previous debates and concerns
about what the right name for that refinement is, as /OPT and /TRY
have a coherent meaning.  Little code was affected, as the name
`SET*` was used while anticipating a final decision on the refinement's
name.  It turned out that the missing link was that the name was
different for GET and SET, based on the difference in how the
operations lean.

This required some amount of shakeup in the LOAD code, and the
opportunity was taken to try and make it a bit clearer in the process.