### PR TITLE
JS-AWAITER and rebPromise() JavaScript features

### DIFF
--- a/make/configs/emscripten.r
+++ b/make/configs/emscripten.r
@@ -29,14 +29,149 @@ extensions: make map! [
     ZeroMQ -
 ]
 
+
+; emcc command-line options:
+; https://kripken.github.io/emscripten-site/docs/tools_reference/emcc.html
+; https://github.com/kripken/emscripten/blob/incoming/src/settings.js
+;
+; Note environment variable EMCC_DEBUG for diagnostic output
+
 cflags: reduce [
     {-DDEBUG_STDIO_OK}
     {-DDEBUG_HAS_PROBE}
+    {-DDEBUG_COUNT_TICKS}
+
+    {-DTO_JAVASCRIPT} ;-- Guides %a-lib.c to add rebPromise() implementation
+
+    ; {-s USE_PTHREADS=1} ;-- must be on compile -and- link to use pthreads
 ]
 
-ldflags: reduce [
-    unspaced ["-O" optimize]
-    unspaced [{-s 'ASSERTIONS=} either debug = 'none [0] [1] {'}]
-    {-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]'}
+ldflags: compose [
+    (unspaced ["-O" optimize])
+
+    ; Originally `-s ENVIRONMENT='worker'` was used, due to a belief that
+    ; having Rebol running on a thread separate from the GUI would make it
+    ; easier to suspend the stack while requests were made to JavaScript to
+    ; do GUI updates.  While this is true, it prohibits emterpreter builds
+    ; (which aren't compatible with PTHREAD builds) from ever mixing JS code
+    ; that manipulates the DOM with code that calls the libRebol API, which
+    ; is nearly disqualifying.  Also, in PTHREAD use of MAIN_THREAD_EM_ASM()
+    ; requires that the initial `main()` be started from the GUI thread in
+    ; order to do synchronous calls to the GUI.  So we use `web` for both.
+    ;
+    {-s ENVIRONMENT='web'}
+
+    {-s ASSERTIONS=0}
+;    (unspaced [{-s 'ASSERTIONS=} either debug = 'none [0] [1] {'}])
+
+    (if false [[
+        ; In theory, using the closure compiler will reduce the amount of
+        ; unused support code in %libr3.js, at the cost of slower compilation. 
+        ; Level 2 is also available, but is not recommended as it impedes
+        ; various optimizations.  See the published limitations:
+        ;
+        ; https://developers.google.com/closure/compiler/docs/limitations
+        ;
+        ; !!! A closure compile has not been successful yet.  See notes here:
+        ; https://github.com/kripken/emscripten/issues/7288
+        ; If you get past that issue, the problem looks a lot like:
+        ; https://github.com/kripken/emscripten/issues/6828
+        ; The suggested workaround for adding --externals involves using
+        ; EMCC_CLOSURE_ARGS, which is an environment variable...not a param
+        ; to emcc, e.g.
+        ;     export EMCC_CLOSURE_ARGS="--externs closure-externs.json"
+        ;
+        ;{-s IGNORE_CLOSURE_COMPILER_ERRORS=1} ;-- maybe useful
+        {-g1} ;-- Note: this level can be used with closure compiler
+        {--closure 1}
+    ]] else [[
+        {--closure 0}
+    ]])
+
+    ; Minification usually tied to optimization, but can be set separately.
+    ;
+    ;{--minify 0}
+
+    ; %reb-lib.js is produced by %make-reb-lib.js - It contains the wrapper
+    ; code that proxies JavaScript calls to `rebElide(...)` etc. into calls
+    ; to the functions that take a `va_list` pointer, e.g. `_RL_rebElide()`.
+    ;
     {--post-js prep/include/reb-lib.js}
+
+    ; While over the long term it may be the case that C++ builds support the
+    ; exception mechanism, the JavaScript build is going to be based on
+    ; embracing the JS exception model.  So disable C++ exceptions.
+    ; https://forum.rebol.info/t//555
+    ;
+    {-s DISABLE_EXCEPTION_CATCHING=1}
+    {-s DEMANGLE_SUPPORT=0} ;-- C++ build does all exports as C, not needed
+
+    ; Currently the exported functions come from EMTERPRETER_KEEP_ALIVE
+    ; annotations, but it would be preferable if a JSON file were produced
+    ; and used, as %emscripten.h should not (in general) be included by
+    ; the %rebol.h file--it has to have a fake #define at the moment.
+    ;
+    ;{-s EXPORTED_FUNCTIONS="['_something']"}
+
+    ; Documentation claims a `--pre-js` or `--post-js` script that uses
+    ; internal methods will auto-export them since the linker "sees" it.  But
+    ; that doesn't seem to be the case for %reb-lib.js or things called from
+    ; EM_ASM() in the C...so do it explicitly.
+    ;
+    {-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap", "allocateUTF8"]'}
+
+    ; WASM does not have source maps, so disabling it can aid in debugging
+    ; But emcc WASM=0 does not work in VirtualBox shared folders by default
+    ; https://github.com/kripken/emscripten/issues/6813
+    ;
+    ; SAFE_HEAP=1 does not work with WASM
+    ; https://github.com/kripken/emscripten/issues/4474
+    ;
+    {-s WASM=1 -s SAFE_HEAP=0}
+
+    ; This allows memory growth but disables asm.js optimizations (little to
+    ; no effect on WASM).  Disable until it becomes an issue.
+    ;
+    ;{-s ALLOW_MEMORY_GROWTH=0}
+
+    ; The inability to communicate synchronously between the worker and GUI
+    ; in JavaScript means that being deep in a C-based interpreter stack on
+    ; the worker cannot receive data from the GUI.  Some methods to get past
+    ; this appear to be on the horizon with SharedArrayBuffer, which has
+    ; spotty support in browsers and was disabled in all of them in 2018 due
+    ; to potential security flaws.
+    ;
+    (if true [[
+        {-s EMTERPRETIFY=1}
+        {-s EMTERPRETIFY_ASYNC=1}
+        {-s EMTERPRETIFY_FILE="libr3.bytecode"}
+
+        ; !!! Is this yet another file, different from the .bytecode?
+        ;
+        ;{--memory-init-file 1}
+
+        ; "There's always a blacklist.  The whitelist starts empty.  If there
+        ; is a non-empty whitelist then everything not in it gets added to the
+        ; blacklist.  Everything not in the blacklist gets emterpreted."
+        ; https://github.com/kripken/emscripten/issues/7239
+        ;
+        ; For efficiency, it's best if all functions that can be blacklisted
+        ; are.  This is ideally done with a JSON file that is generated via
+        ; analysis of the code to see which routines cannot call the
+        ; emscripten_sleep_with_yield() function.  Currently anything that
+        ; runs the evaluator can, but low-level routines like Make_Series()
+        ; could be on the list.
+        ;
+        ;{-s EMTERPRETIFY_BLACKLIST="['_malloc']"}
+        ;{-s EMTERPRETIFY_WHITELIST=@emterpreter_whitelist.json}
+    ]] else [[
+        {-s USE_PTHREADS=1} ;-- must be on compile and link
+    ]])
+
+    ; When debugging in the emterpreter, stack frames all appear to have the
+    ; function name `emterpret`.  Asking to turn on profiling will inject an
+    ; extra stack frame with the name of the function being called.  It runs
+    ; slower, but makes the build process *A LOT* slower.
+    ;
+    ;{--profiling-funcs} ;-- more minimal than `--profiling`, just the names
 ]

--- a/src/extensions/javascript/mod-javascript.c
+++ b/src/extensions/javascript/mod-javascript.c
@@ -26,6 +26,14 @@
 //
 //=////////////////////////////////////////////////////////////////////////=//
 //
+// This module enables the creation of Rebol ACTION!s whose bodies are strings
+// of JavaScript code.  To use it, Rebol must be built with emscripten:
+//
+// http://kripken.github.io/emscripten-site/
+//
+// Once built, it must be loaded into a host (e.g. a web browser or node.js)
+// which provides a JavaScript interpreter.
+//
 
 #include "sys-core.h"
 #include "sys-ext.h"
@@ -45,11 +53,11 @@ enum {
 
 
 //
-//  JavaScript_Dispatcher: C
+//  JavaScript_Native_Dispatcher: C
 //
 // Called when the ACTION! produced by JS-NATIVE is run.
 //
-const REBVAL *JavaScript_Dispatcher(REBFRM *f)
+const REBVAL *JavaScript_Native_Dispatcher(REBFRM *f)
 {
     REBARR *details = ACT_DETAILS(FRM_PHASE(f));
     UNUSED(details);
@@ -71,6 +79,70 @@ const REBVAL *JavaScript_Dispatcher(REBFRM *f)
 
 
 //
+//  JavaScript_Awaiter_Dispatcher: C
+//
+// Called when the ACTION! produced by JS-AWAITER is run.  The tricky bit is
+// that it doesn't actually return to the caller when the body of the JS code
+// is done running...it has to wait for either the `resolve` or `reject`
+// parameter functions to get called.
+//
+const REBVAL *JavaScript_Awaiter_Dispatcher(REBFRM *f)
+{
+    REBARR *details = ACT_DETAILS(FRM_PHASE(f));
+    UNUSED(details);
+
+    // Getting a value back from JavaScript via EM_ASM_INT can give back an
+    // unsigned int.  There are cases in the emscripten code where this is
+    // presumed to be good enough to hold any heap address.  Do a sanity
+    // check that we aren't truncating.
+    //
+    uintptr_t id = cast(uintptr_t, ACT_PARAMLIST(FRM_PHASE(f)));
+    assert(id < UINT_MAX);
+
+    REBYTE volatile atomic = 0;
+
+    // RL_AsyncDispatch() creates two functions that signal back when called
+    // to write the atomic with either a 1 or a 2, indicating completion.
+    //
+    EM_ASM_({
+        RL_AsyncDispatch($0, $1)
+    }, id, &atomic);
+
+    while (atomic == 0) {
+        if (Eval_Signals & SIG_HALT) {
+            //
+            // !!! TBD: How to handle halts?  We're spinning here, so the
+            // GUI should theoretically have a chance to write some cancel.
+            // Is it a reject()?
+            //
+            Eval_Signals &= ~SIG_HALT; // don't preserve state once observed
+        }
+        emscripten_sleep_with_yield(50); // no resolve(), no reject() calls...
+    }
+
+    // Current limitations disallow the calling of EXPORTED_FUNCTIONS during
+    // an emscripten_sleep_with_yield().  This might be something that can
+    // be worked around with the PTHREAD worker situation...rebPromise()
+    // could spawn a thread, which could block and queue off work to the
+    // main thread, but then the main thread could still call rebSpell() or
+    // other routines that might be necessary to manipulate handles.
+    //
+    // We work around this limitation in the emterpreter for the moment by
+    // forcing all the asynchronous work to speak in terms of JavaScript types
+    // and then resolve() with a function that is run -after- the yield,
+    // which can do whatever work it needs to with the API to translate the
+    // JavaScript types back into Rebol.
+
+    uintptr_t r = EM_ASM_INT({
+        return RL_Await($0)
+    }, &atomic);
+
+    REBVAL *result = cast(REBVAL*, r);
+    return result;
+}
+
+
+//
 // cleanup_js_native: C
 //
 // GC-able HANDLE! avoids leaking in the table mapping integers (pointers) to
@@ -87,29 +159,25 @@ void cleanup_js_native(const REBVAL *v) {
 
 
 //
-//  js-native: native/export [
+//  Make_JavaScript_Action_Common: C
 //
-//  {Create an ACTION! whose body is a string of JavaScript code}
+// Shared code for creating JS-NATIVE and JS-PROMISE, since there's a fair
+// bit in common.
 //
-//      return: [action!]
-//      spec [block!]
-//          {Function specification (similar to the one used by FUNC)}
-//      source [text!]
-//          {JavaScript code as a text string}
-//  ]
-//
-REBNATIVE(js_native)
-{
-    JAVASCRIPT_INCLUDE_PARAMS_OF_JS_NATIVE;
+REBACT *Make_JavaScript_Action_Common(
+    const REBVAL *spec,
+    const REBVAL *source,
+    bool is_awaiter
+){
+    // !!! Should it optimize for empty source in the native case with
+    // Voider_Dispatcher()?  Note that empty source for a promise will not
+    // be fulfilled...
 
-    REBVAL *source = ARG(source);
-
-    if (VAL_LEN_AT(source) == 0)
-        fail ("Source for JS-NATIVE can't be empty"); // auto return void?
-
-    REBACT *native = Make_Action(
-        Make_Paramlist_Managed_May_Fail(ARG(spec), MKF_MASK_NONE),
-        &JavaScript_Dispatcher, // will be replaced e.g. by COMPILE
+    REBACT *action = Make_Action(
+        Make_Paramlist_Managed_May_Fail(spec, MKF_MASK_NONE),
+        is_awaiter
+            ? &JavaScript_Awaiter_Dispatcher
+            : &JavaScript_Native_Dispatcher,
         nullptr, // no facade (use paramlist)
         nullptr, // no specialization exemplar (or inherited exemplar)
         IDX_NATIVE_MAX // details capacity [source module linkname tcc_state]
@@ -119,7 +187,7 @@ REBNATIVE(js_native)
     // into something that evaluates without having GC protection on array
     // elements when operating by index like this.  Pre-fill them.
     //
-    REBARR *details = ACT_DETAILS(native);
+    REBARR *details = ACT_DETAILS(action);
     int idx;
     for (idx = 0; idx < IDX_NATIVE_MAX; ++idx)
         Init_Unreadable_Blank(ARR_AT(details, idx));
@@ -146,11 +214,16 @@ REBNATIVE(js_native)
     Append_Unencoded(mo->series, "RL_Register(");
 
     REBYTE buf[60]; // !!! Why 60?  Copied from MF_Integer()
-    REBINT len = Emit_Integer(buf, cast(uintptr_t, ACT_PARAMLIST(native)));
+    REBINT len = Emit_Integer(buf, cast(uintptr_t, ACT_PARAMLIST(action)));
     Append_Unencoded_Len(mo->series, s_cast(buf), len);
 
     Append_Unencoded(mo->series, ", function() {\n"); // would add ID number
-    Append_Unencoded(mo->series, "return async function() {\n");
+    Append_Unencoded(mo->series, "return function"); // !!!! async function?
+    if (is_awaiter)
+        Append_Unencoded(mo->series, "(resolve, reject)"); // implicit args
+    else
+        Append_Unencoded(mo->series, "()"); // only has rebArg(...)
+    Append_Unencoded(mo->series, " {");
 
     // By not using `new function` we are able to make this an async function,
     // as well as avoid escaping of string literals.
@@ -165,7 +238,7 @@ REBNATIVE(js_native)
     );
     Append_Utf8_Utf8(mo->series, cs_cast(BIN_AT(temp, offset)), size);
 
-    Append_Unencoded(mo->series, "\n}\n"); // end `async function() {`
+    Append_Unencoded(mo->series, "}\n"); // end `function() {`
     Append_Unencoded(mo->series, "}()"); // invoke dummy function
     Append_Unencoded(mo->series, ");"); // end `RL_Register(`
 
@@ -186,13 +259,65 @@ REBNATIVE(js_native)
 
     Init_Handle_Managed(
         ARR_AT(details, IDX_NATIVE_HANDLE),
-        ACT_PARAMLIST(native),
+        ACT_PARAMLIST(action),
         0,
         &cleanup_js_native
     );
 
-    SET_VAL_FLAGS(ACT_ARCHETYPE(native), ACTION_FLAG_NATIVE);
+    SET_VAL_FLAGS(ACT_ARCHETYPE(action), ACTION_FLAG_NATIVE);
+    return action;
+}
+
+
+//
+//  js-native: native/export [
+//
+//  {Create ACTION! from JavaScript code}
+//
+//      return: [action!]
+//      spec [block!]
+//          {Function specification (similar to the one used by FUNC)}
+//      source [text!]
+//          {JavaScript code as a text string}
+//  ]
+//
+REBNATIVE(js_native)
+{
+    JAVASCRIPT_INCLUDE_PARAMS_OF_JS_NATIVE;
+
+    REBACT *native = Make_JavaScript_Action_Common(
+        ARG(spec),
+        ARG(source),
+        false // not is_awaiter
+    );
+
     return Init_Action_Unbound(D_OUT, native);
+}
+
+
+//
+//  js-awaiter: native/export [
+//
+//  {Create ACTION! from JavaScript code, won't return until resolve() called}
+//
+//      return: [action!]
+//      spec [block!]
+//          {Function specification (similar to the one used by FUNC)}
+//      source [text!]
+//          {JavaScript code as a text string}
+//  ]
+//
+REBNATIVE(js_awaiter)
+{
+    JAVASCRIPT_INCLUDE_PARAMS_OF_JS_AWAITER;
+
+    REBACT *awaiter = Make_JavaScript_Action_Common(
+        ARG(spec),
+        ARG(source),
+        true // is_awaiter
+    );
+
+    return Init_Action_Unbound(D_OUT, awaiter);
 }
 
 


### PR DESCRIPTION
This is a first cut at implementing a variant on JS-NATIVE, tentatively
called a JS-AWAITER.  What an awaiter does is that it simulates
a synchronous operation which is actually done through asynchronous
JavaScript calls.  Paralleling JS promises, it does this by not
returning to the caller just when the function body ends...rather, some
asynchronous event can later cause the return by calling resolve().

A simple JS-AWAITER implementing a timer could look like this:

    sleep: js-awaiter [
        {Sleep for the requested number of seconds}
        seconds [integer! decimal!]
    ]{
        setTimeout(
            resolve,
            1000 * rebUnboxDecimal(rebR(rebArg("seconds")))
        )
    }

While it would quickly finish running the body, the caller of the
SLEEP function wouldn't be returned to until JavaScript later called
the resolve() function.

Mechanically, awaiters cannot run synchronously on the JavaScript
call stack.  e.g. if you wrote:

    var x = rebUnboxInteger("sleep 5 | 10 + 20")
    console.log("x is " + x)

This wouldn't be able to work.  The setTimeout won't have a chance to
run if the code can't get up to the main GUI loop, and getting to the
GUI loop will involve pushing the stack forward past the console.log()
with a sum it should't have until after the sleep is finished.

To remedy this situation, the rebPromise() is introduced, which allows
calling JS-AWAITER functions, at the cost of not giving back a result
synchronously:

    var promise = rebPromise("sleep 5 | 10 + 20")
    promise.then(function (value) {
        console.log("x is " + rebUnboxInteger(rebR(value)))
    })

This is fairly standard in JavaScript, and once you are working with
promises you can use techniques like ASYNC/AWAIT:

https://javascript.info/async-await

Other changes in this commit include adding a rebTick() function to
help debugging, as well as factoring out the EnterApi() API check to
be put in by the %make-reb-lib.r script instead of manually in the
API definitions.

One issue about this commit is that it brings in some JavaScript
specific code under an #ifdef in the core %a-lib.c file to implement
the rebPromise().  It may be possible to put that functionality into
a MAKE-PROMISE native of some kind, so it can live in %mod-javascript.c
which will be something to look into.