### PR TITLE
MAP-EACH/REMOVE-EACH return NULL on BREAK, no BREAK/WITH

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -148,7 +148,6 @@ options: construct [] [  ; Options supplied to REBOL during startup
     ; Legacy Behaviors Options (paid attention to only by debug builds)
 
     forever-64-bit-ints: false
-    break-with-overrides: false
     unlocked-source: false
 ]
 

--- a/tests/control/remove-each.test.reb
+++ b/tests/control/remove-each.test.reb
@@ -16,21 +16,31 @@
     ]
     block = [1 4]
 )
+
+; !!! REMOVE-EACH currently has no effect on BREAK.  This is because as part
+; of the loop protocol, it returns NULL and thus cannot return the number
+; of removed elements.
 (
     block: copy [1 2 3 4]
     remove-each i block [
         if i = 3 [break]
         true
     ]
-    block = [3 4]
+    block = [1 2 3 4]
 )
 (
     block: copy [1 2 3 4]
+    returned-null: false
     remove-each i block [
-        if i = 3 [break/with true]
-        false
+        if i = 3 [break]
+        i = 2
+    ] else [
+        returned-null: true
     ]
-    block = [1 2 4]
+    did all [
+        block = [1 2 3 4]
+        returned-null = true
+    ]
 )
 (
     block: copy [1 2 3 4]
@@ -72,11 +82,17 @@
 )
 (
     string: copy "1234"
+    returned-null: false
     remove-each i string [
         if i = #"3" [break]
         true
+    ] else [
+        returned-null: true
     ]
-    string = "34"
+    did all [
+        string = "1234" comment {not changed if BREAK}
+        returned-null = true
+    ]
 )
 (
     string: copy "1234"
@@ -110,11 +126,17 @@
 )
 (
     binary: copy #{01020304}
+    returned-null: false
     remove-each i binary [
         if i = 3 [break]
         true
+    ] else [
+        returned-null: true
     ]
-    binary = #{0304}
+    did all [
+        binary = #{01020304} comment {Not changed with BREAK}
+        returned-null = true
+    ]
 )
 (
     binary: copy #{01020304}


### PR DESCRIPTION
This changes both MAP-EACH and REMOVE-EACH to fall in line with the
convention of returning NULL if a BREAK is encountered, and dropping
the in-progress partial operation:

    >> map-each x [1 2 3 4] [
           if x = 3 [break]
           x + 10
       ]
    ;-- null (would have historically been [11 12])

Now if an in-progress mapping wants to keep partial results, it would
need to do so manually by rejecting subsequent map items:

    >> skipping: false
    >> map-each x [1 2 3 4] [
           if skipping [continue]
           if x = 3 [skipping: true | continue]
           x + 10
       ]
    == [11 12]

*This is for a reason*:

The ability to be able to tell from outside a loop whether it had a
break or not is very important in building composite loop operations.
For instance, imagine a MAP-BOTH which took two MAP-EACH operations and
wanted to run them in sequence for two sets...but if the first map-each
were to encounter a break there'd be no straightforward way for the
MAP-BOTH operation to know that and avoid running the second MAP-EACH.

(It's also very useful, for casually signaling an ELSE or THEN outside
the loop...based on whether it finished or not.)

For these reasons (that have become increasingly important over time)
the /WITH refinement is now formally removed from BREAK.  CONTINUE
still has the refinement, which means to act as if the body end was
reached with the given value.

In the case of REMOVE-EACH, this currently means not doing the pending
removals if a break is encountered, because it would prevent returning
the number of elements that were removed.  This may not be the final
word on the design; it wouldn't seem as necessary if the return result
were just the original series.