### PR TITLE
Introduce "skippable" hard-quoted arguments

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -100,7 +100,6 @@ Script: [
 
     hijack-blank:       {Hijacked function was captured but no body given yet}
 
-    enfix-quote-late:   [:arg1 {can't left quote a forward quoted value}]
     evaluate-null:      {null cannot be evaluated (see UNEVAL)}
 
     enfix-path-group:   [:arg1 {GROUP! can't be in a lookback quoted PATH!}]

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -458,6 +458,7 @@ static void Init_Action_Spec_Tags(void)
     Root_Opt_Tag = rebLock(rebTag("opt"), rebEND);
     Root_End_Tag = rebLock(rebTag("end"), rebEND);
     Root_Local_Tag = rebLock(rebTag("local"), rebEND);
+    Root_Skip_Tag = rebLock(rebTag("skip"), rebEND);
 }
 
 static void Shutdown_Action_Spec_Tags(void)
@@ -468,6 +469,7 @@ static void Shutdown_Action_Spec_Tags(void)
     rebRelease(Root_Opt_Tag);
     rebRelease(Root_End_Tag);
     rebRelease(Root_Local_Tag);
+    rebRelease(Root_Skip_Tag);
 }
 
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1014,19 +1014,6 @@ REBCTX *Error_Need_Value_Core(const RELVAL *target, REBSPC *specifier) {
 
 
 //
-//  Error_Lookback_Quote_Too_Late: C
-//
-REBCTX *Error_Lookback_Quote_Too_Late(const RELVAL *word, REBSPC *specifier) {
-    assert(IS_WORD(word));
-
-    DECLARE_LOCAL (specific);
-    Derelativize(specific, word, specifier);
-
-    return Error_Enfix_Quote_Late_Raw(specific);
-}
-
-
-//
 //  Error_Non_Logic_Refinement: C
 //
 // Ren-C allows functions to be specialized, such that a function's frame can

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -312,6 +312,35 @@ inline static void Finalize_Current_Arg(REBFRM *f) {
 }
 
 
+// !!! Somewhat hacky mechanism for getting the first argument of an action,
+// used when doing typechecks for TYPESET_FLAG_SKIPPABLE on functions that
+// quote their first argument.  Must take into account specialization, as
+// that may have changed the first actual parameter to something other than
+// the first paramlist parameter.
+//
+// Despite being implemented less elegantly than it should be, this is an
+// improtant feature, since it's how `case [true [a] default [b]]` gets the
+// enfixed DEFAULT function to realize the left side is a BLOCK! and not
+// either a SET-WORD! or a SET-PATH!, so it <skip>s the opportunity to hard
+// quote it and defers execution...in this case, meaning it won't run at all.
+//
+inline void Seek_First_Param(REBFRM *f, REBACT *action) {
+    f->param = ACT_PARAMS_HEAD(action);
+    f->special = ACT_SPECIALTY_HEAD(action);
+    for (; NOT_END(f->param); ++f->param, ++f->special) {
+        if (
+            f->special != f->param
+            and GET_VAL_FLAG(f->special, ARG_MARKED_CHECKED)
+        ){
+            continue;
+        }
+        if (VAL_PARAM_CLASS(f->param) == PARAM_CLASS_LOCAL)
+            continue;
+        return;
+    }
+    fail ("Seek_First_Param() failed");
+}
+
 //
 //  Eval_Core: C
 //
@@ -520,6 +549,12 @@ reevaluate:;
                 //
                 //     foo: ('quote) => [print quote]
                 //
+
+                Seek_First_Param(f, VAL_ACTION(current_gotten));
+                if (GET_VAL_FLAG(f->param, TYPESET_FLAG_SKIPPABLE))
+                    if (not TYPE_CHECK(f->param, VAL_TYPE(f->value)))
+                        goto give_up_forward_quote_priority;
+
                 Push_Action(
                     f,
                     VAL_ACTION(current_gotten),
@@ -575,6 +610,8 @@ reevaluate:;
             }
         }
 
+      give_up_forward_quote_priority:;
+
         f->gotten = Try_Get_Opt_Var(f->value, f->specifier);
 
         if (f->gotten and (
@@ -584,6 +621,11 @@ reevaluate:;
                 VALUE_FLAG_ENFIXED | ACTION_FLAG_QUOTES_FIRST_ARG
             )
         )){
+            Seek_First_Param(f, VAL_ACTION(f->gotten));
+            if (GET_VAL_FLAG(f->param, TYPESET_FLAG_SKIPPABLE))
+                if (not TYPE_CHECK(f->param, VAL_TYPE(current)))
+                    goto give_up_backward_quote_priority;
+
             Push_Action(f, VAL_ACTION(f->gotten), VAL_BINDING(f->gotten));
             Begin_Action(f, VAL_WORD_SPELLING(f->value), LOOKBACK_ARG);
 
@@ -601,6 +643,8 @@ reevaluate:;
             goto process_action;
         }
     }
+
+  give_up_backward_quote_priority:;
 
     //==////////////////////////////////////////////////////////////////==//
     //
@@ -1042,6 +1086,8 @@ reevaluate:;
                     assert(GET_VAL_FLAG(f->out, VALUE_FLAG_UNEVALUATED));
                   #endif
 
+                    // TYPESET_FLAG_SKIPPABLE accounted for in pre-lookback
+
                     Move_Value(f->arg, f->out);
                     SET_VAL_FLAG(f->arg, VALUE_FLAG_UNEVALUATED);
                     break;
@@ -1266,6 +1312,20 @@ reevaluate:;
     //=//// HARD QUOTED ARG-OR-REFINEMENT-ARG /////////////////////////////=//
 
             case PARAM_CLASS_HARD_QUOTE:
+                if (GET_VAL_FLAG(f->param, TYPESET_FLAG_SKIPPABLE)) {
+                    if (not TYPE_CHECK(f->param, VAL_TYPE(f->value))) {
+                        assert(GET_VAL_FLAG(f->param, TYPESET_FLAG_ENDABLE));
+                        Init_Endish_Nulled(f->arg); // not DO_FLAG_BARRIER_HIT
+                        SET_VAL_FLAG(f->arg, ARG_MARKED_CHECKED);
+                        goto continue_arg_loop;
+                    }
+                    Quote_Next_In_Frame(f->arg, f);
+                    SET_VAL_FLAGS(
+                        f->arg,
+                        ARG_MARKED_CHECKED | VALUE_FLAG_UNEVALUATED
+                    );
+                    goto continue_arg_loop;
+                }
                 Quote_Next_In_Frame(f->arg, f); // has VALUE_FLAG_UNEVALUATED
                 break;
 
@@ -2473,6 +2533,8 @@ post_switch:;
         or VAL_TYPE(f->gotten) != REB_ACTION
         or NOT_VAL_FLAG(f->gotten, VALUE_FLAG_ENFIXED)
     ){
+      lookback_quote_too_late:; // run as if starting new expression
+
         if (not (f->flags.bits & DO_FLAG_TO_END)) {
             //
             // Since it's a new expression, EVALUATE doesn't want to run it
@@ -2541,9 +2603,11 @@ post_switch:;
         //     left-quote: enfix func [:value] [:value]
         //     quote <something> left-quote
         //
-        // !!! Is this the ideal place to be delivering the error?
+        // But due to the existence of <end>-able and <skip>-able parameters,
+        // the left quoting function might be okay with seeing nothing on the
+        // left.  Start a new expression and let it error if that's not ok.
         //
-        fail (Error_Lookback_Quote_Too_Late(f->value, f->specifier));
+        goto lookback_quote_too_late;
     }
 
     // !!! Once checked `not f->deferred` because it only deferred once:

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -945,8 +945,8 @@ REBNATIVE(switch)
 //
 //      return: "Former value or branch result, can only be null if no target"
 //          [<opt> any-value!]
-//     'target "Word or path which might be set--no target always branches"
-//          [<end> set-word! set-path!]
+//     :target "Word or path which might be set--no target always branches"
+//          [<skip> set-word! set-path!]
 //      branch "If target not set already, this is evaluated and stored there"
 //          [block! action!]
 //      :look "Variadic lookahead used to make sure at end if no target"

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -222,6 +222,18 @@ REBOOL Update_Typeset_Bits_Core(
             //
             TYPE_SET(typeset, REB_MAX_NULLED);
         }
+        else if (
+            keywords && IS_TAG(item) &&
+                0 == Compare_String_Vals(item, Root_Skip_Tag, TRUE)
+        ){
+            if (VAL_PARAM_CLASS(typeset) != PARAM_CLASS_HARD_QUOTE)
+                fail ("Only hard-quoted parameters are <skip>-able");
+
+            SET_VAL_FLAGS(
+                typeset,
+                TYPESET_FLAG_SKIPPABLE | TYPESET_FLAG_ENDABLE // skip->null
+            );
+        }
         else if (IS_DATATYPE(var)) {
             TYPE_SET(typeset, VAL_TYPE_KIND(var));
         }

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -114,6 +114,7 @@ PVAR REBVAL *Root_Ellipsis_Tag; // marks variadic argument <...>
 PVAR REBVAL *Root_Opt_Tag; // marks optional argument (can be void)
 PVAR REBVAL *Root_End_Tag; // marks endable argument (void if at end of input)
 PVAR REBVAL *Root_Local_Tag; // marks beginning of a list of "pure locals"
+PVAR REBVAL *Root_Skip_Tag; // marks a hard quote as "skippable" if wrong type
 
 PVAR REBVAL *Root_Empty_String; // read-only ""
 PVAR REBVAL *Root_Empty_Block; // read-only []

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -71,14 +71,9 @@ inline static REBSTR *Get_Type_Name(const RELVAL *value)
 
 enum Reb_Param_Class {
     //
-    // `PARAM_CLASS_LOCAL` is a "pure" local, which will be set to void by
+    // `PARAM_CLASS_LOCAL` is a "pure" local, which will be set to null by
     // argument fulfillment.  It is indicated by a SET-WORD! in the function
     // spec, or by coming after a <local> tag in the function generators.
-    //
-    // !!! Initially these were indicated with TYPESET_FLAG_HIDDEN.  That
-    // would allow the PARAM_CLASS to fit in just two bits (if there were
-    // no debug-purpose PARAM_CLASS_0) and free up a scarce typeset flag.
-    // But is it the case that hiding and localness should be independent?
     //
     PARAM_CLASS_LOCAL = 0,
 
@@ -217,6 +212,13 @@ enum Reb_Param_Class {
 // the arity is 1 usually as `>> help foo`)
 //
 #define TYPESET_FLAG_ENDABLE TYPESET_FLAG(3)
+
+// Skippability is used on quoted arguments to indicate that they are willing
+// to "pass" on something that isn't a matching type.  This gives an ability
+// that a variadic doesn't have, which is to make decisions about rejecting
+// a parameter *before* the function body runs.
+//
+#define TYPESET_FLAG_SKIPPABLE TYPESET_FLAG(4)
 
 
 // ^-- STOP AT TYPESET_FLAG(4) --^

--- a/tests/functions/enfix.test.reb
+++ b/tests/functions/enfix.test.reb
@@ -27,3 +27,52 @@
 )
 
 (3 == do reduce [get '+ 1 2])
+
+
+; Only hard-quoted parameters are <skip>-able
+(
+    error? trap [bad-skippy: func [x [<skip> integer!] y] [reduce [try :x y]]]
+)
+
+[
+    (
+        skippy: func [:x [<skip> integer!] y] [reduce [try :x y]]
+        lefty: enfix :skippy
+        true
+    )
+
+    ([_ "hi"] = skippy "hi")
+    ([10 "hi"] = skippy 10 "hi")
+
+    ([_ "hi"] = lefty "hi")
+    ([1 "hi"] = 1 lefty "hi")
+
+    ; Enfixed skipped left arguments mean that a function will not be executed
+    ; greedily...it will run in its own step, as if the left was an end.
+    (
+        unset 'var
+        block: [<tag> lefty "hi"]
+        did all [
+            [lefty "hi"] = block: evaluate/set block 'var
+            <tag> = var
+            [] = evaluate/set block 'var
+            [_ "hi"] = var
+        ]
+    )
+
+    ; Normal operations quoting rightward outrank operations quoting left,
+    ; making the left-quoting operation see nothing on the left, even if the
+    ; type matched what it was looking for.
+    (
+        unset 'var
+        block: [quote 1 lefty "hi"]
+        did all [
+            [lefty "hi"] = block: evaluate/set block 'var
+            1 = var
+            [] evaluate/set block 'var
+            [_ "hi"] = var
+        ]
+    )
+
+    ([_ "hi"] = any [false blank lefty "hi"])
+]


### PR DESCRIPTION
This is a first-cut implementation of a speculative feature for
letting a hard-quoted parameter be specified as skippable if the type
does not match.  It doesn't work on normal args:

    >> bad-skippy: func [x [<skip> integer!] y] [dump [x y]]
    ** Error: Only hard-quoted parameters are <skip>-able

But with a hard-quoted arg, it will be fulfilled if the type matches
or left as a null if not:

    >> skippy: func [:x [<skip> integer!] y] [dump [x y]]

    >> skippy "hi"
    x: => \\ null \\
    y: => "hi"

    >> skippy 10 "hi"
    x: => 10
    y: => "hi"

When enfixed, a skipped left argument will mean that a function will
not be executed greedily...it will run in its own step, as if the left
hand side was an end:

    >> lefty: enfix :skippy

    >> lefty "hi"
    x: => \\ null \\
    y: => "hi"

    >> evaluate [1 lefty "hi"]
    x: => 1
    y: => "hi"
    == []

    >> evaluate [<tag> lefty "hi"]
    == [lefty "hi"]

This also removes an error condition known as "lookback quote too late"
which would come up when a right-quoting operation outranked a left
quoting operation.  Instead, the left-quoted operation runs as a
separate operation, as if there's nothing on the left:

    >> quote 1 lefty "Hi"
    x: => \\ null \\
    y: => "Hi"

This gives a new opportunity to left-quoting operators to act like
non-enfix operations when they do not find what they want on their
left.  DEFAULT takes this opportunity, allowing it to just evaluate
to its right hand side whenever it doesn't see a SET-WORD! or a
SET-PATH! on its left, widening the scope of application.

    >> any [1 < 2 3 < 4 default ["hi"]]
    == "hi"

(Previously it would have complained that the quoted left argument it
found, 4, was not a SET-WORD! or a SET-PATH!.)