### PR TITLE
Update TLS client protocol to support 1.2 / 1.1

### DIFF
--- a/make/tools/make-host-init.r
+++ b/make/tools/make-host-init.r
@@ -111,8 +111,11 @@ file-base: has load %../../make/tools/file-base.r
 ; copied from make-boot.r
 host-protocols: make block! 2
 for-each file file-base/prot-files [
-    m: load/all join-of %../mezz/ file ; not REBOL word
-    append/only append/only host-protocols m/2 skip m 2
+    m: load/all join-of %../mezz/ file
+    assert ['REBOL = m/1]
+    spec: ensure block! m/2
+    contents: skip m 2
+    append host-protocols compose/only [(spec) (contents)]
 ]
 
 insert host-start compose/only [host-prot: (host-protocols)]


### PR DESCRIPTION
This updates the TLS client protocol to achieve a baseline level of
support for TLS 1.2.  It also includes TLS 1.1, as that was an
incremental step on the way to achieving 1.2 support.

It adds TLS version negotiation, and can take a block specifying
the lowest and highest TLS versions supported, with a default of
[1.0 1.2].  However, TLS 1.0 and TLS 1.1 have been deprecated by the
payment card industry as of June 30, 2018, with business industry
ratings punishment for servers that retain support for them.  So it
might be a good idea to change the default to 1.2.

(In any case, adding and testing versioning negotiation and support is
forward-looking for support of TLS 1.3, as there will presumably be
a similar period when TLS 1.2 is phased out.)

From a mechanical point of view, the big change in TLS 1.1 was to not
use "implicit initialization vectors" for block ciphers.  Block ciphers
are designed to take a feed of input and spit out blocks of data which
are encrypted in a way that is sensitive to the previous block.  The
ciphers now use agreed upon random data exchanged by the client and
server to initialize them, instead of implicitly calculating the
initialization from other existing data.

The big change in TLS 1.2 was to provide more flexibility in the
hashing schemes used in the pseudorandom function, and in two other
places that hashes are used (certificate signatures, not currently
checked, and the seed produced to use with the Finished handshake
message.)