### PR TITLE
REPLACE allows null to opt out of pattern or replacement

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -869,8 +869,11 @@ static void Init_Root_Vars(void)
     REBSER *nulled_uni = Make_Unicode(1);
     assert(CHR_CODE(UNI_AT(nulled_uni, 0)) == '\0');
     assert(UNI_LEN(nulled_uni) == 0);
-    Root_Empty_String = Init_Text(Alloc_Value(), nulled_uni);
-    Ensure_Value_Immutable(Root_Empty_String, locker);
+    Root_Empty_Text = Init_Text(Alloc_Value(), nulled_uni);
+    Ensure_Value_Immutable(Root_Empty_Text, locker);
+
+    Root_Empty_Binary = Init_Binary(Alloc_Value(), Make_Binary(0));
+    Ensure_Value_Immutable(Root_Empty_Binary, locker);
 
     Root_Space_Char = rebChar(' ');
     Root_Newline_Char = rebChar('\n');
@@ -890,17 +893,19 @@ static void Init_Root_Vars(void)
 static void Shutdown_Root_Vars(void)
 {
     rebRelease(Root_Stats_Map);
-    Root_Stats_Map = NULL;
+    Root_Stats_Map = nullptr;
 
     rebRelease(Root_Space_Char);
-    Root_Space_Char = NULL;
+    Root_Space_Char = nullptr;
     rebRelease(Root_Newline_Char);
-    Root_Newline_Char = NULL;
+    Root_Newline_Char = nullptr;
 
-    rebRelease(Root_Empty_String);
-    Root_Empty_String = NULL;
+    rebRelease(Root_Empty_Text);
+    Root_Empty_Text = nullptr;
     rebRelease(Root_Empty_Block);
-    Root_Empty_Block = NULL;
+    Root_Empty_Block = nullptr;
+    rebRelease(Root_Empty_Binary);
+    Root_Empty_Binary = nullptr;
 }
 
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -178,7 +178,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
 
     REBDSP definitional_return_dsp = 0;
 
-    // As we go through the spec block, we push TYPESET! BLOCK! STRING! triples.
+    // As we go through the spec block, we push TYPESET! BLOCK! TEXT! triples.
     // These will be split out into separate arrays after the process is done.
     // The first slot of the paramlist needs to be the function canon value,
     // while the other two first slots need to be rootkeys.  Get the process
@@ -189,7 +189,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
     DS_PUSH_TRASH; // paramlist[0] will become ACT_ARCHETYPE()
     Init_Unreadable_Blank(DS_TOP);
     DS_PUSH(EMPTY_BLOCK); // param_types[0] (to be OBJECT! canon value, if any)
-    DS_PUSH(EMPTY_STRING); // param_notes[0] (holds description, then canon)
+    DS_PUSH(EMPTY_TEXT); // param_notes[0] (holds description, then canon)
 
     bool has_description = false;
     bool has_types = false;
@@ -367,13 +367,13 @@ REBARR *Make_Paramlist_Managed_May_Fail(
 
         REBSTR *canon = VAL_WORD_CANON(item);
 
-        // In rhythm of TYPESET! BLOCK! STRING! we want to be on a string spot
+        // In rhythm of TYPESET! BLOCK! TEXT! we want to be on a string spot
         // at the time of the push of each new typeset.
         //
         if (IS_TYPESET(DS_TOP))
             DS_PUSH(EMPTY_BLOCK);
         if (IS_BLOCK(DS_TOP))
-            DS_PUSH(EMPTY_STRING);
+            DS_PUSH(EMPTY_TEXT);
         assert(IS_TEXT(DS_TOP));
 
         // Non-annotated arguments disallow ACTION!, VOID! and NULL.  Not
@@ -491,12 +491,12 @@ REBARR *Make_Paramlist_Managed_May_Fail(
         }
     }
 
-    // Go ahead and flesh out the TYPESET! BLOCK! STRING! triples.
+    // Go ahead and flesh out the TYPESET! BLOCK! TEXT! triples.
     //
     if (IS_TYPESET(DS_TOP))
         DS_PUSH(EMPTY_BLOCK);
     if (IS_BLOCK(DS_TOP))
-        DS_PUSH(EMPTY_STRING);
+        DS_PUSH(EMPTY_TEXT);
     assert((DSP - dsp_orig) % 3 == 0); // must be a multiple of 3
 
     // Definitional RETURN slots must have their argument value fulfilled with
@@ -524,7 +524,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             definitional_return_dsp = DSP;
 
             DS_PUSH(EMPTY_BLOCK);
