### PR TITLE
Reorder DELIMIT parameters

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -436,7 +436,7 @@ FLAG:
 NOTE: 1st 'anonymous' FLAG, if present, set the default^/
 NAME: one of
     }
-    indent delimit extension-names " | "
+    indent delimit " | " extension-names
     {^/
 EXAMPLES:
     extensions: +
@@ -1538,9 +1538,9 @@ prep: make rebmake/entry-class [
         (spaced [
             {$(REBOL)} tools-dir/make-boot-ext-header.r
                 unspaced [{EXTENSIONS=}
-                    delimit map-each ext builtin-extensions [
+                    delimit ":" map-each ext builtin-extensions [
                         to text! ext/name
-                    ] #":"
+                    ]
                 ]
         ])
         (

--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -98,7 +98,7 @@ cscape: function [
                     either block? sub [unspaced sub] [form sub]
                 ]
                 mode = #delim [
-                    delimit sub unspaced [dlm newline]
+                    delimit (unspaced [dlm newline]) sub 
                 ]
                 fail ["Invalid CSCAPE mode:" mode]
             ] or [

--- a/make/tools/common.r
+++ b/make/tools/common.r
@@ -393,6 +393,6 @@ relative-to-path: func [
     ]
     iterate base [base/1: %..]
     append base target
-    to-file delimit base "/"
+    to-file delimit "/" base
 ]
 

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -465,7 +465,7 @@ for-each [ts types] typeset-sets [
         ]
     ]
     e-types/emit [flagits ts] {
-        #define TS_${TS} ($<Delimit Flagits "|">)
+        #define TS_${TS} ($<Delimit "|" Flagits>)
     } ;-- !!! TS_ANY_XXX is wordy, considering TS_XXX denotes a typeset
 ]
 
