### PR TITLE
Don't count dummy stack frames in WHERE information

### DIFF
--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -465,6 +465,8 @@ void Set_Location_Of_Error(
             continue;
         if (Is_Action_Frame_Fulfilling(f))
             continue;
+        if (f->original == PG_Dummy_Action)
+            continue;
 
         DS_PUSH_TRASH;
         Get_Frame_Label_Or_Blank(DS_TOP, f);
@@ -1644,7 +1646,10 @@ void MF_Error(REB_MOLD *mo, const RELVAL *v, bool form)
 
     // Form: ** Where: function
     REBVAL *where = KNOWN(&vars->where);
-    if (not IS_BLANK(where)) {
+    if (
+        not IS_BLANK(where)
+        and (not IS_BLOCK(where) and VAL_LEN_AT(where) == 0)
+    ){
         Append_Utf8_Codepoint(mo->series, '\n');
         Append_Unencoded(mo->series, RM_ERROR_WHERE);
         Form_Value(mo, where);


### PR DESCRIPTION
The call stack is produced by examining the list of frames on the stack
and adding an element to the block for each ACTION! invocation.

However, some frames are "dummy" frames which exist solely as a way
to aggregate API handle lifetimes for C code.  So libRebol API calls
(such as those in the console that come from main() to run lines of
code) are bracketed by what appears to be a function call even though
it is at the top level...so that handles allocated will be cleaned
up when an error is executed.

These dummy frames appeared as anonymous function calls in the stack
trace (currently shown as a BLANK!).  This commit filters those out,
and also makes it so that errors do not show any `Where:` information
when the stack trace is an empty block.

An effect of this is that an error typed in at the top level of the
console with no function call will not have a superfluous WHERE, and
avoids a situation where all error traces start with a BLANK!.