### PR TITLE
Rethink TO behavior for ANY-ARRAY!, move complexity to MAKE

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -252,7 +252,9 @@ parse-ext-build-spec: function [
         return _
     ]
 
-    if set? 'config [do to block! config]
+    if set? 'config [
+        do as block! config ;-- some old Ren-Cs disallowed DO of GROUP!
+    ]
 
     append ext-body compose/only [
         modules: (map-each m modules [make module-class m])

--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -196,7 +196,7 @@ for-each native native-specs [
                     ]
                 ]
                 path? plat [; os-base/os-name format
-                    if plat = to path! reduce [config/os-base config/os-name][
+                    if plat = as path! reduce [config/os-base config/os-name][
                         supported?: true
                         break
                     ]

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -392,3 +392,18 @@ method: enfix func [
 ]
 
 meth: :func ;-- suitable enough synonym in the older Ren-C
+
+
+; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
+;
+for-each modifier [append insert change] [
+    set modifier adapt modifier [
+        if all [
+            not only
+            any-path? :value
+            not any-path? :series
+        ][
+            only: true
+        ]
+    ]
+]

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -41,7 +41,7 @@ REBCNT Modify_Array(
     REBARR *dst_arr,        // target
     REBCNT dst_idx,         // position
     const REBVAL *src_val,  // source
-    REBCNT flags,           // AM_ONLY, AM_PART
+    REBCNT flags,           // AM_SPLICE, AM_PART
     REBINT dst_len,         // length to remove
     REBINT dups             // dup count
 ){
@@ -77,7 +77,8 @@ REBCNT Modify_Array(
     REBINT ilen;
 
     // Check /PART, compute LEN:
-    if (not (flags & AM_ONLY) and ANY_ARRAY(src_val)) {
+    if (flags & AM_SPLICE) {
+        assert(ANY_ARRAY(src_val));
         // Adjust length of insertion if changing /PART:
         if (sym != SYM_CHANGE and (flags & AM_PART))
             ilen = dst_len;

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -2170,7 +2170,7 @@ REBNATIVE(subparse)
 
                 if (flags & (PF_INSERT | PF_CHANGE)) {
                     count = (flags & PF_INSERT) ? 0 : count;
-                    REBCNT mod_flags = (flags & PF_INSERT) ? 0 : AM_PART;
+                    REBOOL only = false;
 
                     if (FRM_AT_END(f))
                         fail (Error_Parse_End());
@@ -2179,7 +2179,7 @@ REBNATIVE(subparse)
                         REBSYM cmd = VAL_CMD(P_RULE);
                         switch (cmd) {
                         case SYM_ONLY:
-                            mod_flags |= AM_ONLY;
+                            only = true;
                             FETCH_NEXT_RULE_MAYBE_END(f);
                             if (FRM_AT_END(f))
                                 fail (Error_Parse_End());
@@ -2222,6 +2222,13 @@ REBNATIVE(subparse)
                         DECLARE_LOCAL (specified);
                         Derelativize(specified, rule, P_RULE_SPECIFIER);
 
+                        REBCNT mod_flags = (flags & PF_INSERT) ? 0 : AM_PART;
+                        if (
+                            not only and
+                            Splices_Into_Type_Without_Only(P_TYPE, specified)
+                        ){
+                            mod_flags |= AM_SPLICE;
+                        }
                         P_POS = Modify_Array(
                             (flags & PF_CHANGE)
                                 ? Canon(SYM_CHANGE)
@@ -2245,6 +2252,9 @@ REBNATIVE(subparse)
                         Derelativize(specified, rule, P_RULE_SPECIFIER);
 
                         P_POS = begin;
+
+                        REBCNT mod_flags = (flags & PF_INSERT) ? 0 : AM_PART;
+
                         if (P_TYPE == REB_BINARY)
                             P_POS = Modify_Binary(
                                 P_INPUT_VALUE,

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -504,6 +504,28 @@ inline static RELVAL *VAL_ARRAY_TAIL(const RELVAL *v) {
     Init_Any_Array((v), REB_PATH, (s))
 
 
+// PATH! types will splice into each other, but not into a BLOCK! or GROUP!.
+// BLOCK! or GROUP! will splice into any other array:
+//
+//     [a b c d/e/f] -- append copy [a b c] 'd/e/f
+//      a/b/c/d/e/f  -- append copy 'a/b/c [d e f]
+//     (a b c d/e/f) -- append copy quote (a b c) 'd/e/f
+//      a/b/c/d/e/f  -- append copy 'a/b/c quote (d e f)
+//      a/b/c/d/e/f  -- append copy 'a/b/c 'd/e/f
+//
+// This rule influences the behavior of TO conversions as well:
+// https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
+//
+inline static REBOOL Splices_Into_Type_Without_Only(
+    enum Reb_Kind array_kind,
+    const REBVAL *arg
+){
+    assert(ANY_ARRAY_KIND(array_kind));
+    return IS_GROUP(arg)
+        or IS_BLOCK(arg)
+        or (ANY_PATH(arg) and ANY_PATH_KIND(array_kind));
+}
+
 
 #ifdef NDEBUG
     #define ASSERT_ARRAY(s) \

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -473,7 +473,7 @@ enum {
 // Move these things:
 enum act_modify_mask {
     AM_PART = 1 << 0,
-    AM_ONLY = 1 << 1,
+    AM_SPLICE = 1 << 1,
     AM_LINE = 1 << 2
 };
 enum act_find_mask {

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -682,8 +682,8 @@ lambda: function [
     {Convenience variadic wrapper for MAKE ACTION!}
 
     return: [action!]
-    :args [<end> word! path! block!]
-        {Block of argument words, or a single word (passed via LIT-WORD!)}
+    :args [<end> word! block!]
+        {Block of argument words, or a single word (if only one argument)}
     :body [any-value! <...>]
         {Block that serves as the body or variadic elements for the body}
 ][

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -38,7 +38,7 @@ dump-obj: function [
             return clip-str any [title-of :val | mold spec-of :val]
         ]
         if object? :val [val: words of val]
-        if typeset? :val [val: to-block val]
+        if typeset? :val [val: make block! val]
         if port? :val [val: reduce [val/spec/title val/spec/ref]]
         if gob? :val [return spaced ["offset:" val/offset "size:" val/size]]
         clip-str mold :val

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -841,6 +841,23 @@ set 'r3-legacy* func [<local>] [
             ]
         ])
 
+        to: (func [
+            return: [any-value!]
+            type [any-value!]
+            spec [any-value!]
+        ][
+            if any-array? :type [
+                if match [text! typeset! map! any-context! vector!] :spec [
+                    return make :type :spec
+                ]
+                if binary? :spec [ ;-- would scan UTF-8 data
+                    return make :type as text! :spec
+                ]
+                return to :type :spec
+            ]
+            return to :type :spec
+        ])
+
         try: (func [
             return: [<opt> any-value!]
             block [block!]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -883,7 +883,7 @@ load-module: function [
             ]
         ]
 
-        if binary? code [code: to block! code]
+        if binary? code [code: make block! code]
 
         ensure object! hdr
         ensure block! code

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -563,7 +563,7 @@ host-start: function [
                     ;; suppress all known start-up files
                     [%rebol.reb %user.reb %console-skin.reb]
                 ] else [
-                    to-block param
+                    make block! param
                 ]
             )
         |

--- a/tests/context/bind.test.reb
+++ b/tests/context/bind.test.reb
@@ -1,7 +1,7 @@
 ; functions/context/bind.r
 
 (
-    e: trap [do to block! ":a"]
+    e: trap [do make block! ":a"]
     e/id = 'not-bound
 )
 

--- a/tests/control/do.test.reb
+++ b/tests/control/do.test.reb
@@ -145,7 +145,7 @@
     all [
         lit-path? a-value
         path? eval :a-value
-        (to-path :a-value) == (eval :a-value)
+        (as path! :a-value) == (eval :a-value)
     ]
 )
 (

--- a/tests/convert/to.test.reb
+++ b/tests/convert/to.test.reb
@@ -7,3 +7,12 @@
 [#1967
     (not same? to binary! [1] to binary! [2])
 ]
+
+; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
+;
+([a/b/c] = to block! 'a/b/c)
+(quote (a/b/c) = to group! 'a/b/c)
+([a b c] = to block! quote (a b c))
+(quote (a b c) = to group! [a b c])
+(quote a/b/c = to path! [a b c])
+(quote a/b/c = to path! quote (a b c))

--- a/tests/datatypes/block.test.reb
+++ b/tests/datatypes/block.test.reb
@@ -9,7 +9,7 @@
 ; alternative literal representation
 ([] == #[block! [[] 1]])
 ([] == make block! 0)
-([] == to block! "")
+([] == make block! "")
 ("[]" == mold [])
 
 (

--- a/tests/datatypes/get-word.test.reb
+++ b/tests/datatypes/get-word.test.reb
@@ -4,7 +4,7 @@
 (get-word! = type of first [:a])
 (
     ; context-less get-word
-    e: trap [do to block! ":a"]
+    e: trap [do make block! ":a"]
     e/id = 'not-bound
 )
 (

--- a/tests/datatypes/lit-path.test.reb
+++ b/tests/datatypes/lit-path.test.reb
@@ -15,5 +15,5 @@
 ; lit-paths are active
 (
     a-value: first ['a/b]
-    strict-equal? to path! :a-value do reduce [:a-value]
+    strict-equal? as path! :a-value do reduce [:a-value]
 )

--- a/tests/datatypes/paren.test.reb
+++ b/tests/datatypes/paren.test.reb
@@ -17,9 +17,11 @@
 (
     num1: 4
     num2: 1
-    fact: to group! [either num1 = 1 [num2] [num2: num1 * num2 num1: num1 - 1]]
+    fact: copy quote (
+        either num1 = 1 [num2] [num2: num1 * num2 num1: num1 - 1]
+    )
     insert/only tail of last fact fact
-    24 = do as block! fact
+    24 = do fact
 )
 ; infinite recursion
 [#1665 (

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -29,7 +29,7 @@
 )
 (
     blk: reduce [charset "a" 3]
-    3 == do reduce [to path! reduce ['blk charset "a"]]
+    3 == do reduce [as path! reduce ['blk charset "a"]]
 )
 (
     blk: [[] 3]

--- a/tests/series/append.test.reb
+++ b/tests/series/append.test.reb
@@ -29,3 +29,11 @@
     block: my append/part/dup [d e f] 2 3
     [a b c d e d e d e] = block
 )
+
+; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
+;
+([a b c d/e/f] = append copy [a b c] 'd/e/f)
+(quote a/b/c/d/e/f = append copy 'a/b/c [d e f])
+(quote (a b c d/e/f) = append copy quote (a b c) 'd/e/f)
+(quote a/b/c/d/e/f = append copy 'a/b/c quote (d e f))
+(quote a/b/c/d/e/f = append copy 'a/b/c 'd/e/f)

--- a/tests/series/insert.test.reb
+++ b/tests/series/insert.test.reb
@@ -38,16 +38,16 @@
 (
     a: make path! 0
     insert a 0
-    a == to path! [0]
+    a == as path! [0]
 )
 (
-    a: to path! [0]
+    a: copy as path! [0]
     b: make path! 0
     insert b first a
     a == b
 )
 (
-    a: to path! [0]
+    a: copy as path! [0]
     b: make path! 0
     insert :b a
     a == b

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -441,9 +441,9 @@ rebsource: context [
             any [nl | eol | wsp]
         ]
 
-        append/only grammar/other-segment to group! [
+        append/only grammar/other-segment quote (
             last-func-end: _
-        ]
+        )
 
     ] proto-parser c.lexical/grammar
 

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -46,7 +46,7 @@ make object! compose [
         ]
 
         case [
-            error? trap [test-block: to block! load source] [
+            error? trap [test-block: make block! load source] [
                 "cannot load test source"
             ]
 
@@ -72,7 +72,7 @@ make object! compose [
             not :result [
                 "test returned #[false]"
             ]
-        ] also message => [
+        ] then message => [
             test-failures: me + 1
             log reduce [space {"failed, } message {"} newline]
         ] else [


### PR DESCRIPTION
A long-discussed behavior has been to not automatically splice paths
when they are appended to BLOCK!s or GROUP!s.  This implements that
behavior:

    >> append copy [a b c] 'd/e/f
    == [a b c d/e/f]

However, BLOCK! and GROUP! continue to splice when APPENDed or INSERTed
or CHANGEed into another ANY-ARRAY! without an /ONLY refinement.  So
the new splicing rule is really only for PATH!--which now just won't
splice unless they are being spliced into *other paths*.

As a further step in the design, this makes it consistent when doing
an APPEND of things of different types, that it will act as if the
item being appended had first been converted to the target type.  This
helps reign in the TO matrix when there are multiple potential meanings,
by choosing the same interpretation for a plain APPEND as a TO.

e.g.

    block: copy [a b]
    m: make map! [c 10 d 20]
    append block m ;-- ??

Should the APPEND be adding one MAP!, or four items (c,10,d,20)...or
something else?  The concept in this commit is that whatever it did
do, it would be the same as:

    append block to block! m

Given that the desired behavior for the APPEND is to add one MAP!, that
would then suggest that TO BLOCK! of a MAP! under these rules would
need to be that MAP! in a single element block.

This commit pushes on that rule.  Among some of the changes, it affects
how TO BLOCK! of a TEXT! works to just putting the string into a block,
because:

    >> append copy [a b c] "d <e> #f"
    == [a b c "d <e> #f"]

If that had been `[a b c d <e> #f]` as an outcome, then TO BLOCK! would
have reasonably invoked the scanner on the string.  But for consistency
that is now needed to be moved to another operation.  (In that case,
MAKE of a BLOCK! from a TEXT! always did this, so that can be used.)