### PR TITLE
PARSE returns null/BAR! by default, allow THROW of ERROR!

### DIFF
--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -143,9 +143,9 @@ make-emitter: function [
 
     temporary: did any [temporary | parse stem ["tmp-" to end]]
 
-    is-c: parse stem [[thru ".c" | thru ".h" | thru ".inc"] end]
+    is-c: did parse stem [[thru ".c" | thru ".h" | thru ".inc"] end]
 
-    is-js: parse stem [thru ".js" end]
+    is-js: did parse stem [thru ".js" end]
 
     e: make object! compose [
         ;

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -198,6 +198,20 @@ case: function [
     :result
 ]
 
+; !!! PARSE returns null or BAR! by default, but this shim can't tell a RETURN
+; explicitly of a true/false from a plain true/false based on end of input.
+;
+parse: chain [
+    :parse
+        |
+    func [return: [<opt> any-value!] x [<opt> any-value!]] [
+        lib/switch/opt :x [
+            #[false] []
+            #[true] ['|]
+            (:x)
+        ]
+    ]
+]
 
 choose: function [
     {Like CASE but doesn't evaluate blocks https://trello.com/c/noVnuHwz}

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -491,7 +491,7 @@ gcc: make compiler-class [
                     opt-level = false ["-O0"]
                     integer? opt-level [unspaced ["-O" opt-level]]
                     find ["s" "z" 's 'z] opt-level [unspaced ["-O" opt-level]]
-                    
+
                     fail ["unrecognized optimization level:" opt-level]
                 ]
             ]

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -109,11 +109,7 @@ Script: [
     reduce-made-null:   {Expression in REDUCE was null, see REDUCE/OPT, /TRY}
     break-not-continue: {Use BREAK/WITH when body is the breaking condition}
 
-    ; !!! Temporary errors while faulty constructs are still outstanding
-    ; (more informative than just saying "function doesn't take that type")
-    use-eval-for-eval:  {Use EVAL or APPLY to call functions arity > 0, not DO}
-    use-fail-for-error: [{Use FAIL (not THROW or DO) to raise} :arg1]
-    use-split-simple:   {Use SPLIT (instead of PARSE) for "simple" parsing}
+    use-eval-for-eval:  {Use EVAL or APPLY on actions of arity > 0, not DO}
 
     limited-fail-input: {FAIL requires complex expressions to be in a GROUP!}
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1143,19 +1143,6 @@ REBNATIVE(throw)
 
     REBVAL *value = ARG(value);
 
-    if (IS_ERROR(value)) {
-        //
-        // We raise an alert from within the implementation of throw for
-        // trying to use it to trigger errors, because if THROW just didn't
-        // take errors in the spec it wouldn't guide what *to* use.
-        //
-        fail (Error_Use_Fail_For_Error_Raw(value));
-
-        // Note: Caller can put the ERROR! in a block or use some other
-        // such trick if it wants to actually throw an error.
-        // (Better than complicating via THROW/ERROR-IS-INTENTIONAL!)
-    }
-
     if (REF(name))
         Move_Value(D_OUT, ARG(name_value));
     else {

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -473,7 +473,7 @@ host-start: function [
 
     while-not [tail? argv] [
 
-        is-option: parse/case argv/1 [
+        is-option: did parse/case argv/1 [
 
             ["--" end] (
                 ; Double-dash means end of command line arguments, and the

--- a/tests/parse-tests.r
+++ b/tests/parse-tests.r
@@ -1,72 +1,71 @@
 ; Is PARSE working at all?
 
-(parse "abc" ["abc"])
+(did parse "abc" ["abc"])
 
 ; Blank and empty block case handling
 
-(parse [] [])
-(parse [] [[[]]])
-(parse [] [_ _ _])
+(did parse [] [])
+(did parse [] [[[]]])
+(did parse [] [_ _ _])
 (not parse [x] [])
 (not parse [x] [_ _ _])
 (not parse [x] [[[]]])
-(parse [] [[[_ _ _]]])
-(parse [x] ['x _])
-(parse [x] [_ 'x])
-(parse [x] [[] 'x []])
+(did parse [] [[[_ _ _]]])
+(did parse [x] ['x _])
+(did parse [x] [_ 'x])
+(did parse [x] [[] 'x []])
 
 ; SET-WORD! (store current input position)
 
 (
-    res: parse ser: [x y] [pos: skip skip]
+    res: did parse ser: [x y] [pos: skip skip]
     all [res | pos = ser]
 )
 (
-    res: parse ser: [x y] [skip pos: skip]
+    res: did parse ser: [x y] [skip pos: skip]
     all [res | pos = next ser]
 )
 (
-    res: parse ser: [x y] [skip skip pos: end]
+    res: did parse ser: [x y] [skip skip pos: end]
     all [res | pos = tail of ser]
 )
 [#2130 (
-    res: parse ser: [x] [set val pos: word!]
+    res: did parse ser: [x] [set val pos: word!]
     all [res | val = 'x | pos = ser]
 )]
 [#2130 (
-    res: parse ser: [x] [set val: pos: word!]
+    res: did parse ser: [x] [set val: pos: word!]
     all [res | val = 'x | pos = ser]
 )]
 [#2130 (
-    res: parse
-    ser: "foo" [copy val pos: skip]
+    res: did parse ser: "foo" [copy val pos: skip]
     all [not res | val = "f" | pos = ser]
 )]
 [#2130 (
-    res: parse ser: "foo" [copy val: pos: skip]
+    res: did parse ser: "foo" [copy val: pos: skip]
     all [not res | val = "f" | pos = ser]
 )]
 
 ; TO/THRU integer!
 
-(parse "abcd" [to 3 "cd"])
-(parse "abcd" [to 5])
-(parse "abcd" [to 128])
+(did parse "abcd" [to 3 "cd"])
+(did parse "abcd" [to 5])
+(did parse "abcd" [to 128])
 
 [#1965
-    (parse "abcd" [thru 3 "d"])
+    (did parse "abcd" [thru 3 "d"])
 ]
 [#1965
-    (parse "abcd" [thru 4])
+    (did parse "abcd" [thru 4])
 ]
 [#1965
-    (parse "abcd" [thru 128])
+    (did parse "abcd" [thru 128])
 ]
 [#1965
-    (parse "abcd" ["ab" to 1 "abcd"])
+    (did parse "abcd" ["ab" to 1 "abcd"])
 ]
 [#1965
-    (parse "abcd" ["ab" thru 1 "bcd"])
+    (did parse "abcd" ["ab" thru 1 "bcd"])
 ]
 
 ; parse THRU tag!
@@ -86,20 +85,20 @@
 )
 
 [#1959
-    (parse "abcd" [thru "d"])
+    (did parse "abcd" [thru "d"])
 ]
 [#1959
-    (parse "abcd" [to "d" skip])
+    (did parse "abcd" [to "d" skip])
 ]
 
 [#1959
-    (parse "<abcd>" [thru <abcd>])
+    (did parse "<abcd>" [thru <abcd>])
 ]
 [#1959
-    (parse [a b c d] [thru 'd])
+    (did parse [a b c d] [thru 'd])
 ]
 [#1959
-    (parse [a b c d] [to 'd skip])
+    (did parse [a b c d] [to 'd skip])
 ]
 
 ; self-invoking rule
@@ -139,10 +138,10 @@
 ; NOT rule
 
 [#1246
-    (parse "1" [not not "1" "1"])
+    (did parse "1" [not not "1" "1"])
 ]
 [#1246
-    (parse "1" [not [not "1"] "1"])
+    (did parse "1" [not [not "1"] "1"])
 ]
 [#1246
     (not parse "" [not 0 "a"])
@@ -151,13 +150,13 @@
     (not parse "" [not [0 "a"]])
 ]
 [#1240
-    (parse "" [not "a"])
+    (did parse "" [not "a"])
 ]
 [#1240
-    (parse "" [not skip])
+    (did parse "" [not skip])
 ]
 [#1240
-    (parse "" [not fail])
+    (did parse "" [not fail])
 ]
 
 [#100
@@ -167,13 +166,13 @@
 ; TO/THRU + bitset!/charset!
 
 [#1457
-    (parse "a" compose [thru (charset "a")])
+    (did parse "a" compose [thru (charset "a")])
 ]
 [#1457
     (not parse "a" compose [thru (charset "a") skip])
 ]
 [#1457
-    (parse "ba" compose [to (charset "a") skip])
+    (did parse "ba" compose [to (charset "a") skip])
 ]
 [#1457
     (not parse "ba" compose [to (charset "a") "ba"])
@@ -186,22 +185,22 @@
 (
     https://github.com/metaeducation/ren-c/issues/377
     o: make object! [a: 1]
-    true = parse "a" [o/a: skip]
+    '| = parse "a" [o/a: skip]
 )
 
 ; A couple of tests for the problematic DO operation
 
-(parse [1 + 2] [do [quote 3]])
-(parse [1 + 2] [do integer!])
-(parse [1 + 2] [do [integer!]])
+(did parse [1 + 2] [do [quote 3]])
+(did parse [1 + 2] [do integer!])
+(did parse [1 + 2] [do [integer!]])
 (not parse [1 + 2] [do [quote 100]])
-(parse [reverse copy [a b c]] [do [into ['c 'b 'a]]])
+(did parse [reverse copy [a b c]] [do [into ['c 'b 'a]]])
 (not parse [reverse copy [a b c]] [do [into ['a 'b 'c]]])
 
 ; AHEAD and AND are synonyms
 ;
-(parse ["aa"] [ahead text! into ["a" "a"]])
-(parse ["aa"] [and text! into ["a" "a"]])
+(did parse ["aa"] [ahead text! into ["a" "a"]])
+(did parse ["aa"] [and text! into ["a" "a"]])
 
 ; INTO is not legal if a string parse is already running
 ;


### PR DESCRIPTION
PARSE is not strictly a LOGIC!-returning function, and can return
anything with RETURN.  Hence, it is useful to make its failure map
to null instead of false, so it can be used e.g. like:

    value: <not-found> unless parse data [
        some 'foo return (<some-foos-found>)
    ]

This changes the failure to be a null.  The default return of success
is a BAR! value, which is what is typically used for "synthesized"
truthy values...as returning #[true] would give the incorrect
impression that the failure case would be #[false].  Hence it cues
users to go to either a DID PARSE or NOT PARSE (if they were interested
in a LOGIC!) or a TRY PARSE (if they were going to return a value or
fail otherwise, and want to put that value into a variable).

Also, speculatively makes PARSE able to take a BLANK! value in and then
return a NULL out...which makes it join in the "blank in, null out"
protocol that is followed by many non-mutating routines.

!!! Since PARSE can sometimes mutate, this is a little dodgy, so it
should be reviewed if it turns out to seem misleading in some cases...
depends on how useful people find it in the meantime.

Given the recent tendency toward fewer restrictions "for the safety of
the programmer", this takes away the restriction that THROW can't
throw a value of type ERROR!.  This was added when there was widespread
belief that THROW MAKE ERROR! was a good way to invoke the error (the
actual previous correct way was DO MAKE ERROR!).  Ren-C has FAIL, and
it is less of an issue...so allowing a full-spectrum throw seems the
better path at this point.