### PR TITLE
Make FOR-NEXT/FOR-SKIP take word, introduce ITERATE

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -470,11 +470,10 @@ help: function [topic [text! blank!]] [
 ]
 
 ; process help: {-h | -help | --help} [TOPIC]
-if commands [
-    for-next commands [
-        if find ["-h" "-help" "--help"] first commands [
-            help try second commands quit
-        ]
+
+iterate commands [
+    if find ["-h" "-help" "--help"] commands/1 [
+        help try :commands/2 quit
     ]
 ]
 
@@ -1207,7 +1206,7 @@ for-each name user-config/extensions [
         ]
         '* '- [
             item: _
-            for-next builtin-extensions [
+            iterate builtin-extensions [
                 if builtin-extensions/1/name = name [
                     item: take builtin-extensions
                     all [
@@ -1801,8 +1800,8 @@ solution: make rebmake/solution-class [
 
 target: user-config/target
 if not block? target [target: reduce [target]]
-for-next target [
-    if null? switch target/1 targets [
+iterate target [
+    switch target/1 targets else [
         fail [
             newline
             newline

--- a/make/tools/common.r
+++ b/make/tools/common.r
@@ -277,7 +277,7 @@ parse-args: function [
     standalone: make block! 4
     args: any [args copy []]
     if not block? args [args: split args [some " "]]
-    for-next args [
+    iterate args [
         name: _
         value: args/1
         case [
@@ -391,7 +391,7 @@ relative-to-path: func [
         base: next base
         target: next target
     ]
-    for-next base [base/1: %..]
+    iterate base [base/1: %..]
     append base target
     to-file delimit base "/"
 ]

--- a/make/tools/make-ext-natives.r
+++ b/make/tools/make-ext-natives.r
@@ -283,7 +283,7 @@ e1/emit {
 }
 e1/emit newline
 
-for-next native-list [
+iterate native-list [
     if tail? next native-list [break]
 
     any [

--- a/make/tools/make-headers.r
+++ b/make/tools/make-headers.r
@@ -345,7 +345,7 @@ generic-list: load output-dir/boot/tmp-generics.r
 
 ; Search file for definition.  Will be `generic-name: generic [paramlist]`
 ;
-for-next generic-list [
+iterate generic-list [
     if 'generic = pick generic-list 2 [
         assert [set-word? generic-list/1]
         (emit-include-params-macro

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -557,3 +557,13 @@ unless: enfix func [ ; https://forum.rebol.info/t/881
 ]
 
 --: :dump
+
+iterate: :for-next
+for-next: for-skip: for-back: func [dummy:] [
+    fail/where [
+        "FOR-NEXT, FOR-SKIP, and FOR-BACK different in modern R3"
+        "so don't use them in the compatibility layer."
+        "Only ITERATE is defined."
+        https://forum.rebol.info/t/892
+    ] 'dummy
+]

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -1864,23 +1864,23 @@ visual-studio: make generator-class [
     ]
 
     find-compile-as: method [
+        return: [<opt> text!]
         cflags [block!]
     ][
-        for-next cflags [
-            if i: filter-flag cflags/1 "msc" [
-                case [
-                    parse i ["/TP" to end] [
-                        comment [remove cflags] ; extensions wouldn't get it
-                        return "CompileAsCpp"
-                    ]
-                    parse i ["/TC" to end] [
-                        comment [remove cflags] ; extensions wouldn't get it
-                        return "CompileAsC"
-                    ]
+        iterate cflags [
+            i: filter-flag cflags/1 "msc" else [continue]
+            case [
+                parse i ["/TP" to end] [
+                    comment [remove cflags] ; extensions wouldn't get it
+                    return "CompileAsCpp"
+                ]
+                parse i ["/TC" to end] [
+                    comment [remove cflags] ; extensions wouldn't get it
+                    return "CompileAsC"
                 ]
             ]
         ]
-        return blank
+        return null
     ]
 
     find-stack-size: method [

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -379,14 +379,14 @@ do: emulate [
         if action? :source [
             code: reduce [:source]
             params: words of :source
-            for-next params [
+            iterate params [
                 append code switch type of params/1 [
                     word! [take normals]
                     lit-word! [take softs]
                     get-word! [take hards]
                     set-word! [[]] ;-- empty block appends nothing
                     refinement! [break]
-                ] else [
+
                     fail ["bad param type" params/1]
                 ]
             ]
@@ -853,8 +853,8 @@ foreach: emulate [
 
 loop: emulate [devoider :loop]
 repeat: emulate [devoider :repeat]
-forall: emulate [devoider :for-next]
-forskip: emulate [devoider :for-skip]
+forall: emulate [devoider :iterate]
+forskip: emulate [devoider :iterate-skip]
 
 any: emulate [devoider :any]
 all: emulate [devoider :all]

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -542,7 +542,7 @@ void Virtual_Bind_Deep_To_New_Context(
             TYPE_SET(key, REB_TS_UNBINDABLE);
             TYPE_SET(key, REB_TS_HIDDEN);
             Derelativize(var, item, specifier);
-            SET_VAL_FLAGS(var, CELL_FLAG_PROTECTED | NODE_FLAG_MARKED);
+            SET_VAL_FLAGS(var, CELL_FLAG_PROTECTED | VAR_MARKED_REUSE);
 
             // We don't want to stop `for-each ['x 'x] ...` necessarily,
             // because if we're saying we're using the existing binding they

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -156,9 +156,10 @@ REBCTX *Make_Context_For_Action_Int_Partials(
     //=//// NON-REFINEMENT SLOT HANDLING //////////////////////////////////=//
 
         if (VAL_PARAM_CLASS(param) != PARAM_CLASS_REFINEMENT) {
-            if (GET_VAL_FLAG(special, ARG_MARKED_CHECKED)) {
+            if (Is_Param_Hidden(param)) {
+                assert(GET_VAL_FLAG(special, ARG_MARKED_CHECKED));
                 Move_Value(arg, special); // !!! copy the flag?
-                SET_VAL_FLAG(arg, ARG_MARKED_CHECKED);
+                SET_VAL_FLAG(arg, ARG_MARKED_CHECKED); // !!! not copied
                 goto continue_specialized; // Eval_Core_Throws() checks type
             }
             goto continue_unspecialized;
@@ -430,6 +431,10 @@ bool Specialize_Action_Throws(
         for (; NOT_END(key); ++key, ++var) {
             if (Is_Param_Unbindable(key))
                 continue; // !!! is this flag still relevant?
+            if (Is_Param_Hidden(key)) {
+                assert(GET_VAL_FLAG(var, ARG_MARKED_CHECKED));
+                continue;
+            }
             if (GET_VAL_FLAG(var, ARG_MARKED_CHECKED))
                 continue; // may be refinement from stack, now specialized out
             Remove_Binder_Index(&binder, VAL_KEY_CANON(key));

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -506,7 +506,7 @@ static inline REBVAL *Get_Mutable_Var_May_Fail(
     //
     if (GET_VAL_FLAG(var, CELL_FLAG_PROTECTED)) {
         DECLARE_LOCAL (unwritable);
-        Init_Word(unwritable, VAL_WORD_SPELLING(unwritable));
+        Init_Word(unwritable, VAL_WORD_SPELLING(any_word));
         fail (Error_Protected_Word_Raw(unwritable));
     }
 

--- a/src/include/sys-rebnod.h
+++ b/src/include/sys-rebnod.h
@@ -284,6 +284,7 @@ union Reb_Header {
 
 #define ARG_MARKED_CHECKED NODE_FLAG_MARKED
 #define OUT_MARKED_STALE NODE_FLAG_MARKED
+#define VAR_MARKED_REUSE NODE_FLAG_MARKED
 
 
 //=//// NODE_FLAG_TRANSIENT (fifth-leftmost bit) //////////////////////////=//

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -253,8 +253,8 @@ function: func [
     ; COLLECT-WORDS interface to efficiently give this result, as well as
     ; a possible COLLECT-WORDS/INTO
     ;
-    for-skip locals 1 [ ;-- FOR-NEXT not specialized yet
-        append new-spec to set-word! locals/1
+    for-each loc locals [
+        append new-spec to set-word! loc
     ]
 
     ;; dump [{after} new-spec defaulters]
@@ -602,6 +602,39 @@ for-back: redescribe [
 ](
     specialize 'for-skip [skip: -1]
 )
+
+iterate-skip: redescribe [
+    "Variant of FOR-SKIP that directly modifies a series variable in a word"
+](
+    specialize enclose 'for-skip function [f] [
+        word: f/word
+        if not word [return null]
+        f/word: to lit-word! word ;-- do not create new virtual binding
+        saved: f/series: get word
+        trap/with [set* quote result: do f] func [e] [
+            ;-- If there's an error, restore series and propagate error
+            set* word saved
+            fail e
+        ]
+        set* word saved
+        :result
+    ][
+        series: <overwritten>
+    ]
+)
+
+iterate: iterate-next: redescribe [
+    "Variant of FOR-NEXT that directly modifies a series variable in a word"
+](
+    specialize 'iterate-skip [skip: 1]
+)
+
+iterate-back: redescribe [
+    "Variant of FOR-BACK that directly modifies a series variable in a word"
+](
+    specialize 'iterate-skip [skip: -1]
+)
+
 
 count-up: redescribe [
     "Loop the body, setting a word from 1 up to the end value given"
@@ -992,7 +1025,7 @@ cause-error: func [
     args: compose [(:args)]
 
     ; Filter out functional values:
-    for-next args [
+    iterate args [
         if action? first args [
             change/only args meta-of first args
         ]

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -77,7 +77,7 @@ extreme-of: func [
     size: default [1]
     if 1 > size [cause-error 'script 'out-of-range size]
     spot: series
-    for-skip series size [
+    iterate-skip series size [
         if (comparator first series first spot) [spot: series]
     ]
     spot

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -435,14 +435,14 @@ extract: func [
         ]
         out: make (type of series) len * length of pos
         if not default_EXTRACT and [any-string? out] [value: copy ""]
-        for-skip series width [for-next pos [
+        iterate-skip series width [iterate pos [
             val: pick series pos/1 else [value]
             append/only out :val
         ]]
     ] else [
         out: make (type of series) len
         if not default_EXTRACT and [any-string? out] [value: copy ""]
-        for-skip series width [
+        iterate-skip series width [
             val: pick series pos else [value]
             append/only out :val
         ]

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -190,7 +190,7 @@ make-tls-error: func [
 parse-asn: function [
     {Create a legible Rebol-structured BLOCK! from an ASN.1 BINARY! encoding}
 
-    return: [block!]
+    return: [<opt> block!]
     data [binary!]
 
     <static>
@@ -241,7 +241,7 @@ parse-asn: function [
     class: _
     tag: _
 
-    return collect [ keep [] for-next data [
+    return collect [ iterate data [
         byte: data/1
 
         switch mode [

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -263,8 +263,8 @@ init-schemes: func [
             if not block? ports [return blank]
 
             ; Are any of the requested ports awake?
-            for-next ports [
-                if port: find waked first ports [return true]
+            for-each port ports [
+                find waked port then [return true]
             ]
 
             false ; keep waiting

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -893,11 +893,10 @@ pe-format: context [
         ;print ["Section headers end at:" index of end-of-section-header]
         sort/compare sections func [a b][a/physical-offset < b/physical-offset]
 
-        secs: sections
-        first-section-by-phy-offset: secs/1 or [ catch [
-            for-next secs [
-                if not zero? secs/1/physical-offset [
-                    throw secs/1
+        first-section-by-phy-offset: sections/1 or [ catch [
+            for-each sec sections [
+                if not zero? sec/physical-offset [
+                    throw sec
                 ]
             ]
         ] ]

--- a/src/os/unzip.reb
+++ b/src/os/unzip.reb
@@ -265,7 +265,7 @@ ctx-zip: context [
         ]
 
         source: to block! source
-        for-next source [
+        iterate source [
             name: source/1
             root+name: if find "\/" name/1 [
                 if verbose [print ["Warning: absolute path" name]]

--- a/tests/control/forall.test.reb
+++ b/tests/control/forall.test.reb
@@ -2,7 +2,7 @@
 (
     str: "abcdef"
     out: copy ""
-    for-next str [append out first str]
+    iterate str [append out first str]
     all [
         head? str
         out = head of str
@@ -11,54 +11,54 @@
 (
     blk: [1 2 3 4]
     sum: 0
-    for-next blk [sum: sum + first blk]
+    iterate blk [sum: sum + first blk]
     sum = 10
 )
 ; cycle return value
 (
     blk: [1 2 3 4]
-    true = for-next blk [true]
+    true = iterate blk [true]
 )
 (
     blk: [1 2 3 4]
-    false = for-next blk [false]
+    false = iterate blk [false]
 )
 ; break cycle
 (
     str: "abcdef"
-    for-next str [if #"c" = char: str/1 [break]]
+    iterate str [if #"c" = char: str/1 [break]]
     char = #"c"
 )
 ; break return value
 (
     blk: [1 2 3 4]
-    null? for-next blk [break]
+    null? iterate blk [break]
 )
 ; continue cycle
 (
     success: true
     x: "a"
-    for-next x [continue | success: false]
+    iterate x [continue | success: false]
     success
 )
 ; zero repetition
 (
     success: true
     blk: []
-    for-next blk [success: false]
+    iterate blk [success: false]
     success
 )
 ; Test that return stops the loop
 (
     blk: [1]
-    f1: func [] [for-next blk [return 1 2]]
+    f1: func [] [iterate blk [return 1 2]]
     1 = f1
 )
 ; Test that errors do not stop the loop and errors can be returned
 (
     num: 0
     blk: [1 2]
-    e: for-next blk [num: first blk trap [1 / 0]]
+    e: iterate blk [num: first blk trap [1 / 0]]
     all [error? e num = 2]
 )
 ; recursivity
@@ -66,13 +66,13 @@
     num: 0
     blk1: [1 2 3 4 5]
     blk2: [6 7]
-    for-next blk1 [
+    iterate blk1 [
         num: num + first blk1
-        for-next blk2 [num: num + first blk2]
+        iterate blk2 [num: num + first blk2]
     ]
     num = 80
 )
 [#81 (
     blk: [1]
-    1 == for-next blk [blk/1]
+    1 == iterate blk [blk/1]
 )]

--- a/tests/control/forskip.test.reb
+++ b/tests/control/forskip.test.reb
@@ -2,22 +2,22 @@
 (
     blk: copy out: copy []
     for i 1 25 1 [append blk i]
-    for-skip blk 3 [append out blk/1]
+    iterate-skip blk 3 [append out blk/1]
     out = [1 4 7 10 13 16 19 22 25]
 )
 ; cycle return value
 (
     blk: [1 2 3 4]
-    true = for-skip blk 1 [true]
+    true = iterate-skip blk 1 [true]
 )
 (
     blk: [1 2 3 4]
-    false = for-skip blk 1 [false]
+    false = iterate-skip blk 1 [false]
 )
 ; break cycle
 (
     str: "abcdef"
-    for-skip str 2 [
+    iterate-skip str 2 [
         if #"c" = char: str/1 [break]
     ]
     char = #"c"
@@ -25,33 +25,33 @@
 ; break return value
 (
     blk: [1 2 3 4]
-    null? for-skip blk 2 [break]
+    null? iterate-skip blk 2 [break]
 )
 ; continue cycle
 (
     success: true
     x: "a"
-    for-skip x 1 [continue | success: false]
+    iterate-skip x 1 [continue | success: false]
     success
 )
 ; zero repetition
 (
     success: true
     blk: []
-    for-skip blk 1 [success: false]
+    iterate-skip blk 1 [success: false]
     success
 )
 ; Test that return stops the loop
 (
     blk: [1]
-    f1: func [] [for-skip blk 2 [return 1 2]]
+    f1: func [] [iterate-skip blk 2 [return 1 2]]
     1 = f1
 )
 ; Test that errors do not stop the loop and errors can be returned
 (
     num: 0
     blk: [1 2]
-    e: for-skip blk 1 [num: first blk trap [1 / 0]]
+    e: iterate-skip blk 1 [num: first blk trap [1 / 0]]
     all [error? e num = 2]
 )
 ; recursivity
@@ -59,9 +59,9 @@
     num: 0
     blk1: [1 2 3 4 5]
     blk2: [6 7]
-    for-skip blk1 1 [
+    iterate-skip blk1 1 [
         num: num + first blk1
-        for-skip blk2 1 [num: num + first blk2]
+        iterate-skip blk2 1 [num: num + first blk2]
     ]
     num = 80
 )

--- a/tests/functions/oneshot.test.reb
+++ b/tests/functions/oneshot.test.reb
@@ -4,7 +4,7 @@
     once: oneshot
     did all [
         10 = once [5 + 5]
-        null = once [5 + 5] 
+        null = once [5 + 5]
         null = once [5 + 5]
     ]
 )(


### PR DESCRIPTION
Rebol2/R3-Alpha had a FORALL construct, whose name did not obviously
distinguish it from FOREACH.  (What's the difference between doing
something "for all" elements in a block and "for each" element in a
block?)

However it was different in two big ways.  One was that it fetched the
series via word from a variable you passed in, and modified that
variable as it went--vs. taking in a variable name separate from what
was to be enumerated as FOR and FOR-EACH did.  This creates the
question of under what conditions that variable should be put back
to the initial series position.  It would do so in a THROW situation,
but not on an error, see:

https://github.com/rebol/rebol-issues/issues/2331

The other way in which it was different was that it visited each series
position, instead of each value.  It was also possible to change the
position during the iteration, so that it would NEXT whatever it was

In Ren-C, the name was changed to FOR-NEXT, which made more sense in
distinguishing the nature of the iteration.  But not taking a variable
to iterate made it odd for a "FOR" function, and also introduced the
question of what happened to the variable on loop ending.

This commit breaks those issues out by making FOR-NEXT take a variable
to set.  If you use the FOR-NEXT form, you don't have to worry about
what happens to the "original variable" in the iteration, because it
is a normal loop variable:

    for-next pos data [...]

Whatever you passed in as data was by value, not a word.  But FOR-NEXT
obeys the protocol of LIT-WORD! meaning to "use an existing binding".
So you can write:

    for-next 'data data [...]

This is the basis for a specialization called ITERATE, which does this
for you and provides the functionality of FORALL.  Decisions on what
this should do in response to throws or errors then becomes part of
that userspace construct.  For the moment, it does not do any restore
on either throws or errors...and those who are concerned about the
state of the iteration in such cases should use FOR-NEXT instead.