### PR TITLE
Make RETURN endable, all can be arity 0 -or- 1

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -162,7 +162,7 @@ script: construct [] [
 ]
 
 standard: construct [] [
-    ; FUNC+PROC implement a native-optimized variant of an action generator.
+    ; FUNC implements a native-optimized variant of an action generator.
     ; This is the body template that it provides as the code *equivalent* of
     ; what it is doing (via a more specialized/internal method).  Though
     ; the only "real" body stored and used is the one the user provided
@@ -174,8 +174,8 @@ standard: construct [] [
 
     func-body: [
         return: make action! [
-            [{Returns a value from an action} value [<opt> any-value!]]
-            [unwind/with (binding of 'return) :value]
+            [{Returns a value from an action} value [<opt> <end> any-value!]]
+            [unwind/with (binding of 'return) end? 'value ?? void !! :value]
         ] #BODY
     ]
 
@@ -183,10 +183,10 @@ standard: construct [] [
 
     proc-body: [
         return: make action! [
-            [{Leaves an action, giving no result to the caller}]
-            [unwind (binding of 'return)]
+            [{Returns a value from an action} value [<opt> <end> any-value!]]
+            [unwind/with (binding of 'return) end? 'value ?? void !! :value]
         ] #BODY
-        ; #[void] ;-- illegal notation in legacy R3s, but returns this
+        void
     ]
 
     ; !!! The PORT! and actor code is deprecated, but this bridges it so

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -229,7 +229,7 @@ inline static void Finalize_Arg(
         if (NOT_VAL_FLAG(param, TYPESET_FLAG_ENDABLE))
             fail (Error_No_Arg(f_state, param));
 
-        Init_Endish_Void(arg);
+        Init_Endish_Nulled(arg);
         SET_VAL_FLAG(arg, ARG_FLAG_TYPECHECKED);
         return;
     }
@@ -899,16 +899,9 @@ reevaluate:;
                 SET_VAL_FLAG(f->arg, ARG_FLAG_TYPECHECKED);
                 goto continue_arg_loop;
 
-            case PARAM_CLASS_RETURN_1:
+            case PARAM_CLASS_RETURN:
                 assert(VAL_PARAM_SYM(f->param) == SYM_RETURN);
-                Move_Value(f->arg, NAT_VALUE(return_1)); // !!! f->special?
-                INIT_BINDING(f->arg, f->varlist);
-                SET_VAL_FLAG(f->arg, ARG_FLAG_TYPECHECKED);
-                goto continue_arg_loop;
-
-            case PARAM_CLASS_RETURN_0:
-                assert(VAL_PARAM_SYM(f->param) == SYM_RETURN);
-                Move_Value(f->arg, NAT_VALUE(return_0)); // !!! f->special?
+                Move_Value(f->arg, NAT_VALUE(return)); // !!! f->special?
                 INIT_BINDING(f->arg, f->varlist);
                 SET_VAL_FLAG(f->arg, ARG_FLAG_TYPECHECKED);
                 goto continue_arg_loop;
@@ -1022,7 +1015,7 @@ reevaluate:;
                     if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_ENDABLE))
                         fail (Error_No_Arg(f, f->param));
 
-                    Init_Endish_Void(f->arg);
+                    Init_Endish_Nulled(f->arg);
                     SET_VAL_FLAG(f->arg, ARG_FLAG_TYPECHECKED);
                     goto continue_arg_loop;
                 }
@@ -1216,7 +1209,7 @@ reevaluate:;
                 if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_ENDABLE))
                     fail (Error_No_Arg(f, f->param));
 
-                Init_Endish_Void(f->arg);
+                Init_Endish_Nulled(f->arg);
                 SET_VAL_FLAG(f->arg, ARG_FLAG_TYPECHECKED);
                 goto continue_arg_loop;
             }
@@ -1246,7 +1239,7 @@ reevaluate:;
                 if (NOT_VAL_FLAG(f->param, TYPESET_FLAG_ENDABLE))
                     fail (Error_No_Arg(f, f->param));
 
-                Init_Endish_Void(f->arg);
+                Init_Endish_Nulled(f->arg);
                 SET_VAL_FLAG(f->arg, ARG_FLAG_TYPECHECKED);
                 goto continue_arg_loop;
             }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -66,8 +66,7 @@ REBARR *List_Func_Words(const RELVAL *func, REBOOL pure_locals)
             break;
 
         case PARAM_CLASS_LOCAL:
-        case PARAM_CLASS_RETURN_1: // "magic" local - prefilled invisibly
-        case PARAM_CLASS_RETURN_0: // "magic" local - prefilled invisibly
+        case PARAM_CLASS_RETURN: // "magic" local - prefilled invisibly
             if (not pure_locals)
                 continue; // treat as invisible, e.g. for WORDS-OF
 
@@ -527,10 +526,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             //
             DS_PUSH_TRASH;
             Init_Typeset(DS_TOP, ALL_64, Canon(SYM_RETURN));
-            if (header_bits & ACTION_FLAG_VOIDER)
-                INIT_VAL_PARAM_CLASS(DS_TOP, PARAM_CLASS_RETURN_0);
-            else
-                INIT_VAL_PARAM_CLASS(DS_TOP, PARAM_CLASS_RETURN_1);
+            INIT_VAL_PARAM_CLASS(DS_TOP, PARAM_CLASS_RETURN);
             definitional_return_dsp = DSP;
 
             DS_PUSH(EMPTY_BLOCK);
@@ -540,11 +536,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         else {
             REBVAL *param = DS_AT(definitional_return_dsp);
             assert(VAL_PARAM_CLASS(param) == PARAM_CLASS_LOCAL);
-            INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_RETURN_1);
-            if (header_bits & ACTION_FLAG_VOIDER)
-                INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_RETURN_0);
-            else
-                INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_RETURN_1);
+            INIT_VAL_PARAM_CLASS(param, PARAM_CLASS_RETURN);
 
             // definitional_return handled specially when paramlist copied
             // off of the stack...
