### PR TITLE
Rethink FOREVER construct as CYCLE, add STOP ability

### DIFF
--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -225,3 +225,11 @@ applique: function [
 
     do frame ;-- nulls are optionals
 ]
+
+
+; The name FOREVER likely dissuades its use, since many loops aren't intended
+; to run forever.  CYCLE gives similar behavior without suggesting the
+; permanence.  It also is unique among loop constructs by supporting a value
+; return via STOP, since it has no "normal" loop termination condition.
+;
+forever: :cycle

--- a/tests/atronix/test-libs.r
+++ b/tests/atronix/test-libs.r
@@ -1,6 +1,6 @@
 REBOL []
 recycle/torture
-forever [
+cycle [
     libs: make library! %./libs.so
     N_REPEAT: 10
     read-s10: make routine! compose [

--- a/tests/control/forever.test.reb
+++ b/tests/control/forever.test.reb
@@ -1,32 +1,32 @@
 ; functions/control/forever.r
 (
     num: 0
-    forever [
+    cycle [
         num: num + 1
         if num = 10 [break]
     ]
     num = 10
 )
 ; Test break and continue
-(null? forever [break])
+(null? cycle [break])
 (
     success: true
     cycle?: true
-    forever [if cycle? [cycle?: false continue | success: false] break]
+    cycle [if cycle? [cycle?: false continue | success: false] break]
     success
 )
 ; Test that arity-1 return stops the loop
 (
-    f1: func [] [forever [return 1]]
+    f1: func [] [cycle [return 1]]
     1 = f1
 )
 ; Test that arity-0 return stops the loop
-(void? eval func [return: <void>] [forever [return]])
+(void? eval func [return: <void>] [cycle [return]])
 ; Test that errors do not stop the loop and errors can be returned
 (
     num: 0
     e: _
-    forever [
+    cycle [
         num: num + 1
         if num = 10 [e: trap [1 / 0] break]
         trap [1 / 0]
@@ -37,10 +37,10 @@
 (
     num1: 0
     num3: 0
-    forever [
+    cycle [
         if num1 = 5 [break]
         num2: 0
-        forever [
+        cycle [
             if num2 = 2 [break]
             num3: num3 + 1
             num2: num2 + 1
@@ -49,3 +49,9 @@
     ]
     10 = num3
 )
+
+; Unlike loops with ordinary termination conditions, CYCLE can return a
+; value with STOP
+;
+(void? cycle [stop])
+(10 = cycle [stop 10])


### PR DESCRIPTION
The FOREVER construct seemed on the surface as a more efficient and
more fluent way to write `while [true]`.  But its name is long-ish, and
actually rather jarring for casual use of "loop until some condition
sensed within the loop causes a break".  That is not sensibly called
"forever"--so it didn't really seem to get used much at all.

CYCLE is a shorter name, without that baggage.  "Keep cycling until
something stops the cycle".

It also adds a distinct feature of STOPping cycles with a result value.
While loops aren't allowed to "return a value from a break", that's
because they need to distinguish a stopping request from normal
completion.  However, *CYCLE has no normal loop termination condition*.
It isn't counting anything, or testing anything.  So its return result
would go somewhat to waste if there wasn't a way to give one.

Rather than tamper with the BREAK-is-null concept, this adds a unique
variant called STOP that only CYCLE will respond to:

    >> x: 1
    >> cycle [
           if x = 3 [stop <stopped>]
           print [x]
           x: x + 1
       ]
    1
    2
    == <stopped>

STOP will not accept NULL.  So from the outside one can still tell a
BREAK condition from a "normal" stop of a cycle.

FOREVER is temporarily aliased to CYCLE; there may be a point to
keeping it around, though it should probably not be offering a BREAK
or a STOP if it's "forever" (!)