### PR TITLE
Restrict PRINT to TEXT!/BLOCK!, remove /EVAL, ??+!! debug

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -1266,7 +1266,7 @@ for-each [label list] reduce [
 ][
     print label
     for-each ext list [
-        print/eval collect [ ;-- CHAR! values don't auto-space in Ren-C PRINT
+        print collect [ ;-- CHAR! values don't auto-space in Ren-C PRINT
             keep ["ext:" ext/name #":" space #"["]
             for-each mod ext/modules [
                 keep to-text mod/name

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -471,3 +471,18 @@ maybe: enfix func [
 ; showing args that span multiple lines.
 ;
 set quote <- func [x [<end> any-value!]] [:x]
+
+print: func [
+    return: [<opt> blank!]
+    line [blank! text! block!]
+][
+    write-stdout switch type of line [
+        blank! [return null]
+        text! [line]
+        block! [spaced line]
+    ]
+    write-stdout newline
+    _ ;-- would be a VOID! in modern Ren-C
+]
+
+print-newline: specialize 'write-stdout [value: newline]

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -594,10 +594,19 @@ ajoin: emulate [:unspaced]
 
 reform: emulate [:spaced]
 
-; To be on the safe side, the PRINT in the box won't do evaluations on
-; blocks unless the literal argument itself is a block
-;
-print: emulate [specialize 'print [eval: true]]
+
+print: emulate [
+    func [
+        return: <void!>
+        value [any-value!] ;-- Ren-C only takes TEXT!, BLOCK!, BLANK!
+    ][
+        write-stdout case [
+            block? :value [spaced value]
+            default [form :value]
+        ]
+        write-stdout newline
+    ]
+]
 
 quit: emulate [
     function [

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -26,7 +26,7 @@ REBOL [
 
 c-break-debug: :c-debug-break ;-- easy to mix up
 
-probe: func [
+??: probe: func [
     {Debug print a molded value and returns that same value.}
     return: [<opt> any-value!]
         {Same as the input value.}
@@ -254,37 +254,20 @@ eval func [
 
 
 print: func [
-    "Textually output value (evaluating elements if a block), adds newline"
+    {Textually output value (evaluating elements if a block), adds newline}
 
-    return: <void>
-    value [any-value!]
-        "Value or BLOCK! literal (NULL means print nothing)"
-    /eval
-        "Allow value to be a block and evaluated (even if not literal)"
-    <local> eval_PRINT ;quote_PRINT
+    return: "NULL if blank input, otherwise VOID!"
+        [<opt> void!]
+    line "Line of text or block to run SPACED on, blank prints nothing"
+        [blank! text! block!]
 ][
-    eval_PRINT: eval
-    eval: :lib/eval
-
-    if null? :value [return]
-
-    write-stdout case [
-        not block? value [
-            form :value
-        ]
-
-        eval_PRINT or [semiquoted? 'value] [
-            spaced value
-        ]
-
-        default [
-            fail/where
-                <- "PRINT called on non-literal block without /EVAL switch"
-                <- 'value
-        ]
+    write-stdout switch type of line [
+        blank! [return null]
+        text! [line]
+        block! [spaced line]
     ]
-
     write-stdout newline
+    return
 ]
 
 print-newline: specialize 'write-stdout [value: newline]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -98,7 +98,7 @@ dump-obj: function [
 ]
 
 
-dump: func [
+!!: dump: func [
     {Show the name of a value (or block of expressions) with the value itself}
 
     return: []

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -35,33 +35,17 @@ REBOL [
 ;
 host-prot: default [_]
 
-boot-print: function [
+boot-print: redescribe [
     "Prints during boot when not quiet."
-    return: <void>
-    data
-    /eval
-][
-    eval_BOOT_PRINT: eval
-    eval: :lib/eval
+](
+    enclose 'print func [f] [if not system/options/quiet [do f]]
+)
 
-    if not system/options/quiet [
-        print/(try all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
-    ]
-]
-
-loud-print: function [
+loud-print: redescribe [
     "Prints during boot when verbose."
-    return: <void>
-    data
-    /eval
-][
-    eval_BOOT_PRINT: eval
-    eval: :lib/eval
-
-    if system/options/verbose [
-        print/(try all [any [eval_BOOT_PRINT | semiquoted? 'data] 'eval]) :data
-    ]
-]
+](
+    enclose 'print func [f] [if system/options/verbose [do f]]
+)
 
 make-banner: function [
     "Build startup banner."


### PR DESCRIPTION
This addresses a longstanding concern about the polymorphism of PRINT,
where the willingness to accept any datatype put it at risk for a
concealed "double-evaluation".  Users leaning on it for writing out
an ANY-VALUE! might overlook the fact that if at some point that value
ever turns out to be a BLOCK!, then it will run code.

Previous attempts to deal with the concern added an /EVAL switch, so
that non-literal blocks had to be consciously evaluated--only literal
blocks in source didn't require it.  This was messy, and made PRINT
harder to work with.

This commit removes /EVAL and instead limits PRINT to TEXT! and BLOCK!
input.  Accepting TEXT! is necessary to use it with `print unspaced [...]` as well
as `print "some message"` being quite entrenched.  So it is a compromise,
which should still help avoid lulling people into a false sense of security about
using it with ANY-VALUE.

It includes the behavior of BLANK!-in, NULL-out to allow for opting
out of a PRINT as a no-op, and then acting on that inaction with ELSE,
THEN, etc.

Helping to motivate this change was the belief that ?? and !! were
symbols that "stuck out" in a way that made them ideal for debugging,
so they are PROBE and DUMP respectively.  This helps soothe any pain
brought on by making it harder to PRINT an ANY-VALUE!, by giving better
options for debugging (!! is invisible to the evaluator) as well as
making debugging code more prominent, to help avoid committing them.