### PR TITLE
Make null "falsey", can't assign null w/SET-WORD!/PATH!

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -6,18 +6,11 @@ do %tools/common.r
 do %tools/systems.r
 file-base: make object! load %tools/file-base.r
 
-; !!! Since %rebmake.r is a module,
-    ; it presents a challenge for the "shim" code
-    ; when it depends on a change.
-    ; This needs to be addressed in a generic way,
-    ; but that requires foundational work on modules.
-
-append lib compose [
-    file-to-local-hack: (:file-to-local)
-    local-to-file-hack: (:local-to-file)
-    did-hack: (:did)
-]
-rebmake: import %tools/rebmake.r
+; See notes on %rebmake.r for why it is not a module at this time, due to the
+; need to have it inherit the shim behaviors of IF, CASE, FILE-TO-LOCAL, etc.
+;
+; rebmake: import %tools/rebmake.r
+do %tools/rebmake.r
 
 ;;;; GLOBALS
 
@@ -38,7 +31,7 @@ user-config: make object! load make-dir/default-config.r
 args: parse-args system/options/args
 ; now args are ordered and separated by bar:
 ; [NAME VALUE ... '| COMMAND ...]
-either commands: find args '| [
+either commands: try find args '| [
     options: copy/part args commands
     commands: next commands
 ] [options: args]
@@ -68,7 +61,7 @@ for-each [name value] options [
                     if not block? user-ext [
                         fail [
                             "Selected extensions must be a block, not"
-                            (type-of user-ext)
+                            (type of user-ext)
                         ]
                     ]
                     user-config/extensions: user-ext
@@ -341,10 +334,10 @@ targets: [
     ]
     'vs2017
     'visual-studio [
-        rebmake/visual-studio/generate/(all [system-config/os-name = 'Windows-x86 'x86]) %. solution
+        rebmake/visual-studio/generate/(try all [system-config/os-name = 'Windows-x86 'x86]) %. solution
     ]
     'vs2015 [
-        rebmake/vs2015/generate/(all [system-config/os-name = 'Windows-x86 'x86]) %. solution
+        rebmake/vs2015/generate/(try all [system-config/os-name = 'Windows-x86 'x86]) %. solution
     ]
 ]
 target-names: make block! 16
@@ -1310,11 +1303,11 @@ process-module: func [
                 ]
                 true [
                     dump s
-                    fail [type-of s "can't be a dependency of a module"]
+                    fail [type of s "can't be a dependency of a module"]
                 ]
             ]
         ]
