### PR TITLE
patch to prot-http.r to not fail on tiny webserver

### DIFF
--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -289,8 +289,18 @@ check-response: function [port] [
     ; dump spec
     all [
         not headers
-        d1: find conn/data crlfbin
-        d2: find/tail d1 crlf2bin
+        any [
+            all [
+                d1: find conn/data crlfbin
+                d2: find/tail d1 crlf2bin
+                net-log/C "server using standard content separator of #{0D0A0D0A}"
+            ]
+            all [
+                d1: find conn/data #{0A}
+                d2: find/tail d1 #{0A0A}
+                net-log/C "server using malformed line separator of #{0A0A}"
+            ]
+        ]
     ] then [
         info/response-line: line: to text! copy/part conn/data d1
 


### PR DESCRIPTION
The tiny webserver from Carl uses an incorrect separator between the header and body.  This checks for this.