### PR TITLE
Resurrect evaluative CASE branches (brings back IF parity)

### DIFF
--- a/tests/control/case.test.reb
+++ b/tests/control/case.test.reb
@@ -39,14 +39,10 @@
 )
 
 (
-    error? trap [
-        3 = case [true (reduce ['add 1 2])]
-    ] ;-- soft-quoting not supported for CASE branches
+    3 = case [true (reduce ['add 1 2])]
 )
 (
-    error? trap [
-        null? case [false (reduce ['add 1 2])]
-    ] ;-- soft-quoting not supported for CASE branches
+    null? case [false (reduce ['add 1 2])]
 )
 
 (


### PR DESCRIPTION
The following is legal in an IF statement:

    branch: [print "this prints"]
    if true branch

As is this:

    if false (print "this prints too" [print "doesn't print"])

When CASE is thought of as a construct whose behavior parallels IF,
that would suggest the following would be legal as well:

    branch: [print "this prints"]
    case [
        false (print "this prints too" [print "doesn't print"])
        true branch
    ]

That means branches can have a single evaluation step (on false, to
get the branch but not use it) or a double evaluation (on true, because
it adds in the step of running that branch as well).

Ren-C initially brought consistency to this, by doing a 1st-level
branch evaluation even to false cases.  However, the first-level
evaluation caused problems with ELIDE, because it had been forced to
run along with code on its left in order to follow "invisible" rules:

    case [true [print "prints"] elide (print "this did, too :-(")]

Considering that CASE looked for its branches literally, it seemed a
reasonable solution to this problem would be to make CASE only run
literal blocks by inspection with no 1st level evaluation.  Hence no
evaluator step, so the ELIDE would not be seen and processed.  This
was less powerful than IF's branch handling (as if it quoted its arg and
only allowed blocks).  But at the time, it didn't seem like a huge loss.

Yet other situations where ELIDE would run prematurely led to a need
to rethink the evaluator interface to pair up running elides invisibly
with the thing after it.  See:

https://forum.rebol.info/t/767

The newly-corrected behavior of ELIDE (and DUMP, and other invisibles)
opened the door to restoring CASE's previous behavior.