### PR TITLE
Replace EMIT-ITEM/EMIT-LINE usages with CSCAPE EMIT

### DIFF
--- a/make/tools/make-boot-ext-header.r
+++ b/make/tools/make-boot-ext-header.r
@@ -37,13 +37,19 @@ for-each ext extensions [
         DECLARE_EXT_QUIT(${Ext});
     }
 ]
-e/emit-line []
+e/emit newline
 
-e/emit ["static CFUNC *Boot_Extensions [] = {"]
-for-each ext extensions [
-    e/emit-line/indent ["cast(CFUNC *, EXT_INIT(" ext ")),"]
-    e/emit-line/indent ["cast(CFUNC *, EXT_QUIT(" ext ")),"]
+cfuncs: collect [
+    for-each ext extensions [
+        keep cscape/with {cast(CFUNC*, EXT_INIT(${Ext}))} 'ext
+        keep cscape/with {cast(CFUNC*, EXT_QUIT(${Ext}))} 'ext
+    ]
 ]
-e/emit-end
+
+e/emit {
+    static CFUNC *Boot_Extensions [] = {
+        $(CFuncs),
+    };
+}
 
 e/write-emitted

--- a/make/tools/make-embedded-header.r
+++ b/make/tools/make-embedded-header.r
@@ -66,7 +66,7 @@ e/emit {
      */
     extern const REBYTE core_header_source[];
     const REBYTE core_header_source[] = {
-        $(Binary-To-C Join-Of Inp #{00})
+        $<Binary-To-C Join-Of Inp #{00}>
     };
 }
 

--- a/make/tools/make-ext-init.r
+++ b/make/tools/make-ext-init.r
@@ -58,11 +58,11 @@ write-c-file: procedure [
 
     e/emit 'r-file {
         /*
-         * Gzip compression of $(R-File)
-         * Originally $(length-of data) bytes
+         * Gzip compression of $<R-File>
+         * Originally $<length-of data> bytes
          */
-        static const REBYTE script_bytes[$(length-of compressed)] = {
-            $(Binary-To-C Compressed)
+        static const REBYTE script_bytes[$<length-of compressed>] = {
+            $<Binary-To-C Compressed>
         };
     }
 

--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -249,24 +249,33 @@ e2/emit {
     
     #if !defined(MODULE_INCLUDE_DECLARATION_ONLY)
     
-    #define EXT_NUM_NATIVES_${MOD} $(num-native)
-    #define EXT_NAT_COMPRESSED_SIZE_${MOD} $(length-of data)
+    #define EXT_NUM_NATIVES_${MOD} $<num-native>
+    #define EXT_NAT_COMPRESSED_SIZE_${MOD} $<length-of data>
     
     const REBYTE Ext_Native_Specs_${Mod}[EXT_NAT_COMPRESSED_SIZE_${MOD}] = {
-        $(Binary-To-C Compressed)
+        $<Binary-To-C Compressed>
     };
 }
 
-either num-native > 0 [
-    e2/emit ["REBNAT Ext_Native_C_Funcs_${Mod}[EXT_NUM_NATIVES_${MOD}] = {"]
-    for-each item native-list [
-        if set-word? item [
-            e2/emit-item ["N_" u-m-name "_" to word! item]
+either num-native = 0 [ ;-- C++ doesn't support 0-length arrays
+    e2/emit {
+        REBNAT *Ext_Native_C_Funcs_${Mod} = NULL;
+    }
+][
+    names: collect [
+        for-each item native-list [
+            if set-word? item [
+                item: to word! item
+                keep cscape/with {N_${MOD}_${Item}} 'item
+            ]
         ]
     ]
-    e2/emit-end
-][
-    e2/emit ["REBNAT *Ext_Native_C_Funcs_${Mod} = NULL;"]
+
+    e2/emit {
+        REBNAT Ext_Native_C_Funcs_${Mod}[EXT_NUM_NATIVES_${MOD}] = {
+            $(Names),
+        };
+    }
 ]
 
 e2/emit {
@@ -308,7 +317,7 @@ e1/emit {
     ** INCLUDE_PARAMS_OF MACROS: DEFINING PARAM(), REF(), ARG()
     */
 }
-e1/emit-line []
+e1/emit newline
 
 for-next native-list [
     if tail? next native-list [break]
@@ -337,7 +346,7 @@ e1/emit {
     #define REBNATIVE(n) \
         REB_R N_${MOD}_##n(REBFRM *frame_)
 }
-e1/emit-line []
+e1/emit newline
 
 
 e1/emit {
@@ -349,26 +358,36 @@ e1/emit {
     ** in an array that was Alloc_Value()'d...and rebRelease()'d on unload.
     */
 
-    #define NUM_EXT_${MOD}_WORDS $(length-of word-list)
+    #define NUM_EXT_${MOD}_WORDS $<length-of word-list>
 }
-e1/emit-line []
+e1/emit newline
 
 either empty? word-list [
-    e1/emit ["#define INIT_${MOD}_WORDS"]
+    e1/emit {
+        #define INIT_${MOD}_WORDS
+    }
 ][
-    e1/emit ["static const char* Ext_Words_${Mod}[NUM_EXT_${MOD}_WORDS] = {"]
-    for-next word-list [
-        e1/emit-line/indent [ {"} to text! word-list/1 {",} ]
+    words1: collect [
+        for-next word-list [
+            keep unspaced [{"} to text! word-list/1 {"}]
+        ]
     ]
-    e1/emit-end
 
-    e1/emit ["static REBSTR* Ext_Canons_${Mod}[NUM_EXT_${MOD}_WORDS];"]
+    e1/emit {
+        static const char* Ext_Words_${Mod}[NUM_EXT_${MOD}_WORDS] = {
+            $(Words1),
+        };
+    }
+
+    e1/emit {
+        static REBSTR* Ext_Canons_${Mod}[NUM_EXT_${MOD}_WORDS];
+    }
 
     seq: 0
     for-next word-list [
-        e1/emit [
-            "#define ${MOD}_WORD_${WORD-LIST/1} Ext_Canons_${Mod}[$(seq)]"
-        ]
+        e1/emit {
+            #define ${MOD}_WORD_${WORD-LIST/1} Ext_Canons_${Mod}[$<seq>]
+        }
         seq: seq + 1
     ]
 
@@ -392,24 +411,24 @@ e1/emit {
 }
 
 if not empty? error-list [
-    e1/emit ["enum Ext_${Mod}_Errors {"]
-    error-collected: copy []
-    for-each [key val] error-list [
-        if not set-word? key [
-            fail ["key (" mold key ") must be a set-word!"]
-        ]
-        if find error-collected key [
-            fail ["Duplicate error key" (to word! key)]
-        ]
-        append error-collected key
-        e1/emit-item/upper [
-            {RE_EXT_ENUM_} u-m-name {_} to-c-name to word! key
+    errs: collect [
+        for-each [key val] error-list [
+            if not set-word? key [
+                fail ["key (" mold key ") must be a set-word!"]
+            ]
+            key: to word! key
+            keep cscape/with {RE_EXT_ENUM_${MOD}_${KEY}} [mod key]
         ]
     ]
-    e1/emit-end
+
+    e1/emit {
+        enum Ext_${Mod}_Errors {
+            $(Errs),
+        };
+    }
 ]
 
-e1/emit-line []
+e1/emit newline
 for-each [key val] error-list [
     key: to-word key
     e1/emit 'key {

--- a/make/tools/make-headers.r
+++ b/make/tools/make-headers.r
@@ -91,15 +91,18 @@ emit-proto: proc [proto] [
 
     append prototypes proto
 
-    e-funcs/emit-line ["RL_API " proto "; // " the-file]
+    e-funcs/emit [proto the-file] {
+        RL_API $<Proto>; /* $<The-File> */
+    }
+
     either "REBTYPE" = proto-parser/proto.id [
-        e-syms/emit-line [
-            "    SYM_CFUNC(T_" proto-parser/proto.arg.1 "), // " the-file
-        ]
+        e-syms/emit [the-file proto-parser] {
+            /* $<The-File> */ SYM_CFUNC(T_$<Proto-Parser/Proto.Arg.1>),
+        }
     ][
-        e-syms/emit-line [
-            "    SYM_CFUNC(" proto-parser/proto.id "), // " the-file
-        ]
+        e-syms/emit [the-file proto-parser] {
+            /* $<The-File> */ SYM_CFUNC($<Proto-Parser/Proto.Id>),
+        }
     ]
 ]
 
@@ -108,10 +111,9 @@ process-conditional: procedure [
     dir-position
     emitter [object!]
 ][
-    emitter/emit-line [
-        directive
-        ;;; " // " the-file " #" text-line-of dir-position
-    ]
+    emitter/emit [directive the-file dir-position] {
+        $<Directive> /* $<The-File> #$<text-line-of dir-position> */
+    }
 
     ; Minimise conditionals for the reader - unnecessary for compilation.
     ;
@@ -144,69 +146,82 @@ process: function [
 
 ;-------------------------------------------------------------------------
 
-e-syms/emit {#include "sys-core.h"
+e-syms/emit {
+    #include "sys-core.h"
 
-// Note that cast() macro causes problems here with clang for some reason.
-//
-// !!! Also, void pointers and function pointers are not guaranteed to be
-// the same size, even if TCC assumes so for these symbol purposes.
-//
-#define SYM_CFUNC(x) {#x, (CFUNC*)(x)}
-#define SYM_DATA(x) {#x, &x}
+    /* Note that cast() macro causes problems here with clang for some reason.
+     *
+     * !!! Also, void pointers and function pointers are not guaranteed to be
+     * the same size, even if TCC assumes so for these symbol purposes.
+     */
+    #define SYM_CFUNC(x) {#x, (CFUNC*)(x)}
+    #define SYM_DATA(x) {#x, &x}
 
-struct rebol_sym_cfunc_t {
-    const char *name;
-    CFUNC *cfunc;
-};
+    struct rebol_sym_cfunc_t {
+        const char *name;
+        CFUNC *cfunc;
+    };
 
-struct rebol_sym_data_t {
-    const char *name;
-    void *data;
-};
+    struct rebol_sym_data_t {
+        const char *name;
+        void *data;
+    };
 
-extern const struct rebol_sym_cfunc_t rebol_sym_cfuncs [];
-const struct rebol_sym_cfunc_t rebol_sym_cfuncs [] = ^{
+    extern const struct rebol_sym_cfunc_t rebol_sym_cfuncs [];
+    const struct rebol_sym_cfunc_t rebol_sym_cfuncs [] = ^{
 }
+;-- !!! Note the #ifdef conditional handling here is weird, and is based on
+;-- the emitter state.  So it would take work to turn this into something
+;-- that would collect the symbols and then insert them into the emitter
+;-- all at once.  The original code seems a bit improvised, and could use a
+;-- more solid mechanism.
 
-e-funcs/emit {
-// When building as C++, the linkage on these functions should be done without
-// "name mangling" so that library clients will not notice a difference
-// between a C++ build and a C build.
-//
-// http://stackoverflow.com/q/1041866/
-//
-#ifdef __cplusplus
-extern "C" ^{
-#endif
-
-//
-// Native Prototypes: REBNATIVE is a macro which will expand such that
-// REBNATIVE(parse) will define a function named `N_parse`.  The prototypes
-// are included in a system-wide header in order to allow recognizing a
-// given native by identity in the C code, e.g.:
-//
-//     if (VAL_ACT_DISPATCHER(native) == &N_parse) { ... }
-//
-}
-e-funcs/emit newline
 
 boot-natives: load output-dir/boot/tmp-natives.r
 
+e-funcs/emit {
+    /*
+     * When building as C++, the linkage on these functions should be done
+     * without "name mangling" so that library clients will not notice a
+     * difference between a C++ build and a C build.
+     *
+     * http://stackoverflow.com/q/1041866/
+     */
+    #ifdef __cplusplus
+    extern "C" ^{
+    #endif
+
+    /*
+     * NATIVE PROTOTYPES
+     *
+     * REBNATIVE is a macro which will expand such that REBNATIVE(parse) will
+     * define a function named `N_parse`.  The prototypes are included in a
+     * system-wide header in order to allow recognizing a given native by
+     * identity in the C code, e.g.:
+     *
+     *     if (VAL_ACT_DISPATCHER(native) == &N_parse) { ... }
+     */
+}
+e-funcs/emit newline
+
 for-each val boot-natives [
     if set-word? val [
-        e-funcs/emit-line ["REBNATIVE(" to-c-name (to word! val) ");"]
+        e-funcs/emit 'val {
+            REBNATIVE(${to word! val});
+        }
     ]
 ]
 
 e-funcs/emit {
-
-//
-// Other Prototypes: These are the functions that are scanned for in the %.c
-// files by %make-headers.r, and then their prototypes placed here.  This
-// means it is not necessary to manually keep them in sync to make calls to
-// functions living in different sources.  (`static` functions are skipped
-// by the scan.)
-//
+    /*
+     * OTHER PROTOTYPES
+     *
+     * These are the functions that are scanned for in the %.c files by
+     * %make-headers.r, and then their prototypes placed here.  This means it
+     * is not necessary to manually keep them in sync to make calls to
+     * functions living in different sources.  (`static` functions are skipped
+     * by the scan.)
+     */
 }
 e-funcs/emit newline
 
@@ -238,10 +253,11 @@ for-each item file-base/core [
 ]
 
 
-e-funcs/emit newline
-e-funcs/emit-line "#ifdef __cplusplus"
-e-funcs/emit-line "}"
-e-funcs/emit-line "#endif"
+e-funcs/emit {
+    #ifdef __cplusplus
+    ^}
+    #endif
+}
 
 e-funcs/write-emitted
 
@@ -279,7 +295,9 @@ sys-globals.parser: context [
 
         declaration: [
             some [opt wsp [copy id identifier | not #";" punctuator] ] #";" thru newline (
-                e-syms/emit-line ["    SYM_DATA(" id "),"]
+                e-syms/emit 'id {
+                    SYM_DATA($<Id>),
+                }
             )
         ]
 
@@ -362,10 +380,11 @@ parse to text! read %a-constants.c [
         copy constd to "="
         (
             remove constd
-            insert constd "extern "
-            append trim/tail constd #";"
+            trim/tail constd
 
-            e-strings/emit-line constd
+            e-strings/emit {
+                extern $<Constd>;
+            }
         )
     ]
 ]

--- a/make/tools/make-host-init.r
+++ b/make/tools/make-host-init.r
@@ -54,11 +54,11 @@ write-c-file: procedure [
     e/emit 'compressed {
         /*
          * Gzip compression of host initialization code
-         * Originally $(length-of data) bytes
+         * Originally $<length-of data> bytes
          */
-        #define REB_INIT_SIZE $(length-of compressed)
+        #define REB_INIT_SIZE $<length-of compressed>
         const unsigned char Reb_Init_Code[REB_INIT_SIZE] = {
-            $(Binary-To-C Compressed)
+            $<Binary-To-C Compressed>
         };
     }
 

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -1207,7 +1207,7 @@ generator-class: make object! [
                 apply any [:gen-cmd-strip :target-platform/gen-cmd-strip] compose [cmd: (cmd)]
             ]
         ][
-            fail ["Unkonwn cmd class:" cmd/class-name]
+            fail ["Unknown cmd class:" cmd/class-name]
         ]
     ]
 

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -332,8 +332,3 @@ Command: [
 ;   ssl-error:          [{SSL Error: } :arg1]
     command-fail:       ["Command failed"]
 ]
-
-; If new category added, be sure to update RE_MAX in %make-boot.r
-; (currently RE_COMMAND_MAX because `Command: [...]` is the last category)
-
-; Note that INT32_MAX is hardcoded constant in %make-boot.r used for RE_USER

--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -136,9 +136,7 @@ REBOL [
 
 [name       class       path    make    mold     typesets]
 
-; 0 is not a real data type.  It is reserved for internal purposes.
-
-0           0           -       -       -       -
+; Note: REB_0 is reserved for internal purposes and not a "type"
 
 ; There is only one "invokable" type in Ren-C, and it takes the name ACTION!
 ; instead of the name FUNCTION!: https://forum.rebol.info/t/596


### PR DESCRIPTION
This pushes the build process to use more CSCAPE-based code, which
gives a better view of the templated output of the C being produced.

It introduces the new features of $[] to output a list with a delimiter
on each line (e.g. `$[fields];` can be used output a block that
contains a list of struct fields with a semicolon on each line) and
$() to output a list with a delimiter on all lines but the last
(e.g. `$(enum-items),` will put a comma on each line except the last.

This means that many "emit-as-you-go" bits of code have been changed
to "collect and then emit".  While somewhat slower, it is vastly
more clear to read.

Also changes the type table to not have an entry for 0.