### PR TITLE
all 30n responses can be ignored

### DIFF
--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -12,7 +12,7 @@ REBOL [
     Name: http
     Type: module
     File: %prot-http.r
-    Version: 0.1.47
+    Version: 0.1.48
     Purpose: {
         This program defines the HTTP protocol scheme for REBOL 3.
     }
@@ -346,9 +346,11 @@ check-response: function [port] [
                     ]
                     |
                     #"3" [
+                        (if spec/follow = 'ok [throw 'ok])
+
                         "02" (throw spec/follow)
                         |
-                        "03" (throw either spec/follow = 'ok ['ok] [see-other])
+                        "03" (throw 'see-other)
                         |
                         "04" (throw 'not-modified)
                         |


### PR DESCRIPTION
Previously when we used the no-redirect keyword only 302s were not followed.  Now, we do this for all 30n codes ignoring that 305 is no longer used.  See https://developer.att.com/video-optimizer/docs/best-practices/http-300-status-codes

>> to string! write http://www.ayadesajn.net [no-redirect GET []]
== {<html>^M
<head><title>301 Moved Permanently</title></head>^M
<body bgcolor="white">^M
<center><h1>301 Moved Permanently</h1></center>^M
<hr><center>nginx/1.4.6 (Ubuntu)</center>^M
</body>^M
</html>^M
}

>> read http://www.ayadesajn.net
** Access Error: protocol error: "Redirect to other host - requires custom handling"
** Where: fail switch take* any unless awake either do-redirect then if switch check-response switch take* any unless _ wake-up either while-not _ wait while-not sync-op else _ read _
** Near: [... _
    fail error ~~]
** File: prot-http.reb
** Line: 99