@@ -899,7 +891,7 @@ REBACT *Make_Action(
         case PARAM_CLASS_LOCAL:
             break; // skip
 
-        case PARAM_CLASS_RETURN_1: {
+        case PARAM_CLASS_RETURN: {
             assert(VAL_PARAM_SYM(param) == SYM_RETURN);
 
             // See notes on ACTION_FLAG_INVISIBLE.
@@ -907,10 +899,6 @@ REBACT *Make_Action(
             if (VAL_TYPESET_BITS(param) == 0)
                 SET_VAL_FLAG(rootparam, ACTION_FLAG_INVISIBLE);
             break; }
-
-        case PARAM_CLASS_RETURN_0: {
-            assert(VAL_PARAM_SYM(param) == SYM_RETURN);
-            break; } // skip.
 
         case PARAM_CLASS_REFINEMENT:
             //

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -376,8 +376,7 @@ REBOOL Redo_Action_Throws(REBFRM *f, REBACT *run)
 
         if (
             pclass == PARAM_CLASS_LOCAL
-            or pclass == PARAM_CLASS_RETURN_0
-            or pclass == PARAM_CLASS_RETURN_1
+            or pclass == PARAM_CLASS_RETURN
         ){
              continue; // don't add a callsite expression for it (can't)!
         }

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -536,8 +536,7 @@ REBOOL Specialize_Action_Throws(
             SET_VAL_FLAG(arg, ARG_FLAG_TYPECHECKED);
             goto specialized_arg_no_typecheck; }
 
-        case PARAM_CLASS_RETURN_1:
-        case PARAM_CLASS_RETURN_0:
+        case PARAM_CLASS_RETURN:
         case PARAM_CLASS_LOCAL:
             assert(IS_NULLED(arg)); // no bindings, you can't set these
             goto unspecialized_arg;
@@ -1117,8 +1116,7 @@ REBOOL Make_Invocation_Frame_Throws(
             break;
 
         case PARAM_CLASS_LOCAL:
-        case PARAM_CLASS_RETURN_1:
-        case PARAM_CLASS_RETURN_0:
+        case PARAM_CLASS_RETURN:
             break;
 
         default:

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -191,8 +191,8 @@ REBNATIVE(bind)
 
     // Binding an ACTION! to a context means it will obey derived binding
     // relative to that context.  See METHOD for usage.  (Note that the same
-    // binding pointer is also used in cases like RETURN_0 and RETURN_1 to
-    // link them to the FRAME! that they intend to return from.)
+    // binding pointer is also used in cases like RETURN to link them to the
+    // FRAME! that they intend to return from.)
     //
     if (IS_ACTION(v)) {
         Move_Value(D_OUT, v);

--- a/src/core/n-native.c
+++ b/src/core/n-native.c
@@ -509,8 +509,7 @@ REBNATIVE(compile)
                 enum Reb_Param_Class pclass = VAL_PARAM_CLASS(param);
                 switch (pclass) {
                 case PARAM_CLASS_LOCAL:
-                case PARAM_CLASS_RETURN_1:
-                case PARAM_CLASS_RETURN_0:
+                case PARAM_CLASS_RETURN:
                     assert(FALSE); // natives shouldn't generally use these...
                     break;
 

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -470,7 +470,7 @@ REB_R PD_Varargs(REBPVS *pvs, const REBVAL *picker, const REBVAL *opt_setval)
     if (r == R_THROWN)
         assert(FALSE); // VARARG_OP_FIRST can't throw
     else if (r == R_END)
-        Init_Endish_Void(pvs->out);
+        Init_Endish_Nulled(pvs->out);
     else
         assert(r == pvs->out);
 
@@ -521,7 +521,7 @@ REBTYPE(Varargs)
         if (not REF(part)) {
             REB_R r = Do_Vararg_Op_May_Throw(D_OUT, value, VARARG_OP_TAKE);
             if (r == R_END)
-                Init_Endish_Void(D_OUT);
+                Init_Endish_Nulled(D_OUT);
             else
                 assert(r == D_OUT);
             return D_OUT;

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -957,7 +957,7 @@ inline static REBIXO Do_Array_At_Core(
 
     if (FRM_AT_END(f)) {
         if (flags & DO_FLAG_FULFILLING_ARG)
-            Init_Endish_Void(out);
+            Init_Endish_Nulled(out);
         else
             Init_Nulled(out); // shouldn't set VALUE_FLAG_UNEVALUATED
         return END_FLAG;
@@ -980,7 +980,7 @@ inline static REBIXO Do_Array_At_Core(
     if (FRM_AT_END(f)) {
         if (IS_END(f->out)) {
             if (flags & DO_FLAG_FULFILLING_ARG)
-                Init_Endish_Void(out);
+                Init_Endish_Nulled(out);
             else
                 Init_Nulled(out); // shouldn't set VALUE_FLAG_UNEVALUATED
         }

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -136,10 +136,10 @@ enum Reb_Param_Class {
     //
     PARAM_CLASS_TIGHT = 0x04,
 
-    // PARAM_CLASS_RETURN_1 acts like a pure local, but is pre-filled with a
-    // definitionally-scoped function value that takes 1 arg and returns it.
+    // PARAM_CLASS_RETURN acts like a pure local, but is pre-filled with a
+    // ACTION! bound to the frame, that takes 0 or 1 arg and returns it.
     //
-    PARAM_CLASS_RETURN_1 = 0x05,
+    PARAM_CLASS_RETURN = 0x05,
 
     // `PARAM_CLASS_SOFT_QUOTE` is cued by a LIT-WORD! in the function spec
     // dialect.  It quotes with the exception of GROUP!, GET-WORD!, and
@@ -161,10 +161,7 @@ enum Reb_Param_Class {
     //
     PARAM_CLASS_SOFT_QUOTE = 0x06,
 
-    // `PARAM_CLASS_RETURN_0` acts like a pure local, but is pre-filled with a
-    // definitionally-scoped function value that takes 0 args and returns void
-    //
-    PARAM_CLASS_RETURN_0 = 0x07,
+    PARAM_CLASS_UNUSED_0x07 = 0x07,
 
     PARAM_CLASS_MAX
 };

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -935,11 +935,11 @@ inline static RELVAL *REL(REBVAL *v) {
 #endif
 
 // !!! A theory was that the "evaluated" flag would help a function that took
-// both <opt> and <end>, which are converted to voids, distinguish what kind
-// of void it is.  This may or may not be a good idea, but unevaluating it
+// both <opt> and <end>, which are converted to nulls, distinguish what kind
+// of null it is.  This may or may not be a good idea, but unevaluating it
 // here just to make a note of the concept, and tag it via the callsites.
 //
-#define Init_Endish_Void(v) \
+#define Init_Endish_Nulled(v) \
     RESET_VAL_CELL((v), REB_MAX_NULLED, \
         VALUE_FLAG_FALSEY | VALUE_FLAG_UNEVALUATED)
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -83,9 +83,8 @@ was: func [
     elide take evaluation
 ]
 
-;-- These are internal and not meant to be exposed or called directly
-unset 'return-0
-unset 'return-1
+assert [null = binding of :return] ;-- it's archetypal, nowhere to return to
+unset 'return ;-- so don't let the archetype be visible
 
 function: func [
     {Make action with set-words as locals, <static>, <in>, <with>, <local>}

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -31,6 +31,14 @@
 
 (
     ; https://github.com/metaeducation/ren-c/issues/510
+    ;
+    ; !!! RETURN has been changed to being <end>-able, where endability is
+    ; currently the very hack by which <- assumes you want "to the end".
+    ; It's curious that RETURN would turn out to purposefully need the very
+    ; feature that was chosen as the "hack" to signal overriding eager
+    ; left completion...which may indicate the hack has merit.  The issue
+    ; is being left open to explore, but for the moment the quirk is "fixed"
+    ; for the case of RETURN.
 
     c: func [i] [
         return if i < 15 [30] else [4]
@@ -42,7 +50,7 @@
 
     did all [
         30 = c 10
-        () = c 20
+        4 = c 20 ;-- !!! was () = c 20
         30 = d 10
         4 = d 20
     ]

--- a/tests/control/leave.test.reb
+++ b/tests/control/leave.test.reb
@@ -1,7 +1,7 @@
 ; functions/control/leave.r
 (
     success: true
-    f1: func [return: <void>] [return success: false]
+    f1: func [return: <void>] [return | success: false]
     f1
     success
 )


### PR DESCRIPTION
This commit changes it so that RETURN can always be given an argument
or not.  If it is not given an argument, then it acts just the same
as if someone had written RETURN VOID.  Hence the following is legal:

     foo: func [x] [
         if x > 0 [return] else [return 100]
     ]

The return type will still be type checked, so void must be one of the
legal return types for the function.  (It is legal if there is no
return type annotation given.)

Historical Rebol had two different forms of RETURN...an arity-1 version
called RETURN, and an arity-0 version called EXIT.  Either form could
be used from any function, and invoking EXIT would mean that the
result would be an UNSET!.

Definitional returns changed the mechanics of RETURN significantly, and
there were two different kinds of function generators: FUNC/FUNCTION
which defined an arity-1 RETURN for each invocation, and PROC/PROCEDURE
which defined an arity-0 LEAVE for each invocation.  These were
eventually fused back to where "PROCEDURE" semantics were achieved by
just a FUNC or FUNCTION that said `return: <void>` in its spec, and
this affected whether the RETURN would be arity-0 or arity-1.