### PR TITLE
Scan => and =<, kill ?, <- enforce non-NULL, nullable SET

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -422,16 +422,16 @@ static void Add_Lib_Keys_R3Alpha_Cant_Make(void)
         "<",
         ">",
 
-        "<=", // less than or equal to
-        "=>", // no current system meaning
+        "<=", // less than or equal !!! https://forum.rebol.info/t/349/11
+        "=>", // Lambda function, quotes optional left argument
 
         ">=", // greater than or equal to
-        "=<",
+        "=<", // equal to or less than
 
         "<>", // not equal (the chosen meaning, as opposed to "empty tag")
 
-        "->", // FUNCTION-style lambda ("reaches in")
-        "<-", // FUNC-style lambda ("reaches out"),
+        "->", // no current meaning
+        "<-", // Non-null implicit GROUP! begin, e.g. `7 = 1 + <- 2 * 3`
 
         "|>", // Evaluate to next single expression, but do ones afterward
         "<|", // Evaluate to previous expression, but do rest (like ALSO)

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -251,11 +251,11 @@ ATTRIBUTE_NO_RETURN void Fail_Core(const void *p)
         static REBOOL probing = FALSE;
 
         if (p == cast(void*, VAL_CONTEXT(Root_Stackoverflow_Error))) {
-            printf("PROBE(Stack Overflow) -> mold in PROBE would recurse\n");
+            printf("PROBE(Stack Overflow): mold in PROBE would recurse\n");
             fflush(stdout);
         }
         else if (probing) {
-            printf("PROBE(Recursing) -> recursing for unknown reason\n");
+            printf("PROBE(Recursing): recursing for unknown reason\n");
             panic (p);
         }
         else {

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -244,8 +244,8 @@ inline static void Finalize_Arg(
 
         if (IS_FALSEY(refine)) {
             //
-            // FALSE -> refinement already revoked, void is okay
-            // BLANK! -> refinement was never in use, so also okay
+            // FALSE means refinement already revoked, void is okay
+            // BLANK! means refinement was never in use, so also okay
             //
             return;
         }
@@ -492,18 +492,18 @@ reevaluate:;
                 // it an error, but instead give the left hand side precedence
                 // over the right.  This means something like:
                 //
-                //     foo: quote -> [print quote]
+                //     foo: quote => [print quote]
                 //
                 // Would be interpreted as:
                 //
-                //     foo: (quote ->) [print quote]
+                //     foo: (quote =>) [print quote]
                 //
                 // This is a good argument for not making enfixed operations
                 // that hard-quote things that can dispatch functions.  A
                 // soft-quote would give more flexibility to override the
                 // left hand side's precedence, e.g. the user writes:
                 //
-                //     foo: ('quote) -> [print quote]
+                //     foo: ('quote) => [print quote]
                 //
                 Push_Action(
                     f,

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1702,8 +1702,15 @@ scanword:
         // has chars not allowed in word (eg % \ )
         fail (Error_Syntax(ss));
     }
+
     if (HAS_LEX_FLAG(flags, LEX_SPECIAL_LESSER)) {
         // Allow word<tag> and word</tag> but not word< word<= word<> etc.
+
+        if (*cp == '=' and cp[1] == '<' and IS_LEX_DELIMIT(cp[2])) {
+            ss->token = TOKEN_WORD; // enable `=<`
+            return;
+        }
+
         cp = Skip_To_Byte(cp, ss->end, '<');
         if (
             cp[1] == '<' or cp[1] == '>' or cp[1] == '='
@@ -1714,8 +1721,13 @@ scanword:
         }
         ss->end = cp;
     }
-    else if (HAS_LEX_FLAG(flags, LEX_SPECIAL_GREATER))
+    else if (HAS_LEX_FLAG(flags, LEX_SPECIAL_GREATER)) {
+        if (*cp == '=' and cp[1] == '>' and IS_LEX_DELIMIT(cp[2])) {
+            ss->token = TOKEN_WORD; // enable `=>`
+            return;
+        }
         fail (Error_Syntax(ss));
+    }
 
     return;
 }

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -706,8 +706,6 @@ REBNATIVE(resolve)
 //          {Word or path, or block of words and paths}
 //      value [<opt> any-value!]
 //          "Value or block of values"
-//      /opt
-//          {Treat void values as unsetting the target instead of an error}
 //      /single
 //          {If target and value are blocks, set each item to the same value}
 //      /some
@@ -754,9 +752,6 @@ REBNATIVE(set)
             single = FALSE;
         }
         else {
-            if (IS_VOID(ARG(value)) and not REF(opt))
-                fail (Error_No_Value(ARG(value)));
-
             value = ARG(value);
             value_specifier = SPECIFIED;
             single = TRUE;
@@ -776,9 +771,6 @@ REBNATIVE(set)
         //
         assert(ANY_WORD(target) or ANY_PATH(target) or IS_BAR(target));
 
-        if (IS_VOID(ARG(value)) and not REF(opt))
-            fail (Error_No_Value(ARG(value)));
-
         value = ARG(value);
         value_specifier = SPECIFIED;
         single = TRUE;
@@ -789,7 +781,7 @@ REBNATIVE(set)
     for (
         ;
         NOT_END(target);
-        ++target, single || IS_END(value) ? NOOP : (++value, NOOP)
+        ++target, (single or IS_END(value)) ? NOOP : (++value, NOOP)
      ){
         if (REF(some)) {
             if (IS_END(value))
@@ -948,8 +940,8 @@ REBNATIVE(semiquoted_q)
 //
 //  {Function for returning the same value that it got in (identity function)}
 //
-//      return: [<opt> any-value!]
-//      value [<opt> <end> any-value!]
+//      return: [any-value!]
+//      value [<end> any-value!]
 //          {Accepting <end> means it also limits enfix reach to the left}
 //      /quote
 //          {Make it seem that the return result was quoted}
@@ -963,7 +955,7 @@ REBNATIVE(identity)
 // !!! Quoting version is currently specialized as SEMIQUOTE, for convenience.
 //
 // This is assigned to <- for convenience, but cannot be used under that name
-// in bootstrap.  It uses the <end>-ability to stop left reach.
+// in bootstrap with R3-Alpha.  It uses the <end>-ability to stop left reach.
 {
     INCLUDE_PARAMS_OF_IDENTITY;
 

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -554,8 +554,9 @@ compare:
 //
 //  equal?: native [
 //
-//  "Returns TRUE if the values are equal."
+//  {TRUE if the values are equal}
 //
+//      return: [logic!]
 //      value1 [<opt> any-value!]
 //      value2 [<opt> any-value!]
 //  ]
@@ -574,8 +575,9 @@ REBNATIVE(equal_q)
 //
 //  not-equal?: native [
 //
-//  "Returns TRUE if the values are not equal."
+//  {TRUE if the values are not equal}
 //
+//      return: [logic!]
 //      value1 [<opt> any-value!]
 //      value2 [<opt> any-value!]
 //  ]
@@ -594,8 +596,9 @@ REBNATIVE(not_equal_q)
 //
 //  strict-equal?: native [
 //
-//  "Returns TRUE if the values are strictly equal."
+//  {TRUE if the values are strictly equal}
 //
+//      return: [logic!]
 //      value1 [<opt> any-value!]
 //      value2 [<opt> any-value!]
 //  ]
@@ -614,8 +617,9 @@ REBNATIVE(strict_equal_q)
 //
 //  strict-not-equal?: native [
 //
-//  "Returns TRUE if the values are not strictly equal."
+//  {TRUE if the values are not strictly equal}
 //
+//      return: [logic!]
 //      value1 [<opt> any-value!]
 //      value2 [<opt> any-value!]
 //  ]
@@ -634,8 +638,9 @@ REBNATIVE(strict_not_equal_q)
 //
 //  same?: native [
 //
-//  "Returns TRUE if the values are identical."
+//  {TRUE if the values are identical}
 //
+//      return: [logic!]
 //      value1 [<opt> any-value!]
 //      value2 [<opt> any-value!]
 //  ]
@@ -749,8 +754,9 @@ REBNATIVE(same_q)
 //
 //  lesser?: native [
 //
-//  {Returns TRUE if the first value is less than the second value.}
+//  {TRUE if the first value is less than the second value}
 //
+//      return: [logic!]
 //      value1 value2
 //  ]
 //
@@ -766,16 +772,17 @@ REBNATIVE(lesser_q)
 
 
 //
-//  lesser-or-equal?: native [
+//  equal-or-lesser?: native [
 //
-//  {Returns TRUE if the first value is less than or equal to the second value.}
+//  {TRUE if the first value is equal to or less than the second value}
 //
+//      return: [logic!]
 //      value1 value2
 //  ]
 //
-REBNATIVE(lesser_or_equal_q)
+REBNATIVE(equal_or_lesser_q)
 {
-    INCLUDE_PARAMS_OF_LESSER_OR_EQUAL_Q;
+    INCLUDE_PARAMS_OF_EQUAL_OR_LESSER_Q;
 
     if (Compare_Modify_Values(ARG(value1), ARG(value2), -2))
         return R_FALSE;
@@ -787,8 +794,9 @@ REBNATIVE(lesser_or_equal_q)
 //
 //  greater?: native [
 //
-//  {Returns TRUE if the first value is greater than the second value.}
+//  {TRUE if the first value is greater than the second value}
 //
+//      return: [logic!]
 //      value1 value2
 //  ]
 //
@@ -806,8 +814,9 @@ REBNATIVE(greater_q)
 //
 //  greater-or-equal?: native [
 //
-//  {Returns TRUE if the first value is greater than or equal to the second value.}
+//  {TRUE if the first value is greater than or equal to the second value}
 //
+//      return: [logic!]
 //      value1 value2
 //  ]
 //

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -73,7 +73,7 @@ maybe: enfix func [
         ] 'value
     ]
 
-    set* target either-test/opt
+    set target either-test/opt
         (only ?? :value? !! :something?) ;-- test function
         :value ;-- value being tested
         [get target] ;-- branch to evaluate and return if test fails
@@ -513,13 +513,6 @@ maybe*: enfix redescribe [
 semiquote: specialize 'identity [quote: true]
 
 
-set*: redescribe [
-    {Variation of SET where voids are tolerated for unsetting variables.}
-](
-    specialize 'set [opt: true]
-)
-
-
 if*: redescribe [
     {Same as IF/OPT (null, not blank, if branch evaluates to null)}
 ](
@@ -770,6 +763,8 @@ infix?: redescribe [
 )
 
 
+;-- => cannot be loaded by R3-Alpha, or even earlier Ren-C
+;
 lambda: function [
     {Convenience variadic wrapper for MAKE ACTION!}
 

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -98,18 +98,25 @@ for-each [set-op function-name] [
 ;
 =: !=: ==: !==: =?: _
 
-for-each [comparison-op function-name] [
+; <= looks a lot like a left arrow.  In the interest of "new thought", core
+; defines the operation in terms of =< 
+;
+lesser-or-equal?: :equal-or-lesser?
+
+for-each [comparison-op function-name] compose [
     =       equal?
     <>      not-equal?
     <       lesser?
-    <=      lesser-or-equal? ;-- !!! or left arrow?  Consider `=<`
+    (r3-alpha-quote "=<") equal-or-lesser?
     >       greater?
     >=      greater-or-equal?
 
+    <=      lesser-or-equal? ;-- !!! https://forum.rebol.info/t/349/11
+
     !=      not-equal? ;-- !!! http://www.rebol.net/r3blogs/0017.html
 
-    ==      strict-equal?
-    !==     strict-not-equal?
+    ==      strict-equal? ;-- !!! https://forum.rebol.info/t/349 
+    !==     strict-not-equal? ;-- !!! bad pairing, most would think !=
 
     =?      same?
 ][
@@ -124,31 +131,6 @@ for-each [comparison-op function-name] [
     ; languages)...and a small price to pay.  Hence no TIGHTEN call here.
     ;
     set/enfix comparison-op (get function-name)
-]
-
-
-; !!! Originally in Rebol2 and R3-Alpha, ? was a synonym for HELP.  This seems
-; wasteful for the language as a whole, when it's easy enough to type HELP,
-; or add it to the console-specific abbreviations as H (as with Q for QUIT).
-;
-; This experiments with making `? var` equivalent to `set? 'var`.  Some are
-; made uncomfortable by ? being prefix and not infix, but this is a very
-; useful feature to have a shorthand for.  (Note: might `! var` being a
-; shorthand for `not set? 'var` make more sense than meaning NOT, because
-; there the tradeoff of literacy for symbology actually makes something a
-; bit clearer instead of less clear?)
-;
-?: func [
-    {Determine whether a word represents a variable that is SET?}
-
-    'var [any-word! any-path!]
-        {Variable name to test}
-][
-    ; Note: since this just changes the parameter convention, it could use a
-    ; facade (the way TIGHTEN does) and run the native code for SET?.  Revisit
-    ; when REDESCRIBE has this ability.
-    ;
-    set? var
 ]
 
 
@@ -188,12 +170,10 @@ for-each [comparison-op function-name] [
     either-test-value/opt :left [:right]
 ]
 
-; !!! By naming this ?! it somewhat suggests `?? () !!`, e.g. a shortening and
-; skipping over of a truthy clause.  If it were !? it might suggest a "not"
-; of the test.  For now we'll enable both and just see if people wind up
-; favoring one over the other enough to make it canon.
+; By naming this ?! it somewhat suggests `?? () !!`, e.g. a shortening and
+; skipping over of a truthy clause.
 ;
-!?: ?!: enfix func [
+?!: enfix func [
     {If TO LOGIC! of the left is false, return right value, otherwise null}
 
     return: [<opt> any-value!]
@@ -384,7 +364,7 @@ me: enfix func [
     :rest [any-value! <...>]
         {Code to run with var as left (first element should be enfixed)}
 ][
-    set* var eval-enfix (get var) rest
+    set var eval-enfix (get var) rest
 ]
 
 my: enfix func [
@@ -396,14 +376,14 @@ my: enfix func [
     :rest [any-value! <...>]
         {Code to run with var as left (first element should be prefix)}
 ][
-    set* var eval-enfix/prefix (get var) rest
+    set var eval-enfix/prefix (get var) rest
 ]
 
 
 ; Lambdas are experimental quick function generators via a symbol.  The
 ; identity is used to shake up enfix ordering.
 ;
-set/enfix (r3-alpha-quote "->") :lambda
+set/enfix (r3-alpha-quote "=>") :lambda
 set (r3-alpha-quote "<-") :identity ;-- not enfix, just affects enfix
 
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -429,7 +429,7 @@ r3-alpha-apply: function [
             using-args: set (in frame params/1) to-logic :arg
         ][
             if using-args [
-                set* (in frame params/1) :arg
+                set (in frame params/1) :arg
             ]
         ]
 
@@ -652,7 +652,7 @@ set 'r3-legacy* func [<local>] [
 
         ??: (:dump)
 
-        null: (#"^@") ; -> NUL https://en.wikipedia.org/wiki/Null_character
+        null: (#"^@") ; now NUL https://en.wikipedia.org/wiki/Null_character
 
         unset?: (:null?) ; https://trello.com/c/shR4v8tS
 
@@ -752,7 +752,6 @@ set 'r3-legacy* func [<local>] [
             apply 'set [
                 target: either any-context? target [words of target] [target]
                 value: :value
-                only: set_ANY
                 some: set_SOME
                 enfix: enfix
             ]
@@ -774,7 +773,6 @@ set 'r3-legacy* func [<local>] [
                 source: source unless any-context? source [
                     words of source
                 ]
-                only: any_GET
             ]
         ])
 

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -801,7 +801,7 @@ load-module: function [
             hdr/options: append any [hdr/options make block! 1] 'private
         ]
     ]
-    if not tuple? set* 'modver :hdr/version [
+    if not tuple? set 'modver :hdr/version [
         modver: 0.0.0 ; get version
     ]
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -375,18 +375,14 @@ host-start: function [
             return blank
         ]
 
-        any [
-            get-env 'HOME
-
+        return try <- get-env 'HOME or [
             all [
                 homedrive: get-env 'HOMEDRIVE
                 homepath: get-env 'HOMEPATH
                 join-of homedrive homepath
             ]
-        ] then home -> [
+        ] then lambda home [
             to-dir home
-        ] else [
-            blank
         ]
     ]
 

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -8,7 +8,7 @@
 ]
 
 (error? trap [a: () a])
-(not error? trap [set/opt 'a ()])
+(not error? trap [set 'a ()])
 
 (
     a-value: 10

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -70,7 +70,7 @@ make object! compose [
             not :result [
                 "failed"
             ]
-        ] also message -> [
+        ] also message => [
             set 'test-failures (test-failures + 1)
             log reduce [space {"} message {"} newline]
         ] else [


### PR DESCRIPTION
This contains a number of changes provoked by the idea that `SET 'WORD`
should act the same as `WORD:`, while settling on the concept that
`:WORD` acts the same as `GET 'WORD`.

One idea is that the <- operator disallow null.  Its previous main
purpose was precedence manipulation, such that you could write
`return <- if condition [...] else [...]` to stop the default
interpretation as `(return if condition [...]) else [...]`.  But
there's not a particularly compelling reason for it to allow null,
so it can do double duty as a checking construct.

e.g. consider `foo: <- :bar` .  Precedence-wise that's interpreted as
`foo: (:bar)`, which doesn't change anything, since there is no enfix
involved.  But the null check means the person doing the assignment can
be confident that the :bar fetched something.

So this commit makes a greater commitment to the idea that <- (and not
<| as in F# or Elm, and not $ as in Haskell) is the means of making
an implicit GROUP!.  With that commitment, -> is taken away from
lambda, which is shifted to the heavier-looking =>.  This required
a change to the scanner, as => and =< were not allowed previously
(despite being added to root words in lib long ago, the scanner still
wouldn't allow them).

(Hence the mezzanine must use the non-enfix form LAMBDA, as => cannot
be scanned in bootstrap.)

Given the decision that <- will be the means for null checking, SET
and SET-WORD! are reconciled with the elimination of /OPT refinement,
and hence SET* is not needed to unset a variable.  `set 'x ()` works,
and those concerned are to use `set 'x <- ...`

An unused definition of ? is killed as well, conversation here:

https://forum.rebol.info/t/the-question-of-plain-old-and-plain-old/624

Since =< is now legal, it is halfheartedly promoted as the "main"
form of comparison by changing the native LESSER-OR-EQUAL? to
EQUAL-OR-LESSER?, while preserving <= and LESSER-OR-EQUAL? as
mezzanine synonyms.

An oversight in the console in delivering internal errors is corrected,
as a print command was issued in generated code after a fail was
issued, which meant it would never be seen.