-            DS_PUSH(EMPTY_STRING);
+            DS_PUSH(EMPTY_TEXT);
             // no need to move it--it's already at the tail position
         }
         else {

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -53,6 +53,15 @@ REBCNT Modify_Array(
     const RELVAL *src_rel;
     REBSPC *specifier;
 
+    if (IS_NULLED(src_val) and sym == SYM_CHANGE) {
+        //
+        // Tweak requests to CHANGE to a null to be a deletion; basically
+        // what happens with an empty block.
+        //
+        flags |= AM_SPLICE;
+        src_val = EMPTY_BLOCK;
+    }
+
     if (IS_NULLED(src_val) or dups <= 0) {
         // If they are effectively asking for "no action" then all we have
         // to do is return the natural index result for the operation.
@@ -237,6 +246,15 @@ REBCNT Modify_Binary(
     else
         limit = -1;
 
+    if (IS_NULLED(src_val) and sym == SYM_CHANGE) {
+        //
+        // Tweak requests to CHANGE to a null to be a deletion; basically
+        // what happens with an empty binary.
+        //
+        flags |= AM_SPLICE;
+        src_val = EMPTY_BINARY;
+    }
+
     if (IS_NULLED(src_val) || limit == 0 || dups < 0)
         return sym == SYM_APPEND ? 0 : dst_idx;
 
@@ -379,6 +397,15 @@ REBCNT Modify_String(
         limit = dst_len; // should be non-negative
     else
         limit = -1;
+
+    if (IS_NULLED(src_val) and sym == SYM_CHANGE) {
+        //
+        // Tweak requests to CHANGE to a null to be a deletion; basically
+        // what happens with an empty string.
+        //
+        flags |= AM_SPLICE;
+        src_val = EMPTY_TEXT;
+    }
 
     if (IS_NULLED(src_val) || limit == 0 || dups < 0)
         return sym == SYM_APPEND ? 0 : dst_idx;

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -456,8 +456,11 @@ inline static REBARR* Copy_Array_At_Extra_Deep_Flags_Managed(
 #define EMPTY_ARRAY \
     PG_Empty_Array // Note: initialized from VAL_ARRAY(Root_Empty_Block)
 
-#define EMPTY_STRING \
-    Root_Empty_String
+#define EMPTY_TEXT \
+    Root_Empty_Text
+
+#define EMPTY_BINARY \
+    Root_Empty_Binary
 
 
 inline static void INIT_VAL_ARRAY(RELVAL *v, REBARR *a) {

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -122,7 +122,8 @@ PVAR REBVAL *Root_End_Tag; // marks endable argument (NULL if at end of input)
 PVAR REBVAL *Root_Local_Tag; // marks beginning of a list of "pure locals"
 PVAR REBVAL *Root_Skip_Tag; // marks a hard quote as "skippable" if wrong type
 
-PVAR REBVAL *Root_Empty_String; // read-only ""
+PVAR REBVAL *Root_Empty_Text; // read-only ""
+PVAR REBVAL *Root_Empty_Binary; // read-only #{}
 PVAR REBVAL *Root_Empty_Block; // read-only []
 PVAR REBARR* PG_Empty_Array; // optimization of VAL_ARRAY(Root_Empty_Block)
 

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -685,7 +685,7 @@ struct Reb_Frame {
     // * If EMPTY_BLOCK, it's an ordinary arg...and not a refinement.  It will
     //   be evaluated normally but is not involved with revocation.
     //
-    // * If EMPTY_STRING, the evaluator's next argument fulfillment is the
+    // * If EMPTY_TEXT, the evaluator's next argument fulfillment is the
     //   left-hand argument of a lookback operation.  After that fulfillment,
     //   it will be transitioned to EMPTY_BLOCK.
     //
@@ -889,7 +889,7 @@ typedef const REBVAL* (*REBDSF)(REBFRM * const);
 // * If EMPTY_BLOCK, it's an ordinary arg...and not a refinement.  It will
 //   be evaluated normally but is not involved with revocation.
 //
-// * If EMPTY_STRING, the evaluator's next argument fulfillment is the
+// * If EMPTY_TEXT, the evaluator's next argument fulfillment is the
 //   left-hand argument of a lookback operation.  After that fulfillment,
 //   it will be transitioned to EMPTY_BLOCK.
 //
@@ -925,7 +925,7 @@ typedef const REBVAL* (*REBDSF)(REBFRM * const);
     m_cast(REBVAL*, EMPTY_BLOCK)
 
 #define LOOKBACK_ARG \
-    m_cast(REBVAL*, EMPTY_STRING)
+    m_cast(REBVAL*, EMPTY_TEXT)
 
 
 #if !defined(DEBUG_CHECK_CASTS) || !defined(CPLUSPLUS_11)

--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -52,6 +52,8 @@
                 "]'"
             ])
         ] data
-        length of data > 500'000 and [find data "summary: {Initial commit}"]
+        length of data > 500'000 and [
+            did find data "summary: {Initial commit}"
+        ]
     ]
 )

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -207,6 +207,7 @@
 %series/rejoin.test.reb
 %series/remove.test.reb
 %series/reverse.test.reb
+%series/replace.test.reb
 %series/select.test.reb
 %series/skip.test.reb
 %series/sort.test.reb

--- a/tests/series/replace.test.reb
+++ b/tests/series/replace.test.reb
@@ -1,0 +1,111 @@
+; REPLACE tests, initial set from:
+;
+; File: %replace-test.red
+; Author: "Nenad Rakocevic & Peter W A Wood & Toomas Vooglaid"
+; Rights: "Copyright (C) 2011-2015 Red Foundation. All rights reserved."
+; License: "BSD-3 - https://github.com/red/red/blob/master/BSD-3-License.txt"
+;
+
+
+; REPLACE
+
+([1 2 8 4 5] = replace [1 2 3 4 5] 3 8)
+([1 2 8 9 4 5] = replace [1 2 3 4 5] 3 [8 9])
+([1 2 8 9 5] = replace [1 2 3 4 5] [3 4] [8 9])
+([1 2 8 5] = replace [1 2 3 4 5] [3 4] 8)
+([1 2 a 5] = replace [1 2 3 4 5] [3 4] 'a)
+([a g c d] = replace [a b c d] 'b 'g)
+('a/b/g/d/e = replace 'a/b/c/d/e 'c 'g)
+('a/b/g/h/i/d/e = replace 'a/b/c/d/e 'c 'g/h/i)
+(#{006400} = replace #{000100} #{01} 100)
+(%file.ext = replace %file.sub.ext ".sub." #".")
+("abra-abra" = replace "abracadabra" "cad" #"-")
+("abra-c-adabra" = replace "abracadabra" #"c" "-c-")
+
+; Red has a bizarre behavior for this which is in the tests:
+; https://github.com/red/red/blob/12ad56be0fc474f7738c0ef891725e49f9738010/tests/source/units/replace-test.red#L24
+;
+;    ('a/b/c/h/i/d/e = replace 'a/b/g/h/i/d/e 'g/h/i 'c)
+;
+; That's not what Rebol2 does, and not consistent with BLOCK! replacement
+;
+('a/b/c/d/e = replace 'a/b/g/h/i/d/e 'g/h/i 'c)
+
+; REPLACE/ALL
+
+([1 4 3 4 5] = replace/all [1 2 3 2 5] 2 4)
+([1 4 5 3 4 5] = replace/all [1 2 3 2] 2 [4 5])
+([1 8 9 8 9] = replace/all [1 2 3 2 3] [2 3] [8 9])
+([1 8 8] = replace/all [1 2 3 2 3] [2 3] 8)
+('a/b/g/d/g = replace/all 'a/b/c/d/c 'c 'g)
+('a/b/g/h/d/g/h = replace/all 'a/b/c/d/c 'c 'g/h)
+(#{640164} = replace/all #{000100} #{00} #{64})
+(%file.sub.ext = replace/all %file!sub!ext #"!" #".")
+(<tag body end> = replace/all <tag_body_end> "_" " ")
+
+; REPLACE/CASE
+
+("axbAab" = replace/case "aAbAab" "A" "x")
+("axbxab" = replace/case/all "aAbAab" "A" "x")
+("axbAab" = replace/case "aAbAab" ["A"] does ["x"])
+("axbxab" = replace/case/all "aAbAab" ["A"] does ["x"])
+(%file.txt = replace/case %file.TXT.txt %.TXT "")
+(%file.txt = replace/case/all %file.TXT.txt.TXT %.TXT "")
+(<tag xyXx> = replace/case <tag xXXx> "X" "y")
+(<tag xyyx> = replace/case/all <tag xXXx> "X" "y")
+('a/X/o/X = replace/case 'a/X/x/X 'x 'o)
+('a/o/x/o = replace/case/all 'a/X/x/X 'X 'o)
+(["a" "B" "x"] = replace/case/all ["a" "B" "a" "b"] ["a" "b"] "x")
+((quote :x/b/A/x/B) = replace/case/all quote :a/b/A/a/B [a] 'x)
+((quote (x A x)) = replace/case/all quote (a A a) 'a 'x)
+
+;((make hash! [x a b [a B]]) = replace/case make hash! [a B a b [a B]] [a B] 'x)
+
+; REPLACE null behavior (Ren-C only, as only it has null)
+; https://forum.rebol.info/t/null-first-class-values-and-safety/895/2
+
+([3 4] = replace copy [3 0 4] 0 null)
+([3 0 4] = replace copy [3 0 4] null 1020)
+([2 0 2 0] = replace/all copy [1 0 2 0 1 0 2 0] [1 0] null)
+("34" = replace copy "304" "0" null)
+("304" = rplace copy "304" null "1020")
+("2020" = replace/all copy "10201020" "10" null)
+(#{3040} = replace copy #{300040} #{00} null)
+(#{300040} = replace copy #{300040} null #{10002000})
+(#{20002000} = replace/all copy #{1000200010002000} #{1000})
+
+; REPLACE/DEEP - /DEEP not (yet?) implemented in Ren-C
+
+;([1 2 3 [8 5]] = replace/deep [1 2 3 [4 5]] [quote 4] 8)
+;([1 2 3 [4 8 9]] = replace/deep [1 2 3 [4 5]] [quote 5] [8 9])
+;([1 2 3 [8 9]] = replace/deep [1 2 3 [4 5]] [quote 4 quote 5] [8 9])
+;([1 2 3 [8]] = replace/deep [1 2 3 [4 5]] [quote 4 quote 5] 8)
+;([1 2 a 4 5] = replace/deep [1 2 3 4 5] [quote 8 | quote 4 | quote 3] 'a)
+;([a g h c d] = replace/deep [a b c d] ['b | 'd] [g h])
+
+; REPLACE/DEEP/ALL - /DEEP not (yet?) implemented in Ren-C
+
+;([1 8 3 [4 8]] = replace/deep/all [1 2 3 [4 2]] [quote 2] 8)
+;([1 8 9 3 [4 8 9]] = replace/deep/all [1 2 3 [4 5]] [quote 5 | quote 2] [8 9])
+;([i j c [i j]] = replace/deep/all [a b c [d e]] ['d 'e | 'a 'b] [i j])
+;([a [<tag> [<tag>]]] = replace/all/deep [a [b c [d b]]] ['d 'b | 'b 'c] <tag>)
+
+; REPLACE IN STRING WITH RULE
+;
+; !!! This is a Red invention that seems like a pretty bad idea.  It mixes
+; PARSE mechanisms in with REPLACE, but it only works if the source data is
+; a string...because it "knows" not to treat the block string-like.  This is
+; in contention with many other functions that assume you want to stringify
+; blocks when passed, and block parsing can't use the same idea.  If anything
+; it sounds like a PARSE feature.
+;
+;("!racadabra" = replace "abracadabra" ["ra" | "ab"] #"!")
+;("!!cad!!" = replace/all "abracadabra" ["ra" | "ab"] #"!")
+;("!!cad!!" = replace/all "abracadabra" ["ra" | "ab"] does ["!"])
+;("AbrACAdAbrA" == replace/all "abracadabra" [s: ["a" | "c"]] does [uppercase s/1])
+;("a-babAA-" = replace/case/all "aAbbabAAAa" ["Ab" | "Aa"] "-")
+
+; REPLACE/CASE/DEEP - /DEEP not (yet?) implemented in Ren-C
+
+;([x A x B [x A x B]] = replace/case/deep/all [a A b B [a A b B]] ['a | 'b] 'x)
+;((quote (x A x B (x A x B))) = replace/case/deep/all quote (a A b B (a A b B)) ['a | 'b] 'x)


### PR DESCRIPTION
This modifies the behavior of the CHANGE function w.r.t. NULL when a
/PART refinement is used.

Previously, it would consider a NULL to signal a no-op...now it
considers it the absence of a replacement.  This makes it similar to
a /PART when splicing an empty array:

    >> head change/part copy [a b c d] [] 2
    == [c d]

    >> head change/part copy [a b c d] null 2
    == [c d]

This is applied for BINARY! and STRING! as well.  Since REPLACE is
a mezzanine based on CHANGE, this means it now can support a null
pattern (signaling a no-op) or a null replacement (meaning to just
vaporize any instances of the pattern)

    [3 4] = replace copy [3 0 4] 0 null
    [3 0 4] = replace copy [3 0 4] null 1020
    [2 0 2 0] = replace/all copy [1 0 2 0 1 0 2 0] [1 0] null
    "34" = replace copy "304" "0" null
    "304" = rplace copy "304" null "1020"
    "2020" = replace/all copy "10201020" "10" null
    #{3040} = replace copy #{300040} #{00} null
    #{300040} = replace copy #{300040} null #{10002000}
    #{20002000} = replace/all copy #{1000200010002000} #{1000}