### PR TITLE
Make SWITCH use 0-arity evaluation for match clauses

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -46,10 +46,10 @@ either commands: find args '| [
 
 for-each [name value] options [
     switch/default name [
-        CONFIG LOAD DO [
+        'CONFIG 'LOAD 'DO [
             user-config: make user-config load to-file value
         ]
-        EXTENSIONS [
+        'EXTENSIONS [
             use [ext-file user-ext][
                 either any [
                     exists? ext-file: to file! value
@@ -277,14 +277,14 @@ extension-names: map-each x available-extensions [to-lit-word x/name]
 ; I need targets here, for gathering names
 ; and use they with --help targets ...
 targets: [
-    clean [
+    'clean [
         rebmake/execution/run make rebmake/solution-class [
             depends: reduce [
                 clean
             ]
         ]
     ]
-    prep [
+    'prep [
         rebmake/execution/run make rebmake/solution-class [
             depends: flatten reduce [
                 vars
@@ -294,7 +294,7 @@ targets: [
             ]
         ]
     ]
-    app executable r3 [
+    'app 'executable 'r3 [
         rebmake/execution/run make rebmake/solution-class [
             depends: flatten reduce [
                 vars
@@ -304,7 +304,7 @@ targets: [
             ]
         ]
     ]
-    library [
+    'library [
         rebmake/execution/run make rebmake/solution-class [
             depends: flatten reduce [
                 vars
@@ -314,7 +314,7 @@ targets: [
             ]
         ]
     ]
-    all execution [
+    'all 'execution [
         rebmake/execution/run make rebmake/solution-class [
             depends: flatten reduce [
                 clean
@@ -326,29 +326,28 @@ targets: [
             ]
         ]
     ]
-    makefile [
+    'makefile [
         rebmake/makefile/generate %makefile solution
     ]
-    nmake [
+    'nmake [
         rebmake/nmake/generate %makefile solution
     ]
-    vs2017
-    visual-studio [
+    'vs2017
+    'visual-studio [
         rebmake/visual-studio/generate/(all [system-config/os-name = 'Windows-x86 'x86]) %. solution
     ]
-    vs2015 [
+    'vs2015 [
         rebmake/vs2015/generate/(all [system-config/os-name = 'Windows-x86 'x86]) %. solution
     ]
 ]
 target-names: make block! 16
 for-each x targets [
-    either word? x [
-        append target-names x
+    either lit-word? x [
+        append target-names to word! x
         append target-names '|
     ][
         take/last target-names
-        append target-names
-        newline
+        append target-names newline
     ]
 ]
 
@@ -513,17 +512,17 @@ if blank? rebmake/default-linker [
 ]
 
 switch/default rebmake/default-compiler/name [
-    gcc [
+    'gcc [
         if rebmake/default-linker/name != 'ld [
             fail ["Incompatible compiler (GCC) and linker: " rebmake/default-linker/name]
         ]
     ]
-    clang [
+    'clang [
         if not find [ld llvm-link] rebmake/default-linker/name [
             fail ["Incompatible compiler (CLANG) and linker: " rebmake/default-linker/name]
         ]
     ]
-    cl [
+    'cl [
         if rebmake/default-linker/name != 'link [
             fail ["Incompatible compiler (CL) and linker: " rebmake/default-linker/name]
         ]
@@ -552,25 +551,25 @@ app-config: make object! [
 cfg-sanitize: false
 cfg-symbols: false
 switch/default user-config/debug [
-    #[false] no false off none [
+    #[false] 'no 'false 'off 'none [
         append app-config/definitions ["NDEBUG"]
         app-config/debug: off
     ]
-    #[true] yes true on [
+    #[true] 'yes 'true 'on [
         app-config/debug: on
     ]
-    asserts [
+    'asserts [
         ; /debug should only affect the "-g -g3" symbol inclusions in rebmake.
         ; To actually turn off asserts or other checking features, NDEBUG must
         ; be defined.
         ;
         app-config/debug: off
     ]
-    symbols [
+    'symbols [
         cfg-symbols: true
         app-config/debug: on
     ]
-    sanitize [
+    'sanitize [
         app-config/debug: on
         cfg-symbols: true
         cfg-sanitize: true
@@ -582,7 +581,7 @@ switch/default user-config/debug [
     ; be used when trying to find bugs that only appear in release builds or
     ; higher optimization levels.
     ;
-    callgrind [
+    'callgrind [
         cfg-symbols: true
         append app-config/definitions ["NDEBUG"]
         append app-config/cflags "-g" ;; for symbols
@@ -610,7 +609,7 @@ switch/default user-config/debug [
 ]
 
 switch user-config/optimize [
-    #[false] false no off 0 [
+    #[false] 'false 'no 'off 0 [
         app-config/optimization: false
     ]
     1 2 3 4 "s" "z" 's 'z [
@@ -621,20 +620,20 @@ switch user-config/optimize [
 cfg-cplusplus: false
 ;standard
 append app-config/cflags opt switch/default user-config/standard [
-    c [
+    'c [
         _
     ]
-    gnu89 c99 gnu99 c11 [
+    'gnu89 'c99 'gnu99 'c11 [
         to tag! unspaced ["gnu:--std=" user-config/standard]
     ]
-    c++ [
+    'c++ [
         cfg-cplusplus: true
         [
             <gnu:-x c++>
             <msc:/TP>
         ]
     ]
-    c++98 c++0x c++11 c++14 c++17 c++latest [
+    'c++98 'c++0x 'c++11 'c++14 'c++17 'c++latest [
 
         cfg-cplusplus: true
         compose [
@@ -700,13 +699,13 @@ append app-config/cflags opt switch/default user-config/standard [
 ;
 cfg-pre-vista: false
 append app-config/definitions opt switch/default user-config/pre-vista [
-    #[true] yes on true [
+    #[true] 'yes 'on 'true [
         cfg-pre-vista: true
         compose [
             "PRE_VISTA"
         ]
     ]
-    _ #[false] no off false [
+    _ #[false] 'no 'off 'false [
         cfg-pre-vista: false
         _
     ]
@@ -716,7 +715,7 @@ append app-config/definitions opt switch/default user-config/pre-vista [
 
 cfg-rigorous: false
 append app-config/cflags opt switch/default user-config/rigorous [
-    #[true] yes on true [
+    #[true] 'yes 'on 'true [
         cfg-rigorous: true
         compose [
             <gnu:-Werror> <msc:/WX>;-- convert warnings to errors
@@ -927,7 +926,7 @@ append app-config/cflags opt switch/default user-config/rigorous [
             <msc:/wd5039>
         ]
     ]
-    _ #[false] no off false [
+    _ #[false] 'no 'off 'false [
         cfg-rigorous: false
         _
     ]
@@ -936,11 +935,11 @@ append app-config/cflags opt switch/default user-config/rigorous [
 ]
 
 append app-config/ldflags opt switch/default user-config/static [
-    _ no off false #[false] [
+    _ 'no 'off 'false #[false] [
         ;pass
         _
     ]
-    yes on #[true] [
+    'yes 'on #[true] [
         compose [
             <gnu:-static-libgcc>
             (if cfg-cplusplus [<gnu:-static-libstdc++>])
@@ -1158,10 +1157,10 @@ builtin-extensions: copy available-extensions
 dynamic-extensions: make block! 8
 for-each [action name modules] user-config/extensions [
     switch/default action [
-        + [; builtin
+        '+ [; builtin
             ;pass, default action
         ]
-        * - [
+        '* '- [
             item: _
             for-next builtin-extensions [
                 if builtin-extensions/1/name = name [
@@ -1536,10 +1535,10 @@ add-new-obj-folders: procedure [
 ][
     for-each lib objs [
         switch/default lib/class-name [
-            object-file-class [
+            'object-file-class [
                 lib: reduce [lib]
             ]
-            object-library-class [
+            'object-library-class [
                 lib: lib/depends
             ]
         ][

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -150,7 +150,7 @@ e-dispatch/emit {
 for-each-record t type-table [
     switch/default t/class [
         0 [e-dispatch/emit-item "NULL"] ;-- never dispatch on REB_0
-        * [e-dispatch/emit-item "T_Unhooked"] ;-- extensions replace this
+        '* [e-dispatch/emit-item "T_Unhooked"] ;-- extensions replace this
     ][
         e-dispatch/emit-item ["T_" propercase-of ensure word! t/class]
     ]
@@ -168,9 +168,9 @@ e-dispatch/emit {
 }
 for-each-record t type-table [
     switch/default t/path [
-        - [e-dispatch/emit-item "PD_Fail"]
-        + [e-dispatch/emit-item ["PD_" propercase-of ensure word! t/class]]
-        * [e-dispatch/emit-item "PD_Unhooked"]
+        '- [e-dispatch/emit-item "PD_Fail"]
+        '+ [e-dispatch/emit-item ["PD_" propercase-of ensure word! t/class]]
+        '* [e-dispatch/emit-item "PD_Unhooked"]
     ][
         ; !!! Today's PORT! path dispatches through context even though
         ; that isn't its technical "class" for responding to actions.
@@ -191,9 +191,9 @@ e-dispatch/emit {
 }
 for-each-record t type-table [
     switch/default t/make [
-        - [e-dispatch/emit-item "MAKE_Fail"]
-        + [e-dispatch/emit-item ["MAKE_" propercase-of ensure word! t/class]]
-        * [e-dispatch/emit-item "MAKE_Unhooked"]
+        '- [e-dispatch/emit-item "MAKE_Fail"]
+        '+ [e-dispatch/emit-item ["MAKE_" propercase-of ensure word! t/class]]
+        '* [e-dispatch/emit-item "MAKE_Unhooked"]
     ][
         fail "MAKE in %types.r should be, -, +, or *"
     ]
@@ -211,9 +211,9 @@ e-dispatch/emit {
 }
 for-each-record t type-table [
     switch/default t/make [
-        - [e-dispatch/emit-item "TO_Fail"]
-        + [e-dispatch/emit-item ["TO_" propercase-of ensure word! t/class]]
-        * [e-dispatch/emit-item "TO_Unhooked"]
+        '- [e-dispatch/emit-item "TO_Fail"]
+        '+ [e-dispatch/emit-item ["TO_" propercase-of ensure word! t/class]]
+        '* [e-dispatch/emit-item "TO_Unhooked"]
     ][
         fail "TO in %types.r should be -, +, or *"
     ]
@@ -231,9 +231,9 @@ e-dispatch/emit {
 }
 for-each-record t type-table [
     switch/default t/mold [
-        - [e-dispatch/emit-item "MF_Fail"]
-        + [e-dispatch/emit-item ["MF_" propercase-of ensure word! t/class]]
-        * [e-dispatch/emit-item "MF_Unhooked"]
+        '- [e-dispatch/emit-item "MF_Fail"]
+        '+ [e-dispatch/emit-item ["MF_" propercase-of ensure word! t/class]]
+        '* [e-dispatch/emit-item "MF_Unhooked"]
     ][
         ; ERROR! may be a context, but it has its own special forming
         ; beyond the class (falls through to ANY-CONTEXT! for mold), and
@@ -256,7 +256,7 @@ e-dispatch/emit {
 for-each-record t type-table [
     switch/default t/class [
         0 [e-dispatch/emit-item "NULL"]
-        * [e-dispatch/emit-item "CT_Unhooked"]
+        '* [e-dispatch/emit-item "CT_Unhooked"]
     ][
         e-dispatch/emit-item ["CT_" propercase-of ensure word! t/class]
     ]

--- a/make/tools/make-headers.r
+++ b/make/tools/make-headers.r
@@ -66,7 +66,7 @@ emit-proto: proc [proto] [
     ]
 
     switch/default header/2 [
-        RL_API [
+        'RL_API [
             ; Currently the RL_API entries should only occur in %a-lib.c, and
             ; are processed by %make-reb-lib.r.  Their RL_XxxYyy() forms don't
             ; appear in the %tmp-funcs.h file, but core includes %reb-lib.h
@@ -75,7 +75,7 @@ emit-proto: proc [proto] [
             ;
             leave
         ]
-        C [
+        'C [
             ; The only accepted type for now
         ]
         ; Natives handled by searching for REBNATIVE() currently.  If it

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -169,6 +169,26 @@ if true = attempt [void? :some-undefined-thing] [
         ]
     ]
 
+    if not error? trap [switch 3 [1 + 2 [3]]] [ ;-- no error is non-evaluative
+        switch: adapt 'switch [
+            cases: map-each c cases [
+                case [
+                    lit-word? :c [to word! c]
+                    lit-path? :c [to path! c]
+
+                    path? :c [
+                        fail/where ["Switch now evaluative" c] 'cases
+                    ]
+                    word? :c [
+                        fail/where ["Switch now evaluative" c] 'cases
+                    ]
+
+                    true [:c]
+                ]
+            ]
+        ]
+    ]
+                    
     QUIT ;-- !!! stops running if Ren-C here.
 ]
 

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -98,23 +98,23 @@ pkg-config: function [
     lib [any-string!]
 ][
     switch/default var [
-        includes [
+        'includes [
             dlm: "-I"
             opt: "--cflags-only-I"
         ]
-        searches [
+        'searches [
             dlm: "-L"
             opt: "--libs-only-L"
         ]
-        libraries [
+        'libraries [
             dlm: "-l"
             opt: "--libs-only-l"
         ]
-        cflags [
+        'cflags [
             dlm: _
             opt: "--cflags-only-other"
         ]
-        ldflags [
+        'ldflags [
             dlm: _
             opt: "--libs-only-other"
         ]
@@ -252,22 +252,22 @@ set-target-platform: func [
     platform
 ][
     switch/default platform [
-        posix [
+        'posix [
             target-platform: posix
         ]
-        linux [
+        'linux [
             target-platform: linux
         ]
-        android [
+        'android [
             target-platform: android
         ]
-        windows [
+        'windows [
             target-platform: windows
         ]
-        osx [
+        'osx [
             target-platform: osx
         ]
-        emscripten [
+        'emscripten [
             target-platform: emscripten
         ]
     ][
@@ -756,7 +756,7 @@ ld: make linker-class [
         lib
     ][
         switch/default dep/class-name [
-            object-file-class [
+            'object-file-class [
                 ;if find words-of dep 'depends [
                     ;for-each ddep dep/depends [
                     ;    dump ddep
@@ -764,7 +764,7 @@ ld: make linker-class [
                 ;]
                 file-to-local dep/output
             ]
-            ext-dynamic-class [
+            'ext-dynamic-class [
                 either tag? dep/output [
                     if lib: filter-flag dep/output id [
                         unspaced ["-l" lib]
@@ -776,22 +776,22 @@ ld: make linker-class [
                     ]
                 ]
             ]
-            ext-static-class [
+            'ext-static-class [
                 file-to-local dep/output
             ]
-            object-library-class [
+            'object-library-class [
                 spaced map-each ddep dep/depends [
                     file-to-local ddep/output
                 ]
                 ;pass
             ]
-            application-class [
+            'application-class [
                 ;pass
             ]
-            var-class [
+            'var-class [
                 ;pass
             ]
-            entry-class [
+            'entry-class [
                 ;pass
             ]
         ][
@@ -874,7 +874,7 @@ llvm-link: make linker-class [
         lib
     ][
         switch/default dep/class-name [
-            object-file-class [
+            'object-file-class [
                 ;if find words-of dep 'depends [
                     ;for-each ddep dep/depends [
                     ;    dump ddep
@@ -882,25 +882,25 @@ llvm-link: make linker-class [
                 ;]
                 file-to-local dep/output
             ]
-            ext-dynamic-class [
+            'ext-dynamic-class [
                 ;ignored
             ]
-            ext-static-class [
+            'ext-static-class [
                 ;ignored
             ]
-            object-library-class [
+            'object-library-class [
                 spaced map-each ddep dep/depends [
                     file-to-local ddep/output
                 ]
                 ;pass
             ]
-            application-class [
+            'application-class [
                 ;pass
             ]
-            var-class [
+            'var-class [
                 ;pass
             ]
-            entry-class [
+            'entry-class [
                 ;pass
             ]
         ][
@@ -973,7 +973,7 @@ link: make linker-class [
         ddep
     ][
         switch/default dep/class-name [
-            object-file-class [
+            'object-file-class [
                 ;if find words-of dep 'depends [
                     ;for-each ddep dep/depends [
                     ;    dump ddep
@@ -981,7 +981,7 @@ link: make linker-class [
                 ;]
                 file-to-local to-file dep/output
             ]
-            ext-dynamic-class [
+            'ext-dynamic-class [
                 ;static property is ignored
                 ;import file
                 either tag? dep/output [
@@ -995,22 +995,22 @@ link: make linker-class [
                     ]
                 ]
             ]
-            ext-static-class [
+            'ext-static-class [
                 file-to-local dep/file
             ]
-            object-library-class [
+            'object-library-class [
                 spaced map-each ddep dep/depends [
                     file-to-local to-file ddep/output
                 ]
                 ;pass
             ]
-            application-class [
+            'application-class [
                 file-to-local any [dep/implib join-of dep/basename ".lib"]
             ]
-            var-class [
+            'var-class [
                 ;pass
             ]
-            entry-class [
+            'entry-class [
                 ;pass
             ]
         ][
@@ -1197,13 +1197,13 @@ generator-class: make object! [
         cmd [object!]
     ][
         switch/default cmd/class-name [
-            cmd-create-class [
+            'cmd-create-class [
                 apply any [:gen-cmd-create :target-platform/gen-cmd-create] compose [cmd: (cmd)]
             ]
-            cmd-delete-class [
+            'cmd-delete-class [
                 apply any [:gen-cmd-delete :target-platform/gen-cmd-delete] compose [cmd: (cmd)]
             ]
-            cmd-strip-class [
+            'cmd-strip-class [
                 apply any [:gen-cmd-strip :target-platform/gen-cmd-strip] compose [cmd: (cmd)]
             ]
         ][
@@ -1311,10 +1311,10 @@ generator-class: make object! [
         case [
             blank? project/output [
                 switch/default project/class-name [
-                    object-file-class [
+                    'object-file-class [
                         project/output: copy project/source
                     ]
-                    object-library-class [
+                    'object-library-class [
                         project/output: to string! project/name
                     ]
                 ][
@@ -1352,12 +1352,11 @@ generator-class: make object! [
         ;print ["Setting outputs for:"]
         ;dump project
         switch/default project/class-name [
-            application-class
-            dynamic-library-class
-            static-library-class
-            solution-class
-            object-library-class
-            [
+            'application-class
+            'dynamic-library-class
+            'static-library-class
+            'solution-class
+            'object-library-class [
                 if project/generated? [leave]
                 setup-output project
                 project/generated?: true
@@ -1365,7 +1364,8 @@ generator-class: make object! [
                     setup-outputs dep
                 ]
             ]
-            object-file-class [
+
+            'object-file-class [
                 setup-output project
             ]
         ][
@@ -1389,7 +1389,7 @@ makefile: make generator-class [
         cmd
     ][
         switch/default entry/class-name [
-            var-class [
+            'var-class [
                 unspaced [
                     entry/name either entry/default [
                         unspaced [either nmake? ["="]["?="] entry/default]
@@ -1399,7 +1399,7 @@ makefile: make generator-class [
                     newline
                 ]
             ]
-            entry-class [
+            'entry-class [
                 unspaced [
                     either file? entry/target [
                         file-to-local entry/target
@@ -1411,13 +1411,13 @@ makefile: make generator-class [
                         block? entry/depends [
                             spaced map-each w entry/depends [
                                 switch/default w/class-name [
-                                    var-class [
+                                    'var-class [
                                         unspaced ["$(" w/name ")"]
                                     ]
-                                    entry-class [
+                                    'entry-class [
                                         w/target
                                     ]
-                                    ext-dynamic-class ext-static-class [
+                                    'ext-dynamic-class 'ext-static-class [
                                         ;only contribute to the command line
                                     ]
                                 ][
@@ -1503,10 +1503,9 @@ makefile: make generator-class [
                 ]
             ]
             switch/default dep/class-name [
-                application-class
-                dynamic-library-class
-                static-library-class
-                [
+                'application-class
+                'dynamic-library-class
+                'static-library-class [
                     objs: make block! 8
                     ;dump dep
                     for-each obj dep/depends [
@@ -1524,7 +1523,8 @@ makefile: make generator-class [
                     ]
                     emit buf dep
                 ]
-                object-library-class [
+
+                'object-library-class [
                     ;assert [dep/class-name != 'object-library-class] ;No nested object-library-class allowed
                     for-each obj dep/depends [
                         assert [obj/class-name = 'object-file-class]
@@ -1534,14 +1534,17 @@ makefile: make generator-class [
                         ]
                     ]
                 ]
-                object-file-class [
+
+                'object-file-class [
                     ;print ["generate object rule"]
                     append buf gen-rule dep/gen-entries project
                 ]
-                entry-class var-class [
+
+                'entry-class 'var-class [
                     append buf gen-rule dep
                 ]
-                ext-dynamic-class ext-static-class [
+
+                'ext-dynamic-class 'ext-static-class [
                     ;pass
                 ]
             ][
@@ -1588,10 +1591,10 @@ mingw-make: make makefile [
 ; Execute the command to generate the target directly
 Execution: make generator-class [
     host: switch/default system/platform/1 [
-        Windows [windows]
-        Linux [linux]
-        OSX [osx]
-        Android [android]
+        'Windows [windows]
+        'Linux [linux]
+        'OSX [osx]
+        'Android [android]
     ][
         print unspaced ["Untested platform " system/platform ", assuming is POSIX compilant"]
         posix
@@ -1608,10 +1611,10 @@ Execution: make generator-class [
         cmd
     ][
         switch/default target/class-name [
-            var-class [
+            'var-class [
                 ;pass: already been taken care of by PREPARE
             ]
-            entry-class [
+            'entry-class [
                 if all [
                     not word? target/target 
                     ; so you can use words for "phony" targets
@@ -1658,10 +1661,9 @@ Execution: make generator-class [
         ]
 
         switch/default project/class-name [
-            application-class
-            dynamic-library-class
-            static-library-class
-            [
+            'application-class
+            'dynamic-library-class
+            'static-library-class [
                 objs: make block! 8
                 for-each obj project/depends [
                     ;dump obj
@@ -1678,7 +1680,8 @@ Execution: make generator-class [
                     commands: project/command
                 ]
             ]
-            object-library-class [
+
+            'object-library-class [
                 for-each obj project/depends [
                     assert [obj/class-name = 'object-file-class]
                     if not obj/generated? [
@@ -1687,18 +1690,22 @@ Execution: make generator-class [
                     ]
                 ]
             ]
-            object-file-class [
+
+            'object-file-class [
                 ;print ["generate object rule"]
                 assert [parent]
                 run-target project/gen-entries p-project
             ]
-            entry-class var-class [
+
+            'entry-class 'var-class [
                 run-target project
             ]
-            ext-dynamic-class ext-static-class [
+
+            'ext-dynamic-class 'ext-static-class [
                 ;pass
             ]
-            solution-class [
+
+            'solution-class [
                 for-each dep project/depends [
                     run dep
                 ]
@@ -1883,10 +1890,12 @@ visual-studio: make generator-class [
         optimization
     ][
         switch/default optimization [
-            0 _ no false off #[false]["Disabled"]
+            0 _ 'no 'false 'off #[false] [
+                "Disabled"
+            ]
             1 ["MinSpace"]
             2 ["MaxSpeed"]
-            x ["Full"]
+            'x ["Full"]
         ][
             fail ["Unrecognized optimization level:" (optimization)]
         ]
@@ -1958,7 +1967,9 @@ visual-studio: make generator-class [
             lib: make string! 1024
             for-each i project/depends [
                 switch i/class-name [
-                    ext-dynamic-class ext-static-class static-library-class [
+                    'ext-dynamic-class
+                    'ext-static-class
+                    'static-library-class [
                         if ext: filter-flag i/output "msc" [
                             append lib unspaced [
                                 ext
@@ -1967,7 +1978,7 @@ visual-studio: make generator-class [
                             ]
                         ]
                     ]
-                    application-class [
+                    'application-class [
                         append lib unspaced [any [i/implib unspaced [i/basename ".lib"]] ";"]
                         append searches unspaced [
                             unspaced [i/name ".dir\" build-type] ";"
@@ -2020,10 +2031,10 @@ visual-studio: make generator-class [
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
   <ConfigurationType>} switch/default project/class-name [
-      static-library-class object-library-class ["StaticLibrary"]
-      dynamic-library-class ["DynamicLibrary"]
-      application-class ["Application"]
-      entry-class ["Utility"]
+      'static-library-class 'object-library-class ["StaticLibrary"]
+      'dynamic-library-class ["DynamicLibrary"]
+      'application-class ["Application"]
+      'entry-class ["Utility"]
   ][fail ["Unsupported project class:" (project/class-name)]] {</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>

--- a/scripts/changes-file/changes-file.reb
+++ b/scripts/changes-file/changes-file.reb
@@ -171,10 +171,10 @@ notable?: function [
     unless empty? cc [append c compose/only [cc: (cc)]]
 
     ;; if find commit in our cherry-pick map then apply logic / meta info
-    if cherry-value: select cherry-pick c/commit [
+    if did cherry-value: select cherry-pick c/commit [
         switch cherry-value [
-            yes  [return true]       ;; This is a notable change so use (as-is)
-            no   [return false]      ;; NOT notable so skip
+            'yes  [return true]       ;; This is a notable change so use (as-is)
+            'no   [return false]      ;; NOT notable so skip
         ]
 
         ;; so must be block?

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1575,7 +1575,7 @@ REB_R Type_Action_Dispatcher(REBFRM *f)
 
         case SYM_TYPE:
             if (kind == REB_MAX_VOID)
-                return R_BLANK;
+                return R_VOID; // `() = type of ()`, `null = type of ()`
             Init_Datatype(f->out, kind);
             return R_OUT;
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -897,7 +897,7 @@ REBNATIVE(choose)
 //      return: "Last case evaluation, or null if no cases matched"
 //          [<opt> any-value!]
 //      value "Target value"
-//          [any-value!]
+//          [<opt> any-value!]
 //      cases "Block of cases (comparison lists followed by block branches)"
 //          [block!]
 //      /all "Evaluate all matches (not just first one)"

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1143,7 +1143,7 @@ REBNATIVE(quote)
 //
 //      optional [<opt> any-value!]
 //  ][
-//      blank? type of :optional
+//      () = type of :optional
 //  ]
 //
 REBNATIVE(null_q)

--- a/src/extensions/ffi/make-spec.r
+++ b/src/extensions/ffi/make-spec.r
@@ -59,7 +59,7 @@ options: [
             ]
         ][
             switch/default user-config/with-ffi [
-                static dynamic [
+                'static 'dynamic [
                     for-each var [includes cflags searches ldflags][
                         x: rebmake/pkg-config
                             any [user-config/pkg-config {pkg-config}]
@@ -82,7 +82,7 @@ options: [
                         ]
                     ]
                 ]
-                _ no off false #[false] [
+                _ 'no 'off 'false #[false] [
                     ;pass
                 ]
             ][

--- a/src/extensions/odbc/make-spec.r
+++ b/src/extensions/odbc/make-spec.r
@@ -30,7 +30,7 @@ modules: [
             %prep/extensions/odbc ;for %tmp-ext-odbc-init.inc
         ]
         libraries: switch/default system-config/os-base [
-            Windows [
+            'Windows [
                 [%odbc32]
             ]
         ][

--- a/src/extensions/uuid/make-spec.r
+++ b/src/extensions/uuid/make-spec.r
@@ -12,7 +12,7 @@ modules: [
             %prep/extensions/uuid ;for %tmp-extensions-uuid-init.inc
         ]
         depends: try switch system-config/os-base [
-            linux [
+            'linux [
                 [
                     %uuid/libuuid/gen_uuid.c
                     %uuid/libuuid/unpack.c
@@ -23,12 +23,12 @@ modules: [
         ]
 
         libraries: try switch system-config/os-base [
-            Windows [
+            'Windows [
                 [%rpcrt4]
             ]
         ]
         ldflags: try switch system-config/os-base [
-            OSX [
+            'OSX [
                 ["-framework CoreFoundation"]
             ]
         ]

--- a/src/extensions/view/make-spec.r
+++ b/src/extensions/view/make-spec.r
@@ -21,7 +21,7 @@ modules: [
         ;
         libraries: to-value (comment [
             switch system-config/os-base [
-                Windows [
+                'Windows [
                     ; You would currently have to define USE_WINDOWS_DIRCHOOSER
                     ; to try out the REQUEST-DIR code.
                     ;

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -1274,7 +1274,7 @@ inline static REBOOL Eval_Value_Core_Throws(
 //     >> case [false "a" false "b"] then func [x] [print x] else [print "*"]
 //     *
 //
-// Also, Ren-C does something called "blankification", unless the /ONLY
+// Also, Ren-C does something called "blankification", unless the /OPT
 // refinement is used.  This is the process by which a void-producing branch
 // is forced to be a BLANK! instead, allowing void to be reserved for the
 // result when no branch ran.  This gives a uniform way of determining
@@ -1289,7 +1289,7 @@ inline static REBOOL Run_Branch_Throws(
     REBVAL *out,
     const REBVAL *condition,
     const REBVAL *branch,
-    REBOOL only
+    REBOOL opt
 ){
     assert(branch != out); // !!! review, CASE can perhaps do better...
     assert(condition != out); // direct pointer in va_list, also destination
@@ -1306,7 +1306,7 @@ inline static REBOOL Run_Branch_Throws(
             return TRUE;
     }
 
-    if (not only and IS_VOID(out))
+    if (not opt and IS_VOID(out))
         Init_Blank(out); // "blankification", see comment above
 
     CLEAR_VAL_FLAG(out, VALUE_FLAG_UNEVALUATED);

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -165,11 +165,11 @@ script?: func [
     source [file! url! binary! string!]
 ][
     switch type of source [
-        (file!)
-        (url!) [
+        file!
+        url! [
             source: read source
         ]
-        (string!) [
+        string! [
             ; Remove this line if FIND-SCRIPT changed to accept string!
             ;
             source: to binary! source

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -566,7 +566,7 @@ case*: redescribe [
 switch*: redescribe [
     {Same as SWITCH/ONLY (void, not blank, if branch evaluates to void)}
 ](
-    specialize 'switch [only: true]
+    specialize 'switch [opt: true]
 )
 
 skip*: redescribe [

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -181,7 +181,7 @@ list-dir: procedure [
     ]
 
     switch type of :path [
-        _ [] ; Stay here
+        null [] ; Stay here
         file! [change-dir path]
         string! [change-dir local-to-file path]
         word! path! [change-dir to-file path]

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -182,9 +182,9 @@ list-dir: procedure [
 
     switch type of :path [
         _ [] ; Stay here
-        (file!) [change-dir path]
-        (string!) [change-dir local-to-file path]
-        (word!) (path!) [change-dir to-file path]
+        file! [change-dir path]
+        string! [change-dir local-to-file path]
+        word! path! [change-dir to-file path]
     ]
 
     if r [l: true]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -235,8 +235,8 @@ title-of: function [
 
     value [any-value!]
 ][
-    to-value switch type of :value [
-        (action!) [
+    try switch type of :value [
+        action! [
             all [
                 object? meta: meta-of :value
                 string? description: select meta 'description
@@ -244,7 +244,7 @@ title-of: function [
             ]
         ]
 
-        (datatype!) [
+        datatype! [
             spec: spec-of value
             assert [string? spec] ;-- !!! Consider simplifying "type specs"
             spec/title
@@ -664,12 +664,12 @@ source: procedure [
     ; some kind of displayable "source" would have to depend on the dispatcher
     ; used.  For the moment, BODY OF hands back limited information.  Review.
     ;
-    switch type of body: body of :f [
-        (block!) [ ;-- FUNC, FUNCTION, PROC, PROCEDURE or (DOES of a BLOCK!)
+    switch type of (body: body of :f) [
+        block! [ ;-- FUNC, FUNCTION, PROC, PROCEDURE or (DOES of a BLOCK!)
             print [mold body "]"]
         ]
 
-        (frame!) [ ;-- SPECIALIZE (or DOES of an ACTION!)
+        frame! [ ;-- SPECIALIZE (or DOES of an ACTION!)
             print [mold body "]"]
         ]
     ] else [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -560,10 +560,10 @@ format: function [
     for-each rule rules [
         if word? :rule [rule: get rule]
 
-        val: val + switch type of :rule [
-            :integer! [abs rule]
-            :string! [length of rule]
-            :char! [1]
+        val: me + switch type of :rule [
+            integer! [abs rule]
+            string! [length of rule]
+            char! [1]
         ] else [0]
     ]
 
@@ -575,7 +575,7 @@ format: function [
         if word? :rule [rule: get rule]
 
         switch type of :rule [
-            :integer! [
+            integer! [
                 pad: rule
                 val: form first values
                 values: my next
@@ -588,8 +588,8 @@ format: function [
                 change out :val
                 out: skip out pad ; spacing (remainder)
             ]
-            :string!  [out: change out rule]
-            :char!    [out: change out rule]
+            string!  [out: change out rule]
+            char!    [out: change out rule]
         ]
     ]
 

--- a/src/mezz/mezz-shell.r
+++ b/src/mezz/mezz-shell.r
@@ -30,9 +30,9 @@ cd: func [
 ][
     switch type of :path [
         _ []
-        (file!) [change-dir path]
-        (string!) [change-dir local-to-file path]
-        (word!) (path!) [change-dir to-file path]
+        file! [change-dir path]
+        string! [change-dir local-to-file path]
+        word! path! [change-dir to-file path]
     ]
 
     return what-dir
@@ -44,8 +44,8 @@ more: func [
         "Accepts %file and also just words (as file names)"
 ][
     print deline to-string read switch type of :file [
-        (file!) [file]
-        (string!) [local-to-file file]
-        (word!) (path!) [to-file file]
+        file! [file]
+        string! [local-to-file file]
+        word! path! [to-file file]
     ]
 ]

--- a/src/mezz/mezz-shell.r
+++ b/src/mezz/mezz-shell.r
@@ -29,7 +29,7 @@ cd: func [
         "Accepts %file, :variables and just words (as dirs)"
 ][
     switch type of :path [
-        _ []
+        null []
         file! [change-dir path]
         string! [change-dir local-to-file path]
         word! path! [change-dir to-file path]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -655,7 +655,7 @@ load-module: function [
     ; Process the source, based on its type
 
     switch type of source [
-        (word!) [ ; loading the preloaded
+        word! [ ; loading the preloaded
             if as_LOAD_MODULE [
                 cause-error 'script 'bad-refine /as ; no renaming
             ]
@@ -682,11 +682,11 @@ load-module: function [
         ; then any strings passed in to loading have to be UTF-8 converted,
         ; which means making them into BINARY!.
         ;
-        (binary!) [data: source]
-        (string!) [data: to binary! source]
+        binary! [data: source]
+        string! [data: to binary! source]
 
-        (file!)
-        (url!) [
+        file!
+        url! [
             tmp: file-type? source
             case [
                 tmp = 'rebol [
@@ -703,7 +703,7 @@ load-module: function [
             ]
         ]
 
-        (module!) [
+        module! [
             ; see if the same module is already in the list
             if tmp: find/skip next system/modules mod: source 2 [
                 if as_LOAD_MODULE [
@@ -723,7 +723,7 @@ load-module: function [
             ]
         ]
 
-        (block!) [
+        block! [
             if any [version as] [
                 cause-error 'script 'bad-refines blank
             ]

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -125,7 +125,11 @@ finish-init-core: proc [
 
         switch: (adapt 'switch [
             for-each c cases [
-                if (did match [word! path!] c) and (not datatype? get c) [
+                lib/all [ ;-- SWITCH/ALL would override
+                    did match [word! path!] c
+                    'null <> c
+                    not datatype? get c
+                ] then [
                     fail/where [
                         {Temporarily disabled word/path SWITCH clause:} :c LF
 

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -122,6 +122,24 @@ finish-init-core: proc [
         ](
             specialize 'unless [try: true]
         ))])
+
+        switch: (adapt 'switch [
+            for-each c cases [
+                if (did match [word! path!] c) and (not datatype? get c) [
+                    fail/where [
+                        {Temporarily disabled word/path SWITCH clause:} :c LF
+
+                        {You likely meant to use a LIT-WORD! / LIT-PATH!} LF
+
+                        {SWITCH in Ren-C evaluates its match clauses, and}
+                        {will even allow 0-arity ACTION!s (larger arities are}
+                        {put in a GROUP! to facilitate skipping after a match}
+                        {is found.  But to help catch old uses, only datatype}
+                        {lookups are enabled.  SWITCH: :LIB/SWITCH overrides.}
+                    ] 'cases
+                ]
+            ]
+        ])
     ]
 
     comment [

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -379,15 +379,15 @@ host-console: function [
         ]
 
         return-to-c <- switch type of state [
-            (integer!) [ ;-- just tells the calling C loop to exit() process
+            integer! [ ;-- just tells the calling C loop to exit() process
                 assert [empty? instruction]
                 state
             ]
-            (datatype!) [ ;-- type assertion, how to enforce this?
+            datatype! [ ;-- type assertion, how to enforce this?
                 emit spaced ["^-- Result should be" an state]
                 instruction
             ]
-            (group!) [ ;-- means "submit user code"
+            group! [ ;-- means "submit user code"
                 assert [empty? instruction]
                 state
             ]
@@ -778,9 +778,9 @@ echo: procedure [
     case [
         word? instruction [
             switch instruction [
-                on [ensure-echo-on]
-                off [ensure-echo-off]
-                reset [
+                'on [ensure-echo-on]
+                'off [ensure-echo-off]
+                'reset [
                     delete form-target
                     write/append form-target "" ;-- or just have it not exist?
                 ]

--- a/src/os/unzip.reb
+++ b/src/os/unzip.reb
@@ -178,7 +178,7 @@ ctx-zip: context [
                 local-file-sig
                 #{0000} ; version
                 #{0000} ; flags
-                really switch method [store [#{0000}] deflate [#{0800}]]
+                really switch method ['store [#{0000}] 'deflate [#{0800}]]
                 to-msdos-time date/time
                 to-msdos-date date/date
                 crc     ; crc-32
@@ -197,7 +197,7 @@ ctx-zip: context [
                 #{0000} ; version source
                 #{0000} ; version min
                 #{0000} ; flags
-                really switch method [store [#{0000}] deflate [#{0800}]]
+                really switch method ['store [#{0000}] 'deflate [#{0800}]]
                 to-msdos-time date/time
                 to-msdos-date date/date
                 crc     ; crc-32

--- a/tests/control/do.test.reb
+++ b/tests/control/do.test.reb
@@ -159,7 +159,7 @@
 (true = eval true)
 (false = eval false)
 ($1 == eval $1)
-(_ = eval (specialize 'of [property: 'type]) ())
+(null? eval (specialize 'of [property: 'type]) ())
 (blank? do _)
 (
     a-value: make object! []

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -1,6 +1,6 @@
 ; datatypes/unset.r
 (null? ())
-(blank? type of ())
+(null? type of ())
 (not null? 1)
 
 [#68

--- a/tests/log-diff.r
+++ b/tests/log-diff.r
@@ -66,15 +66,15 @@ make-diff: function [
                 write/append diff-file spaced [
                     new-test
                     switch new-result [
-                        succeeded [
+                        'succeeded [
                             new-successes: new-successes + 1
                             "succeeded"
                         ]
-                        failed [
+                        'failed [
                             new-failures: new-failures + 1
                             "failed"
                         ]
-                        crashed [
+                        'crashed [
                             new-crashes: new-crashes + 1
                             "crashed"
                         ]

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -267,9 +267,9 @@ make object! [
             parse tokens [thru 'eol set eol [string! | char!]]
             for-each [type val] tokens [
                 switch/default type [
-                    eol wsp [emit val]
-                    cmt [emit #";" emit val emit eol]
-                    tst [
+                    'eol 'wsp [emit val]
+                    'cmt [emit #";" emit val emit eol]
+                    'tst [
                         replace/all val newline eol
                         if empty? issues [
                             if eol <> last-emit [emit eol]
@@ -330,10 +330,10 @@ make object! [
                             emit #"]"
                         ]
                     ]
-                    fil [emit val]
-                    flg [emit #"<" emit val emit #">"]
-                    isu [append/only issues val]
-                    end []
+                    'fil [emit val]
+                    'flg [emit #"<" emit val emit #">"]
+                    'isu [append/only issues val]
+                    'end []
                 ] [
                     fail [{Cannot render type } (type)]
                 ]


### PR DESCRIPTION
This commit implements a long-discussed, and fairly significant change,
which makes SWITCH evaluate its match clauses.  As an interim measure,
the version exported to the user context will check to see if you
used a plain WORD! that does not evaluate to a datatype, and warn
that you probably meant to use a LIT-WORD!.  However, in the long term
this warning would be removed.

One major sought-after benefit of this is that types need not be
converted to words or be quoted in order to match:

    switch type of 5 [
        integer! [print "This will work, finally!"]
    ]

However, it carries other benefits, including the ability to mix it
in with ELIDE.

    switch type of x [
        string! [...]
        file! [...]

        elide (
           ...code to run if neither of the above matched...
           ...but continue matching afterward...
           ...other invisibles like DUMP can be used, too...
        )

        block! [...]
        group! [...]
    ]

For reasons of mechanics and clarity, only 0-arity evaluations are
allowed.  On the point of clarity:

    switch 'c [
        third [a b c] [print "Block argument looks like code to run"]
    ]

But on the point of mechanics, it would not be possible to skip over
arbitrary-arity evaluative clauses after a match were found.

A GROUP! may be used to get around this:

    switch 'c [
        (third [a b c]) [print "use a GROUP! for arbitrary code"]
    ]