### PR TITLE
Simplified `/`-as-zero-length-path implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -342,7 +342,7 @@ matrix:
         - HOST=arm-eabi
         - WITH_FFI="no"
         - ODBC_REQUIRES_LTDL="no"
-        - EXTENSIONS="Crypt +" # !!! EXTENSIONS="" doesn't work (?)
+        - EXTENSIONS=""
 
     # Android5, release, gcc
     #
@@ -360,7 +360,7 @@ matrix:
         - HOST=arm-eabi
         - WITH_FFI="no"
         - ODBC_REQUIRES_LTDL="no"
-        - EXTENSIONS="Crypt +" # !!! EXTENSIONS="" doesn't work (?)
+        - EXTENSIONS=""
         - TCC="arm-tcc"
         - ARCH_CFLAGS="-DANDROID -DTCC_ARM_EABI -DTCC_ARM_VFP -DTCC_ARM_HARDFLOAT"
       addons:

--- a/make/make.r
+++ b/make/make.r
@@ -53,7 +53,10 @@ for-each [name value] options [
                         (type of user-ext)
                     ]
                 ]
-                if not empty? user-ext and (find [+ - *] user-ext/1) [
+                all [
+                    not empty? user-ext
+                    find [+ - *] user-ext/1
+                ] then [
                     value: take user-ext
                     for-each name user-config/extensions [
                         user-config/extensions/:name: value

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -424,13 +424,11 @@ static void Add_Lib_Keys_R3Alpha_Cant_Make(void)
 
         "<>", // not equal (the chosen meaning, as opposed to "empty tag")
 
-        "->", // no current meaning
+        "->", // enfix path op, "SHOVE": https://trello.com/c/Kg9A45b5
         "<-", // Non-null implicit GROUP! begin, e.g. `7 = 1 + <- 2 * 3`
 
         "|>", // Evaluate to next single expression, but do ones afterward
         "<|", // Evaluate to previous expression, but do rest (like ALSO)
-
-        "/",
 
         NULL
     };

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -700,3 +700,38 @@ REBNATIVE(poke)
 
     RETURN (ARG(value)); // return the value we got in
 }
+
+
+//
+//  path-0: enfix native [
+//
+//  {Temporary native in lieu of PD_Xxx() dispatch so `/` performs division}
+//
+//      #left [<opt> any-value!]
+//      #right [<opt> any-value!]
+//  ]
+//
+REBNATIVE(path_0)
+{
+    INCLUDE_PARAMS_OF_PATH_0;
+
+    REBVAL *left = ARG(left);
+    REBVAL *right = ARG(right);
+
+    // !!! Somewhat whimsically, this goes ahead and guesses at a possible
+    // behavior for "dividing" strings using SPLIT.  This is a placeholder
+    // for the idea that the left hand type gets to dispatch a choice of
+    // what it means, as with ordinary path dispatch.
+    //
+    // Uses the /INTO refinement so that `"abcdef" / 2` divides the string
+    // into two pieces, as opposed to pieces of length 2.
+    //
+    if (ANY_STRING(left) or ANY_ARRAY(left))
+        return rebRun("split/into", left, right, rebEND);
+
+    // Note: DIVIDE is historically a "type action", so technically it is the
+    // left hand side type which gets to pick the behavior--consistent with
+    // the plan for how 0-length paths would work.
+    //
+    return rebRun("divide", left, right, rebEND);
+}

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -1246,12 +1246,15 @@ static void Mark_Frame_Stack_Deep(void)
         if (f->opt_label) // will be null if no symbol
             Mark_Rebser_Only(f->opt_label);
 
-        // refine and special can be used to GC protect an arbitrary
-        // value while a function is running, currently.  (A more
-        // important purpose may come up...)
+        // refine and special can be used to GC protect an arbitrary value
+        // while a function is running, currently.  nullptr is permitted as
+        // well for flexibility (e.g. path frames use nullptr to indicate no
+        // set value on a path)
         //
-        Queue_Mark_Opt_End_Cell_Deep(f->refine);
-        Queue_Mark_Opt_End_Cell_Deep(f->special);
+        if (f->refine)
+            Queue_Mark_Opt_End_Cell_Deep(f->refine);
+        if (f->special)
+            Queue_Mark_Opt_End_Cell_Deep(f->special);
 
         if (f->varlist and GET_SER_FLAG(f->varlist, NODE_FLAG_MANAGED)) {
             //

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -331,6 +331,7 @@ void Shutdown_Pools(void)
             if (IS_FREE_NODE(series))
                 continue;
 
+            assert(NOT_SER_FLAG(series, NODE_FLAG_MANAGED));
             printf("At least one leaked series at shutdown...\n");
             panic (series);
         }

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -552,7 +552,14 @@ REBNATIVE(enclose)
         SPECIFIED,
         SERIES_MASK_ACTION | NODE_FLAG_MANAGED
     );