@@ -734,8 +734,8 @@ for-each [sw-cat list] boot-errors [
 
         e-errfuncs/emit [message cat id f-name params args] {
             /* $<Mold Message> */
-            static inline REBCTX *Error_${F-Name}_Raw($<Delimit Params ", ">) {
-                return Error(SYM_${CAT}, SYM_${ID}, $<Delimit Args ", ">);
+            static inline REBCTX *Error_${F-Name}_Raw($<Delimit ", " Params>) {
+                return Error(SYM_${CAT}, SYM_${ID}, $<Delimit ", " Args>);
             }
         }
         e-errfuncs/emit newline

--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -160,9 +160,9 @@ lib-struct-fields: map-each-api [
     cfunc-params: if empty? paramlist [
         "void"
     ] else [
-        delimit map-each [type var] paramlist [
+        delimit ", " map-each [type var] paramlist [
             spaced [type var]
-        ] ", "
+        ]
     ]
     cscape/with
         <- {$<Returns> (*$<Name>)($<Cfunc-Params>)}
@@ -187,21 +187,21 @@ for-each api api-objects [do in api [
         opt-va-start: {va_list va; va_start(va, p);}
     ]
 
-    wrapper-params: (delimit map-each [type var] paramlist [
+    wrapper-params: (delimit ", " map-each [type var] paramlist [
         if type = "va_list *" [
             "..."
         ] else [
             spaced [type var]
         ]
-    ] ", ") else ["void"]
+    ]) else ["void"]
 
-    proxied-args: try delimit map-each [type var] paramlist [
+    proxied-args: try delimit ", " map-each [type var] paramlist [
         if type = "va_list *" [
             "&va" ;-- to produce vaptr
         ] else [
             to text! var
         ]
-    ] ", "
+    ]
 
     if find spec #noreturn [
         assert [returns = "void"]
@@ -241,9 +241,9 @@ c89-macros: map-each-api [
     cfunc-params: if empty? paramlist [
         "void"
     ] else [
-        delimit map-each [type var] paramlist [
+        delimit ", " map-each [type var] paramlist [
             spaced [type var]
-        ] ", "
+        ]
     ]
     cscape/with
         <- {#define $<Name> $<Name>_inline}

--- a/make/tools/make-zlib.r
+++ b/make/tools/make-zlib.r
@@ -280,9 +280,9 @@ fix-kr: function [
 
                 ;dump param-block
 
-                insert open-paren new-param: delimit (
+                insert open-paren new-param: delimit ",^/    " (
                     extract/index param-block 2 2
-                ) ",^/    "
+                )
                 insert open-paren "^/    "
 
                 length-diff: length-diff + length of new-param
@@ -395,6 +395,6 @@ insert source-lines [
 
 insert source-lines make-warning-lines file-source {ZLIB aggregated source file}
 
-all-source: delimit source-lines "^/"
+all-source: delimit LF source-lines
 
 write join-all [path-source file-source] fix-const-char fix-kr all-source

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -502,7 +502,16 @@ count-up: :repeat ;-- https://forum.rebol.info/t/892
 ; Approximations (can't override null return case with unspaced ["" ...])
 ; https://forum.rebol.info/t/904/2
 ;
-delimit: chain [:delimit | function [x] [if x <> "" [x]]]
+delimit: function [ ;-- Note: order of paramters changed
+    return: [<opt> text!]
+    delimiter [blank! text! block!]
+    line [block! blank!]
+][
+    if blank? line [return null]
+    delimiter: default [""]
+    x: lib/delimit line delimiter
+    if x <> "" [x]
+]
 unspaced: chain [:unspaced | function [x] [if x <> "" [x]]]
 spaced: chain [:spaced | function [x] [if x <> "" [x]]]
 

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -1475,24 +1475,19 @@ makefile: make generator-class [
                         ]
                     ]
                     newline
-                    if all [
+                    all [
                         entry/commands
                         not empty? entry/commands
-                    ][
+                    ] then [
                         unspaced [
                             "^-"
                             either block? entry/commands [
-                                delimit map-each cmd (map-each cmd entry/commands [
-                                    either text? cmd [
-                                        cmd
-                                    ][
-                                        gen-cmd cmd
-                                    ]
-                                ]) [if not empty? cmd [cmd]] "^/^-"
+                                delimit "^/^-" map-each cmd entry/commands [
+                                    c: match text! cmd else [gen-cmd cmd]
+                                    if not empty? c [c]
+                                ]
                             ][
-                                either text? entry/commands [
-                                    entry/commands
-                                ][
+                                match text! entry/commands else [
                                     gen-cmd entry/commands
                                 ]
                             ]
@@ -2173,7 +2168,7 @@ visual-studio: make generator-class [
         ][
             unspaced [ {
     <PreBuildEvent>
-      <Command>} use [cmd][delimit map-each cmd project/commands [reify cmd] "^M^/"] {
+      <Command>} use [cmd][delimit "^M^/" map-each cmd project/commands [reify cmd]] {
       </Command>
     </PreBuildEvent>}
             ]
@@ -2185,7 +2180,7 @@ visual-studio: make generator-class [
     ][
         unspaced [ {
     <PostBuildEvent>
-      <Command>} use [cmd][delimit map-each cmd project/post-build-commands [reify cmd] "^M^/"] {
+      <Command>} use [cmd][delimit "^M^/" map-each cmd project/post-build-commands [reify cmd]] {
       </Command>
     </PostBuildEvent>}
         ]

--- a/scripts/r2warn.reb
+++ b/scripts/r2warn.reb
@@ -56,7 +56,7 @@ repurposed: deprecated: func [block [block!]] [
     append block {Emulation of the old meanings available via %redbol.reb}
 
     return func [dummy:] compose/only [
-        fail/where (delimit block LF) 'dummy
+        fail/where (delimit LF block) 'dummy
     ]
 ]
 

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -101,25 +101,32 @@ static struct {
 //
 //  {Joins a block of values into TEXT! with delimiters.}
 //
-//      return: "Will be null if all block's contents are null"
+//      return: "Null if blank input or block's contents are all null"
 //          [<opt> text!]
-//      block [block!]
-//      delimiter [<opt> char! text!] ;-- should this accept ANY-VALUE!?
+//      delimiter "Blank means no delimiter (same as empty string)"
+//          [blank! char! text!]
+//      line "Will be copied if already a text value"
+//          [blank! text! block!]
 //  ]
 //
 REBNATIVE(delimit)
 {
     INCLUDE_PARAMS_OF_DELIMIT;
 
-    REBVAL *block = ARG(block);
-    REBVAL *delimiter = ARG(delimiter);
+    REBVAL *line = ARG(line);
+    if (IS_BLANK(line))
+        return nullptr; // blank in, null out convention
+    if (IS_TEXT(line))
+        return rebRun("copy", line, rebEND); // !!! Review performance
+
+    assert(IS_BLOCK(line));
 
     if (Form_Reduce_Throws(
         D_OUT,
-        VAL_ARRAY(block),
-        VAL_INDEX(block),
-        VAL_SPECIFIER(block),
-        delimiter
+        VAL_ARRAY(line),
+        VAL_INDEX(line),
+        VAL_SPECIFIER(line),
+        ARG(delimiter)
     )){
         return R_THROWN;
     }

--- a/src/extensions/uuid/ext-uuid-init.reb
+++ b/src/extensions/uuid/ext-uuid-init.reb
@@ -12,7 +12,7 @@ append uuid reduce [
         "Convert the UUID to the text string form ({8-4-4-4-12})"
         uuid [binary!]
     ][
-        delimit map-each w reduce [
+        delimit "-" map-each w reduce [
             copy/part uuid 4
             copy/part (skip uuid 4) 2
             copy/part (skip uuid 6) 2
@@ -21,6 +21,5 @@ append uuid reduce [
         ][
             enbase/base w 16
         ]
-        #"-"
     ]
 ]

--- a/src/extensions/uuid/make-libuuid.reb
+++ b/src/extensions/uuid/make-libuuid.reb
@@ -152,9 +152,10 @@ for-each [file fix] files [
     data: to-text read url: join-of ROOT file
     target: join-of %libuuid/ (last split-path file)
 
-    print url
-    print ["->" target]
-    print []
+    print [
+        url LF
+        "->" target LF
+    ]
 
     if :fix [data: fix data] ;-- correct compiler warnings
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -127,7 +127,7 @@ back: specialize 'skip [
 
 bound?: chain [specialize 'reflect [property: 'binding] | :value?]
 
-unspaced: specialize 'delimit [delimiter: ""]
+unspaced: specialize 'delimit [delimiter: _]
 spaced: specialize 'delimit [delimiter: space]
 
 an: func [
@@ -262,16 +262,17 @@ print: func [
     line "Line of text or block to run SPACED on, blank prints nothing"
         [blank! text! block!]
 ][
-    write-stdout switch type of line [
-        blank! [return null] ;-- don't print the newline
-        text! [line]
-        block! [try spaced line]
-    ]
-    write-stdout newline
-    return
+    ; WRITE-STDOUT will return NULL if given a blank input, and SPACED will
+    ; return null if either the block given to it is all nulls or if it
+    ; gets a blank input.  `print []` is equivalent to `print _`, no newline.
+    ; To print a newline, use `print {}`.
+    ;
+    write-stdout try spaced line then [write-stdout newline]
 ]
 
-print-newline: specialize 'write-stdout [value: newline]
+print-newline: specialize 'write-stdout [ ;-- or use `print {}`
+    value: newline
+]
 
 
 decode-url: _ ; set in sys init

--- a/src/os/host-console.r
+++ b/src/os/host-console.r
@@ -588,7 +588,7 @@ host-console: function [
         ; Note that LOAD/ALL makes BLOCK! even for a single item,
         ; e.g. `load/all "word"` => `[word]`
         ;
-        code: load/all delimit result newline
+        code: load/all delimit newline result
         assert [block? code]
 
     ] then lambda error [

--- a/tests/series/delimit.test.reb
+++ b/tests/series/delimit.test.reb
@@ -1,8 +1,8 @@
-(null? delimit [] #" ")
-("1 2" = delimit [1 2] #" ")
+(null? delimit #" " [])
+("1 2" = delimit #" " [1 2])
 
-(null? delimit [] "unused")
-("1" = delimit [1] "unused")
-("12" = delimit [1 2] "")
+(null? delimit "unused" [])
+("1" = delimit "unused" [1])
+("12" = delimit "" [1 2])
 
-("1^/^/2" = delimit ["1^/" "2"] #"^/")
+("1^/^/2" = delimit #"^/" ["1^/" "2"])


### PR DESCRIPTION
The frequent use case of DELIMIT has a very simple delimiter string,
with a more complex expression producing the things to delimit (such
as a MAP-EACH).  While Rebol has a pattern of mutating operations
typically taking the series being operated on as the first parameter,
DELIMIT is generating a new series...and it's been fairly clear that
the source is more legible when the delimiter is first.

This goes ahead and makes the change.