### PR TITLE
Enable new UNLESS for all users, drop UNLESS*/MAYBE*

### DIFF
--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -264,13 +264,13 @@ to-relative-file: function [
             ; file-to-local drops trailing / in R2, not in R3
             if tmp: find/match file file-to-local what-dir [file: next tmp]
         ]
-        file: maybe find/match file file-to-local what-dir
+        file: maybe opt find/match file file-to-local what-dir
         if as-rebol [
             file: local-to-file file
             no-copy: true
         ]
     ] else [
-        file: maybe find/match file what-dir
+        file: maybe opt find/match file what-dir
         if as-local [
             file: file-to-local file
             no-copy: true

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -273,45 +273,6 @@ hijack 'try adapt copy :try [
     ;-- fall through to native TRY implementation
 ]
 
-
-unless: enfix function [ ;-- error-checking shim, overrides real UNLESS
-    {Returns left hand side, unless the right hand side is something}
-
-    return: [any-value!]
-    left [<end> any-value!]
-    right [<opt> any-value! <...>]
-    :look [any-value! <...>]
-    /try {Consider right being BLANK! a value to override the left}
-][
-    any [
-        unset? 'left
-        elide (right: take* right)
-        block? first look
-    ] then [
-        fail/where [
-            "UNLESS has been repurposed in Ren-C as an enfix operator"
-            "which defaults to the left hand side, unless the right"
-            "side has a value which overrides it.  You may use IF-NOT"
-            "as a replacement, or even define UNLESS: :LIB/IF-NOT,"
-            "though actions like OR, DEFAULT, etc. are usually better"
-            "replacements for the intents that UNLESS was used for."
-            "!!! NOTE: `if not` as two words isn't the same in Ren-C,"
-            "as `if not x = y` is read as `if (not x) = y` since `=`"
-            "completes its left hand side.  Be careful rewriting."
-        ] 'look
-    ]
-
-    either-test (try ?? :value? !! :something?) :right [:left]
-]
-
-
-unless*: enfix redescribe [ ;-- error-checking shim, overrides real UNLESS*
-    {Same as UNLESS/TRY (right hand side being BLANK! overrides the left)}
-](
-    specialize 'unless [try: true]
-)
-
-
 ; The legacy PRIN construct is replaced by WRITE-STDOUT SPACED and similar
 ;
 prin: procedure [

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -707,7 +707,7 @@ sys/make-scheme [
                 ]
             ]
             if action? :port/awake [
-                unless open? port [
+                if not open? port [
                     cause-error 'Access 'not-open port/spec/ref
                 ]
                 if port/state/state <> 'ready [

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -80,29 +80,18 @@ finish-init-core: proc [
             ] 'dummy
         ])
 
-        ; !!! See UNLESS for the plan of it being retaken.  For the moment
-        ; this compatibility shim is active in %mezz-legacy.r, but not
-        ; exposed to the user context.
-
-        unless: (ensure action! get 'if-not)
-
-        (comment [
         unless: (function [ ;-- enfixed below
-            {Returns left hand side, unless the right hand side is something}
+            {Returns left hand side, unless the right hand side is a value}
 
             return: [any-value!]
             left [<end> any-value!]
             right [<opt> any-value! <...>]
             :look [any-value! <...>]
-            /try {Consider right being BLANK! a value to override the left}
         ][
-            any [
-                unset? 'left
-                elide (right: take* right)
-                block? first look
-            ] then [
+            right: take* right
+            if unset? 'left or (block? first look) [
                 fail/where [
-                    "UNLESS has been repurposed in Ren-C as an enfix operator"
+                    "UNLESS has been repurposed in Ren-C as an infix operator"
                     "which defaults to the left hand side, unless the right"
                     "side has a value which overrides it.  You may use IF-NOT"
                     "as a replacement, or even define UNLESS: :LIB/IF-NOT,"
@@ -114,14 +103,8 @@ finish-init-core: proc [
                 ] 'look
             ]
 
-            either-test (try ?? :value? !! :something?) :right [:left]
+            either-test-value :right [:left]
         ])
-
-        unless*: (redescribe [ ;-- enfixed below
-            {Same as UNLESS/TRY (right side being BLANK! overrides the left)}
-        ](
-            specialize 'unless [try: true]
-        ))])
 
         switch: (adapt 'switch [
             for-each c cases [
@@ -200,10 +183,7 @@ finish-init-core: proc [
         any-object?: (ensure action! :any-context?)
     ]
 
-    comment [
-        tmp/unless: enfix :tmp/unless
-        tmp/unless*: enfix :tmp/unless*
-    ]
+    tmp/unless: enfix :tmp/unless
 
     system/contexts/user: tmp
 

--- a/tests/control/unless.test.reb
+++ b/tests/control/unless.test.reb
@@ -12,28 +12,24 @@
 ; This makes it a bit strange, but allows it to alert people used to the
 ; old habits about the new behavior.
 
-(comment [
-    (
-        20 = (10 unless 20)
-    )(
-        10 = (10 unless _)
-    )(
-        10 = (10 unless ())
-    )(
-        _ = (10 unless* _) ;-- /TRY option considers blank a purposeful value
-    )(
-        x: 10 + 20 unless case [
-            false [<no>]
-            false [<nope>]
-            false [<nada>]
-        ]
-        x = 30
-    )(
-        x: 10 + 20 unless case [
-            false [<no>]
-            true [<yip!>]
-            false [<nada>]
-        ]
-        x = <yip!>
-    )
-] true)
+(
+    20 = (10 unless 20)
+)(
+    _ = (10 unless _)
+)(
+    10 = (10 unless ())
+)(
+    x: 10 + 20 unless case [
+        false [<no>]
+        false [<nope>]
+        false [<nada>]
+    ]
+    x = 30
+)(
+    x: 10 + 20 unless case [
+        false [<no>]
+        true [<yip!>]
+        false [<nada>]
+    ]
+    x = <yip!>
+)


### PR DESCRIPTION
The speculative feature UNLESS has turned out to be extremely useful,
such that it is unlikely anyone will be mourning its loss as a synonym
for IF NOT.  A shim detects "old-style" UNLESS usages with high
reliability, and directs users to the new definition, as well as
offering `unless: :if-not` as a workaround.

    >> 10 + 20 unless case [
        false [<no>]
        false [<nope>]
        false [<nada>]
    ]
    == 30

    >> 10 + 20 unless case [
        false [<no>]
        true [<yip!>]
        false [<nada>]
    ]
    == <yip!>

This commit also changes UNLESS to consider any non-null value to
override the left.  This means blanks now count:

    >> 10 unless _
    == _

Previously, this behavior would only happen if you used the special
UNLESS* operation.  However, most operations either trigger off of
null/non-null (e.g. ELSE, ALSO, !!) or truthy/falsey (IF, CASE, OR).
It seems better to make UNLESS fit neatly into the former category,
since anyone who has a BLANK! and wants to OPT it can do so:

    >> 10 unless opt _
    == 10

This makes the UNLESS operation more efficient and reduces visual
clutter, for what would likely be a rare operation.  (Most UNLESS uses
have a CASE or SWITCH or IF on the right hand side.)

On that same note, this also eliminates MAYBE* and gives MAYBE the
same semantics, requiring those who have BLANK!s to do OPT (this will
be less common once routines like FIND and MATCH return null)