-    ARR_HEAD(paramlist)->payload.action.paramlist = paramlist;
+    REBVAL *rootparam = KNOWN(ARR_HEAD(paramlist));
+    rootparam->payload.action.paramlist = paramlist;
+
+    // !!! We don't want to inherit the flags of the original action, such
+    // as ACTION_FLAG_NATIVE.  For now just clear out all the type-specific
+    // bits and let Make_Action() cache the flags it needs.
+    //
+    CUSTOM_BYTE(rootparam) = 0;
 
     // See %sysobj.r for `enclosed-meta:` object template
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -345,9 +345,6 @@ void Mold_Array_At(
     REBCNT index,
     const char *sep
 ) {
-    if (sep == NULL)
-        sep = "[]";
-
     // Recursion check:
     if (Find_Pointer_In_Series(TG_Mold_Stack, a) != NOT_FOUND) {
         Emit(mo, "C...C", sep[0], sep[1]);

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -140,7 +140,7 @@ void MF_Action(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     // drops types)
     //
     REBARR *words_list = List_Func_Words(v, TRUE); // show pure locals
-    Mold_Array_At(mo, words_list, 0, 0);
+    Mold_Array_At(mo, words_list, 0, "[]");
     Free_Unmanaged_Array(words_list);
 
     // !!! Previously, ACTION! would mold the body out.  This created a large

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -992,7 +992,7 @@ void MF_Gob(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     Pre_Mold(mo, v);
 
     REBARR *array = Gob_To_Array(VAL_GOB(v));
-    Mold_Array_At(mo, array, 0, 0);
+    Mold_Array_At(mo, array, 0, "[]");
     Free_Unmanaged_Array(array);
 
     End_Mold(mo);

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -407,7 +407,7 @@ const REBVAL *PD_Map(
     if (IS_NULLED(val)) // zombie entry, means unused
         return nullptr;
 
-    return val;
+    return Move_Value(pvs->out, val); // RETURN (...) uses `frame_`, not `pvs`
 }
 
 

--- a/src/extensions/ffi/t-struct.c
+++ b/src/extensions/ffi/t-struct.c
@@ -296,7 +296,7 @@ void MF_Struct(REB_MOLD *mo, const RELVAL *v, REBOOL form)
     Pre_Mold(mo, v);
 
     REBARR *array = Struct_To_Array(VAL_STRUCT(v));
-    Mold_Array_At(mo, array, 0, 0);
+    Mold_Array_At(mo, array, 0, "[]");
     Free_Unmanaged_Array(array);
 
     End_Mold(mo);

--- a/src/extensions/zeromq/mod-zeromq.c
+++ b/src/extensions/zeromq/mod-zeromq.c
@@ -838,7 +838,7 @@ REBNATIVE(zmq_poll)
     int i;
     for (i = 0; i < nitems; ++i) {
         REBVAL *socket = rebRun( // !!! GROUP! needed for MATCH quirk
-            "(match handle! pick", spec, rebI(i * 2), ") else [", 
+            "(match handle! pick", spec, rebI(i * 2), ") else [",
                 "fail {Expected HANDLE! in spec position}",
             "]");
         pollitems[i].socket = VAL_HANDLE_VOID_POINTER(socket);

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -594,6 +594,7 @@ inline static void Drop_Action(REBFRM *f) {
                 NOD(ACT_FACADE(f->original)) // degrade keysource from f
             )
         );
+        assert(NOT_SER_FLAG(f->varlist, NODE_FLAG_MANAGED));
         LINK(f->varlist).keysource = NOD(f);
     }
     else {

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -48,15 +48,21 @@ r3-alpha-quote: func [:spelling [word! text!]] [
 ]
 
 
-; Make top-level words (note: / is added by %b-init.c as an "odd word")
+; Make top-level words
 ;
-+: -: *: _
++: -: *: and+: or+: xor+: _
 
 for-each [math-op function-name] [
     +       add
     -       subtract
     *       multiply
-    /       divide ;-- !!! may become pathing operator (which also divides)
+
+    ; / is a 0-arity PATH! in Ren-C.  While "pathing" with a number on the
+    ; left acts as division, it has slight differences.
+
+    and+    intersect
+    or+     union
+    xor+    difference
 ][
     ; Ren-C's infix math obeys the "tight" parameter convention of R3-Alpha.
     ; But since the prefix functions themselves have normal parameters, this
@@ -69,29 +75,12 @@ for-each [math-op function-name] [
     ; mechanism will eventually generalized to do any rewriting of convention
     ; one wants (e.g. to switch one parameter from normal to quoted).
     ;
+    ; Note: TIGHTEN currently changes all normal parameters to #tight, which
+    ; which for the set operations creates an awkward looking /SKIP's SIZE.
+    ;
     set/enfix math-op (tighten get function-name)
 ]
 
-
-; Make top-level words
-;
-and+: or+: xor+: _
-
-for-each [set-op function-name] [
-    and+    intersect
-    or+     union
-    xor+    difference
-][
-    ; The enfixed versions of the set operations currently can't take any
-    ; refinements, so we go ahead and specialize them out.  (It's also the
-    ; case that TIGHTEN currently changes all normal parameters to #tight,
-    ; which creates an awkward looking /SKIP's SIZE.
-    ;
-    set/enfix set-op (tighten specialize function-name [
-        case: false
-        skip: false
-    ])
-]
 
 
 ; Make top-level words for things not added by %b-init.c

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -144,7 +144,7 @@ math: function [
 
     <static>
 
-    slash (to-lit-word first [ / ])
+    slash (quote /)
 
     expr-val (_)
 

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -149,15 +149,19 @@
 ; This tests the NEAR positioning, though really only a few elements of
 ; the array are mirrored into the error.  This happens to go to the limit of
 ; 3, and shows that the infix expression start was known to the error.
+;
+; !!! This used to use `/` instead of divide, but because `/` is now a zero
+; length path it actually retriggers divide inside the path dispatcher, so
+; that complicated the error delivery.  Review.
 (
-    e1: trap [1 / 0]
-    e2: trap [2 / 0]
+    e1: trap [divide 1 0]
+    e2: trap [divide 2 0]
 
     did all [
         e1/id = 'zero-divide
         e2/id = 'zero-divide
-        [1 / 0] = copy/part e1/near 3
-        [2 / 0] = copy/part e2/near 3
+        [divide 1 0] = copy/part e1/near 3
+        [divide 2 0] = copy/part e2/near 3
         e1 <> e2
     ]
 )

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -199,3 +199,11 @@
         42 = reduce to-path [bl q/w e/r]
     ]
 )
+
+; / is a length 0 PATH! in Ren-C
+(type of quote / = path!)
+(length of quote / = 0)
+
+; foo/ is a length 1 PATH! in Ren-C
+(type of quote foo/ = path!)
+(length of quote foo/ = 1)


### PR DESCRIPTION
This changes `/` from being a WORD! to being a zero-length path.  It
also makes `foo/` the representation of a length-1 path, which acts
the same as whatever the single element would be if not in a path.

(Reasoning for a length-1 path acting like the element alone is to
simplify code which might put an ACTION! in the first slot of a PATH!,
and then progressively build a list of refinements...but wind up with
an empty list.  By allowing the path to run anyway, this means there's
no need to special-case that as just an ACTION!.)

The concept is that the zero length path dispatch in the evaluator goes
to the type on the left, just like in ordinary path dispatching.  But
it runs different code.  Hence `a/b` and `a / b` are two distinct ways
in which the value on the left is "pathed".  The former is known as
"path picking" while the latter is tentatively called "path splitting".

In path picking, the right hand side is given quoted as-is to the
dispatcher (unless in a GROUP! or if it's a GET-WORD!).  But in path
splitting, the right hand side is given to the dispatcher after having
undergone "tight" evaluation.  When combined with the idea that a
number on the left will trigger division, this means that `/` can act
consistently with historical division in Rebol...despite not being
a WORD!.

As an added experiment, if the left hand side is an ANY-STRING! then
the code will run SPLIT with the right hand side.

    >> "abc;defghi;jkl" / ";"
    == ["abc" "defghi" "jkl"]

The implementation does not go formally through a type dispatcher the
way PD_Xxx() functions do for path dispatch presently.  Instead, there
is a native called PATH-0 which is invoked.  This provides the interim
hook point, which can be hijacked or overridden in usermode to add
support for new types if needed.