### PR TITLE
liberal SWITCH eval, kill SWITCH/DEFAULT, CASE fallout

### DIFF
--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -87,12 +87,11 @@ cscape: function [
             ]
             sub: do code
 
-            sub: switch/default mode [
+            sub: switch mode [
                 #cname [to-c-name sub]
                 #unspaced [either block? sub [unspaced sub] [form sub]]
                 #delim [delimit sub unspaced [dlm newline]]
-            ][
-                fail ["Invalid CSCAPE mode:" mode]
+                (fail ["Invalid CSCAPE mode:" mode])
             ]
             case [
                 all [any-upper | not any-lower] [uppercase sub]

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -136,7 +136,7 @@ e-dispatch: make-emitter "Dispatchers" core/tmp-dispatchers.c
 
 tafs: collect [
     for-each-record t type-table [
-        switch/default t/class [
+        if null? switch t/class [
             '* [
                 keep cscape/with {/* $<T/Name> */ T_Unhooked} [t]
             ]
@@ -148,7 +148,7 @@ tafs: collect [
 
 pds: collect [
     for-each-record t type-table [
-        switch/default t/path [
+        if null? switch t/path [
             '- [keep cscape/with {/* $<T/Name> */ PD_Fail} [t]]
             '+ [
                 proper: propercase-of t/class
@@ -167,7 +167,7 @@ pds: collect [
 
 makes: collect [
     for-each-record t type-table [
-        switch/default t/make [
+        if null? switch t/make [
             '- [keep cscape/with {/* $<T/Name> */ MAKE_Fail} [t]]
             '+ [
                 proper: propercase-of t/class
@@ -182,7 +182,7 @@ makes: collect [
 
 tos: collect [
     for-each-record t type-table [
-        switch/default t/make [
+        if null? switch t/make [
             '- [keep cscape/with {/* $<T/Name> */ TO_Fail} [t]]
             '+ [
                 proper: propercase-of T/Class
@@ -197,7 +197,7 @@ tos: collect [
 
 mfs: collect [
     for-each-record t type-table [
-        switch/default t/mold [
+        if null? switch t/mold [
             '- [keep cscape/with {/* $<T/Name> */ MF_Fail"} [t]]
             '+ [
                 proper: propercase-of t/class

--- a/make/tools/make-headers.r
+++ b/make/tools/make-headers.r
@@ -65,7 +65,7 @@ emit-proto: proc [proto] [
         ]
     ]
 
-    switch/default header/2 [
+    if null? switch header/2 [
         'RL_API [
             ; Currently the RL_API entries should only occur in %a-lib.c, and
             ; are processed by %make-reb-lib.r.  Their RL_XxxYyy() forms don't

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -184,7 +184,9 @@ case: function [
     result: null
 
     (:lib/loop-until) [
-        (:lib/if) (:lib/to-value) condition: do/next cases 'cases [
+        condition: do/next cases 'cases
+        lib/if lib/tail? cases [return :condition] ;-- "fallout"
+        (:lib/if) (:lib/to-value) :condition [
             result: (:lib/to-value) do ensure block! cases/1
 
             ;-- NOTE: uses the old-style UNLESS, as its faster than IF NOT

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -101,7 +101,7 @@ pkg-config: function [
     var [word!]
     lib [any-string!]
 ][
-    switch/default var [
+    if null? switch var [
         'includes [
             dlm: "-I"
             opt: "--cflags-only-I"
@@ -255,7 +255,7 @@ windows: make platform-class [
 set-target-platform: func [
     platform
 ][
-    switch/default platform [
+    if null? switch platform [
         'posix [
             target-platform: posix
         ]
@@ -754,18 +754,21 @@ ld: make linker-class [
     ]
 
     accept: func [
+        return: [<opt> string!]
         dep [object!]
         <local>
         ddep
         lib
     ][
-        switch/default dep/class-name [
+        opt switch dep/class-name [
             'object-file-class [
-                ;if find words-of dep 'depends [
-                    ;for-each ddep dep/depends [
-                    ;    dump ddep
-                    ;]
-                ;]
+                comment [ ;-- !!! This was commented out, why?
+                    if find words-of dep 'depends [
+                        for-each ddep dep/depends [
+                            dump ddep
+                        ]
+                    ]
+                ]
                 file-to-local dep/output
             ]
             'ext-dynamic-class [
@@ -787,7 +790,6 @@ ld: make linker-class [
                 spaced map-each ddep dep/depends [
                     file-to-local ddep/output
                 ]
-                ;pass
             ]
             'application-class [
                 ;pass
@@ -798,9 +800,12 @@ ld: make linker-class [
             'entry-class [
                 ;pass
             ]
-        ][
-            dump dep
-            fail "unrecognized dependency"
+
+            ;-- default
+            (
+                dump dep
+                fail "unrecognized dependency"
+            )
         ]
     ]
 
@@ -872,18 +877,21 @@ llvm-link: make linker-class [
     ]
 
     accept: func [
+        return: [<opt> string!]
         dep [object!]
         <local>
         ddep
         lib
     ][
-        switch/default dep/class-name [
+        opt switch dep/class-name [
             'object-file-class [
-                ;if find words-of dep 'depends [
-                    ;for-each ddep dep/depends [
-                    ;    dump ddep
-                    ;]
-                ;]
+                comment [ ;-- !!! This was commented out, why?
+                    if find words-of dep 'depends [
+                        for-each ddep dep/depends [
+                            dump ddep
+                        ]
+                    ]
+                ]
                 file-to-local dep/output
             ]
             'ext-dynamic-class [
@@ -896,7 +904,6 @@ llvm-link: make linker-class [
                 spaced map-each ddep dep/depends [
                     file-to-local ddep/output
                 ]
-                ;pass
             ]
             'application-class [
                 ;pass
@@ -907,9 +914,12 @@ llvm-link: make linker-class [
             'entry-class [
                 ;pass
             ]
-        ][
-            dump dep
-            fail "unrecognized dependency"
+
+            ;-- default
+            (
+                dump dep
+                fail "unrecognized dependency"
+            )
         ]
     ]
 ]
@@ -972,22 +982,25 @@ link: make linker-class [
     ]
 
     accept: func [
+        return: [<opt> string!]
         dep [object!]
         <local>
         ddep
     ][
-        switch/default dep/class-name [
+        opt switch dep/class-name [
             'object-file-class [
-                ;if find words-of dep 'depends [
-                    ;for-each ddep dep/depends [
-                    ;    dump ddep
-                    ;]
-                ;]
+                comment [ ;-- !!! This was commented out, why?
+                    if find words-of dep 'depends [
+                        for-each ddep dep/depends [
+                            dump ddep
+                        ]
+                    ]
+                ]
                 file-to-local to-file dep/output
             ]
             'ext-dynamic-class [
-                ;static property is ignored
-                ;import file
+                comment [import file] ;-- static property is ignored
+
                 either tag? dep/output [
                     filter-flag dep/output id
                 ][
@@ -1006,7 +1019,6 @@ link: make linker-class [
                 spaced map-each ddep dep/depends [
                     file-to-local to-file ddep/output
                 ]
-                ;pass
             ]
             'application-class [
                 file-to-local any [dep/implib join-of dep/basename ".lib"]
@@ -1017,9 +1029,12 @@ link: make linker-class [
             'entry-class [
                 ;pass
             ]
-        ][
-            dump dep
-            fail "unrecognized dependency"
+
+            ;-- default
+            (
+                dump dep
+                fail "unrecognized dependency"
+            )
         ]
     ]
 ]
@@ -1200,7 +1215,7 @@ generator-class: make object! [
     gen-cmd: func [
         cmd [object!]
     ][
-        switch/default cmd/class-name [
+        switch cmd/class-name [
             'cmd-create-class [
                 apply any [:gen-cmd-create :target-platform/gen-cmd-create] compose [cmd: (cmd)]
             ]
@@ -1210,8 +1225,8 @@ generator-class: make object! [
             'cmd-strip-class [
                 apply any [:gen-cmd-strip :target-platform/gen-cmd-strip] compose [cmd: (cmd)]
             ]
-        ][
-            fail ["Unknown cmd class:" cmd/class-name]
+
+            (fail ["Unknown cmd class:" cmd/class-name])
         ]
     ]
 
@@ -1314,7 +1329,7 @@ generator-class: make object! [
 
         case [
             blank? project/output [
-                switch/default project/class-name [
+                if null? switch project/class-name [
                     'object-file-class [
                         project/output: copy project/source
                     ]
@@ -1355,7 +1370,7 @@ generator-class: make object! [
     ][
         ;print ["Setting outputs for:"]
         ;dump project
-        switch/default project/class-name [
+        if null? switch project/class-name [
             'application-class
             'dynamic-library-class
             'static-library-class
@@ -1373,7 +1388,7 @@ generator-class: make object! [
                 setup-output project
             ]
         ][
-            ;leave ;causes Ren-C to crash
+            leave
         ]
     ]
 ]
@@ -1392,7 +1407,7 @@ makefile: make generator-class [
         w
         cmd
     ][
-        switch/default entry/class-name [
+        switch entry/class-name [
             'var-class [
                 unspaced [
                     entry/name either entry/default [
@@ -1414,7 +1429,7 @@ makefile: make generator-class [
                     space case [
                         block? entry/depends [
                             spaced map-each w entry/depends [
-                                switch/default w/class-name [
+                                if null? switch w/class-name [
                                     'var-class [
                                         unspaced ["$(" w/name ")"]
                                     ]
@@ -1476,8 +1491,9 @@ makefile: make generator-class [
                     newline
                 ]
             ]
-        ][
-            fail ["Unrecognized entry class:" entry/class-name]
+
+            ;-- default
+            (fail ["Unrecognized entry class:" entry/class-name])
         ]
     ]
 
@@ -1506,7 +1522,7 @@ makefile: make generator-class [
                     dep/generated?: true
                 ]
             ]
-            switch/default dep/class-name [
+            if null? switch dep/class-name [
                 'application-class
                 'dynamic-library-class
                 'static-library-class [
@@ -1594,14 +1610,19 @@ mingw-make: make makefile [
 
 ; Execute the command to generate the target directly
 Execution: make generator-class [
-    host: switch/default system/platform/1 [
+    host: switch system/platform/1 [
         'Windows [windows]
         'Linux [linux]
         'OSX [osx]
         'Android [android]
-    ][
-        print unspaced ["Untested platform " system/platform ", assuming is POSIX compilant"]
-        posix
+
+        ;-- default
+        (
+           print [
+               "Untested platform" system/platform "- assume POSIX compilant"
+           ]
+           posix
+        )
     ]
 
     gen-cmd-create: :host/gen-cmd-create
@@ -1614,7 +1635,7 @@ Execution: make generator-class [
         <local>
         cmd
     ][
-        switch/default target/class-name [
+        if null? switch target/class-name [
             'var-class [
                 ;pass: already been taken care of by PREPARE
             ]
@@ -1664,7 +1685,7 @@ Execution: make generator-class [
             ]
         ]
 
-        switch/default project/class-name [
+        if null? switch project/class-name [
             'application-class
             'dynamic-library-class
             'static-library-class [
@@ -1893,7 +1914,7 @@ visual-studio: make generator-class [
     find-optimization: func [
         optimization
     ][
-        switch/default optimization [
+        if null? switch optimization [
             0 _ 'no 'false 'off #[false] [
                 "Disabled"
             ]
@@ -2037,12 +2058,14 @@ visual-studio: make generator-class [
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-  <ConfigurationType>} switch/default project/class-name [
+  <ConfigurationType>} switch project/class-name [
       'static-library-class 'object-library-class ["StaticLibrary"]
       'dynamic-library-class ["DynamicLibrary"]
       'application-class ["Application"]
       'entry-class ["Utility"]
-  ][fail ["Unsupported project class:" (project/class-name)]] {</ConfigurationType>
+      ;-- default
+      (fail ["Unsupported project class:" (project/class-name)])
+] {</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>} platform-tool-set {</PlatformToolset>

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -253,7 +253,7 @@ REBNATIVE(do)
             REF(next) ? DO_MASK_NONE : DO_FLAG_TO_END
         );
 
-        CLEAR_VAL_FLAG(D_OUT, VALUE_FLAG_UNEVALUATED);
+        assert(NOT_VAL_FLAG(D_OUT, VALUE_FLAG_UNEVALUATED));
 
         if (indexor == THROWN_FLAG)
             return R_OUT_IS_THROWN;

--- a/src/extensions/ffi/make-spec.r
+++ b/src/extensions/ffi/make-spec.r
@@ -63,7 +63,7 @@ options: [
                 ]
             ]
         ][
-            switch/default user-config/with-ffi [
+            if null? switch user-config/with-ffi [
                 'static 'dynamic [
                     for-each var [includes cflags searches ldflags][
                         x: rebmake/pkg-config

--- a/src/extensions/odbc/make-spec.r
+++ b/src/extensions/odbc/make-spec.r
@@ -29,7 +29,7 @@ modules: [
         includes: [
             %prep/extensions/odbc ;for %tmp-ext-odbc-init.inc
         ]
-        libraries: switch/default system-config/os-base [
+        libraries: if null? switch system-config/os-base [
             'Windows [
                 [%odbc32]
             ]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -530,13 +530,13 @@ unless: enfix func [
 
 
 case*: redescribe [
-    {Same as CASE/ONLY (void, not blank, if branch evaluates to void)}
+    {Same as CASE/OPT (null, not blank, if branch evaluates to null)}
 ](
-    specialize 'case [only: true]
+    specialize 'case [opt: true]
 )
 
 switch*: redescribe [
-    {Same as SWITCH/ONLY (void, not blank, if branch evaluates to void)}
+    {Same as SWITCH/OPT (null, not blank, if branch evaluates to null)}
 ](
     specialize 'switch [opt: true]
 )

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -978,7 +978,7 @@ set 'r3-legacy* func [<local>] [
         ][
             apply 'quit [
                 with: ensure logic! return
-                value: :value
+                if return [value: :value]
             ]
         ])
 
@@ -1118,7 +1118,7 @@ set 'r3-legacy* func [<local>] [
         ])
 
         switch: (redescribe [
-            {Ren-C SWITCH evaluates its branches: }
+            {Ren-C SWITCH evaluates matches: https://trello.com/c/9ChhSWC4/}
         ](
             chain [
                 adapt 'switch [
@@ -1126,10 +1126,15 @@ set 'r3-legacy* func [<local>] [
                         for-each c cases [
                             keep/only either block? :c [:c] [uneval :c]
                         ]
+                        if default [ ;-- convert to fallout
+                            keep/only as group! default-branch
+                            default: false
+                            unset 'default-branch
+                        ]
                     ]
                 ]
                     |
-                :try ;-- wants blank on failed select, not null
+                :to-value ;-- wants blank on failed SWITCH, not null
             ]
         ))
 

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -116,13 +116,11 @@ finish-init-core: proc [
                     fail/where [
                         {Temporarily disabled word/path SWITCH clause:} :c LF
 
-                        {You likely meant to use a LIT-WORD! / LIT-PATH!} LF
+                        {You may have meant to use a LIT-WORD! / LIT-PATH!} LF
 
-                        {SWITCH in Ren-C evaluates its match clauses, and}
-                        {will even allow 0-arity ACTION!s (larger arities are}
-                        {put in a GROUP! to facilitate skipping after a match}
-                        {is found.  But to help catch old uses, only datatype}
-                        {lookups are enabled.  SWITCH: :LIB/SWITCH overrides.}
+                        {SWITCH in Ren-C evaluates its match clauses.  But to}
+                        {help catch old uses, only datatype lookups enabled.}
+                        {SWITCH: :LIB/SWITCH overrides.}
                     ] 'cases
                 ]
             ]

--- a/tests/control/case.test.reb
+++ b/tests/control/case.test.reb
@@ -33,18 +33,20 @@
 )]
 
 (
-    error? trap [
-        case [
-            first [a b c] ;-- no corresponding branch, illegal
-        ]
+    'a = case [
+        first [a b c] ;-- no corresponding branch, means "case fallout"
     ]
 )
 
 (
-    3 = case [true (reduce ['add 1 2])]
+    error? trap [
+        3 = case [true (reduce ['add 1 2])]
+    ] ;-- soft-quoting not supported for CASE branches
 )
 (
-    null? case [false (reduce ['add 1 2])]
+    error? trap [
+        null? case [false (reduce ['add 1 2])]
+    ] ;-- soft-quoting not supported for CASE branches
 )
 
 (

--- a/tests/control/switch.test.reb
+++ b/tests/control/switch.test.reb
@@ -25,5 +25,5 @@
 )]
 
 (t: 1 | 1 = switch t [(t)])
-(1 = switch/default 1 [] [1])
+(1 = switch 1 [1])
 


### PR DESCRIPTION
The speculative feature of "SWITCH fallout" has been endorsed as a
legitimate way to return a value from a switch.  This says that if the
last match item is reached with no associated branch block after it,
the match item itself is the evaluative result:

    >> switch 3 [1 ["one"] 2 ["two"] "other"]
    == "other"

A question posed about this was:

    "Does fallout make SWITCH feel like it's fancier and has good
    dialecting bones, taking advantage of Rebol's unconventional-ness?
    Or does it make SWITCH seem weird...like you're looking at
    incomplete code, missing the branch for the last switch case?"

The decision was that for Rebol's domain, this kind of implementation
choice goes well with the "fast-and-loose" character of the language,
especially with a "fully evaluative switch".  It enables styles of
coding that may appeal to programmers who are already used to the
general flexibility of the language, such as:

    x: 3
    switch x [
       1 + 4 ["five"]
       2 ["two"]
       fail "No match found"
    ]

Going along with the endorsement is the elimination of SWITCH/DEFAULT,
which is not relevant considering the null protocol.  Cases that don't use
the result can get the same effect with:

    if null? switch [
        ...
    ][
        ...
    ]

But more importantly, if the result is to be used, you can use the fallout
feature...or it can work with ELSE or UNLESS or any of the other
null-triggered constructs.

Since SWITCH allows the last evaluated condition to fall out, this
extends the ability to CASE.  CASE statements now have more structure,
expecting a condition/block alternation...though blocks may appear in
the conditions themselves.  Fallout presents a more elegant and
matching way of handling no match.  Historically this was done with
a truthy final condition:

    case [
       1 > 2 [...]
       3 > 4 [...]
       true [fail "No matching condition"]
    ]

For fail in particular, this would always have worked if written with
the fail in an unpaired condition slot:

    case [
        1 > 2 [...]
        3 > 4 [...]
        fail "No matching condition"
    ]

But with fallout, any value can appear there:

    <fallout> = case [
       1 > 2 [...]
       3 > 4 [...]
       <fallout>
    ]

One strong argument in favor of the feature is that people can use it
if they want, and ignore it if they want.  But it's an option which
errs on the side of expressiveness over strict structure--and anyone
who wants more structure can build that into their own dialects.