### PR TITLE
Make CONTINUE "endable"

### DIFF
--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -100,9 +100,8 @@ REBNATIVE(break)
 //
 //  "Throws control back to top of loop for next iteration."
 //
-//      /with
-//          {Act as if loop body finished current evaluation with a value}
-//      value [any-value!]
+//      value "If provided, act as if loop body finished with this value"
+//          [<end> any-value!]
 //  ]
 //
 REBNATIVE(continue)
@@ -114,9 +113,7 @@ REBNATIVE(continue)
     INCLUDE_PARAMS_OF_CONTINUE;
 
     Move_Value(D_OUT, NAT_VALUE(continue));
-
-    UNUSED(REF(with)); // value will be void if no refinement provided
-    CONVERT_NAME_TO_THROWN(D_OUT, ARG(value));
+    CONVERT_NAME_TO_THROWN(D_OUT, ARG(value)); // null if e.g. `do [continue]`
 
     return D_OUT;
 }

--- a/tests/control/continue.test.reb
+++ b/tests/control/continue.test.reb
@@ -17,3 +17,13 @@
 ]
 ; continue should not be caught by try
 (a: 1 loop 1 [a: error? trap [continue]] :a =? 1)
+
+; CONTINUE with a value pretends loop body finished with that result.
+
+(<result> = loop 1 [continue <result> <not-result>])
+(
+    [2 <big> <big>] = map-each x [1 2000 3000] [
+        if x > 1000 [continue <big>]
+        x + 1
+    ]
+)

--- a/tests/control/remove-each.test.reb
+++ b/tests/control/remove-each.test.reb
@@ -45,7 +45,7 @@
 (
     block: copy [1 2 3 4]
     remove-each i block [
-        if i = 3 [continue/with true]
+        if i = 3 [continue true]
         if i = 4 [true] else [false]
     ]
     block = [1 2]


### PR DESCRIPTION
Ren-C initially introduced the idea of a /WITH parameter to CONTINUE,
so that a CONTINUE operation would be able to make it seem as if that
iteration of the body had returned a value.

However, since CONTINUE is at the tail of an operation, it's possible
to take advantage of that by having it be able to act as arity-0 or
arity-1 depending on the presence of an argument:

    >> map-each x [1 2000 3000] [
           if x > 1000 [continue]
           x + 1
       ]
    == [2]

    >> map-each x [1 2000 3000] [
           if x > 1000 [continue <big>]
           x + 1
       ]
    == [2 <big> <big>]

This parallels the behavior of RETURN, which allowed to repurpose the
EXIT command.