### PR TITLE
Allow ACTION! as data source for FOR-EACH, MAP-EACH, etc.

### DIFF
--- a/tests/control/for-each.test.reb
+++ b/tests/control/for-each.test.reb
@@ -140,3 +140,23 @@
         obj2/x = 4
     ]
 )]
+
+;-- ACTION!s are called repeatedly util NULL is returned
+
+(
+    make-one-thru-five: function [<static> count (0)] [
+        if count = 5 [return null]
+        return count: count + 1
+    ]
+    [10 20 30 40 50] = map-each i :make-one-thru-five [
+        i * 10
+    ]
+)(
+    make-one-thru-five: function [<static> count (0)] [
+        if count = 5 [return null]
+        return count: count + 1
+    ]
+    [[1 2] [3 4] [5]]  = map-each [a b] :make-one-thru-five [
+        compose [(:a) (:b)]
+    ]
+)


### PR DESCRIPTION
This allows the enumeration of arbitrarily large amounts of data
without needing the values generated into a block ahead of time.  A
function is called instead--which returns any value.  Once it returns
NULL, then that is taken to be the end.

    >> make-one-thru-five: function [<static> count (0)] [
          if count = 5 [return null]
          return count: count + 1
       ]

    >> for-each i :make-one-thru-five [-- i]
    -- i: 1
    -- i: 2
    -- i: 3
    -- i: 4
    -- i: 5

It's designed to work with multiple items at a time, as with the other
enumerations.  If at least some of the variables can be set they
will, with the others being unset:

    >> for-each [a b] :make-one-thru-five [-- a b]
    -- a: 1
    -- b: 2
    -- a: 3
    -- b: 4
    -- a: 5
    -- b: // null

Implementing this required some cleanup to the Loop_Each() internal C
function, which was historically a bit obtuse.