### PR TITLE
DELIMIT (and UNSPACED, SPACED, etc.) null if all opt out

### DIFF
--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -89,14 +89,21 @@ cscape: function [
 
             if blank? sub [sub: "/* _ */"] ;-- replaced in post-phase
 
-            sub: switch mode [
-                #cname [to-c-name sub]
-                #unspaced [either block? sub [unspaced sub] [form sub]]
-                #delim [delimit sub unspaced [dlm newline]]
-                default [
-                    fail ["Invalid CSCAPE mode:" mode]
+            sub: opt switch mode [
+                #cname [
+                    if not all [text? sub | empty? sub] [
+                        to-c-name sub
+                    ]
                 ]
-            ]
+                #unspaced [
+                    either block? sub [unspaced sub] [form sub]
+                ]
+                #delim [
+                    delimit sub unspaced [dlm newline]
+                ]
+                fail ["Invalid CSCAPE mode:" mode]
+            ] else [""]
+
             case [
                 all [any-upper | not any-lower] [uppercase sub]
                 all [any-lower | not any-upper] [lowercase sub]

--- a/make/tools/common.r
+++ b/make/tools/common.r
@@ -57,6 +57,13 @@ to-c-name: function [
     word "Either 'global or 'local (defaults global)"
     [word!]
 ][
+    all [
+        text? value
+        empty? value
+    ] then [
+        fail/where ["TO-C-NAME received empty input"] 'value
+    ]
+
     c-chars: charset [
         #"a" - #"z"
         #"A" - #"Z"

--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -186,19 +186,15 @@ for-each api api-objects [do in api [
         opt-va-start: {va_list va; va_start(va, p);}
     ]
 
-    wrapper-params: if empty? paramlist [
-        "void"
-    ] else [
-        delimit map-each [type var] paramlist [
-            if type = "va_list *" [
-                "..."
-            ] else [
-                spaced [type var]
-            ]
-        ] ", "
-    ]
+    wrapper-params: (delimit map-each [type var] paramlist [
+        if type = "va_list *" [
+            "..."
+        ] else [
+            spaced [type var]
+        ]
+    ] ", ") else ["void"]
 
-    proxied-args: delimit map-each [type var] paramlist [
+    proxied-args: try delimit map-each [type var] paramlist [
         if type = "va_list *" [
             "&va" ;-- to produce vaptr
         ] else [

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -497,3 +497,10 @@ so: enfix func [ ;-- https://trello.com/c/RiHjvysQ
 ]
 
 count-up: :repeat ;-- https://forum.rebol.info/t/892
+
+; Approximations (can't override null return case with unspaced ["" ...])
+; https://forum.rebol.info/t/904/2
+;
+delimit: chain [:delimit | function [x] [if x <> "" [x]]]
+unspaced: chain [:unspaced | function [x] [if x <> "" [x]]]
+spaced: chain [:spaced | function [x] [if x <> "" [x]]]

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -99,8 +99,8 @@ REBNATIVE(mold)
 //
 //  "Write text to standard output, or raw BINARY! (for control codes / CGI)"
 //
-//      return: [void!]
-//      value [text! char! binary!]
+//      return: [<opt> void!]
+//      value [blank! text! char! binary!]
 //          "Text to write, if a STRING! or CHAR! is converted to OS format"
 //  ]
 //
@@ -109,6 +109,9 @@ REBNATIVE(write_stdout)
     INCLUDE_PARAMS_OF_WRITE_STDOUT;
 
     REBVAL *v = ARG(value);
+
+    if (IS_BLANK(v))
+        return nullptr;
 
     if (IS_BINARY(v)) {
         //

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -101,7 +101,8 @@ static struct {
 //
 //  {Joins a block of values into TEXT! with delimiters.}
 //
-//      return: [text!]
+//      return: "Will be null if all block's contents are null"
+//          [<opt> text!]
 //      block [block!]
 //      delimiter [<opt> char! text!] ;-- should this accept ANY-VALUE!?
 //  ]

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -262,9 +262,9 @@ print: func [
         [blank! text! block!]
 ][
     write-stdout switch type of line [
-        blank! [return null]
+        blank! [return null] ;-- don't print the newline
         text! [line]
-        block! [spaced line]
+        block! [try spaced line]
     ]
     write-stdout newline
     return

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -35,7 +35,7 @@
 (error? make error! [type: 'syntax id: 'needs])
 
 (error? make error! [type: 'script id: 'no-value])
-(error? make error! [type: 'script id: 'need-value])
+(error? make error! [type: 'script id: 'need-non-void])
 (error? make error! [type: 'script id: 'not-bound])
 (error? make error! [type: 'script id: 'not-in-context])
 (error? make error! [type: 'script id: 'no-arg])

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -10,8 +10,8 @@
 (void! = type of (do []))
 (not void? 1)
 
-[#68
-    ('need-value = (trap [a: ()])/id)
+[#68 ;-- also, https://github.com/metaeducation/ren-c/issues/876
+    ('need-non-void = (trap [a: ()])/id)
 ]
 
 (error? trap [set* quote a: null a])

--- a/tests/functions/invisible.test.reb
+++ b/tests/functions/invisible.test.reb
@@ -252,25 +252,25 @@
 (
     x: <unchanged>
     did all [
-        'need-value = (trap [<discarded> x: ()])/id
+        'need-non-void = (trap [<discarded> x: ()])/id
         x = <unchanged>
     ]
 )(
     x: <unchanged>
     did all [
-        'need-value = (trap [<discarded> x: comment "hi"])/id
+        'need-non-void = (trap [<discarded> x: comment "hi"])/id
         x = <unchanged>
     ]
 )(
     obj: make object! [x: <unchanged>]
     did all [
-        'need-value = (trap [<discarded> obj/x: comment "hi"])/id
+        'need-non-void = (trap [<discarded> obj/x: comment "hi"])/id
         obj/x = <unchanged>
     ]
 )(
     obj: make object! [x: <unchanged>]
     did all [
-        'need-value = (trap [<discarded> obj/x: ()])/id
+        'need-non-void = (trap [<discarded> obj/x: ()])/id
         obj/x = <unchanged>
     ]
 )

--- a/tests/series/delimit.test.reb
+++ b/tests/series/delimit.test.reb
@@ -1,7 +1,7 @@
-("" = delimit [] #" ")
+(null? delimit [] #" ")
 ("1 2" = delimit [1 2] #" ")
 
-("" = delimit [] "unused")
+(null? delimit [] "unused")
 ("1" = delimit [1] "unused")
 ("12" = delimit [1 2] "")
 


### PR DESCRIPTION
This is a change which was contemplated for some time (as early as
the proposal for "COMBINE") which is to distinguish the situation of
a block-to-string conversion that entirely opts out by returning a
null to indicate opting out.

    >> unspaced ["a" if false ["b"] "c"]
    == "ac"

    >> unspaced [if false ["a"] if false ["b"] if false ["c"]]
    // null

Previously an empty string would be returned.  This can still be done
a number of ways, one of which is to provide any empty string as
input in the block:

    >> unspaced ["" if false ["a"] if false ["b"] if false ["c"]]
    == ""

But it can also be done with ELSE, UNLESS, or any other null-reactive
construct.  By doing it this way, empty string isn't the only option,
so for instance if you want to comply with the C standard for function
arguments you aren't supposed to have an empty paramlist as just
`int foo() {...}`, but `int foo(void) {...}`

    >> params-text: "void" unless (delimit c-function-params ",")

Given the options--in particular the option of just putting `""` in
the input block being enough--the advantages of being able to uniquely
react to the empty state are high enough to be worth it.