### PR TITLE
Change TRAP to return NULL on no failure

### DIFF
--- a/make/tools/common-parsers.r
+++ b/make/tools/common-parsers.r
@@ -215,7 +215,7 @@ proto-parser: context [
                 lines: attempt [decode-lines lines {//} { }]
                 parse lines [copy data to {=///} to end]
                 data: attempt [load-until-blank trim/auto data]
-                data: attempt [
+                data: try attempt [
                     if set-word? first data/1 [data/1]
                 ]
                 position ; Success.
@@ -226,7 +226,7 @@ proto-parser: context [
             try all [
                 lines: attempt [decode-lines lines {//} { }]
                 data: load-until-blank lines
-                data: attempt [
+                data: try attempt [
                     if set-word? first data/1 [
                         notes: data/2
                         data/1

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -423,13 +423,24 @@ to: emulate [
 ]
 
 try: emulate [
-    func [
+    function [
+        {See TRAP: https://trello.com/c/IbnfBaLI}
         return: [<opt> any-value!]
         block [block!]
-        /except {TRAP/WITH is better: https://trello.com/c/IbnfBaLI}
+        /except "Note TRAP doesn't take a handler...use THEN instead}
         code [block! action!]
     ][
-        trap/(try if except [/with]) block :code
+        trap [
+            result: do block
+        ] then err => [
+            case [
+                null? :code [err]
+                block? :code [do code]
+                action? :code [code err]
+            ]
+        ] else [
+            result
+        ]
     ]
 ]
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -1314,6 +1314,26 @@ REBNATIVE(null_q)
 
 
 //
+//  voidify: native [
+//
+//  "Turn nulls into voids, passing through all other values"
+//
+//      return: [any-value!]
+//      optional [<opt> any-value!]
+//  ]
+//
+REBNATIVE(voidify)
+{
+    INCLUDE_PARAMS_OF_VOIDIFY;
+
+    if (IS_NULLED(ARG(optional)))
+        return Init_Void(D_OUT);
+
+    RETURN (ARG(optional));
+}
+
+
+//
 //  nothing?: native/body [
 //
 //  "Returns TRUE if argument is either a BLANK! or NULL"

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -56,15 +56,21 @@ bool Catching_Break_Or_Continue(REBVAL *val, bool *broke)
         return false;
 
     if (VAL_ACT_DISPATCHER(val) == &N_break) {
-        *broke = true; // was BREAK (causes loops to always return NULL)
+        *broke = true;
         CATCH_THROWN(val, val);
-        assert(IS_NULLED(val)); // no /WITH refinement
+        assert(IS_NULLED(val)); // BREAK must always return NULL
         return true;
     }
 
     if (VAL_ACT_DISPATCHER(val) == &N_continue) {
-        *broke = false; // was CONTINUE or CONTINUE/WITH
-        CATCH_THROWN(val, val); // will be null if no /WITH was used
+        //
+        // !!! Currently continue with no argument acts the same as asking
+        // for CONTINUE NULL (the form with an argument).  This makes sense
+        // in cases like MAP-EACH (one wants a continue to not add any value,
+        // as opposed to a void) but may not make sense for all cases.
+        //
+        *broke = false;
+        CATCH_THROWN(val, val);
         return true;
     }
 

--- a/src/extensions/ffi/ext-ffi-init.reb
+++ b/src/extensions/ffi/ext-ffi-init.reb
@@ -89,8 +89,8 @@ make-callback: function [
 
     safe: function r-args
         <- (if fallback [
-            compose/deep [
-                trap/with [(body)] func [error] [
+            compose/deep/only [
+                trap [return (as group! body)] then error => [
                     print "** TRAPPED CRITICAL ERROR DURING FFI CALLBACK:"
                     print mold error
                     (fallback-value)

--- a/src/extensions/process/ext-process-init.reb
+++ b/src/extensions/process/ext-process-init.reb
@@ -28,10 +28,10 @@ browse*: function [
         ][
             location
         ]
-        trap/with [
+        trap [
             call/shell command ; don't use /WAIT
             return
-        ][
+        ] then [
             ;-- Just keep trying
         ]
     ]

--- a/src/include/sys-frame.h
+++ b/src/include/sys-frame.h
@@ -69,7 +69,7 @@ inline static void CONVERT_NAME_TO_THROWN(REBVAL *name, const REBVAL *arg) {
     Move_Value(&TG_Thrown_Arg, arg);
 }
 
-static inline void CATCH_THROWN(REBVAL *arg_out, REBVAL *thrown) {
+static inline void CATCH_THROWN(RELVAL *arg_out, REBVAL *thrown) {
     //
     // Note: arg_out and thrown may be the same pointer
     //

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -25,7 +25,7 @@ info?: function [
     if file? target [
         return query target
     ]
-    if error? trap [
+    trap [
         t: write target [HEAD]
         if only [return 'file]
         return make object! [
@@ -34,7 +34,7 @@ info?: function [
             date: t/3
             type: 'url
         ]
-    ][
+    ] then [
         return null
     ]
 ]
@@ -139,7 +139,7 @@ make-dir: func [
     for-each dir dirs [
         path: either empty? path [dir][path/:dir]
         append path slash
-        trap/with [make-dir path] func [e] [
+        trap [make-dir path] then lambda e [
             for-each dir created [attempt [delete dir]]
             fail e
         ]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -587,10 +587,15 @@ take: redescribe [
 attempt: func [
     {Tries to evaluate a block and returns result or NULL on error.}
 
-    return: [<opt> any-value!]
+    return: "null on error, if code runs and produces null it becomes void"
+        [<opt> any-value!]
     code [block! action!]
 ][
-    trap [return do code] then [return null]
+    trap [
+        return voidify do code
+    ] then [
+        return null
+    ]
 ]
 
 for-next: redescribe [

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -584,12 +584,14 @@ take: redescribe [
     ]
 )
 
-attempt: redescribe [
+attempt: func [
     {Tries to evaluate a block and returns result or NULL on error.}
-](
-    ;-- REVIEW: Voidify nulls so they are the only way to get NULL, or not?
-    specialize 'trap [with: true | handler: [null]]
-)
+
+    return: [<opt> any-value!]
+    code [block! action!]
+][
+    trap [return do code] then [return null]
+]
 
 for-next: redescribe [
     "Evaluates a block for each position until the end, using NEXT to skip"
@@ -613,7 +615,7 @@ iterate-skip: redescribe [
 
         ; !!! https://github.com/rebol/rebol-issues/issues/2331
         comment [
-            trap/with [set* quote result: do f] func [e] [
+            trap [set* quote result: do f] then lambda e [
                 set* word saved
                 fail e
             ]

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -328,10 +328,10 @@ check-response: function [port] [
         if quote (txt) <> last body-of :net-log [ ; net-log is in active state
             print "Dumping Webserver headers and body"
             net-log/S info
-            trap/with [
+            trap [
                 body: to text! conn/data
                 dump body
-            ][
+            ] then [
                 print unspaced [
                     "S: " length of conn/data " binary bytes in buffer ..."
                 ]

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -354,11 +354,12 @@ init-schemes: func [
         spec: system/standard/port-spec-serial
         init: func [port <local> path speed] [
             if url? port/spec/ref [
-                parse port/spec/ref
-                    [thru #":" 0 2 slash copy path [to slash | end] skip copy speed to end]
-                if speed: trap [to-integer/unsigned speed] [
-                    port/spec/speed: speed
+                parse port/spec/ref [
+                    thru #":" 0 2 slash
+                    copy path [to slash | end] skip
+                    copy speed to end
                 ]
+                attempt [port/spec/speed: to-integer/unsigned speed]
                 port/spec/path: to file! path
             ]
             return

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -1001,9 +1001,9 @@ pe-format: context [
         /header "Return only the section header"
         /data "Return only the section data"
     ][
-        trap/with [
+        trap [
             parse-exe exe-data
-        ][
+        ] then lambda err [
             ;print ["Failed to parse exe:" err]
             return _
         ]
@@ -1330,9 +1330,9 @@ get-encap: function [
     rebol-path [file!]
         {The executable to search for the encap information in}
 ][
-    trap/with [
+    trap [
         read/part rebol-path 1
-    ] func [e <with> return] [
+    ] then func [e <with> return] [
         print [e]
         print ["Can't check for embedded code in Rebol path:" rebol-path]
         return blank

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -246,7 +246,7 @@ start-console: function [
         o/resources
         exists? skin-file: join-of o/resources skin-file
     ] then [
-        trap/with [
+        trap [
             new-skin: do load skin-file
 
             ;; if loaded skin returns console! object then use as prototype
@@ -263,8 +263,8 @@ start-console: function [
             proto-skin/name: default ["loaded"]
             append o/loaded skin-file
 
-        ] func [error] [
-            skin-error: error       ;; show error later if --verbose
+        ] then lambda e [
+            skin-error: e       ;; show error later if --verbose
             proto-skin/name: "error"
         ]
     ]
@@ -583,7 +583,7 @@ host-console: function [
         return <prompt>
     ]
 
-    trap/with [
+    trap [
         ;
         ; Note that LOAD/ALL makes BLOCK! even for a single item,
         ; e.g. `load/all "word"` => `[word]`
@@ -591,7 +591,7 @@ host-console: function [
         code: load/all delimit result newline
         assert [block? code]
 
-    ] lambda error [
+    ] then lambda error [
         ;
         ; If loading the string gave back an error, check to see if it
         ; was the kind of error that comes from having partial input

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -622,7 +622,7 @@ host-start: function [
     ; things could affect this, e.g. a complex userspace TRACE which was
     ; run during boot.
     ;
-    trap [c-debug-break-at/compensate 1000] ;-- fails in release build
+    attempt [c-debug-break-at/compensate 1000] ;-- fails in release build
 
     ; As long as there was no `--script` pased on the command line explicitly,
     ; the first item after the options is implicitly the script.
@@ -697,12 +697,12 @@ comment [
         elide (loud-print ["Checking for rebol.reb file in" o/bin])
         exists? o/bin/rebol.reb
     ] then [
-        trap/with [
+        trap [
             do o/bin/rebol.reb
             append o/loaded o/bin/rebol.reb
             loud-print ["Finished evaluating script:" o/bin/rebol.reb]
-        ] func [error] [
-            die/error "Error found in rebol.reb script" error
+        ] then lambda e [
+            die/error "Error found in rebol.reb script" e
         ]
     ]
 
@@ -715,12 +715,12 @@ comment [
         elide (loud-print ["Checking for user.reb file in" o/resources])
         exists? o/resources/user.reb
     ] then [
-        trap/with [
+        trap [
             do o/resources/user.reb
             append o/loaded o/resources/user.reb
             loud-print ["Finished evaluating script:" o/resources/user.reb]
-        ] func [error] [
-            die/error "Error found in user.reb script" error
+        ] then lambda e [
+            die/error "Error found in user.reb script" e
         ]
     ]
 

--- a/src/os/unzip.reb
+++ b/src/os/unzip.reb
@@ -408,9 +408,9 @@ ctx-zip: context [
                         ]
 
                         data: copy/part data compressed-size
-                        if error? trap [
+                        trap [
                             data: inflate/max data uncompressed-size
-                        ][
+                        ] then [
                             info "^- -> failed [deflate]^/"
                             throw blank
                         ]

--- a/tests/control/attempt.test.reb
+++ b/tests/control/attempt.test.reb
@@ -15,9 +15,9 @@
 (null? loop 1 [attempt [break 2] 2])
 ; recursion
 (1 = attempt [attempt [1]])
-(null? attempt [attempt [1 / 0]])
+(void? attempt [attempt [1 / 0]])
 ; infinite recursion
 (
     blk: [attempt blk]
-    null? attempt blk
+    void? attempt blk
 )

--- a/tests/control/catch.test.reb
+++ b/tests/control/catch.test.reb
@@ -8,21 +8,21 @@
     success
 )
 ; catch results
-(void? catch [])
-(void? catch [()])
-(error? catch [trap [1 / 0]])
-(1 = catch [1])
+(null? catch [])
+(null? catch [()])
+(error? catch [throw trap [1 / 0]])
+(1 = catch [throw 1])
 (void? catch [throw do []])
 (error? first catch [throw reduce [trap [1 / 0]]])
 (1 = catch [throw 1])
 ; catch/name results
-(void? catch/name [] 'catch)
-(void? catch/name [()] 'catch)
-(error? catch/name [trap [1 / 0]] 'catch)
-(1 = catch/name [1] 'catch)
-(void? catch/name [throw/name (void) 'catch] 'catch)
-(error? first catch/name [throw/name reduce [trap [1 / 0]] 'catch] 'catch)
-(1 = catch/name [throw/name 1 'catch] 'catch)
+(null? catch/name [] 'catch)
+(null? catch/name [()] 'catch)
+(null? catch/name [trap [1 / 0]] 'catch)
+(null? catch/name [1] 'catch)
+([catch #[void]] = catch/name [throw/name (void) 'catch] 'catch)
+(error? first second catch/name [throw/name reduce [trap [1 / 0]] 'catch] 'catch)
+([catch 1] = catch/name [throw/name 1 'catch] 'catch)
 ; recursive cases
 (
     num: 1

--- a/tests/control/reduce.test.reb
+++ b/tests/control/reduce.test.reb
@@ -14,7 +14,7 @@
 ]
 (void? loop 1 [reduce [continue]])
 (1 = catch [reduce [throw 1]])
-(1 = catch/name [reduce [throw/name 1 'a]] 'a)
+([a 1] = catch/name [reduce [throw/name 1 'a]] 'a)
 (1 = eval func [] [reduce [return 1 2] 2])
 (null? if 1 < 2 [eval does [reduce [unwind :if 1] 2]])
 ; recursive behaviour

--- a/tests/control/try.test.reb
+++ b/tests/control/try.test.reb
@@ -20,16 +20,15 @@
     error? trap [f1]
     success
 )
-; testing TRAP/WITH
 [#822
-    (error? trap/with [make error! ""] [0])
+    (trap [make error! ""] then [<branch-not-run>] else [true])
 ]
-(trap/with [fail make error! ""] [true])
-(trap/with [1 / 0] :error?)
-(trap/with [1 / 0] func [e] [error? e])
-(trap/with [true] func [e] [false])
+(trap [fail make error! ""] then [true])
+(trap [1 / 0] then :error?)
+(trap [1 / 0] then func [e] [error? e])
+(trap [] then func [e] [<handler-not-run>] else [true])
 [#1514
-    (error? trap [trap/with [1 / 0] :add])
+    (error? trap [trap [1 / 0] then :add])
 ]
 
 [#1506 ((

--- a/tests/control/while.test.reb
+++ b/tests/control/while.test.reb
@@ -108,10 +108,10 @@
     cycle?: true
     1 = catch [while [if cycle? [throw 1] false] [cycle?: false]]
 )
-(1 = catch/name [cycle?: true while [cycle?] [throw/name 1 'a cycle?: false]] 'a)
+([a 1] = catch/name [cycle?: true while [cycle?] [throw/name 1 'a cycle?: false]] 'a)
 (  ; bug#1519
     cycle?: true
-    1 = catch/name [while [if cycle? [throw/name 1 'a] false] [cycle?: false]] 'a
+    [a 1] = catch/name [while [if cycle? [throw/name 1 'a] false] [cycle?: false]] 'a
 )
 ; Test that disarmed errors do not stop the loop and errors can be returned
 (

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -10,7 +10,7 @@
 ; reserved by the system and must be formed from mezzanine/user code in
 ; accordance with the structure the system would form.  Hence, illegal.
 ;
-(trap/with [make error! [type: 'script id: 'nonexistent-id]] [true])
+(trap [make error! [type: 'script id: 'nonexistent-id]] then [true])
 
 ; triggered errors should not be assignable
 ;

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -233,14 +233,17 @@
 )
 ; THROW out leaves a "running" function in a "clean" state
 (
-    1 = catch [
-        f: func [x] [
-            either x = 1 [
-                catch [f 2]
-                x
-            ] [throw 1]
+    did all [
+        null? catch [
+            f: func [x] [
+                either x = 1 [
+                    catch [f 2]
+                    x
+                ] [throw 1]
+            ]
+            result: f 1
         ]
-        f 1
+        result = 1
     ]
 )
 

--- a/tests/misc/gtk.r
+++ b/tests/misc/gtk.r
@@ -2,19 +2,19 @@ REBOL []
 
 recycle/torture
 
-libgtk: trap/with [
+libgtk: attempt [
     make library! %libgtk-3.so
-][
+] else [
     make library! %libgtk-3.so.0
 ]
-libglib: trap/with [
+libglib: attempt [
     make library! %libglib-2.0.so
-][
+] else [
     make library! %libglib-2.0.so.0
 ]
-libgob: trap/with [
+libgob: attempt [
     make library! %libgobject-2.0.so
-][
+] else [
     make library! %libgobject-2.0.so.0
 ]
 

--- a/tests/system/gc.test.reb
+++ b/tests/system/gc.test.reb
@@ -80,5 +80,5 @@
     'file = exists? http://www.rebol.com/index.html
 )]
 
-(not error? trap [read http://example.com])
-(not error? trap [read https://example.com])
+(binary? read http://example.com)
+(binary? read https://example.com)

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -37,14 +37,14 @@ make object! [
 
             ["{" | {"}] (
                 ; handle string using TRANSCODE
-                success: either error? trap [
+                success-rule: trap [
                     position: second transcode/next position
-                ] [
+                ] then [
                     [end skip]
-                ] [
+                ] else [
                     [:position]
                 ]
-            ) success
+            ) success-rule
                 |
             ["{" | {"}] :position break
                 |
@@ -87,20 +87,20 @@ make object! [
         current-dir: what-dir
         print ["file:" mold test-file]
 
-        either error? err: trap [
+        trap [
             if file? test-file [
                 test-file: clean-path test-file
                 change-dir first split-path test-file
             ]
             test-sources: get in load-testfile test-file 'contents
-        ][
+        ] then err => [
             ; probe err
             append collected-tests reduce [
                 test-file 'dialect {^/"failed, cannot read the file"^/}
             ]
             change-dir current-dir
             return
-        ][
+        ] else [
             change-dir current-dir
             append collected-tests test-file
         ]
@@ -122,9 +122,9 @@ make object! [
         any-wsp: [any [wsp emit-token]]
 
         single-value: parsing-at x [
-            if not error? trap [
+            trap [
                 set [value: next-position:] transcode/next x
-            ][
+            ] else [
                 type: in types 'val
                 next-position
             ]
@@ -220,7 +220,7 @@ make object! [
             {collect the logged results here (modified)}
         log-file [file!]
     ][
-        if error? trap [log-contents: read log-file] [
+        trap [log-contents: read log-file] then [
             fail ["Unable to read " mold log-file]
         ]
 


### PR DESCRIPTION
R3-Alpha's error-trapping function (TRY) could take a handler--which
could be a block or a single-arity function--for handling the case
when an error was raised.  If no handler was provided, it would
return the error value...but this would be mixed up with the possible
return value of the expression evaluated itself.

This rethinks TRAP to return NULL if there is no failure.  That means
it doesn't need to interact with handlers, you can use THEN and ELSE.
This does make it a little harder to get a return value from the
expression, but many expressions written as:

    foo: trap [...]

Can be rewritten as:

    trap [... foo: ...]