### PR TITLE
Restore Rebol2-era PICKing/PATHing of negative/zero indices

### DIFF
--- a/src/core/t-vector.c
+++ b/src/core/t-vector.c
@@ -574,16 +574,24 @@ void Pick_Vector(REBVAL *out, const REBVAL *value, const REBVAL *picker) {
     REBSER *vect = VAL_SERIES(value);
 
     REBINT n;
-    if (IS_INTEGER(picker) || IS_DECIMAL(picker))
+    if (IS_INTEGER(picker) or IS_DECIMAL(picker)) // #2312
         n = Int32(picker);
     else
         fail (Error_Invalid(picker));
 
+    if (n == 0) {
+        Init_Void(out);
+        return; // Rebol2/Red convention, 0 is bad pick
+    }
+
+    if (n < 0)
+        ++n; // Rebol/Red convention, picking -1 from tail gives last item
+
     n += VAL_INDEX(value);
 
-    if (n <= 0 || cast(REBCNT, n) > SER_LEN(vect)) {
-        Init_Void(out); // out of range of vector data
-        return;
+    if (n <= 0 or cast(REBCNT, n) > SER_LEN(vect)) {
+        Init_Void(out);
+        return; // out of range of vector data
     }
 
     REBYTE *vp = SER_DATA_RAW(vect);
@@ -614,14 +622,19 @@ void Poke_Vector_Fail_If_Read_Only(
     FAIL_IF_READ_ONLY_SERIES(vect);
 
     REBINT n;
-    if (IS_INTEGER(picker) || IS_DECIMAL(picker))
+    if (IS_INTEGER(picker) or IS_DECIMAL(picker)) // #2312
         n = Int32(picker);
     else
         fail (Error_Invalid(picker));
 
+    if (n == 0)
+        fail (Error_Out_Of_Range(picker)); // Rebol2/Red convention
+    if (n < 0)
+        ++n; // Rebol2/Red convention, poking -1 from tail sets last item
+
     n += VAL_INDEX(value);
 
-    if (n <= 0 || cast(REBCNT, n) > SER_LEN(vect))
+    if (n <= 0 or cast(REBCNT, n) > SER_LEN(vect))
         fail (Error_Out_Of_Range(picker));
 
     REBYTE *vp = SER_DATA_RAW(vect);

--- a/tests/series/pick.test.reb
+++ b/tests/series/pick.test.reb
@@ -4,9 +4,9 @@
 (null? pick at [1 2 3 4 5] 3 -2147483648)
 (null? pick at [1 2 3 4 5] 3 -2147483647)
 (null? pick at [1 2 3 4 5] 3 -3)
-(null? pick at [1 2 3 4 5] 3 -2)
-(1 = pick at [1 2 3 4 5] 3 -1)
-(2 = pick at [1 2 3 4 5] 3 0)
+(1 pick at [1 2 3 4 5] 3 -2)
+(2 = pick at [1 2 3 4 5] 3 -1)
+(null = pick at [1 2 3 4 5] 3 0)
 (3 = pick at [1 2 3 4 5] 3 1)
 (4 = pick at [1 2 3 4 5] 3 2)
 (5 = pick at [1 2 3 4 5] 3 3)
@@ -20,10 +20,10 @@
 (null? pick at "12345" 3 -2147483648)
 (null? pick at "12345" 3 -2147483647)
 (null? pick at "12345" 3 -3)
-(null? pick at "12345" 3 -2)
-(#"1" = pick at "12345" 3 -1)
+(#"1" pick at "12345" 3 -2)
+(#"2" = pick at "12345" 3 -1)
 [#857
-    (#"2" = pick at "12345" 3 0)
+    (null = pick at "12345" 3 0)
 ]
 (#"3" = pick at "12345" 3 1)
 (#"4" = pick at "12345" 3 2)
@@ -32,3 +32,28 @@
 (null? pick at "12345" 3 2147483647)
 <64bit>
 (error? trap [pick at "12345" 3 9223372036854775807])
+
+[#2312 (
+    data: [<a> <b>]
+    did all [
+        null = :data/0.5
+        null = :data/0.999999
+        <a> = data/1.0
+        <a> = data/1.5
+        <b> = data/2.0
+        <b> = data/2.000000001
+        null = :data/3.0
+    ]
+)]
+[#2312 (
+    data: "ab"
+    did all [
+        null = :data/0.5
+        null = :data/0.999999
+        #"a" = data/1.0
+        #"a" = data/1.5
+        #"b" = data/2.0
+        #"b" = data/2.000000001
+        null = :data/3.0
+    ]
+)]


### PR DESCRIPTION
Consensus in general was that the negative indexing behavior of
R3-Alpha was not pleasing.  This restores the historical behavior.
Also makes it so that picking with DECIMAL! will round the decimal
down and use the INTEGER! value, vs. SELECT-ing the DECIMAL.

Commit initiated by Oldes in:

https://github.com/Oldes/r3/pull/5

His comments there:

"In Rebol2, picking value with index 0 was always returning null. In
R3-Alpha it was changed that zero index was working like index -1...
more at this blog http://www.rebol.net/cgi-bin/r3blog.r?view=0173"

"I decided to revert this change and let it working as before (and so
be compatible with Red too)"

"So now it works for example like:"

    >> pick tail "123" -1
    == #"3"
    >> pick tail "123" 0
    == none

"and it is also consistent with AT positioning:"

    >> at tail "123" -1
    == "3"

"Related issues:"

rebol/rebol-issues#608
rebol/rebol-issues#609
rebol/rebol-issues#748
rebol/rebol-issues#857
rebol/rebol-issues#2117

"and also:"

rebol/rebol-issues#613