### PR TITLE
PATH!s with inert head elements are themselves inert

### DIFF
--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -145,12 +145,12 @@ action      action      +       +       +       -
 
 ; ANY-WORD!, order matters (tests like ANY_WORD use >= REB_WORD, <= REB_ISSUE)
 ;
-word        word        -       +       +       word
-set-word    word        -       +       +       word
-get-word    word        -       +       +       word
-lit-word    word        -       +       +       word
-refinement  word        -       +       +       word
-issue       word        -       +       +       word
+word        word        +       +       +       word
+set-word    word        +       +       +       word
+get-word    word        +       +       +       word
+lit-word    word        +       +       +       word
+refinement  word        +       +       +       word
+issue       word        +       +       +       word
 
 ; ANY-ARRAY!, order matters (and contiguous with ANY-SERIES below matters!)
 ;

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -298,6 +298,19 @@ REBOOL Do_Path_Throws_Core(
 ){
     assert(kind == REB_PATH or kind == REB_SET_PATH or kind == REB_GET_PATH);
 
+    // Paths that start with inert values do not evaluate.  So `/foo/bar` has
+    // a REFINEMENT! at its head, and it will just be inert.  This also
+    // means that `/foo/1` is inert, as opposed to #"o".  Note that this
+    // is different from `(/foo)/1` or `ref: /foo | ref/1`, both of which
+    // would be #"o".
+    //
+    if (ANY_INERT(ARR_AT(array, index))) {
+        if (kind != REB_PATH)
+            fail ("Can't evaluate GET-PATH! or SET_PATH! with inert head");
+        Init_Any_Array_At(out, REB_PATH, array, index);
+        return FALSE;
+    }
+
     DECLARE_FRAME (pvs);
 
     pvs->refine = KNOWN(&pvs->cell);

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -18,6 +18,7 @@ REBOL [
 ; would be DSA, 3DES, ECDH, ECDHE, ECDSA, SHA256, SHA384...)
 ;
 ; https://testssl.sh/openssl-rfc.mapping.html
+; https://fly.io/articles/how-ciphersuites-work/
 ;
 ; If you want to get a report on what suites a particular site has:
 ;

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -167,3 +167,22 @@
         a = [3 4]
     ]
 )
+
+; PATH! beginning with an inert item will itself be inert
+;
+[
+    (/ref/inement/path = as path! [/ref inement path])
+    (/refinement/3 = as path! [/refinement 3])
+    ((/refinement)/3 = #"f")
+    (r: /refinement | r/3 = #"f")
+][
+    (#iss/ue/path = as path! [#iss ue path])
+    (#issue/3 = as path! [#issue 3])
+    ((#issue)/3 = #"s")
+    (i: #issue | i/3 = #"s")
+][
+    ("te"/xt/path = as path! ["te" xt path])
+    ("text"/3 = as path! ["text" 3])
+    (("text")/3 = #"x")
+    (t: "text" | t/3 = #"x")
+]


### PR DESCRIPTION
This makes it so that any evaluator-inactive type at the head of a path
will curb evaluation of that path.  Hence you can write:

    >> <json>/1.2.30
    == <json>/1.2.30

    >> /dir/subdir ;-- first path element is REFINEMENT!
    == /dir/subdir

    >> "abc"/2
    == "abc"/2

The path can become activated by either putting the head element in
a GROUP!, or referring to it via an evaluative entity

    >> ("abc")/2
    == #"b"

    >> text: "abc"
    >> text/2
    == #"b"

Since ANY-WORD! historically has no path behavior, it was difficult
to demonstrate the inert vs. active difference.  This adds a quick and
dirty ability to pick characters by integer out of words--which with
the ANY-STRING!/ANY-WORD! unification would ultimately align with
whatever other operations might be legal on strings.