-        libraries: all [
+        libraries: try all [
             mod/libraries
             map-each lib mod/libraries [
                 case [

--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -95,8 +95,8 @@ cscape: function [
                 fail ["Invalid CSCAPE mode:" mode]
             ]
             case [
-                any-upper and (not any-lower) [uppercase sub]
-                any-lower and (not any-upper) [lowercase sub]
+                all [any-upper | not any-lower] [uppercase sub]
+                all [any-lower | not any-upper] [lowercase sub]
             ]
 
             ; If the substitution started at a certain column, make any line
@@ -142,7 +142,7 @@ make-emitter: function [
 
     stem: second split-path file
 
-    temporary: any [temporary | parse stem ["tmp-" to end]]
+    temporary: did any [temporary | parse stem ["tmp-" to end]]
 
     is-c: parse stem [[thru ".c" | thru ".h" | thru ".inc"] end]
 
@@ -166,7 +166,7 @@ make-emitter: function [
             :look [any-value! <...>]
             data [text! char! <...>]
         ][
-            context: ()
+            context: _
             firstlook: first look
             if any [
                 lit-word? :firstlook
@@ -177,9 +177,9 @@ make-emitter: function [
             ]
 
             data: take data
-            switch type-of data [
+            switch type of data [
                 text! [
-                    adjoin buf-emit cscape/with data :context
+                    adjoin buf-emit cscape/with data opt context
                 ]
                 char! [
                     adjoin buf-emit data
@@ -196,7 +196,7 @@ make-emitter: function [
                 fail "WRITE-EMITTED needs NEWLINE as last character in buffer"
             ]
 
-            if tab-pos: find buf-emit tab [
+            if tab-pos: try find buf-emit tab [
                 probe skip tab-pos -100
                 fail "tab character passed to emit"
             ]
@@ -271,6 +271,5 @@ make-emitter: function [
         ]
         e/emit newline
     ]
-
     return e
 ]

--- a/make/tools/common.r
+++ b/make/tools/common.r
@@ -121,7 +121,7 @@ to-c-name: function [
     if empty? string [
         fail [
             "empty identifier produced by to-c-name for"
-            (mold value) "of type" (mold type-of value)
+            (mold value) "of type" (mold type of value)
         ]
     ]
 
@@ -326,7 +326,7 @@ parse-args: function [
         name: _
         value: args/1
         case [
-            idx: find value #"=" [; name=value
+            idx: try find value #"=" [; name=value
                 name: to word! copy/part value (index-of idx) - 1
                 value: copy next idx
             ]

--- a/make/tools/make-embedded-header.r
+++ b/make/tools/make-embedded-header.r
@@ -35,7 +35,7 @@ remove-macro: proc [
     <local> pos-m inc eol
 ][
     if not binary? macro [macro: to binary! macro]
-    pos-m: find inp macro
+    pos-m: try find inp macro
     if pos-m [
         inc: find/reverse pos-m to binary! "#define"
         eol: find pos-m to binary! newline

--- a/make/tools/make-headers.r
+++ b/make/tools/make-headers.r
@@ -121,7 +121,7 @@ process-conditional: procedure [
     ;
     if all [
         find/match directive "#endif"
-        position: find/last tail-of emitter/buf-emit "#if"
+        position: try find/last tail-of emitter/buf-emit "#if"
     ][
         rewrite-if-directives position
     ]

--- a/make/tools/make-os-ext.r
+++ b/make/tools/make-os-ext.r
@@ -80,7 +80,7 @@ count: func [s c /local n] [
     if find ["()" "(void)"] s [return "()"]
     output-buffer: copy "(a"
     n: 1
-    while [s: find/tail s c][
+    while [s: try find/tail s c][
         adjoin output-buffer [#"," #"a" + n]
         n: n + 1
     ]
@@ -95,7 +95,7 @@ emit-proto: proc [
         trim proto
         not find proto "static"
 
-        pos.id: find proto "OS_"
+        pos.id: try find proto "OS_"
 
         ;-- !!! All functions *should* start with OS_, not just
         ;-- have OS_ somewhere in it!  At time of writing, Atronix

--- a/make/tools/make-zlib.r
+++ b/make/tools/make-zlib.r
@@ -72,7 +72,7 @@ disable-user-includes: procedure [
             any space {include}
             some space include-rule to end
         ] then [
-            if inline and (pos: find headers to file! name) [
+            if inline and (pos: try find headers to file! name) [
                 change/part line-iter (read/lines join-all [path-zlib name]) 1 
                 take pos
             ] else [

--- a/make/tools/parsing-tools.reb
+++ b/make/tools/parsing-tools.reb
@@ -27,13 +27,13 @@ parsing-at: func [
     /end {Drop the default tail check (allows evaluation at the tail).}
 ] [
     use [result position][
-        block: compose/only [try (to group! block)]
+        block: compose/only [try (as group! block)]
         if not end [
-            block: compose/deep [all [not tail? (word) (block)]]
+            block: compose/deep [try all [not tail? (word) (block)]]
         ]
         block: compose/deep [result: either position: (block) [[:position]] [[end skip]]]
         use compose [(word)] compose/deep [
-            [(to set-word! :word) (to group! block) result]
+            [(as set-word! :word) (as group! block) result]
         ]
     ]
 ]

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -1,902 +1,286 @@
 REBOL [
-    Title: "Rebol2 and R3-Alpha Future Bridge to Ren-C"
+    Title: "Shim to bring old executables up to date to use for bootstrapping"
     Rights: {
         Rebol 3 Language Interpreter and Run-time Environment
         "Ren-C" branch @ https://github.com/metaeducation/ren-c
 
-        Copyright 2012 REBOL Technologies
-        Copyright 2012-2017 Rebol Open Source Contributors
+        Copyright 2012-2018 Rebol Open Source Contributors
         REBOL is a trademark of REBOL Technologies
     }
     License: {
         Licensed under the Apache License, Version 2.0
         See: http://www.apache.org/licenses/LICENSE-2.0
     }
-    Note: {
-        !!! This file currenly only works in older/bootstrap Ren-C.  It
-        needs attention to make it work in R3-Alpha or Rebol2 again, which
-        probably wouldn't take much work, but is not currently a priority.
-    }
     Purpose: {
-        These routines can be run from R3-Alpha or Rebol2 to make them act
-        more like the vision of Rebol3-Beta and beyond (as conceived by the
-        "Ren-C" initiative).
+        This file was originally used to make an R3-Alpha "act like" a Ren-C.
+        That way, bootstrapping code could be written under various revised
+        language conventions--while still using older executables to build.
 
-        It also must remain possible to run it from Ren-C without disrupting
-        the environment.  This is because the primary motivation for its
-        existence is to shim older R3-MAKE utilities to be compatible with
-        Ren-C...and the script is run without knowing whether the R3-MAKE
-        you are using is old or new.  No canonized versioning strategy has
-        been yet chosen, so words are "sniffed" for existing definitions in
-        this somewhat simplistic method.
+        Changes in the language have become drastic enough that an R3-Alpha
+        lacks the compositional tools (such as ADAPT, SPECIALIZE, CHAIN) to
+        feasibly keep up.  Hence, the shim is only used with older Ren-C
+        executables...which are both more in sync with modern definitions,
+        and have those composition tools available:
 
-        !!! Because the primary purpose is for Ren-C's bootstrap, the file
-        is focused squarely on those needs.  However, it is a beginning for
-        a more formalized compatibility effort.  Hence it is awaiting someone
-        who has a vested interest in Rebol2 or R3-Alpha code to become a
-        "maintenance czar" to extend the concept.  In the meantime it will
-        remain fairly bare-bones, but enhanced if-and-when needed.
+        https://github.com/metaeducation/ren-c/issues/815
+
+        It also must remain possible to run it from a state-of-the-art build
+        without disrupting the environment.  This is because the script does
+        not know whether the R3-MAKE you are using is old or new.  No good
+        versioning strategy has been yet chosen, so words are "sniffed" for
+        existing definitions to upgrade in a somewhat ad-hoc way.
     }
 ]
 
-; Neither R3-Alpha nor early bootstrapping Ren-C have "choose", but it's a
-; very useful form of CASE
-;
-if :choose = () [
-    choose: function [choices [block!] /local result] [
-        while [not tail? choices] [
-            set 'result do/next choices 'choices
-            if :result [
-                return do/next choices 'choices
-            ]
-        ]
-        return ()
+for-each w [ELSE THEN ALSO OR AND UNLESS !! !? ?!] [
+    set w func [dummy:] compose [
+        fail/where [
+            "Do not use" w "in bootstrap.  It is based on normal enfix"
+            "mechanics that worked differently in the stable snapshot version"
+            "committed in 0da70da4c12677bf71ce4cf3fad1923c185db0b8, so"
+            "until a new stable snapshot is picked" w "must be avoided."
+        ] 'dummy
     ]
 ]
 
-; Renamed, tightened, and extended with new features (add /PASS feature?)
+; The snapshotted Ren-C existed when VOID? was the name for NULL?.  What we
+; will (falsely) assume is that any Ren-C that knows NULL? is "modern" and
+; does not need patching forward.  What this really means is that we are
+; only catering the shim code to the snapshot.
 ;
-if :file-to-local = () [
-    file-to-local: :to-local-file
-    local-to-file: :to-rebol-file
-]
-
-; As 3-letter words go, TRY is more useful to turn words to blank, but
-; R3-Alpha and older Ren-C had this as a synonym for TRAP.
+; (It would be possible to rig up shim code for pretty much any specific other
+; version if push came to shove, but it would be work for no obvious reward.)
 ;
-if find words-of :try 'block [
-    try: :to-value
-]
-
-
-; OF is an action-like dispatcher which is used for property extraction.  It
-; quotes its left argument, which R3-Alpha cannot do.  One might think it
-; could be quoted by turning the properties being asked for by WORD! into
-; functions, and letting them handle the dispatch...ignoring the OF:
-;
-;     length: func ['w [word!] series] [
-;         assert [w = 'of]
-;         return length of series
-;     ]
-;
-; The problem with this is that you now can't call your variables LENGTH or
-; TYPE or WORDS--which are all very common.  Instead they are set by default
-; to functions that warn you about this.  They can be overwritten.
-;
-if :of = () [
-    index: func [dummy:] [
-        fail/where "INDEX OF not supported in R3-Alpha, use INDEX-OF" 'dummy
-    ]
-    offset: func [dummy:] [
-        fail/where "OFFSET OF not supported in R3-Alpha, use OFFSET-OF" 'dummy
-    ]
-    length: func [dummy:] [
-        fail/where "LENGTH OF not supported in R3-Alpha, use LENGTH-OF" 'dummy
-    ]
-    type: func [dummy:] [
-        fail/where "TYPE OF not supported in R3-Alpha, use TYPE-OF" 'dummy
-    ]
-    words: func [dummy:] [
-        fail/where "WORDS OF not supported in R3-Alpha, use WORDS-OF" 'dummy
-    ]
-]
-
-if true = attempt [void? :some-undefined-thing] [
+if true = attempt [null? :some-undefined-thing] [
     ;
-    ; With libRebol parity of Rebol's NULL being committed to as C's NULL,
-    ; sharing names makes more sense than the "illusion of void"
-
-    null: :void
-    null?: :void?
-    unset 'void
-    unset 'void?
-
-    append lib compose [
-        text!: (string!)
-        text?: (:string?)
-        to-text: (:to-string)
-    ]
-    text!: lib/text!
-    text?: :lib/text?
-    to-text: :lib/to-text
-
-    ; THEN and ELSE use a mechanic (non-tight infix evaluation) that is simply
-    ; impossible in R3-Alpha or Rebol2.
+    ; COPY AS TEXT! can't be made to work in the old Ren-C, so it just
+    ; aliases its SPELLING-OF to COPY-AS-TEXT.  Define that for compatibilty.
     ;
-    else: does [
-        fail "Do not use ELSE in scripts which want compatibility w/R3-Alpha" 
-    ]
-    then: does [
-        fail "Do not use THEN in scripts which want compatibility w/R3-Alpha"
-    ]
-
-    ; UNTIL was deprecated under its old meaning, but ultimately reverted
-    ; so put it back...
-    ;
-    until: :loop-until
-
-    ; WHILE-NOT can't be written correctly in usermode R3-Alpha (RETURN won't
-    ; work definitionally)
-    ;
-    while-not: does [
-        fail "Don't use WHILE-NOT when you want R3-Alpha compatibility"
-    ]
-    until-not: does [
-        fail "Don't use UNTIL-NOT when you want R3-Alpha compatibility"
-    ]
-
-    either () = :really [
-        ;-- Ren-Cs up to around Jan 27, 2018
-
-        assert [find words-of :ensure 'test]
-        really: func [optional [<opt> any-value!]] [
-            if any [null? :optional blank? :optional] [
-                fail/where [
-                    "REALLY expects argument to be SOMETHING?"
-                ] 'optional
-            ]
-            :optional
-        ]
-    ][
-        assert [find words-of :ensure 'test]
-    ]
-
-    did: func [optional [<opt> any-value!]] [
-        either all [lib/not null? :optional | :optional] [true] [false]
-    ]
-    not: func [optional [<opt> any-value!]] [
-        either any [null? :optional | :optional] [false] [true]
-    ]
-
-    ; COMPRESS no longer supports "Rebol format compression" (which was
-    ; non-raw zlib envelope plus 32-bit length)
-    ;
-    if (set? 'compress) and (find words-of :compress /gzip) [
-        deflate: specialize 'compress [gzip: false | only: true] ;; "raw"
-        inflate: specialize 'decompress [gzip: false | only: true] ;; "raw"
-
-        gzip: specialize 'compress [gzip: true]
-        gunzip: specialize 'decompress [gzip: true]
-
-        compress: decompress: does [
-            fail "COMPRESS/DECOMPRESS replaced by gzip/gunzip/inflate/deflate"
-        ]
-    ]
-
-    if not error? trap [switch 3 [1 + 2 [3]]] [ ;-- no error is non-evaluative
-        switch: adapt 'switch [
-            cases: map-each c cases [
-                case [
-                    lit-word? :c [to word! c]
-                    lit-path? :c [to path! c]
-
-                    path? :c [
-                        fail/where ["Switch now evaluative" c] 'cases
-                    ]
-                    word? :c [
-                        if not datatype? get c [
-                            fail/where ["Switch now evaluative" c] 'cases
-                        ]
-                        get c
-                    ]
-
-                    true [:c]
-                ]
-            ]
-        ]
-    ]
-
-    copy-as-text: :spelling-of
-
-    QUIT ;-- !!! stops running if Ren-C here.
-]
-
-if true == attempt [null? :some-undefined-thing] [
     copy-as-text: chain [
         specialize 'as [type: text!]
             |
         :copy
     ]
 
-    QUIT ;-- !!! a Ren-C post VOID? => NULL? conversion, circa 2-May-2018
+    QUIT
 ]
 
-write-stdout: func [value] [prin :value]
-print-newline: does [prin newline]
+print "== SHIMMING OLDER R3 TO MODERN LANGUAGE DEFINITIONS =="
+
+; NOTE: The slower these routines are, the slower the overall build will be.
+; It's worth optimizing it as much as is reasonable.
 
 
-; Running R3-Alpha/Rebol2, bootstrap NULL? into existence and continue
+; https://forum.rebol.info/t/behavior-of-to-string-as-string-mold/630
 ;
-null?: :unset?
-null: does []
+copy-as-text: :spelling-of
 
 
-unset 'function ;-- we'll define it later, use FUNC until then
-
-
-; Capture the UNSET! datatype, so that `func [x [*opt-legacy* integer!]]` can
-; be used to implement `func [x [<opt> integer!]]`.
-; 
-*opt-legacy*: unset!
-
-
-; Ren-C changed the function spec dialect to use TAG!s.  Although MAKE of
-; an ACTION! as a fundamental didn't know keywords (e.g. RETURN), FUNC
-; was implemented as a native that could also be implemented in usermode.
-; FUNCTION added some more features.
+; https://forum.rebol.info/t/null-in-the-librebol-api-and-void-null/597
 ;
-old-func: :func
-func: old-func [
-    spec [block!]
-    body [block!]
-    /local pos type
-][
-    spec: copy/deep spec
-    parse spec [while [
-        pos:
-        [
-            <local> (change pos quote /local)
-        |
-            ; WITH is just commentary in FUNC, but for it to work we'd have
-            ; to go through and take words that followed it out.
-            ;
-            <with> (fail "<with> not supported in R3-Alpha FUNC")
-        |
-            and block! into [any [
-                type:
-                [
-                    <opt> (change type '*opt-legacy*)
-                |
-                    <end> (fail "<end> not supported in R3-Alpha mode")
-                |
-                    skip
-                ]
-            ]]
-        |
-            ; Just get rid of any RETURN: specifications (purely commentary)
-            ;
-            remove [quote return: opt block! opt text!]
-        |
-            ; We could conceivably gather the SET-WORD!s and put them into
-            ; the /local list, but that's annoying work.
-            ;
-            copy s set-word! (
-                fail ["SET-WORD!" s "not supported for <local> in R3-Alpha"]
-            )
-        |
-            skip
-        ]
-    ]]
+null: :void
+null?: :void?
+unset 'void
+unset 'void?
+set*: :set ;-- used to allow nulls by default
 
-    ; R3-Alpha did not copy the spec or body in MAKE ACTION!, but FUNC and
-    ; FUNCTION would do it.  Since we copied above in order to mutate to
-    ; account for differences in the spec language, don't do it again.
-    ;
-    make function! reduce [spec body]
+; http://blog.hostilefork.com/did-programming-opposite-of-not/
+;
+; Note that ADAPT can't be used here, because TRUE?/FALSE? did not take <opt>
+;
+did: func [optional [<opt> any-value!]] compose/deep [
+    (:lib/true?) (:lib/to-value) :optional
+]
+not: func [optional [<opt> any-value!]] compose/deep [
+    (:lib/false?) (:lib/to-value) :optional
 ]
 
-
-; PROTECT/DEEP isn't exactly the same thing as LOCK, since you can unprotect
+; https://forum.rebol.info/t/if-at-first-you-dont-select-try-try-again/589
 ;
-lock: func [x] [protect/deep :x]
+try: :to-value
 
 
-blank?: get 'none?
-blank!: get 'none!
-blank: get 'none
-_: none
-
-; BAR! is really just a WORD!, but can be recognized
+; https://forum.rebol.info/t/squaring-the-circle-of-length-and-length-of/385
 ;
-bar?: func [x] [x = '|]
-
-; ANY-VALUE! is anything that isn't void.
-;
-any-value!: difference any-type! (make typeset! [unset!])
-value?: any-value?: func [optional [<opt> any-value!]] [not null? :optional]
-
-
-; Used in function definitions before the mappings
-;
-any-context!: :any-object!
-any-context?: :any-object?
-
-set?: func [
-    "Returns whether a bound word has a value (fails if unbound)"
-    any-word [any-word!]
-][
-    if not bound? any-word [
-        fail [any-word "is not bound in set?"]
-    ]
-    value? any-word ;-- the "old" meaning of value...
-]
-
-verify: :assert ;-- ASSERT is a no-op in Ren-C in "release", but verify isn't
-
-
-
-leave: does [
-    do make error! "LEAVE cannot be implemented in usermode R3-Alpha"
-]
-
-proc: func [spec body] [
-    func spec compose [(body) void]
-]
-
-
-did: :to-logic
-
-; Ren-C replaces the awkward term PAREN! with GROUP!  (Retaining PAREN!
-; for compatibility as pointing to the same datatype).  Older Rebols
-; haven't heard of GROUP!, so establish the reverse compatibility.
-;
-group?: get 'paren?
-group!: get 'paren!
-
-
-; The HAS routine in Ren-C is used for object creation with no spec, as
-; a parallel between FUNCTION and DOES.  It is favored for this purpose
-; over CONTEXT which is very "noun-like" and may be better for holding
-; a variable that is an ANY-CONTEXT!
-;
-; Additionally, the CONSTRUCT option behaves like MAKE ANY-OBJECT, sort of,
-; as the way of creating objects with parents or otherwise.
-;
-has: :context
-
-construct-legacy: :construct
-
-construct: func [
-    spec [datatype! block! any-context!]
-    body [block! any-context! none!]
-    /only
-][
-    either only [
-        if block? spec [spec: make object! spec]
-        construct-legacy/only/with body spec
-    ][
-        if block? spec [
-            ;
-            ; If they supplied a spec block, do a minimal behavior which
-            ; will create a parent object with those fields...then run
-            ; the traditional gathering added onto that using the body
-            ;
-            spec: map-each item spec [
-                assert [word? :item]
-                to-set-word item
-            ]
-            append spec none
-            spec: make object! spec
-        ]
-        make spec body
-    ]
-]
-
-
-; Lone vertical bar is an "expression barrier" in Ren-C, but a word character
-; in other situations.  Having a word behave as a function that returns an
-; UNSET! in older Rebols is not the same, e.g. `do [1 + 2 |]` will be UNSET!
-; as opposed to 3.  But since UNSET!s do not vote in many ANY/ALL situations
-; it can act similarly.
-;
-|: does []
-
-
-; Ren-C's SET acts like SET/ANY, always accept null assignments.
-;
-lib-set: get 'set ; overwriting lib/set for now
-set: function [
-    target [any-word! any-path! block!]
-    value [<opt> any-value!]
-    /pad
-][
-    set_ANY: true
-    apply :lib-set [target :value set_ANY pad]
-]
-
-
-; Ren-C's GET acts like GET/ANY, always getting null for unset variables.
-;
-lib-get: get 'get
-get: function [
-    source [any-word! any-path! block!]
-][
-    lib-get/any source
-]
-
-
-; R3-Alpha would only REDUCE a block and pass through other outputs.
-; REDUCE in Ren-C (and also in Red) is willing to reduce anything that
-; does not require EVAL-like argument consumption (so GROUP!, GET-WORD!,
-; GET-PATH!).
-;
-lib-reduce: get 'reduce
-reduce: func [
-    value
-    /no-set
-    /only
-    words [block! blank!]
-    /into
-    target [any-array!]
-][
-    either block? :value [
-        apply :lib-reduce [value no-set only words into target]
-    ][
-        ; For non-blocks, put the item in a block, reduce the block,
-        ; then pick the first element out.  This may error (e.g. if you
-        ; try to reduce a word looking up to a function taking arguments)
-        ;
-        ; !!! Simple with no refinements for now--enhancement welcome.
-        ;
-        assert [not no-set not only not into]
-        first (lib-reduce lib-reduce [:value])
-    ]
-]
-
-
-; Ren-C's FAIL dialect is still being designed, but the basic is to be
-; able to ramp up from simple strings to block-composed messages to
-; fully specifying ERROR! object fields.  Most commonly it is a synonym
-; for `do make error! form [...]`.
-;
-fail: func [
-    reason [error! text! block!]
-][
-    switch type-of reason [
-        error! [do error]
-        string! [do make error! reason]
-        block! [
-            for-each item reason [
-                if not any [
-                    any-scalar? :item
-                    text? :item
-                    group? :item
-                    all [
-                        word? :item
-                        not action? get :item
-                    ]
-                ][
-                    probe reason
-                    do make error! (
-                        "FAIL requires complex expressions in a GROUP!"
-                    )
-                ]
-            ]
-            do make error! form reduce reason
-        ]
-    ]
-]
-
-
-unset!: does [
-    fail "UNSET! not a type, use *opt-legacy* as <opt> in func specs"
-]
-
-unset?: does [
-    fail "UNSET? reserved for future use, use NULL? to test no value"
-]
-
-
-; Note: EVERY cannot be written in R3-Alpha because there is no way
-; to write loop wrappers, given lack of definitionally scoped return
-;
-for-each: get 'foreach
-foreach: does [
-    fail "In Ren-C code, please use FOR-EACH and not FOREACH"
-]
-
-for-next: get 'forall
-forall: does [
-    fail "In Ren-C code, please use FOR-NEXT and not FORALL"
-]
-
-
-decompress: compress: does [
-    fail [
-        "COMPRESS in R3-Alpha produced corrupt data using the /GZIP option."
-        "Ren-C uses gzip by default, and does not support 'Rebol compression'"
-        "(which was a non-raw zlib envelope plus 32-bit length, which can be"
-        "implemented using the new DEFLATE native and appending 4 bytes)."
-        "For forward compatibility, use DEFLATE, and store the size somewhere"
-        "to use with a Ren-C INFLATE call for more efficient decompression"
-    ]
-]
-
-gzip: gunzip: does [
-    fail [
-        "R3-Alpha's COMPRESS/GZIP was broken.  If bootstrap for Ren-C ever"
-        "is made to work with R3-Alpha again, either DEFLATE would need to be"
-        "used (storing the size elsewhere) or a usermode fake up of GZIP"
-        "would have to be implemented.  The latter is the better idea, and"
-        "isn't that difficult to do."
-     ]
-]
-
-deflate: func [data [binary! text!]] [
-    compressed: compress data
-    loop 4 [take/last compressed] ;-- 32-bit size at tail in "Rebol format"
-    compressed
-]
-
-
-; Not having category members have the same name as the category
-; themselves helps both cognition and clarity inside the source of the
-; implementation.
-;
-any-array?: get 'any-block?
-any-array!: get 'any-block!
-
-
-; Renamings to conform to ?-means-returns-true-false rule
-; https://trello.com/c/BxLP8Nch
-;
-length: length-of: get 'length?
-index-of: get 'index?
-offset-of: get 'offset?
-type-of: get 'type?
-
-
-; Source code that comes back from LOAD or is in a module is read-only in
-; Ren-C by default.  Non-mutating forms of the "mutate by default"
-; operators are suffixed by -OF (APPEND-OF, INSERT-OF, etc.)  There
-; is a relationship between historical "JOIN" and "REPEND" that is very
-; much like this, and with JOIN the mutating form and JOIN-OF the one
-; that copies, it brings about consistency and kills an annoying word.
-;
-; Rather than change this all at once, JOIN becomes JOIN-OF and REPEND
-; is left as it is (as the word has no intent to be reclaimed for other
-; purposes.)
-;
-join-of: get 'join 
-join: does [
-    fail "use JOIN-OF for JOIN (one day, JOIN will replace REPEND)"
-]
-
-; R3-Alpha's version of REPEND was built upon R3-Alpha's notion of REDUCE,
-; which wouldn't reduce anything but BLOCK!.  Having it be a no-op on PATH!
-; or WORD! was frustrating, so Red and Ren-C made it actually reduce whatever
-; it got.  But that affected REPEND so that it arguably became less useful.
-;
-; With Ren-C retaking JOIN, it makes more sense to take more artistic license
-; and make the function more useful than strictly APPEND REDUCE as suggested
-; by the name REPEND.  So in that spirit, the JOIN will only reduce blocks.
-; This makes it like R3-Alpha's REPEND.
-;
-; The temporary name is ADJOIN, which will be changed to JOIN someday when
-; existing JOIN usages have all been changed to JOIN-OF.
-;
-adjoin: get 'repend
-
-
-; Note: any-context! and any-context? supplied at top of file
-
-; *all* typesets now ANY-XXX to help distinguish them from concrete types
-; https://trello.com/c/d0Nw87kp
-;
-any-scalar?: get 'scalar?
-any-scalar!: scalar!
-any-series?: get 'series?
-any-series!: series!
-any-number?: get 'number?
-any-number!: number!
-
-
-; "optional" (a.k.a. void) handling
-opt: func [
+type-of: chain [:lib/type-of | :opt] ;-- type of null is now null
+of: enfix function [
+    return: [<opt> any-value!]
+    'property [word!]
     value [<opt> any-value!]
 ][
-    either* blank? :value [()] [:value]
-]
-
-trap: func [
-    code [block! function!]
-    /with
-    handler [block! function!]
-][
-    either with [
-        lib/try/except :code :handler
+    lib/switch*/default property [ ;-- non-evaluative, pass through null
+        index [index-of :value]
+        offset [offset-of :value]
+        length [length-of :value]
+        type [type-of :value] ;-- type of null is null
+        words [words-of :value]
     ][
-        lib/try :code
+        fail/where ["Unknown reflector:" property] 'property
     ]
 ]
 
-something?: func [value [<opt> any-value!]] [
-    not any [
-        null? :value
-        blank? :value
-    ]
-]
 
-; It is not possible to make a version of eval that does something other
-; than everything DO does in an older Rebol.  Which points to why exactly
-; it's important to have only one function like eval in existence.
+; https://forum.rebol.info/t/the-benefits-of-a-falsey-null-any-major-drawbacks/675
 ;
-eval: get 'do
-
-
-; R3-Alpha and Rebol2 did not allow you to make custom infix operators.
-; There is no way to get a conditional infix AND using those binaries.
-; In some cases, the bitwise and will be good enough for logic purposes...
+; Unfortunately, new functions are needed here vs. just adaptations, because
+; the spec of IF and EITHER etc. do not take <opt> :-(
 ;
-and+: get 'and
-and?: func [a b] [to-logic all [:a :b]]
-and: get 'and ; see above
+if: func [
+    return: [<opt> any-value!]
+    condition [<opt> any-value!]
+    branch [block! action!]
+    ;-- /OPT processing would be costly, omit the refinement for now
+] compose/deep [
+    (:lib/if) (:lib/to-value) :condition :branch
+]
+either: func [
+    return: [<opt> any-value!]
+    condition [<opt> any-value!]
+    true-branch [block! action!]
+    false-branch [block! action!]
+    ;-- /OPT processing would be costly, omit the refinement for now
+] compose/deep [
+    (:lib/either) (:lib/to-value) :condition :true-branch :false-branch
+]
+while: adapt 'lib/while compose/deep [
+    condition: reduce [quote (:lib/to-value) as group! :condition]
+]
+any: function [
+    return: [<opt> any-value!]
+    block [block!]
+] compose/deep [
+    (:lib/loop-until) [
+        (:lib/if) value: (:lib/to-value) do/next block 'block [
+            return :value
+        ]
+        (:lib/tail?) block
+    ]
+    return null
+]
+all: function [
+    return: [<opt> any-value!]
+    block [block!]
+] compose/deep [
+    value: '|
+    (:lib/loop-until) [
+        ;-- NOTE: uses the old-style UNLESS, as its faster than IF NOT
+        (:lib/unless) value: (:lib/to-value) do/next block 'block [
+            return null
+        ]
+        (:lib/tail?) block
+    ]
+    :value
+]
+find: chain [:lib/find | :opt]
+select: chain [:lib/select | :opt]
+case: function [
+    return: [<opt> any-value!]
+    cases [block!]
+    /all
+    ;-- /OPT processing would be costly, omit the refinement for now
+] compose/deep [
+    result: null
 
-or+: get 'or
-or?: func [a b] [to-logic any [:a :b]]
-or: get 'or ; see above
+    (:lib/loop-until) [
+        (:lib/if) (:lib/to-value) condition: do/next cases 'cases [
+            result: (:lib/to-value) do ensure block! cases/1
 
-xor+: get 'xor
-xor?: func [a b] [to-logic any [all [:a (not :b)] all [(not :a) :b]]]
+            ;-- NOTE: uses the old-style UNLESS, as its faster than IF NOT
+            (:lib/unless) all [return :result]
+        ]
+        (:lib/tail?) cases: (:lib/next) cases
+    ]
+    :result
+]
 
 
-; UNSPACED in Ren-C corresponds rougly to AJOIN, and SPACED corresponds very
-; roughly to REFORM.  A similar "sort-of corresponds" applies to REJOIN being
-; like JOIN-ALL.
+choose: function [
+    {Like CASE but doesn't evaluate blocks https://trello.com/c/noVnuHwz}
+    choices [block!] /local result
+] compose/deep [
+    (:lib/loop-until) [
+        (:lib/if) (:lib/to-value) do/next choices 'choices [
+            return choices/1
+        ]
+        (:lib/tail?) choices: (:lib/next) choices
+    ]
+    return null
+]
+
+; Renamed, tightened, and extended with new features
 ;
-delimit: func [x delimiter] [
-    either block? x [
-        pending: false
-        out: make text! 10
-        while [not tail? x] [
-            if bar? first x [
-                pending: false
-                append out newline
-                x: next x
-                continue
-            ]
-            set/opt 'item do/next x 'x
-            case [
-                any [blank? :item | null? :item] [
-                    ;-- append nothing
-                ]
-
-                true [
-                    case [
-                        ; Characters (e.g. space or newline) are not counted
-                        ; in delimiting.
-                        ;
-                        char? :item [
-                            append out item
-                            pending: false
-                        ]
-                        all [pending | not blank? :delimiter] [
-                            append out form :delimiter
-                            append out form :item
-                            pending: true
-                        ]
-                        true [
-                            append out form :item
-                            pending: true
-                        ]
-                    ]
-                ]
-            ]
-        ]
-        out
-    ][
-        reform :x
-    ]
-]
-
-unspaced: func [x] [
-    delimit x blank
-]
-
-spaced: func [x] [
-    delimit :x space
-]
-
-join-all: :rejoin
+file-to-local: :to-local-file
+local-to-file: :to-rebol-file
+unset 'to-local-file
+unset 'to-rebol-file
 
 
-make-action: func [
-    {Internal generator used by FUNCTION and PROCEDURE specializations.}
-    return: [action!]
-    generator [action!]
-        {Arity-2 "lower"-level generator to use (e.g. FUNC or PROC)}
-    spec [block!]
-    body [block!]
-    <local>
-        new-spec var other
-        new-body exclusions locals defaulters statics
-][
-    exclusions: copy []
-    new-spec: make block! length-of spec
-    new-body: _
-    statics: _
-    defaulters: _
-    var: _
-    locals: copy []
-
-    ;; dump [spec]
-
-    ; Gather the SET-WORD!s in the body, excluding the collected ANY-WORD!s
-    ; that should not be considered.  Note that COLLECT is not defined by
-    ; this point in the bootstrap.
-    ;
-    ; !!! REVIEW: ignore self too if binding object?
-    ;
-    parse spec [any [
-        if (set? 'var) [
-            set var: any-word! (
-                append exclusions :var ;-- exclude args/refines
-                append new-spec :var ;-- need GET-WORD! for R3-Alpha lit decay
-            )
-        |
-            set other: [block! | text!] (
-                append/only new-spec other ;-- spec notes or data type blocks
-            )
-        ]
-    |
-        other:
-        [group!] (
-            if not var [
-                fail [
-                    ; <where> spec
-                    ; <near> other
-                    "Default value not paired with argument:" (mold other/1)
-                ]
-            ]
-            if not defaulters [
-                defaulters: copy []
-            ]
-            append defaulters compose/deep [
-                (to set-word! var) default [(reduce other/1)]
-            ]
-        )
-    |
-        (unset 'var) ;-- everything below this line clears var
-        fail ;-- failing here means rolling over to next rule
-    |
-        <local>
-        any [set var: word! (other: _) opt set other: group! (
-            append locals var
-            append exclusions var
-            if other [
-                if not defaulters [
-                    defaulters: copy []
-                ]
-                append defaulters compose/deep [
-                    (to set-word! var) default [(reduce other)]
-                ]
-            ]
-        )]
-        (unset 'var) ;-- don't consider further GROUP!s or variables
-    |
-        <in> (
-            if not new-body [
-                append exclusions 'self
-                new-body: copy/deep body
-            ]
-        )
-        any [
-            set other: [word! | path!] (
-                other: really any-context! get other
-                bind new-body other
-                for-each [key val] other [
-                    append exclusions key
-                ]
-            )
-        ]
-    |
-        <with> any [
-            set other: [word! | path!] (append exclusions other)
-        |
-            text! ;-- skip over as commentary
-        ]
-    |
-        <static> (
-            if not statics [
-                statics: copy []
-            ]
-            if not new-body [
-                append exclusions 'self
-                new-body: copy/deep body
-            ]
-        )
-        any [
-            set var: word! (other: quote ()) opt set other: group! (
-                append exclusions var
-                append statics compose/only [
-                    (to set-word! var) (other)
-                ]
-            )
-        ]
-        (unset 'var)
-    |
-        end accept
-    |
-        other: (
-            fail [
-                ; <where> spec
-                ; <near> other
-                "Invalid spec item:" (mold other/1)
-            ]
-        )
-    ]]
-
-    collected-locals: collect-words/deep/set/ignore body exclusions
-
-    ;; dump [{before} statics new-spec exclusions]
-
-    if statics [
-        statics: has statics
-        bind new-body statics
-    ]
-
-    ; !!! The words that come back from COLLECT-WORDS are all WORD!, but we
-    ; need SET-WORD! to specify pure locals to the generators.  Review the
-    ; COLLECT-WORDS interface to efficiently give this result, as well as
-    ; a possible COLLECT-WORDS/INTO
-    ;
-    append new-spec <local> ;-- SET-WORD! not supported in R3-Alpha mode
-    for-next collected-locals [
-        append new-spec collected-locals/1
-    ]
-    for-next locals [
-        append new-spec locals/1
-    ]
-
-    ;; dump [{after} new-spec defaulters]
-
-    generator new-spec either defaulters [
-        append/only defaulters as group! any [new-body body]
-    ][
-        any [new-body body]
-    ]
-]
-
-;-- These are "redescribed" after REDESCRIBE is created
+; https://forum.rebol.info/t/text-vs-string/612
 ;
-function: func [spec body] [
-    make-action :func spec body
-]
-
-procedure: func [spec body] [
-    make-action :proc spec body
-]
+text!: (string!)
+text?: (:string?)
+to-text: (:to-string)
 
 
-; This isn't a full implementation of REALLY with function-oriented testing,
-; but it works well enough for types.
+; https://forum.rebol.info/t/reverting-until-and-adding-while-not-and-until-not/594
 ;
-really: function [type [datatype! block!] value [<opt> any-value!]] [
-    either block? type [
-        type: make typeset! type
-        if not find type type-of :value [
-            probe :value
-            fail [
-                "REALLY expected:" (mold type) "but got" (mold type-of :value)
+; Note: WHILE-NOT can't be written correctly in usermode R3-Alpha (RETURN
+; won't work definitionally.)  Assume we'll never bootstrap under R3-Alpha.
+;
+until: :loop-until
+while-not: adapt 'while compose/deep [
+    condition: reduce [
+        quote (:lib/not) quote (:lib/to-value) as group! :condition
+    ]
+]
+until-not: adapt 'until compose/deep [
+    body: reduce [
+        quote (:lib/not) quote (:lib/to-value) as group! :body
+    ]
+]
+
+
+; https://trello.com/c/XnDsvsM0
+;
+assert [find words-of :ensure 'test]
+really: func [optional [<opt> any-value!]] [
+    if null? :optional [
+        fail/where [
+            "REALLY expects argument to be non-null"
+        ] 'optional
+    ]
+    return :optional
+]
+
+; https://trello.com/c/Bl6Znz0T
+;
+deflate: specialize 'compress [gzip: false | only: true] ;; "raw"
+inflate: specialize 'decompress [gzip: false | only: true] ;; "raw"
+gzip: specialize 'compress [gzip: true]
+gunzip: specialize 'decompress [gzip: true]
+compress: decompress: does [
+    fail "COMPRESS/DECOMPRESS replaced by gzip/gunzip/inflate/deflate"
+]
+
+; https://trello.com/c/9ChhSWC4/
+;
+switch: adapt 'switch [
+    cases: map-each c cases [
+        lib/case [
+            lit-word? :c [to word! c]
+            lit-path? :c [to path! c]
+
+            path? :c [
+                fail/where ["Switch now evaluative" c] 'cases
             ]
-        ]
-    ][        
-        if type != type-of :value [
-            probe :value
-            fail [
-                "REALLY expected:" (mold type) "but got" (mold type-of :value)
+            word? :c [
+                if not datatype? get c [
+                    fail/where ["Switch now evaluative" c] 'cases
+                ]
+                get c
             ]
+
+            true [:c]
         ]
     ]
-    return :value
 ]

--- a/make/tools/read-deep.reb
+++ b/make/tools/read-deep.reb
@@ -44,18 +44,18 @@ read-deep: function [
         {Include root path, retains full paths vs. returning relative paths.}
     /strategy
         {Allows Queue building to be overridden.}
-    take [action!]
+    taker [action!]
         {TAKE next item from queue, building the queue as necessary.}
 ][
-    take: default [:read-deep-seq]
+    taker: default [:read-deep-seq]
 
     result: make block! []
 
     queue: compose [(root)]
 
     while-not [tail? queue][
-        path: take queue
-        append result :path ; Possible void.
+        path: try taker queue ;-- Possible null
+        append result opt path
     ]
 
     if not full [

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -548,7 +548,7 @@ config-system: function [
     hint [blank! text! tuple!]
         {Version ID (blank means guess)}
 ][
-    version: switch type-of hint [
+    version: switch type of hint [
         blank! [ ;-- Try same version as this r3-make was built with
             to tuple! reduce [0 system/version/4 system/version/5]
         ]
@@ -557,6 +557,8 @@ config-system: function [
     ]
 
     if not tuple? version [
+        print mold type of version
+        wait 5
         fail ["Expected OS_ID tuple like 0.3.1, not:" version]
     ]
 

--- a/make/tools/text-lines.reb
+++ b/make/tools/text-lines.reb
@@ -30,7 +30,7 @@ decode-lines: function [
             {and end with newline.}
         ]
     ]
-    if pos: back tail-of text [remove pos]
+    if pos: try back tail-of text [remove pos]
     text
 ]
 

--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -396,6 +396,8 @@ close: action [
 
 read: action [
     {Read from a file, URL, or other port.}
+    return: [<opt> binary! text! block! port!]
+        "null on (some) failures !!! REVIEW as part of port model review"
     source [port! file! url! block!]
     /part {Partial read a given number of units (source relative)}
         limit [any-number!]
@@ -403,8 +405,6 @@ read: action [
         index [any-number!]
     /string {Convert UTF and line terminators to standard text string}
     /lines {Convert to block of strings (implies /string)}
-;   /as {Convert to string using a specified encoding}
-;       encoding [blank! any-number!] {UTF number (0 8 16 -16)}
 ]
 
 write: action [
@@ -426,6 +426,7 @@ write: action [
 
 query: action [
     {Returns information about a port, file, or URL.}
+    return: [<opt> object!]
     target [port! file! url! block!]
     /mode "Get mode information"
     field [word! blank!] "NONE will return valid modes for port type"
@@ -433,6 +434,8 @@ query: action [
 
 modify: action [
     {Change mode or control for port or file.}
+    return: [logic!]
+        "TRUE if successful, FALSE if unsuccessful (!!! REVIEW)"
     target [port! file!]
     field [word! blank!]
     value
@@ -447,6 +450,7 @@ modify: action [
 ;
 on-wake-up: action [
     {Updates external and internal states (normally after read/write).}
+    return: [<opt>]
     port [port!]
 ]
 

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -77,7 +77,7 @@ Script: [
     type: "script error"
 
     no-value:           [:arg1 {has no value}]
-    need-value:         [:arg1 {needs a value}]
+    need-value:         [:arg1 {needs a value (use TRY, DID, ELSE, or SET*)}]
     not-bound:          [:arg1 {word is not bound to a context}]
     no-relative:        [:arg1 {word is bound relative to context not on stack}]
     not-in-context:     [:arg1 {is not in the specified context}]

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1147,7 +1147,7 @@ REBOOL RL_rebDid(const void *p, ...) {
     if (indexor == THROWN_FLAG)
         fail (Error_No_Catch_For_Throw(condition));
 
-    return not IS_VOID_OR_FALSEY(condition); // DID treats voids as "falsey"
+    return IS_TRUTHY(condition);
 }
 
 
@@ -1173,7 +1173,7 @@ REBOOL RL_rebNot(const void *p, ...) {
     if (indexor == THROWN_FLAG)
         fail (Error_No_Catch_For_Throw(condition));
 
-    return IS_VOID_OR_FALSEY(condition); // NOT treats voids as "falsey"
+    return IS_FALSEY(condition);
 }
 
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1028,6 +1028,18 @@ REBCTX *Error_User(const char *utf8) {
 
 
 //
+//  Error_Need_Value_Core: C
+//
+REBCTX *Error_Need_Value_Core(const RELVAL *target, REBSPC *specifier) {
+    assert(IS_SET_WORD(target) or IS_SET_PATH(target));
+
+    DECLARE_LOCAL (specific);
+    Derelativize(specific, target, specifier);
+    return Error_Need_Value_Raw(specific);
+}
+
+
+//
 //  Error_Lookback_Quote_Too_Late: C
 //
 REBCTX *Error_Lookback_Quote_Too_Late(const RELVAL *word, REBSPC *specifier) {

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1794,6 +1794,9 @@ reevaluate:;
             // or we ARE evaluating and there IS A special exemption.  Treat
             // the f->value as inert.
             //
+            if (IS_VOID(f->value))
+                fail (Error_Need_Value_Core(current, f->specifier));
+
             Derelativize(f->out, f->value, f->specifier);
             Move_Value(Sink_Var_May_Fail(current, f->specifier), f->out);
         }
@@ -1813,6 +1816,9 @@ reevaluate:;
                 DS_DROP;
                 goto finished;
             }
+
+            if (IS_VOID(f->out))
+                fail (Error_Need_Value_Raw(DS_TOP));
 
             // if x: [1 < 2] [print "errors if set-word doesn't clear flag"]
             //
@@ -2021,6 +2027,9 @@ reevaluate:;
             // or we ARE evaluating and there IS A special exemption.  Treat
             // the f->value as inert.
 
+            if (IS_VOID(f->value))
+                fail (Error_Need_Value_Core(current, f->specifier));
+
             Derelativize(f->out, f->value, f->specifier);
 
             // !!! Due to the way this is currently designed, throws need to
@@ -2054,6 +2063,9 @@ reevaluate:;
                 DS_DROP;
                 goto finished;
             }
+
+            if (IS_VOID(f->out))
+                fail (Error_Need_Value_Raw(DS_TOP));
 
             // The path cannot be executed directly from the data stack, so
             // it has to be popped.  This could be changed by making the core

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -58,13 +58,13 @@ void Dump_Frame_Location(const RELVAL *current, REBFRM *f)
 {
     DECLARE_LOCAL (dump);
 
-    if (current != NULL) {
+    if (current) {
         Derelativize(dump, current, f->specifier);
         printf("Dump_Frame_Location() current\n");
         PROBE(dump);
     }
 
-    if (f->value != NULL) {
+    if (f->value) {
         Derelativize(dump, f->value, f->specifier);
         printf("Dump_Frame_Location() next\n");
         PROBE(dump);
@@ -72,6 +72,14 @@ void Dump_Frame_Location(const RELVAL *current, REBFRM *f)
 
     if (FRM_AT_END(f)) {
         printf("...then Dump_Frame_Location() is at end of array\n");
+        if (not current and not f->value) { // well, that wasn't informative
+            if (not f->prior)
+                printf("...and no parent frame, so you're out of luck\n");
+            else {
+                printf("...dumping parent in case that's more useful?\n");
+                Dump_Frame_Location(NULL, f->prior);
+            }
+        }
     }
     else {
         printf("Dump_Frame_Location() rest\n");

--- a/src/core/d-stack.c
+++ b/src/core/d-stack.c
@@ -223,7 +223,7 @@ REBNATIVE(near_of)
 //
 //  "Get word label used to invoke a function call (if still on stack)"
 //
-//      return: [word! blank!]
+//      return: [<opt> word!]
 //      frame [frame!]
 //  ]
 //
@@ -233,8 +233,8 @@ REBNATIVE(label_of)
 
     REBFRM *f = CTX_FRAME_MAY_FAIL(VAL_CONTEXT(ARG(frame)));
 
-    if (f->opt_label == NULL)
-        return R_BLANK;
+    if (not f->opt_label)
+        return R_NULL;
 
     Init_Word(D_OUT, f->opt_label);
     return R_OUT;
@@ -275,7 +275,7 @@ REBNATIVE(action_of)
 //
 //  "Get the parent of a FRAME!"
 //
-//      return: [blank! frame!]
+//      return: [<opt> frame!]
 //      frame [frame!]
 //  ]
 //
@@ -299,7 +299,7 @@ REBNATIVE(parent_of)
         }
     }
 
-    return R_BLANK;
+    return R_NULL;
 }
 
 

--- a/src/core/d-stats.c
+++ b/src/core/d-stats.c
@@ -40,6 +40,7 @@
 //
 //  {Provides status and statistics information about the interpreter.}
 //
+//      return: [<opt> time! integer!]
 //      /show
 //          "Print formatted results to console"
 //      /profile
@@ -116,7 +117,7 @@ REBNATIVE(stats)
     if (REF(dump_series)) {
         REBVAL *pool_id = ARG(pool_id);
         Dump_Series_In_Pool(VAL_INT32(pool_id));
-        return R_BLANK;
+        return R_NULL;
     }
 
     Init_Integer(D_OUT, Inspect_Series(REF(show)));

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -97,7 +97,7 @@ REB_R Series_Common_Action_Maybe_Unhandled(
                 );
                 return R_OUT;
             }
-            return R_BLANK; }
+            return R_NULL; }
 
         case SYM_LINE: {
             REBSER *s = VAL_SERIES(value);
@@ -105,7 +105,7 @@ REB_R Series_Common_Action_Maybe_Unhandled(
                 Init_Integer(D_OUT, MISC(s).line);
                 return R_OUT;
             }
-            return R_BLANK; }
+            return R_NULL; }
 
         default:
             break;
@@ -155,12 +155,12 @@ REB_R Series_Common_Action_Maybe_Unhandled(
 
         if (i > cast(REBI64, tail)) {
             if (REF(only))
-                return R_BLANK;
+                return R_NULL;
             i = cast(REBI64, tail); // past tail clips to tail if not /ONLY
         }
         else if (i < 0) {
             if (REF(only))
-                return R_BLANK;
+                return R_NULL;
             i = 0; // past head clips to head if not /ONLY
         }
 

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -205,7 +205,7 @@ REBNATIVE(eval_enfix)
 //
 //      return: [<opt> any-value!]
 //      source [
-//          blank! ;-- useful for `do any [...]` scenarios when no match
+//          blank! ;-- useful for `do try ...` scenarios when no match
 //          block! ;-- source code in block form
 //          group! ;-- same as block (or should it have some other nuance?)
 //          text! ;-- source code in text form
@@ -239,7 +239,7 @@ REBNATIVE(do)
 
     switch (VAL_TYPE(source)) {
     case REB_BLANK:
-        return R_BLANK;
+        return R_NULL;
 
     case REB_BLOCK:
     case REB_GROUP: {

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -62,7 +62,7 @@ static REBVAL *Trap_Dangerous(REBFRM *frame_) {
 //
 //  {Tries to DO a block, trapping raised errors}
 //
-//      return: "ERROR! if raised, else result (void if non-raised ERROR!)"
+//      return: "ERROR! if raised, else result (null if non-raised ERROR!)"
 //          [<opt> any-value!]
 //      code "Code to execute and monitor"
 //          [block! action!]
@@ -78,13 +78,15 @@ REBNATIVE(trap)
     REBVAL *error = rebRescue(cast(REBDNG*, &Trap_Dangerous), frame_);
     UNUSED(ARG(code)); // gets used by the above call, via the frame_ pointer
 
-    if (error == NULL) {
+    if (not error) {
         if (THROWN(D_OUT)) // though code didn't fail(), it may have thrown
             return R_OUT_IS_THROWN;
 
         if (not REF(with) and IS_ERROR(D_OUT)) // code may evaluate to ERROR!
             return R_NULL; // ...but void it so ERROR! *always* means raised
 
+        if (IS_VOID(D_OUT))
+            return R_BLANK; // blankify output (should there be an /OPT ?)
         return R_OUT;
     }
 

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -665,8 +665,8 @@ REBNATIVE(enclose)
 //
 //  {Cause all existing references to an ACTION! to invoke another ACTION!}
 //
-//      return: [action! blank!]
-//          {The hijacked action value, blank if self-hijack (no-op)}
+//      return: [<opt> action!]
+//          {The hijacked action value, null if self-hijack (no-op)}
 //      victim [action! word! path!]
 //          {Action value whose references are to be affected.}
 //      hijacker [action! word! path!]
@@ -723,7 +723,7 @@ REBNATIVE(hijack)
         // Permitting a no-op hijack has some applications...but offer a
         // distinguished result for those who want to detect the condition.
         //
-        return R_BLANK;
+        return R_NULL;
     }
 
     REBARR *victim_paramlist = VAL_ACT_PARAMLIST(victim);

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -1244,6 +1244,7 @@ REBNATIVE(to_hex)
 //
 //  {Find a script header within a binary string. Returns starting position.}
 //
+//      return: [<opt> binary!]
 //      script [binary!]
 //  ]
 //
@@ -1255,7 +1256,7 @@ REBNATIVE(find_script)
 
     REBINT offset = Scan_Header(VAL_BIN_AT(arg), VAL_LEN_AT(arg));
     if (offset == -1)
-        return R_BLANK;
+        return R_NULL;
 
     VAL_INDEX(arg) += offset;
 
@@ -1267,7 +1268,7 @@ REBNATIVE(find_script)
 //
 //  invalid-utf8?: native [
 //
-//  {Checks UTF-8 encoding; if correct, returns blank else position of error.}
+//  {Checks UTF-8 encoding; if correct, returns null else position of error.}
 //
 //      data [binary!]
 //  ]
@@ -1279,8 +1280,8 @@ REBNATIVE(invalid_utf8_q)
     REBVAL *arg = ARG(data);
 
     REBYTE *bp = Check_UTF8(VAL_BIN_AT(arg), VAL_LEN_AT(arg));
-    if (bp == NULL)
-        return R_BLANK;
+    if (not bp)
+        return R_NULL;
 
     VAL_INDEX(arg) = bp - VAL_BIN_HEAD(arg);
 

--- a/src/core/p-clipboard.c
+++ b/src/core/p-clipboard.c
@@ -66,8 +66,8 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         if (req->command == RDC_READ) {
             // this could be executed twice:
             // once for an event READ, once for the CLOSE following the READ
-            if (req->common.data == NULL)
-                return R_BLANK;
+            if (not req->common.data)
+                return R_BAR;
 
             REBVAL *data = cast(REBVAL*, req->common.data); // Hack!
             Move_Value(arg, data);
@@ -78,7 +78,7 @@ static REB_R Clipboard_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         else if (req->command == RDC_WRITE) {
             Init_Blank(arg);  // Write is done.
         }
-        return R_BLANK;
+        return R_BAR;
 
     case SYM_READ: {
         INCLUDE_PARAMS_OF_READ;

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -325,8 +325,8 @@ static REB_R Dir_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         assert(result != NULL); // should be synchronous
 
         if (rebDid("lib/error?", result, END)) {
-            rebRelease(result); // !!! R3-Alpha threw out error, returns blank
-            return R_BLANK;
+            rebRelease(result); // !!! R3-Alpha threw out error, returns null
+            return R_NULL;
         }
 
         rebRelease(result); // ignore result

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -174,7 +174,7 @@ static REB_R DNS_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         goto return_port; }
 
     case SYM_ON_WAKE_UP:
-        return R_BLANK;
+        return R_BAR;
 
     default:
         break;

--- a/src/core/p-event.c
+++ b/src/core/p-event.c
@@ -172,7 +172,7 @@ static REB_R Event_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         break; }
 
     case SYM_ON_WAKE_UP:
-        return R_BLANK;
+        return R_BAR;
 
     // Normal block actions done on events:
     case SYM_POKE:

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -582,7 +582,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
             assert(result != NULL);
             if (rebDid("lib/error?", result, END)) {
                 rebRelease(result); // !!! R3-Alpha returned blank on error
-                return R_BLANK;
+                return R_NULL;
             }
             rebRelease(result); // ignore result
         }
@@ -607,7 +607,7 @@ static REB_R File_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
             assert(result != NULL);
             if (rebDid("lib/error?", result, END)) {
                 rebRelease(result); // !!! R3-Alpha returned blank on error
-                return R_BLANK;
+                return R_FALSE;
             }
             rebRelease(result); // ignore result
         }

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -282,7 +282,7 @@ static REB_R Transport_Actor(
         else if (sock->command == RDC_WRITE) {
             Init_Blank(port_data); // Write is done.
         }
-        return R_BLANK; }
+        return R_BAR; }
 
     case SYM_READ: {
         INCLUDE_PARAMS_OF_READ;

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -283,7 +283,7 @@ static REB_R Serial_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         else if (req->command == RDC_WRITE) {
             Init_Blank(data);  // Write is done.
         }
-        return R_BLANK; }
+        return R_BAR; }
 
     case SYM_CLOSE:
         if (req->flags & RRF_OPEN) {

--- a/src/core/p-signal.c
+++ b/src/core/p-signal.c
@@ -251,7 +251,7 @@ static REB_R Signal_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
                 update(signal, len, arg);
             }
         }
-        return R_BLANK; }
+        return R_BAR; }
 
     case SYM_READ: {
         // This device is opened on the READ:
@@ -272,7 +272,7 @@ static REB_R Signal_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
 
         if (len <= 0) {
             Free_Unmanaged_Series(ser);
-            return R_BLANK;
+            return R_NULL;
         }
 
         update(signal, len, arg);

--- a/src/core/p-timer.c
+++ b/src/core/p-timer.c
@@ -83,7 +83,7 @@ static REB_R Timer_Actor(REBFRM *frame_, REBCTX *port, REBSYM verb)
         break; }
 
     case SYM_ON_WAKE_UP:
-        return R_BLANK;
+        return R_BAR;
 
     // Normal block actions done on events:
     case SYM_POKE:

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -631,7 +631,7 @@ REBTYPE(Bitset)
             fail (Error_Bad_Refines_Raw());
 
         if (not Check_Bits(VAL_SERIES(value), arg, REF(case)))
-            return R_BLANK;
+            return R_NULL;
         return R_BAR;
     }
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -793,8 +793,6 @@ REBTYPE(Array)
     case SYM_SELECT: {
         INCLUDE_PARAMS_OF_FIND; // must be same as select
 
-        const REB_R r_not_found = (verb == SYM_FIND) ? R_BLANK : R_NULL;
-
         UNUSED(PAR(series));
         UNUSED(PAR(value)); // aliased as arg
 
@@ -821,7 +819,7 @@ REBTYPE(Array)
         );
 
         if (ret >= limit)
-            return r_not_found;
+            return R_NULL;
 
         if (REF(only))
             len = 1;
@@ -835,7 +833,7 @@ REBTYPE(Array)
         else {
             ret += len;
             if (ret >= limit)
-                return r_not_found;
+                return R_NULL;
 
             Derelativize(D_OUT, ARR_AT(array, ret), specifier);
         }
@@ -1022,7 +1020,7 @@ REBTYPE(Array)
 
         if (REF(only)) { // pick an element out of the array
             if (index >= VAL_LEN_HEAD(value))
-                return R_BLANK;
+                return R_NULL;
 
             Init_Integer(
                 ARG(seed),

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -224,7 +224,7 @@ REBTYPE(Action)
         case SYM_CONTEXT: {
             if (Get_Context_Of(D_OUT, value))
                 return R_OUT;
-            return R_BLANK; }
+            return R_NULL; }
 
         case SYM_WORDS:
             Init_Block(D_OUT, List_Func_Words(value, FALSE)); // no locals
@@ -262,12 +262,12 @@ REBTYPE(Action)
         //
         case SYM_FILE: {
             if (not ANY_SERIES(VAL_ACT_BODY(value)))
-                return R_BLANK;
+                return R_NULL;
 
             REBSER *s = VAL_SERIES(VAL_ACT_BODY(value));
 
             if (NOT_SER_FLAG(s, ARRAY_FLAG_FILE_LINE))
-                return R_BLANK;
+                return R_NULL;
 
             // !!! How to tell whether it's a URL! or a FILE! ?
             //
@@ -278,12 +278,12 @@ REBTYPE(Action)
 
         case SYM_LINE: {
             if (not ANY_SERIES(VAL_ACT_BODY(value)))
-                return R_BLANK;
+                return R_NULL;
 
             REBSER *s = VAL_SERIES(VAL_ACT_BODY(value));
 
             if (NOT_SER_FLAG(s, ARRAY_FLAG_FILE_LINE))
-                return R_BLANK;
+                return R_NULL;
 
             Init_Integer(D_OUT, MISC(s).line);
             return R_OUT; }
@@ -324,15 +324,15 @@ REB_R PD_Action(REBPVS *pvs, const REBVAL *picker, const REBVAL *opt_setval)
     if (IS_BLANK(picker)) {
         //
         // Leave the function value as-is, and continue processing.  This
-        // enables things like `append/(all [only 'only])/dup`...
+        // enables things like `append/(only ?? 'only !! _)/dup`...
         //
         // Note this feature doesn't have obvious applications to refinements
         // that take arguments...only ones that don't.  Use "revoking" to
         // pass void as arguments to a refinement that is always present
         // in that case.
         //
-        // Void might seem more convenient, e.g. `append/(only ?? 'only)/dup`,
-        // however it is disallowed to use voids at the higher level path
+        // Null might seem more convenient, e.g. `append/(only ?? 'only)/dup`,
+        // however it is disallowed to use nulls at the higher level path
         // protocol.  This is probably for the best.
         //
         return R_OUT;

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -1069,10 +1069,10 @@ REBTYPE(Gob)
             fail (Error_Invalid(arg));
 
         if (!GOB_PANE(gob))
-            return R_BLANK;
+            return R_NULL;
         index += Get_Num_From_Arg(arg) - 1;
         if (index >= tail)
-            return R_BLANK;
+            return R_NULL;
         gob = *GOB_AT(gob, index);
         index = 0;
         goto set_index;
@@ -1186,7 +1186,7 @@ REBTYPE(Gob)
         if (index + len > tail)
             len = tail - index;
         if (index >= tail)
-            return R_BLANK;
+            return R_NULL;
 
         if (!REF(part)) { // just one value
             RESET_VAL_HEADER(D_OUT, REB_GOB);
@@ -1212,10 +1212,10 @@ REBTYPE(Gob)
         if (IS_GOB(arg)) {
             index = Find_Gob(gob, VAL_GOB(arg));
             if (index == NOT_FOUND)
-                return R_BLANK;
+                return R_NULL;
             goto set_index;
         }
-        return R_BLANK;
+        return R_NULL;
 
     case SYM_REVERSE:
         for (index = 0; index < tail/2; index++) {

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -784,7 +784,7 @@ REBTYPE(Map)
         );
 
         if (n == 0)
-            return verb == SYM_FIND ? R_BLANK : R_NULL;
+            return R_NULL;
 
         Move_Value(
             D_OUT,
@@ -792,7 +792,7 @@ REBTYPE(Map)
         );
 
         if (verb == SYM_FIND)
-            return IS_VOID(D_OUT) ? R_BLANK : R_BAR;
+            return IS_VOID(D_OUT) ? R_NULL : R_BAR;
 
         return R_OUT; }
 

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1264,8 +1264,6 @@ REBTYPE(String)
     case SYM_FIND: {
         INCLUDE_PARAMS_OF_FIND;
 
-        const REB_R r_not_found = (verb == SYM_FIND) ? R_BLANK : R_NULL;
-
         UNUSED(PAR(series));
         UNUSED(PAR(value));
 
@@ -1326,7 +1324,7 @@ REBTYPE(String)
         );
 
         if (ret >= cast(REBCNT, tail))
-            return r_not_found;
+            return R_NULL;
 
         if (REF(only))
             len = 1;
@@ -1339,7 +1337,7 @@ REBTYPE(String)
         else {
             ret++;
             if (ret >= cast(REBCNT, tail))
-                return r_not_found;
+                return R_NULL;
 
             if (IS_BINARY(v)) {
                 Init_Integer(v, *BIN_AT(VAL_SERIES(v), ret));
@@ -1382,7 +1380,7 @@ REBTYPE(String)
 
         if (cast(REBINT, VAL_INDEX(v)) >= tail) {
             if (not REF(part))
-                return R_BLANK;
+                return R_NULL;
             Init_Any_Series(D_OUT, VAL_TYPE(v), Make_Binary(0));
             return R_OUT;
         }
@@ -1632,7 +1630,7 @@ REBTYPE(String)
 
         if (REF(only)) {
             if (index >= tail)
-                return R_BLANK;
+                return R_NULL;
             index += (REBCNT)Random_Int(REF(secure)) % (tail - index);
             if (IS_BINARY(v)) { // same as PICK
                 Init_Integer(D_OUT, *VAL_BIN_AT_HEAD(v, index));

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -495,7 +495,7 @@ REBTYPE(Tuple)
   poke_it:
         a = Get_Num_From_Arg(arg);
         if (a <= 0 || a > len) {
-            if (action == A_PICK) return R_BLANK;
+            if (action == A_PICK) return R_NULL;
             fail (Error_Out_Of_Range(arg));
         }
         if (action == A_PICK) {

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -391,7 +391,7 @@ REBTYPE(Typeset)
         if (TYPE_CHECK(val, VAL_TYPE_KIND(arg)))
             return R_BAR;
 
-        return R_BLANK;
+        return R_NULL;
 
     case SYM_INTERSECT:
     case SYM_UNION:

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -261,7 +261,7 @@ REBTYPE(Word)
         case SYM_CONTEXT: {
             if (Get_Context_Of(D_OUT, val))
                 return R_OUT;
-            return R_BLANK; }
+            return R_NULL; }
 
         default:
             break;

--- a/src/extensions/crypt/mod-crypt.c
+++ b/src/extensions/crypt/mod-crypt.c
@@ -485,7 +485,7 @@ static REBNATIVE(aes)
         REBINT len = VAL_LEN_AT(ARG(data));
 
         if (len == 0)
-            return R_BLANK;
+            return R_NULL; // !!! Is NULL a good result for 0 data?
 
         REBINT pad_len = (((len - 1) >> 4) << 4) + AES_BLOCKSIZE;
 
@@ -533,7 +533,7 @@ static REBNATIVE(aes)
 
         if (IS_BINARY(ARG(iv))) {
             if (VAL_LEN_AT(ARG(iv)) < AES_IV_SIZE)
-                return R_BLANK;
+                fail ("Length of initialization vector less than AES size");
 
             memcpy(iv, VAL_BIN_AT(ARG(iv)), AES_IV_SIZE);
         }

--- a/src/extensions/debugger/ext-debugger-init.reb
+++ b/src/extensions/debugger/ext-debugger-init.reb
@@ -33,7 +33,7 @@ backtrace*: function [
     get-frame: not blank? :level
 
     if get-frame [
-        if any [limit brief] [
+        any [limit brief] then [
             fail "Can't use /LIMIT or /BRIEF unless getting a list of frames"
         ]
 

--- a/src/extensions/debugger/mod-debugger.c
+++ b/src/extensions/debugger/mod-debugger.c
@@ -897,8 +897,8 @@ return_temp:
 //
 //  "Get the index of a given frame or function as BACKTRACE shows it"
 //
-//      return: [integer! blank!]
-//          {BLANK! if no match}
+//      return: [<opt> integer!]
+//          {null if no match}
 //      level [action! frame!]
 //          {The action or frame to get an index for}
 //  ]
@@ -914,7 +914,7 @@ static REBNATIVE(backtrace_index)
         return R_OUT;
     }
 
-    return R_BLANK;
+    return R_NULL;
 }
 
 
@@ -999,7 +999,7 @@ modify_with_confidence:
         "feature you want isn't implemented doesn't mean you can't add it!)\n"
     );
 
-    return R_BLANK;
+    return R_NULL;
 }
 
 #include "tmp-mod-debugger-last.h"

--- a/src/extensions/ffi/make-spec.r
+++ b/src/extensions/ffi/make-spec.r
@@ -67,7 +67,7 @@ options: [
                 'static 'dynamic [
                     for-each var [includes cflags searches ldflags][
                         x: rebmake/pkg-config
-                            any [user-config/pkg-config {pkg-config}]
+                            try any [user-config/pkg-config {pkg-config}]
                             var
                             %libffi
                         if not empty? x [
@@ -76,7 +76,7 @@ options: [
                     ]
 
                     libs: rebmake/pkg-config
-                        any [user-config/pkg-config {pkg-config}]
+                        try any [user-config/pkg-config {pkg-config}]
                         'libraries
                         %libffi
 

--- a/src/extensions/locale/mod-locale.c
+++ b/src/extensions/locale/mod-locale.c
@@ -108,7 +108,7 @@ REBNATIVE(locale)
 //
 //  {Set/Get current locale, just a simple wrapper around C version}
 //
-//      return: [text! blank!]
+//      return: [<opt> text!]
 //      category [word!]
 //      value [text!]
 //  ]
@@ -177,7 +177,7 @@ REBNATIVE(setlocale)
     rebFree(value_utf8);
 
     if (not result)
-        return R_BLANK;
+        return R_NULL;
 
     REBVAL *str = rebText(result);
     Move_Value(D_OUT, str);

--- a/src/extensions/odbc/mod-odbc.c
+++ b/src/extensions/odbc/mod-odbc.c
@@ -8,7 +8,7 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // Copyright 2010-2011 Christian Ensel
-// Copyright 2017 Rebol Open Source Contributors
+// Copyright 2017-2018 Rebol Open Source Contributors
 // REBOL is a trademark of REBOL Technologies
 //
 // See README.md and CREDITS.md for more information.
@@ -877,7 +877,7 @@ REBNATIVE(insert_odbc)
     REBOOL use_cache = FALSE;
 
     REBOOL get_catalog = rebDid(
-        "word? <- try match [word! text!]", value, "or [",
+        "word? <- match [word! text!]", value, "else [",
             "fail {SQL dialect must start with WORD! or STRING! value}"
         "]", END
     );

--- a/src/extensions/view/mod-view.c
+++ b/src/extensions/view/mod-view.c
@@ -106,8 +106,8 @@ REBOOL osDialogOpen = FALSE;
 //
 //  {Asks user to select file(s) and returns full file path(s)}
 //
-//      return: [file! block! blank!]
-//          {Blank if canceled, otherwise a path or block of paths}
+//      return: [<opt> file! block!]
+//          {Null if canceled, otherwise a path or block of paths}
 //      /save
 //          "File save mode"
 //      /multi
@@ -501,13 +501,13 @@ REBNATIVE(request_file_p)
         fail (error);
 
     if (DSP == dsp_orig)
-        return R_BLANK;
+        return R_NULL;
 
     if (REF(multi)) {
         //
         // For the caller's convenience, return a BLOCK! if they requested
         // /MULTI and there's even just one file.  (An empty block might even
-        // be better than BLANK! for that case?)
+        // be better than null for that case?)
         //
         Init_Block(D_OUT, Pop_Stack_Values(dsp_orig));
         return R_OUT;

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -215,7 +215,7 @@
         fflush(stdout); \
         Dump_Frame_Location(NULL, FS_TOP); \
         debug_break(); /* see %debug_break.h */ \
-    } while (true)
+    } while (false)
 
 #define BREAK_ON_TICK(tick) \
     if (tick == TG_Tick) BREAK_NOW()

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -187,7 +187,7 @@ eval proc [
     <local>
         set-word type-name tester meta
 ][
-    while [value? set-word: take* set-word...] [
+    while [set-word: try take* set-word...] [
         type-name: copy as text! set-word
         change back tail of type-name "!" ;-- change ? at tail to !
         tester: typechecker (get bind (as word! type-name) set-word)

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -55,12 +55,14 @@ modulo: function [
 ] [
     ; Coerce B to a type compatible with A
     any [any-number? a  b: make a b]
+
     ; Get the "accurate" MOD value
     r: mod a abs b
-    ; If the MOD result is "near zero", w.r.t. A and B,
-    ; return 0--the "expected" result, in human terms.
-    ; Otherwise, return the result we got from MOD.
-    either any [(a - r) = a | (r + b) = b] [make r 0] [r]
+
+    ; If the MOD result is "near zero", w.r.t. A and B, return 0--the
+    ; "expected" result.  Otherwise, return the result we got from MOD.
+    ;
+    any [(a - r) = a | (r + b) = b] then [make r 0] else [r]
 ]
 
 

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -54,8 +54,8 @@ save: function [
     ;-- Special datatypes use codecs directly (e.g. PNG image file):
     all [
         not header ; User wants to save value as script, not data file
-        did match [file! url!] where
-        type: file-type? where
+        match [file! url!] where
+        type: try file-type? where
         type <> 'rebol ;-- handled by this routine, not by WRITE+ENCODE
     ] then [
         ; We have a codec.  Will check for valid type.

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -162,7 +162,7 @@ replace: function [
         any-array? :pattern [length of :pattern]
     ]
 
-    while [pos: find/(all [case_REPLACE 'case]) target :pattern] [
+    while [pos: try find/(case_REPLACE ?? 'case !! _) target :pattern] [
         ; apply replacement if function, or drops pos if not
         ; the parens quarantine function invocation to maximum arity of 1
         (value: replacement pos)
@@ -236,8 +236,8 @@ reword: function [
     ;
     ; Integers have to be converted also.
     ;
-    if did match [integer! word!] prefix [prefix: to-text prefix]
-    if did match [integer! word!] suffix [suffix: to-text suffix]
+    if match [integer! word!] prefix [prefix: to-text prefix]
+    if match [integer! word!] suffix [suffix: to-text suffix]
 
     ; MAKE MAP! will create a map with no duplicates from the input if it
     ; is a BLOCK! (though differing cases of the same key will be preserved).
@@ -334,7 +334,7 @@ reword: function [
                         ;
                         output: insert/part output a b
 
-                        v: select/(all [case_REWORD 'case]) values keyword-match
+                        v: select/(case_REWORD ?? 'case !! _) values keyword-match
                         output: insert output case [
                             action? :v [v :keyword-match]
                             block? :v [do :v]
@@ -363,7 +363,7 @@ reword: function [
         (output: insert output a)
     ]
 
-    parse/(all [case_REWORD 'case]) source rule or [
+    parse/(case_REWORD ?? 'case !! _) source rule or [
         fail "Unexpected error in REWORD's parse rule, should not happen."
     ]
 
@@ -453,18 +453,18 @@ alter: func [
     case: :lib/case
 
     if bitset? series [
-        return either find series :value [
-            remove/part series :value false
-        ][
-            append series :value true
+        if find series :value [
+            remove/part series :value
+            return false
         ]
-    ]
-    either remove (find/(all [case_ALTER ['case]]) series :value) [
         append series :value
-        true
-    ][
-        false
+        return true
     ]
+    if remove (find/(case_ALTER ?? 'case !! _) series :value) [
+        append series :value
+        return true
+    ]
+    return false
 ]
 
 

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -42,7 +42,7 @@ use [word] [
         ; overwrite any NATIVE! implementations.  (e.g. TO-INTEGER is a
         ; native with a refinement for interpreting as unsigned.)
 
-        if (word: in lib word) and (blank? get word) [
+        if (word: try in lib word) and (blank? get word) [
             set word redescribe compose [
                 (spaced ["Converts to" form type "value."])
             ](

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -291,13 +291,13 @@ check-response: function [port] [
         not headers
         any [
             all [
-                d1: find conn/data crlfbin
-                d2: find/tail d1 crlf2bin
+                d1: try find conn/data crlfbin
+                d2: try find/tail d1 crlf2bin
                 net-log/C "server using standard content separator of #{0D0A0D0A}"
             ]
             all [
-                d1: find conn/data #{0A}
-                d2: find/tail d1 #{0A0A}
+                d1: try find conn/data #{0A}
+                d2: try find/tail d1 #{0A0A}
                 net-log/C "server using malformed line separator of #{0A0A}"
             ]
         ]
@@ -736,7 +736,7 @@ sys/make-scheme [
                 error: _
                 close?: no
                 info: construct port/scheme/info [type: 'file]
-                awake: :port/awake
+                awake: ensure [action! blank!] :port/awake
             ]
             port/state/connection: conn: make port! compose [
                 scheme: (

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -139,7 +139,7 @@ do*: function [
         ;
         do-needs hdr  ; Load the script requirements
         intern code   ; Bind the user script
-        result: catch/quit/with [
+        set* quote result: catch/quit/with [
             ;
             ; The source string may have been mutable or immutable, but the
             ; loaded code is not locked for this case.  So this works:
@@ -160,10 +160,10 @@ do*: function [
         ; to whether a directory listing would be possible (HTTP does not
         ; define a standard for that)
         ;
-        if all [
+        all [
             match [file! url!] source
-            file: find/last/tail source slash
-        ][
+            file: try find/last/tail source slash
+        ] then [
             change-dir copy/part source file
         ]
 
@@ -177,7 +177,7 @@ do*: function [
         ; Make the new script object
         original-script: system/script  ; and save old one
         system/script: construct system/standard/script [
-            title: select hdr 'title
+            title: try select hdr 'title
             header: hdr
             parent: :original-script
             path: what-dir
@@ -197,7 +197,7 @@ do*: function [
         ][
             do-needs hdr  ; Load the script requirements
             intern code   ; Bind the user script
-            result: catch/quit/with [
+            set* quote result: catch/quit/with [
                 do/next code :var ;-- If var is void, /NEXT is revoked
             ] :finalizer
         ]

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -65,9 +65,9 @@ make-port*: function [
 
     ; Defaults:
     port/actor: try get in scheme 'actor ; avoid evaluation
-    port/awake: any [
-        try get in port/spec 'awake
-        try get 'scheme/awake
+    port/awake: try any [
+        get try in port/spec 'awake
+        get 'scheme/awake
     ]
     port/spec/ref: default [spec]
     port/spec/title: default [scheme/title]
@@ -261,7 +261,7 @@ init-schemes: func [
 
             ; Are any of the requested ports awake?
             for-next ports [
-                if port: find waked first ports [return true]
+                if port: try find waked first ports [return true]
             ]
 
             false ; keep waiting

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -88,7 +88,7 @@ finish-init-core: proc [
             right [<opt> any-value! <...>]
             :look [any-value! <...>]
         ][
-            right: take* right
+            set* quote right: take* right
             if unset? 'left or (block? first look) [
                 fail/where [
                     "UNLESS has been repurposed in Ren-C as an infix operator"
@@ -108,8 +108,8 @@ finish-init-core: proc [
 
         switch: (adapt 'switch [
             for-each c cases [
-                lib/all [ ;-- SWITCH/ALL would override
-                    did match [word! path!] c
+                lib/all [ ;-- SWITCH's /ALL would override
+                    match [word! path!] c
                     'null <> c
                     not datatype? get c
                 ] then [

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -1038,9 +1038,9 @@ pe-format: context [
         section-name [text!]
         section-data [binary!]
     ][
-        target-sec: find-section/header exe-data section-name; this will parse exe-data
-        ;dump target-sec
-        if blank? target-sec [
+        ; FIND-SECTION will parse exe-data
+        ;
+        target-sec: find-section/header exe-data section-name else [
             return add-section exe-data section-name section-data
         ]
 
@@ -1085,7 +1085,9 @@ pe-format: context [
         exe-data [binary!]
         section-name [text!]
     ][
-        target-sec: find-section/header exe-data section-name; this will parse exe-data
+        ; FIND-SECTION will parse exe-data
+        ;
+        target-sec: find-section/header exe-data section-name
         ;dump target-sec
 
         ;dump COFF-header

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -100,7 +100,7 @@ console!: make object! [
     ]
 
     print-result: procedure [v [<opt> any-value!]]  [
-        last-result: :v
+        set* (quote last-result:) :v
         case [
             null? :v [
                 ; Historically Rebol wouldn't print any eval result in the
@@ -134,7 +134,7 @@ console!: make object! [
             ;
             pos: molded: mold/limit :v 2048
             loop 20 [
-                pos: (next find pos newline) else [break]
+                pos: next (find pos newline else [break])
             ] also [ ; e.g. didn't break
                 insert clear pos "..."
             ]
@@ -339,7 +339,7 @@ host-console: function [
             [block! issue! text!]
         <with> instruction
     ][
-        really* switch type of item [
+        really switch type of item [
             issue! [
                 if not empty? instruction [append/line instruction '|]
                 insert instruction item
@@ -623,7 +623,7 @@ host-console: function [
         return <prompt>
     ]
 
-    if did shortcut: select system/console/shortcuts try first code [
+    if shortcut: try select system/console/shortcuts try first code [
         ;
         ; Shortcuts like `q => [quit]`, `d => [dump]`
         ;
@@ -668,7 +668,7 @@ why: procedure [
 ][
     err: default [system/state/last-error]
 
-    if did match [word! path!] err [
+    if match [word! path!] err [
         err: get err
     ]
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -45,7 +45,7 @@ boot-print: procedure [
     eval: :lib/eval
 
     if not system/options/quiet [
-        print/(all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
+        print/(try all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
     ]
 ]
 
@@ -58,7 +58,7 @@ loud-print: procedure [
     eval: :lib/eval
 
     if system/options/verbose [
-        print/(all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
+        print/(try all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
     ]
 ]
 
@@ -393,13 +393,13 @@ host-start: function [
     ][
         ;; lives under systems/options/home
 
-        path: join-of o/home switch/default system/platform/1 [
+        path: join-of o/home <- switch system/platform/1 [
             'Windows [%REBOL/]
-        ][
+        ] else [
             %.rebol/     ;; default *nix (covers Linux, MacOS (OS X) and Unix)
         ]
 
-        all [exists? path | path]
+        try all [exists? path | path]
     ]
 
     ; Set system/users/home (users HOME directory)

--- a/tests/context/bind.test.reb
+++ b/tests/context/bind.test.reb
@@ -6,7 +6,7 @@
 )
 
 [#50
-    (blank? context of to word! "zzz")
+    (null? context of to word! "zzz")
 ]
 ; BIND works 'as expected' in object spec
 [#1549 (

--- a/tests/control/all.test.reb
+++ b/tests/control/all.test.reb
@@ -1,7 +1,6 @@
 ; functions/control/all.r
 ; zero values
 (bar? all [])
-(null? all* [])
 ; one value
 (:abs = all [:abs])
 (
@@ -57,10 +56,10 @@
     :a-value == all [:a-value]
 )
 (true = all [true])
-(blank? all [false])
+(null? all [false])
 ($1 == all [$1])
 (same? :append all [:append])
-(blank? all [_])
+(null? all [_])
 (
     a-value: make object! []
     same? :a-value all [:a-value]
@@ -98,8 +97,7 @@
 )
 (0:00 == all [0:00])
 (0.0.0 == all [0.0.0])
-(error? trap [all [()]])
-(null? all* [()])
+(null? all [()])
 ('a == all ['a])
 ; two values
 (:abs = all [true :abs])
@@ -157,7 +155,7 @@
 )
 ($1 == all [true $1])
 (same? :append all [true :append])
-(blank? all [true _])
+(null? all [true _])
 (
     a-value: make object! []
     same? :a-value all [true :a-value]
@@ -195,8 +193,7 @@
 )
 (0:00 == all [true 0:00])
 (0.0.0 == all [true 0.0.0])
-(error? trap [all [1020 ()]])
-(1020 == all* [1020 ()])
+(null? all [1020 ()])
 ('a == all [true 'a])
 (true = all [:abs true])
 (
@@ -252,11 +249,11 @@
     true = all [:a-value true]
 )
 (true = all [true true])
-(blank? all [false true])
-(blank? all [true false])
+(null? all [false true])
+(null? all [true false])
 (true = all [$1 true])
 (true = all [:append true])
-(blank? all [_ true])
+(null? all [_ true])
 (
     a-value: make object! []
     true = all [:a-value true]
@@ -294,7 +291,6 @@
 )
 (true = all [0:00 true])
 (true = all [0.0.0 true])
-(true = all* [() true])
 (true = all ['a true])
 ; evaluation stops after encountering FALSE or NONE
 (

--- a/tests/control/any.test.reb
+++ b/tests/control/any.test.reb
@@ -1,7 +1,6 @@
 ; functions/control/any.r
 ; zero values
-(blank? any [])
-(null? any* [])
+(null? any [])
 ; one value
 (:abs = any [:abs])
 (
@@ -57,10 +56,10 @@
     :a-value == any [:a-value]
 )
 (true = any [true])
-(blank? any [false])
+(null? any [false])
 ($1 == any [$1])
 (same? :append any [:append])
-(blank? any [_])
+(null? any [_])
 (
     a-value: make object! []
     same? :a-value any [:a-value]
@@ -99,8 +98,7 @@
 )
 (0:00 == any [0:00])
 (0.0.0 == any [0.0.0])
-(error? trap [any [()]])
-(null? any* [()])
+(null? any [()])
 ('a == any ['a])
 ; two values
 (:abs = any [false :abs])
@@ -157,10 +155,10 @@
     :a-value == any [false :a-value]
 )
 (true = any [false true])
-(blank? any [false false])
+(null? any [false false])
 ($1 == any [false $1])
 (same? :append any [false :append])
-(blank? any [false _])
+(null? any [false _])
 (
     a-value: make object! []
     same? :a-value any [false :a-value]
@@ -198,8 +196,7 @@
 )
 (0:00 == any [false 0:00])
 (0.0.0 == any [false 0.0.0])
-(error? trap [any [false ()]])
-(blank? any* [false ()])
+(null? any [false ()])
 ('a == any [false 'a])
 (:abs = any [:abs false])
 (
@@ -257,7 +254,7 @@
 (true = any [true false])
 ($1 == any [$1 false])
 (same? :append any [:append false])
-(blank? any [_ false])
+(null? any [_ false])
 (
     a-value: make object! []
     same? :a-value any [:a-value false]
@@ -295,8 +292,7 @@
 )
 (0:00 == any [0:00 false])
 (0.0.0 == any [0.0.0 false])
-(error? trap [any [() false]])
-(blank? any* [() false])
+(null? any [() false])
 ('a == any ['a false])
 ; evaluation stops after encountering something else than FALSE or NONE
 (
@@ -345,7 +341,7 @@
 )
 ; recursivity
 (any [false any [true]])
-(blank? any [false any [false]])
+(null? any [false any [false]])
 ; infinite recursion
 (
     blk: [any blk]

--- a/tests/control/attempt.test.reb
+++ b/tests/control/attempt.test.reb
@@ -3,7 +3,7 @@
     (blank? attempt [1 / 0])
 ]
 (1 = attempt [1])
-(null? attempt [])
+(blank? attempt [])
 ; RETURN stops attempt evaluation
 (
     f1: func [] [attempt [return 1 2] 2]

--- a/tests/control/default.test.reb
+++ b/tests/control/default.test.reb
@@ -14,7 +14,7 @@
     x = 20
 )
 (
-    o: make object! [x: 10 y: _ z: ()]
+    o: make object! [x: 10 y: _ set* quote z: ()]
     o/x: default [20]
     o/y: default [20]
     o/z: default [20]

--- a/tests/control/do.test.reb
+++ b/tests/control/do.test.reb
@@ -160,7 +160,7 @@
 (false = eval false)
 ($1 == eval $1)
 (null? eval (specialize 'of [property: 'type]) ())
-(blank? do _)
+(null? do _)
 (
     a-value: make object! []
     same? :a-value eval :a-value

--- a/tests/control/either.test.reb
+++ b/tests/control/either.test.reb
@@ -72,17 +72,20 @@
     blk: [either false [] blk]
     error? trap blk
 )
-(
+
+[
     ; This exercises "deferred typechecking"; even though it passes through a
     ; step where there is a void in the condition slot, that's not the final
     ; situation since the equality operation will be run later, so the test
     ; has to wait.
-    ;
-    either () = () [true] [false]
-)
-(
-    ; complement to the above, need to type check the final product
-    ;
-    infix-voider: enfix func [return: [<opt>] x y] []
-    'arg-required = (trap [either 1 infix-voider 2 [false] [false]])/id
-)
+
+    (
+        takes-2-logics: func [x [logic!] y [logic!]] [x]
+        infix-voider: enfix func [return: [<opt>] x y] []
+        true
+    )
+
+    (takes-2-logics () = () false)
+
+    ('arg-required = (trap [takes-2-logics true infix-voider true false])/id)
+]

--- a/tests/control/match.test.reb
+++ b/tests/control/match.test.reb
@@ -12,23 +12,23 @@
 ;
 
 ("aaa" = match parse "aaa" [some "a"])
-(_ = match parse "aaa" [some "b"])
+(null = match parse "aaa" [some "b"])
 
 (10 = match integer! 10)
-(_ = match integer! "ten")
+(null = match integer! "ten")
 
 ("ten" = match [integer! text!] "ten")
 (20 = match [integer! text!] 20)
-(_ = match [integer! text!] <tag>)
+(null = match [integer! text!] <tag>)
 
 (10 = match :even? 10)
-(_ = match :even? 3)
-(_ = match 'odd? 20)
+(null = match :even? 3)
+(null = match 'odd? 20)
 (7 = match 'odd? 7)
 
 (bar? match blank! _)
-(_ = match blank! 10)
-(null? match blank! false)
+(null = match blank! 10)
+(null = match blank! false)
 
 ; Since its other features were implemented with a fairly complex enclosed
 ; specialization, it's good to keep that usermode implementation around,
@@ -54,12 +54,11 @@
         ;
         ; Rather than have MATCH return a falsey result in these cases, pass
         ; back a BAR!.  But on failure, pass back a null.  That will cue
-        ; attention to the distorted success result, and lead those writing
-        ; expressions like the above to use DID MATCH.
+        ; attention to the distorted success result.
 
-        result: do f ;-- can't access f/arg after the DO
+        set* quote result: do f ;-- can't access f/arg after the DO
 
-        if all [not :arg | not null? :result] [
+        if not :arg and (not null? :result) [
             return '| ;-- BAR! if matched a falsey type
         ]
         to-value :result ;-- return blank if no match, else truthy result

--- a/tests/control/unless.test.reb
+++ b/tests/control/unless.test.reb
@@ -15,7 +15,7 @@
 (
     20 = (10 unless 20)
 )(
-    _ = (10 unless _)
+    _ = (10 unless _) ;-- BLANK! is considered a value (use OPT if not)
 )(
     10 = (10 unless ())
 )(

--- a/tests/convert/mold.test.reb
+++ b/tests/convert/mold.test.reb
@@ -36,7 +36,7 @@
     ("#[block! [[1 2] 2]]" == mold/all next [1 2])
 ]
 [#77
-    (blank? find mold/flat make object! [a: 1] "    ")
+    (null? find mold/flat make object! [a: 1] "    ")
 ]
 
 [#84

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -4,11 +4,11 @@
 (not null? 1)
 
 [#68
-    (null? trap/with [a: ()] [_])
+    ('need-value = (trap [a: ()])/id)
 ]
 
-(error? trap [a: () a])
-(not error? trap [set 'a ()])
+(error? trap [set* quote a: () a])
+(not error? trap [set* 'a ()])
 
 (
     a-value: 10

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -109,16 +109,16 @@
 ; <| and |> were originally enfix, so the following tests would have meant x
 ; would be unset
 (
-    value: ()
-    x: ()
+    unset 'value
+    unset 'x
 
     3 = (value: 1 + 2 <| 30 + 40 x: value  () ())
 
     did all [value = 3 | x = 3]
 )
 (
-    value: ()
-    x: ()
+    unset 'value
+    unset 'x
 
     70 = (value: 1 + 2 |> 30 + 40 x: value () () ())
 

--- a/tests/file/file-typeq.test.reb
+++ b/tests/file/file-typeq.test.reb
@@ -1,4 +1,4 @@
 ; functions/file/file-typeq.r
-[#1651 ; "FILE-TYPE? should return NONE for unknown types"
-    (blank? file-type? %foo.0123456789bar0123456789)
+[#1651 ; "FILE-TYPE? should return NULL for unknown types"
+    (null? file-type? %foo.0123456789bar0123456789)
 ]

--- a/tests/functions/does.test.reb
+++ b/tests/functions/does.test.reb
@@ -51,7 +51,7 @@
     did all [
         z = <finish> | x = 11 | y = 22
         elide (flag: false)
-        z = _ | x = 12 | y = 22
+        z = null | x = 12 | y = 22
     ]
 )
 

--- a/tests/functions/enfix.test.reb
+++ b/tests/functions/enfix.test.reb
@@ -1,6 +1,6 @@
 ; %enfix.test.reb
 
-(action! = type-of :+)
+(action! = type of :+)
 (true = enfixed? '+)
 
 (

--- a/tests/parse-tests.r
+++ b/tests/parse-tests.r
@@ -242,5 +242,5 @@
     "abc" = match parse "abc" ["a" "b" "c"]
 )
 (
-    blank? match parse "abc" ["a" "b" "d"]
+    null? match parse "abc" ["a" "b" "d"]
 )

--- a/tests/series/back.test.reb
+++ b/tests/series/back.test.reb
@@ -1,7 +1,7 @@
 ; functions/series/back.r
 (
     a: [1]
-    blank? back a
+    null? back a
 )
 (
     a: tail of [1]
@@ -10,7 +10,7 @@
 ; path
 (
     a: 'b/c
-    blank? back a
+    null? back a
 )
 (
     a: tail of 'b/c
@@ -23,5 +23,5 @@
 )
 (
     a: "1"
-    blank? back a
+    null? back a
 )

--- a/tests/series/find.test.reb
+++ b/tests/series/find.test.reb
@@ -2,23 +2,23 @@
 [#473 (
     null? find blank 1
 )]
-(blank? find [] 1)
+(null? find [] 1)
 (
     blk: [1]
     same? blk find blk 1
 )
-(blank? find/part [x] 'x 0)
+(null? find/part [x] 'x 0)
 (equal? [x] find/part [x] 'x 1)
 (equal? [x] find/reverse tail of [x] 'x)
 (equal? [y] find/match [x y] 'x)
 (equal? [x] find/last [x] 'x)
 (equal? [x] find/last [x x x] 'x)
 [#66
-    (blank? find/skip [1 2 3 4 5 6] 2 3)
+    (null? find/skip [1 2 3 4 5 6] 2 3)
 ]
 [#88
     ("c" = find "abc" charset ["c"])
 ]
 [#88
-    (blank? find/part "ab" "b" 1)
+    (null? find/part "ab" "b" 1)
 ]

--- a/tests/series/next.test.reb
+++ b/tests/series/next.test.reb
@@ -5,5 +5,5 @@
 )
 (
     blk: tail of [1]
-    blank? next blk
+    null? next blk
 )

--- a/tests/series/remove.test.reb
+++ b/tests/series/remove.test.reb
@@ -6,12 +6,12 @@
 (
     a-bitset: charset "a"
     remove/part a-bitset "a"
-    blank? find a-bitset #"a"
+    null? find a-bitset #"a"
 )
 (
     a-bitset: charset "a"
     remove/part a-bitset to integer! #"a"
-    blank? find a-bitset #"a"
+    null? find a-bitset #"a"
 )
 
 (

--- a/tests/series/skip.test.reb
+++ b/tests/series/skip.test.reb
@@ -62,15 +62,15 @@
 )
 (
     blk: []
-    blank? skip* blk 2147483647
+    null? skip* blk 2147483647
 )
 (
     blk: []
-    blank? skip* blk -1
+    null? skip* blk -1
 )
 (
     blk: []
-    blank? skip* blk -2147483648
+    null? skip* blk -2147483648
 )
 (
     blk: next [1 2 3]
@@ -86,25 +86,25 @@
 )
 (
     blk: next [1 2 3]
-    blank? skip* blk 2147483647
+    null? skip* blk 2147483647
 )
 (
     blk: at [1 2 3] 3
-    blank? skip* blk 2147483646
+    null? skip* blk 2147483646
 )
 (
     blk: at [1 2 3] 4
-    blank? skip* blk 2147483645
+    null? skip* blk 2147483645
 )
 (
     blk: [1 2 3]
-    blank? skip* blk -1
+    null? skip* blk -1
 )
 (
     blk: [1 2 3]
-    blank? skip* blk -2147483647
+    null? skip* blk -2147483647
 )
 (
     blk: next [1 2 3]
-    blank? skip* blk -2147483648
+    null? skip* blk -2147483648
 )

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -256,7 +256,7 @@ rebsource: context [
             ; Identify line termination.
 
             all [
-                position: find data #{0a}
+                position: try find data #{0a}
                 1 < index of position
                 13 = first back position
             ] then [

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -201,7 +201,7 @@ make object! compose [
                     end | (fail "do-recover log file parsing problem")
                 ]
                 last-vector
-                test-sources: find/last/tail test-sources last-vector
+                test-sources: try find/last/tail test-sources last-vector
             ][
                 print [
                     "recovering at:"


### PR DESCRIPTION
This is a watershed change.  Firstly, nulls are considered false by
IF, CASE, ALL, ANY, DID, NOT, AND, OR, and other constructs.  They no
longer give an error from existing in the indeterminate state of
"neither true nor false":

    >> if () [print "now, falsey"]
    ;-- no result

That opens the doors to wider use of NULL as the uniform result for
"not found" or "no match" (this has also been called "soft failure").
Due to a progressive evolution, some routines had used BLANK! for this
purpose (ANY, FIND, MATCH, etc.) while others were using NULL
(SELECT, IF, CASE, etc.).  Now it is uniform:

    >> find [a b] 'c
    ;-- no result

    >> any [false false]
    ;-- no result

    >> all [true true () true]
    ;-- no result

    >> match integer! <some-tag>
    ;-- no result

This uniform behavior opens the doors to using routines like ELSE and
ALSO with any routine that has "soft failure", as well as making it
easy to opt-out of operations without winding up with stray blanks:

    >> data: copy [a b c]
    >> append data all [
        1 < 2
        1 > 2
        'foobar
    ]
    == [a b c] ;-- previously this would be [a b c _]

    >> x: all [
           true
           select [a 10 b 20] 'c
       ] else [
           first [d e]
       ]
    == d

    >> pos: <not-found> unless find [a b c] 'd
    == <not-found>

As a general policy, NULLs are "de-stigmatized" in cases like APPEND,
INSERT, COMPOSE, PRINT, etc.  Since they are not ANY-VALUE! and cannot
be stored in blocks, they are reserved for the special intent of "no
value was intended".  BLANK!s on the other hand are now committed to be
actual values which get appended or composed:

    >> data: [a b c]
    >> append data _
    == [a b c _]

    >> compose [a (_) b]
    == [a _ b]

However, this commit brings back one aspect of "stigma" for NULLs in
that you cannot directly assign them via SET-WORD! or SET-PATH!, which
was true of UNSET! in R3-Alpha:

    >> x: ()
    ** Error: Needs value

But with the widened scope of NULL usage, this means many things that
would not cause errors in R3-Alpha now will:

    >> x: all [10 false]
    ** Error: Needs value

    >> pos: find [a b c] 'd
    ** Error: Needs value

While this may seem like a drawback at first, it is actually a benefit.
With NULLs being casually accepted by APPEND and other places, having
them raise an error here is doing so at exactly the right point...it
is a "hot potato" in the sense of saying *something must be done with
it before it is stored*.  The easiest thing to do is to use TRY to
convert it to a BLANK!, or DID to convert it to a LOGIC!.

    >> x: try all [10 false]
    == _

    >> pos: did find [a b c] 'd
    == #[true]

In this way, erroring on the assign becomes an implicit assert.  If
you write `x: all [...]`, you are saying *all those things are true,
and you want the last one*.  If you say `pos: find data item` you are
saying *it will be found*.  Needing other reactions is specifically
an expression of what you are doing if it's not.  Making fixes to
accomodate this change actually IMPROVE the quality of the code.

Plus there are many other NULL-handling constructs now, which permit
clever rewrites, e.g.

    if not pos: find data item [
       fail ["Could not find" :item]
    ]

    ; ...can avoid null assignment with...

    pos: find data item else [
       fail ["Could not find" :item]
    ]

Most cases permit rewrites of this form.  "SET/ANY" is brought back as
SET/OPT, and specialized as SET*.

    >> set* 'x ()
    ;-- no value

    >> set? 'x
    == #[false]

Though a major step in the development of NULL, not all questions are
answered yet.  But this is definitely an improvement.