### PR TITLE
Remove Extension-Words feature in favor of libRebol word access

### DIFF
--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -87,10 +87,7 @@ proto-parser/process source.text
 
 
 ;
-; At this point the natives will all be in the UNSORTED-BUFFER.  Extensions
-; have added a concept of adding words (as from %words.r) for use as symbols,
-; as well as errors--both possible to specify in the C comments just like
-; the native headers have.
+; At this point the natives will all be in the UNSORTED-BUFFER.
 ;
 
 native-list: load unsorted-buffer
@@ -98,7 +95,6 @@ native-list: load unsorted-buffer
 
 native-spec: make object! [
     spec: _
-    words: _
     errors: _
     platforms: _
     name: _
@@ -107,7 +103,6 @@ native-spec: make object! [
 native-specs: copy []
 
 spec: _
-words: _
 errors: _
 platforms: _
 n-name: _
@@ -119,7 +114,7 @@ native-list-rule: [
                 |
             'native/body 2 block!
                 |
-                [
+            [
                 'native/export block!
                     |
                 'native/export/body 2 block!
@@ -133,7 +128,6 @@ native-list-rule: [
                     name: (to lit-word! n-name)
                     spec: (copy n-spec)
                     errors: (either errors [copy errors][_])
-                    words: (either words [copy words][_])
                     platforms: (either platforms [copy platforms][_])
                 ]
             ]
@@ -141,14 +135,9 @@ native-list-rule: [
             n-name: w
             n-spec: spec
             spec: _
-            words: _
             errors: _
             platforms: _
         )
-            |
-        remove [
-            quote new-words: set words block!
-        ]
             |
         remove [
             quote new-errors: set errors block!
@@ -162,8 +151,7 @@ native-list-rule: [
 
 if not parse native-list native-list-rule [
     fail [
-        "failed to parse" mold native-list ":"
-        "current word-list:" mold word-list
+        "failed to parse" mold native-list
     ]
 ]
 
@@ -173,13 +161,11 @@ if not blank? n-name [
         name: (to lit-word! n-name)
         spec: (copy n-spec)
         errors: (either errors [copy errors][_])
-        words: (either words [copy words][_])
         platforms: (either platforms [copy platforms][_])
     ]
 ]
 
 clear native-list
-word-list: copy []
 export-list: copy []
 error-list: copy []
 num-native: 0
@@ -215,22 +201,15 @@ for-each native native-specs [
         append export-list to word! native/name
     ]
     if not blank? native/errors [append error-list native/errors]
-    if not blank? native/words [append word-list native/words]
     append native-list reduce [to set-word! native/name]
     append native-list native/spec
 ]
 
 ;print ["specs:" mold native-list]
-word-list: unique word-list
 spec: compose/deep/only [
     REBOL [
         name: (to word! m-name)
         exports: (export-list)
-    ]
-]
-if not empty? word-list [
-    append spec compose/only [
-        words: (word-list)
     ]
 ]
 if not empty? error-list [
@@ -272,8 +251,6 @@ either num-native > 0 [
 
 e2/emit {
     int Module_Init_${Mod}(RELVAL *out) {
-        INIT_${MOD}_WORDS;
-
         Ext_${Mod}_Error_Base = Find_Next_Error_Base_Code();
         assert(Ext_${Mod}_Error_Base > 0);
         REBARR *arr = Make_Extension_Module_Array(
@@ -339,49 +316,6 @@ e1/emit {
         REB_R N_${MOD}_##n(REBFRM *frame_)
 }
 e1/emit-line []
-
-
-e1/emit {
-    /*
-    ** DEFINE WORDS TO BE USED BY THE EXTENSION FROM ITS C CODE
-    **
-    ** !!! These use REBSTR* pointers, which are not protected from garbage
-    ** collection.  They should be Alloc_Value()'d WORD!s, or WORD!s living
-    ** in an array that was Alloc_Value()'d...and rebRelease()'d on unload.
-    */
-
-    #define NUM_EXT_${MOD}_WORDS $(length-of word-list)
-}
-e1/emit-line []
-
-either empty? word-list [
-    e1/emit ["#define INIT_${MOD}_WORDS"]
-][
-    e1/emit ["static const char* Ext_Words_${Mod}[NUM_EXT_${MOD}_WORDS] = {"]
-    for-next word-list [
-        e1/emit-line/indent [ {"} to string! word-list/1 {",} ]
-    ]
-    e1/emit-end
-
-    e1/emit ["static REBSTR* Ext_Canons_${Mod}[NUM_EXT_${MOD}_WORDS];"]
-
-    seq: 0
-    for-next word-list [
-        e1/emit [
-            "#define ${MOD}_WORD_${WORD-LIST/1} Ext_Canons_${Mod}[$(seq)]"
-        ]
-        seq: seq + 1
-    ]
-
-    e1/emit {
-        #define INIT_${MOD}_WORDS \
-            Init_Extension_Words( \
-                cast(const REBYTE**, Ext_Words_${Mod}), \
-                Ext_Canons_${Mod}, \
-                NUM_EXT_${MOD}_WORDS \
-            )
-    }
-]
 
 
 e1/emit {

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -478,25 +478,6 @@ REBNATIVE(unload_native)
 
 
 //
-//  Init_Extension_Words: C
-//
-// Intern strings and save their canonical forms.
-//
-// !!! Are these protected from GC?  If not, then they need to be--one of the
-// better ways to do so might be to load them as API WORD!s and give them
-// a lifetime until they are explicitly freed.
-//
-void Init_Extension_Words(const REBYTE* strings[], REBSTR *canons[], REBCNT n)
-{
-    REBCNT i;
-    for (i = 0; i < n; ++i) {
-        REBSTR* s = Intern_UTF8_Managed(strings[i], LEN_BYTES(strings[i]));
-        canons[i] = STR_CANON(s);
-    }
-}
-
-
-//
 //  Hook_Datatype: C
 //
 // Poor-man's user-defined type hack: this really just gives the ability to


### PR DESCRIPTION
Extensions needed to do comparisons and mentions of WORD! from C code.
This was done by listing the words they wanted to register in comment
blocks, then the prep process would generate the code to register
a set of REBSTR* series pointers into an array.

One mechanical problem with this is that those REBSTR* arrays were not
known to the GC.  Hence it was technically possible for the spellings
to be GC'd and then cause a crash.

But more generally, the libRebol API is focused on making it easy to
work with Rebol code in a direct format.  If someone wanted to cache a
GC-protected word value in an extension, they should be able to do
so fairly naturally with the API...then the API handles would (should)
be scoped to the lifetime of the extension.  (Today they would have to
be marked as unmanaged.)

In the ongoing interest of simplification and exercising the API,
clients who relied on the words list now use the API directly.  This
was %mod-crypt.c, %mod-locale.c, and %mod-odbc.c.