### PR TITLE
Allow null to unset a SET-WORD! or SET-PATH!

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -83,7 +83,9 @@ Syntax: [
 
 Script: [
     no-value:           [:arg1 {has no value}]
-    need-value:         [:arg1 {needs a value (use TRY, DID, ELSE, or SET*)}]
+    need-non-void:      [:arg1 {can't be VOID! (use TRY, OPT, or SET*)}]
+    need-non-null:      [:arg1 {needs a value, can't be null (or use SET*)}]
+    need-non-end:       [{end was reached while trying to set} :arg1]
     not-bound:          [:arg1 {word is not bound to a context}]
     no-relative:        [:arg1 {word is bound relative to context not on stack}]
     not-in-context:     [:arg1 {is not in the specified context}]

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -885,9 +885,21 @@ REBCTX *Error_User(const char *utf8) {
 
 
 //
-//  Error_Need_Value_Core: C
+//  Error_Need_Non_End_Core: C
 //
-REBCTX *Error_Need_Value_Core(const RELVAL *target, REBSPC *specifier) {
+REBCTX *Error_Need_Non_End_Core(const RELVAL *target, REBSPC *specifier) {
+    assert(IS_SET_WORD(target) or IS_SET_PATH(target));
+
+    DECLARE_LOCAL (specific);
+    Derelativize(specific, target, specifier);
+    return Error_Need_Non_End_Raw(specific);
+}
+
+
+//
+//  Error_Need_Non_Void_Core: C
+//
+REBCTX *Error_Need_Non_Void_Core(const RELVAL *target, REBSPC *specifier) {
     //
     // SET calls this, and doesn't work on just SET-WORD! and SET-PATH!
     //
@@ -895,7 +907,7 @@ REBCTX *Error_Need_Value_Core(const RELVAL *target, REBSPC *specifier) {
 
     DECLARE_LOCAL (specific);
     Derelativize(specific, target, specifier);
-    return Error_Need_Value_Raw(specific);
+    return Error_Need_Non_Void_Raw(specific);
 }
 
 

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1832,7 +1832,7 @@ void Eval_Core(REBFRM * const f)
             goto inert;
 
         if (IS_END(f->value)) // `do [a:]` is illegal
-            fail (Error_Need_Value_Core(current, f->specifier));
+            fail (Error_Need_Non_End_Core(current, f->specifier));
 
         REBFLGS flags = (f->flags.bits & DO_FLAG_EXPLICIT_EVALUATE);
 
@@ -1848,8 +1848,10 @@ void Eval_Core(REBFRM * const f)
                 goto finished;
         }
 
-        if (IS_NULLED_OR_VOID(f->out))
-            fail (Error_Need_Value_Core(current, f->specifier));
+        // Nulled cells are allowed: https://forum.rebol.info/t/895/4
+        //
+        if (IS_VOID(f->out))
+            fail (Error_Need_Non_Void_Core(current, f->specifier));
 
         Move_Value(Sink_Var_May_Fail(current, f->specifier), f->out);
         break; }
@@ -2073,7 +2075,7 @@ void Eval_Core(REBFRM * const f)
             goto inert;
 
         if (IS_END(f->value)) // `do [a/b:]` is illegal
-            fail (Error_Need_Value_Core(current, f->specifier));
+            fail (Error_Need_Non_End_Core(current, f->specifier));
 
         REBFLGS flags = (f->flags.bits & DO_FLAG_EXPLICIT_EVALUATE);
 
@@ -2089,8 +2091,10 @@ void Eval_Core(REBFRM * const f)
                 goto finished;
         }
 
-        if (IS_NULLED_OR_VOID(f->out))
-            fail (Error_Need_Value_Core(current, f->specifier));
+        // Nulled cells are allowed: https://forum.rebol.info/t/895/4
+        //
+        if (IS_VOID(f->out))
+            fail (Error_Need_Non_Void_Core(current, f->specifier));
 
         if (Eval_Path_Throws_Core(
             FRM_CELL(f), // output if thrown, used as scratch space otherwise

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -596,8 +596,12 @@ REBNATIVE(set)
     REBVAL *target = ARG(target);
     REBVAL *value = ARG(value);
 
-    if (IS_NULLED_OR_VOID(value) and not REF(opt))
-        fail (Error_Need_Value_Raw(target));
+    if (not REF(opt)) {
+        if (IS_NULLED(value))
+            fail (Error_Need_Non_Null_Raw(target));
+        if (IS_VOID(value))
+            fail (Error_Need_Non_Void_Raw(target));
+    }
 
     if (not IS_BLOCK(target)) {
         assert(ANY_WORD(target) or ANY_PATH(target));

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -610,13 +610,13 @@ static void Set_GOB_Vars(REBGOB *gob, const RELVAL *blk, REBSPC *specifier)
             fail (Error_Unexpected_Type(REB_SET_WORD, VAL_TYPE(var)));
 
         if (IS_END(blk))
-            fail (Error_Need_Value_Raw(var));
+            fail (Error_Need_Non_End_Raw(var));
 
         Derelativize(val, blk, specifier);
         ++blk;
 
         if (IS_SET_WORD(val))
-            fail (Error_Need_Value_Raw(var));
+            fail (Error_Need_Non_End_Raw(var));
 
         if (!Set_GOB_Var(gob, var, val))
             fail (Error_Bad_Field_Set_Raw(var, Type_Of(val)));

--- a/src/extensions/ffi/t-struct.c
+++ b/src/extensions/ffi/t-struct.c
@@ -1001,7 +1001,7 @@ void Init_Struct_Fields(REBVAL *ret, REBVAL *spec)
 
         REBVAL *fld_val = spec_item + 1;
         if (IS_END(fld_val))
-            fail (Error_Need_Value_Raw(fld_val));
+            fail (Error_Need_Non_End_Raw(fld_val));
 
         REBARR *fieldlist = VAL_STRUCT_FIELDLIST(ret);
         RELVAL *item = ARR_HEAD(fieldlist);


### PR DESCRIPTION
This restores the behavior from the initial development of null, which
allows it to unset variables:

    >> x: 10
    == 10

    >> x: null
    // null

    >> x
    ** Script Error: x has no value

However, VOID! values (which unlike null *are* values and may appear in
arrays and can be accessed without a GET-WORD!) still cause errors:

    >> x: do []
    ** Script Error: x: can't be VOID! (use TRY, OPT, or SET*)

    >> x: print "hi"
    hi
    ** Script Error: x: can't be VOID! (use TRY, OPT, or SET*)

Allowing null assignments to mean "unset" provides convenient means of
removing keys from maps, which [could be difficult otherwise](https://github.com/red/red/wiki/%5BNOTES%5D-Design-notes-on-removing-keys-from-MAP!-values):

    >> m: make map! [1 a 2 b]
    == make map! [
        1 a
        2 b
    ]

    >> m/1: _

    >> m
    == make map! [
        1 _
        2 b
    ]

    >> m/1: null

    >> m
    == make map! [
        2 b
    ]

The original intent of trying to raise errors on null was to improve
error locality, drawing attention to the moment where an oversight
in handling null conditions happened.  But analyzing the pros and cons
suggest that the only real outcome of this process were kneejerk
mitigations which probably create more opportunities for bugs than
they solve.  Additionally, it led to constructs which would seem clean
and easy to write in Rebol2 seeming to need extra words thrown in for
little benefit.

It is presumed that having the variables assigned be unset--and thus
difficult to work with if used after the point of assignment--is enough
"safety", balanced against the convenience of being able to perform
such assignments.  Also, the flexibility of usermode constructs to be
adapted to catch patterns of common errors in any given codebase which
finds itself plagued by problems related to null performing unsets.