### PR TITLE
Make PARSE return final match position, eliminate RETURN

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -219,7 +219,7 @@ parse-ext-build-spec: function [
         ensure block! ext/options
         parse ext/options [
             any [
-                word! block! opt text! set config: group!
+                word! block! opt text! set config: group! end
                 | end
                 | (print "wrong format for options") return false
             ]
@@ -495,7 +495,7 @@ parse user-config/toolset [
         | pos: (
             if not tail? pos [fail ["failed to parset toolset at:" mold pos]]
         )
-    ]
+    ] end
 ]
 
 ; sanity checking the compiler and linker

--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -90,7 +90,7 @@ cscape: function [
             newline (col: 0 prefix: _ suffix: _) start:
                 |
             skip (col: col + 1)
-        ]]
+        ]] end
     ] else [return string]
 
     list: unique/case list
@@ -173,6 +173,7 @@ cscape: function [
             (nonwhite: true)
             skip
         ]
+        end
     ]
 
     return string
@@ -206,9 +207,9 @@ make-emitter: function [
 
     temporary: did any [temporary | parse stem ["tmp-" to end]]
 
-    is-c: did parse stem [thru [".c" | ".h" | ".inc"]]
+    is-c: did parse stem [thru [".c" | ".h" | ".inc"] end]
 
-    is-js: did parse stem [thru ".js"]
+    is-js: did parse stem [thru ".js" end]
 
     e: make object! compose [
         ;

--- a/make/tools/common-parsers.r
+++ b/make/tools/common-parsers.r
@@ -35,8 +35,9 @@ decode-key-value-text: function [
             data-field
             | newline
         ]
+        end
     ]
-            
+
     data-field: [
         data-field-name eof: [
             #" " to newline any [
@@ -110,7 +111,7 @@ load-until-blank: function [
 ]
 
 
-collapse-whitespace: [some [change some white-space space | skip]]
+collapse-whitespace: [some [change some white-space space | skip] end]
 bind collapse-whitespace c.lexical/grammar
 
 
@@ -127,7 +128,9 @@ proto-parser: context [
     data: _
     eoh: _ ; End of file header.
 
-    process: func [return: <void> text] [parse text grammar/rule]
+    process: func [return: <void> text] [
+        parse text [grammar/rule] ;-- Review: no END (return result unused?)
+    ]
 
     grammar: context bind [
 
@@ -301,6 +304,7 @@ rewrite-if-directives: function [
                 ] (rewritten: true) :position
                 | thru newline
             ]
+            end
         ]
         not rewritten
     ]

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -707,7 +707,7 @@ for-each [sw-cat list] boot-errors [
 
         arity: 0
         if block? message [ ;-- can have N GET-WORD! substitution slots
-            parse message [any [get-word! (arity: arity + 1) | skip]]
+            parse message [any [get-word! (arity: arity + 1) | skip] end]
         ] else [
             ensure text! message ;-- textual message, no arguments
         ]
@@ -716,7 +716,7 @@ for-each [sw-cat list] boot-errors [
         ;
         f-name: uppercase/part to-c-name id 1
         parse f-name [
-            any ["_" w: (uppercase/part w 1) | skip]
+            any ["_" w: (uppercase/part w 1) | skip] end
         ]
 
         if arity = 0 [

--- a/make/tools/make-headers.r
+++ b/make/tools/make-headers.r
@@ -277,7 +277,9 @@ sys-globals.parser: context [
     parse.position: _
     id: _
 
-    process: func [return: <void> text] [parse text grammar/rule]
+    process: func [return: <void> text] [
+        parse text grammar/rule ;-- Review: no END (return result unused?)
+    ]
 
     grammar: context bind [
 
@@ -368,6 +370,7 @@ parse native-list [
             e-params/emit newline
         )
     ]
+    end
 ] or [
     fail "Error processing native-list"
 ]

--- a/make/tools/make-os-ext.r
+++ b/make/tools/make-os-ext.r
@@ -54,8 +54,8 @@ files: copy []
 
 rule: ['+ set scannable [word! | path!] (append files to-file scannable) | skip]
 
-parse file-base/os [some rule]
-parse os-specific-objs [some rule]
+parse file-base/os [some rule end]
+parse os-specific-objs [some rule end]
 
 proto-count: 0
 

--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -100,6 +100,7 @@ emit-proto: func [return: <void> proto] [
                     keep to word! next pos ;-- WORD! of the parameter name
                 )
             ]]
+            end
         ] or [
             fail ["Couldn't extract API schema from prototype:" proto]
         ]
@@ -628,7 +629,7 @@ to-js-type: func [
         ; The differences between undefined and null are subtle and easy to
         ; get wrong, but a void-returning function should map to undefined.
         ;
-        parse s ["void" any space] ["undefined"]
+        parse s ["void" any space end] ["undefined"]
     ]
 ]
 

--- a/make/tools/make-zlib.r
+++ b/make/tools/make-zlib.r
@@ -207,6 +207,7 @@ fix-kr: function [
                             append param-block reduce [name _]
                         )
                     ]
+                    end
                 ]
 
                 ;dump param-block
@@ -294,6 +295,7 @@ fix-kr: function [
             :check-point
             | skip
         ]
+        end
     ] c.lexical/grammar
 
     source
@@ -310,6 +312,7 @@ fix-const-char: func [
                 any white-space "*" any white-space ")"
             | skip
         ]
+        end
     ] c.lexical/grammar
     source
 ]

--- a/make/tools/native-emitters.r
+++ b/make/tools/native-emitters.r
@@ -48,6 +48,7 @@ emit-native-proto: function [
                 to end
             ]
         ]
+        end
     ] then [
         append case [
             ;

--- a/make/tools/prep-extension.r
+++ b/make/tools/prep-extension.r
@@ -143,7 +143,7 @@ native-defs: try collect [
         )
     ]
 
-    parse native-list [any native-rule] or [
+    parse native-list [any native-rule end] or [
         fail [
             "Malformed native found in extension specs" mold native-list
         ]

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -135,6 +135,7 @@ pkg-config: function [
                     append ret to file! item
                 )
             ]
+            end
         ]
         ret
     ][
@@ -1198,6 +1199,7 @@ generator-class: make object! [
                     ] val
                     | skip
                 ]
+                end
             ] or [
                 fail ["failed to do var substitution:" cmd]
             ]
@@ -1776,7 +1778,7 @@ visual-studio: make generator-class [
 
     find-stack-size: method [
         return: [<opt> text!]
-        ldflags [blank! block!]
+        ldflags [<blank> block!]
         <static>
         digit (charset "0123456789")
     ][
@@ -1785,6 +1787,7 @@ visual-studio: make generator-class [
             parse i [
                 "/stack:"
                 copy size: some digit
+                end
             ] then [
                 remove ldflags
                 return size
@@ -1795,7 +1798,7 @@ visual-studio: make generator-class [
 
     find-subsystem: method [
         return: [<opt> text!]
-        ldflags [blank! block!]
+        ldflags [<blank> block!]
     ][
         iterate ldflags [
             i: filter-flag ldflags/1 "msc" else [continue]

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -481,7 +481,9 @@ for-each-system: function [
                 ]
             )
         ]
-    ] ]
+    ] end ] or [
+        fail "Couldn't parse systems.r table"
+    ]
 ]
 
 

--- a/make/tools/text-lines.reb
+++ b/make/tools/text-lines.reb
@@ -23,7 +23,7 @@ decode-lines: function [
     pattern: compose/only [(line-prefix)]
     if not empty? indent [append pattern compose/only [opt (indent)]]
     line: [pos: pattern rest: (rest: remove/part pos rest) :rest thru newline]
-    parse text [any line] or [
+    parse text [any line end] or [
         fail [
             {Expected line} (try text-line-of text pos)
             {to begin with} (mold line-prefix)
@@ -50,6 +50,7 @@ encode-lines: func [
             thru newline pos:
             [newline (pos: insert pos line-prefix) | (pos: insert pos bol)] :pos
         ]
+        end
     ]
 
     ; Indent head if original text did not start with a newline.
@@ -110,6 +111,7 @@ lines-exceeding: function [ ;-- !!! Doesn't appear used, except in tests (?)
     parse text [
         any [bol: to newline eol: skip count-line]
         bol: skip to end eol: count-line
+        end
     ]
 
     opt line-list
@@ -136,6 +138,7 @@ text-line-of: function [
             advance
         ]
         advance
+        end
     ]
 
     if zero? line [return null]
@@ -164,6 +167,7 @@ text-location-of: function [
             advance
         ]
         advance
+        end
     ]
 
     if zero? line [line: _] else [

--- a/scripts/changes-file/changes-file.reb
+++ b/scripts/changes-file/changes-file.reb
@@ -124,6 +124,7 @@ parse-credits-for-authors: function [
                 )
                 | skip
             ]
+            end
         ]
     ]
 ]
@@ -144,14 +145,14 @@ notable?: function [
 
     ;; Let try and categorise type of commit (default is 'Changed)
     category: 'Changed
-    parse text: c/summary [
+    parse text: c/summary [[
         opt "* "
           ["Add" | "-add"]           (category: 'Added)
         | ["Fix" | "Patch" | "-fix"] (category: 'Fixed)
         | ["remove" | "delete"]      (category: 'Removed)
         | "Deprecate"                (category: 'Deprecated)
         | "Security"                 (category: 'Security)
-    ]
+    ] end]
     append c compose [type: quote (category)]
 
     ;; record any bug#NNNN or CC (CureCode) found

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -472,6 +472,7 @@ also: emulate [
 parse: emulate [
     function [
         {Non-block rules replaced by SPLIT: https://trello.com/c/EiA56IMR}
+        return: [logic! block!]
         input [any-series!]
         rules [block! text! blank!]
         /case
@@ -487,7 +488,10 @@ parse: emulate [
             blank! [split input charset reduce [tab space CR LF]]
             text! [split input to-bitset rules]
         ] else [
-            parse/(try if case_PARSE [/case]) input rules
+            if not pos: parse/(try if case_PARSE [/case]) input rules [
+                return false
+            ]
+            return tail? pos
         ]
     ]
 ]

--- a/src/extensions/console/ext-console-init.reb
+++ b/src/extensions/console/ext-console-init.reb
@@ -469,7 +469,7 @@ ext-console-impl: function [
     ;
     directives: try collect [
         if block? prior [
-            parse prior [some [set i: issue! (keep i)]]
+            parse prior [some [set i: issue! (keep i)] end]
         ]
     ]
 

--- a/src/extensions/ffi/ext-ffi-init.reb
+++ b/src/extensions/ffi/ext-ffi-init.reb
@@ -86,6 +86,7 @@ make-callback: function [
     parse args [
         opt text!
         any [arg-rule | attr-rule]
+        end
     ] or [
         fail ["Unrecognized pattern in MAKE-CALLBACK function spec" args]
     ]
@@ -110,6 +111,7 @@ make-callback: function [
             remove [tag! some word!]
             | skip
         ]
+        end
     ]
 
     wrap-callback :safe args

--- a/src/extensions/locale/iso3166.r
+++ b/src/extensions/locale/iso3166.r
@@ -45,6 +45,7 @@ parse cnt [
 
         "^/"
     ]
+    end
 ]
 
 init-code: to text! read init

--- a/src/extensions/locale/iso639.r
+++ b/src/extensions/locale/iso639.r
@@ -51,6 +51,7 @@ parse cnt [
 
         ["^/" | "^M"]
     ]
+    end
 ]
 
 init-code: to text! read init

--- a/src/extensions/uuid/make-libuuid.reb
+++ b/src/extensions/uuid/make-libuuid.reb
@@ -72,6 +72,8 @@ fix-randutils.c: func [
 
             | skip
         ]
+
+        end
     ]
 
     cnt
@@ -132,6 +134,8 @@ fix-gen_uuid.c: function [
 
             | skip
         ]
+
+        end
     ]
     cnt
 ]

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -210,6 +210,7 @@ split-path: func [
             ]
             all [find [%. %..] pos: to file! pos insert tail of pos #"/"]
         )
+        end
     ]
     reduce [dir pos]
 ]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -237,7 +237,7 @@ function: func [
                 "Invalid spec item:" (mold other/1)
             ]
         )
-    ]]
+    ] end]
 
     locals: collect-words/deep/set/ignore body exclusions
 
@@ -434,6 +434,7 @@ redescribe: function [
                 ]
             )]
         ]
+        end
     ] or [
         fail [{REDESCRIBE specs should be STRING! and ANY-WORD! only:} spec]
     ]

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -290,7 +290,7 @@ trim: function [
     ; /ALL just removes all whitespace entirely.  No subtlety needed.
     ;
     if all_TRIM [
-        parse series [while [remove rule | skip | end break]]
+        parse series [while [remove rule | skip | end break] end]
         return series
     ]
 
@@ -300,7 +300,7 @@ trim: function [
         ]
 
         tail_TRIM [
-            parse series [while [remove [some rule end] | skip]] ;-- see #2289
+            parse series [while [remove [some rule end] | skip] end] ;-- #2289
         ]
     ] then [
         return series
@@ -312,7 +312,7 @@ trim: function [
     ; with leading and trailing whitespace removed.
     ;
     if lines [
-        parse series [while [change [some rule] space skip | skip]]
+        parse series [while [change [some rule] space skip | skip] end]
         if first series = space [take series]
         if last series = space [take/last series]
         return series
@@ -331,6 +331,8 @@ trim: function [
             (indent: 0)
             s: some rule e:
             (indent: (index of e) - (index of s))
+
+            end
         ]
     ]
 
@@ -349,6 +351,8 @@ trim: function [
                 skip
             ]
         ]
+
+        end
     ]
 
     ; While trimming with /TAIL takes out any number of newlines, plain TRIM
@@ -357,6 +361,7 @@ trim: function [
     parse series [
         remove [any newline]
         while [newline remove [some newline end] | skip]
+        end
     ]
 
     return series

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -66,6 +66,7 @@ clean-path: function [
                 ]
             )
         ]
+        end
     ]
 
     if (#"/" = last out) and [#"/" <> last file] [

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -318,6 +318,7 @@ help: function [
         copy refinements any [
             refinement! | word! | get-word! | lit-word! | issue!
         ]
+        end
     ]
 
     ; Output exemplar calling string, e.g. LEFT + RIGHT or FOO A B C

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -144,6 +144,7 @@ math: function [
             ['+ (expr-op: 'add) | '- (expr-op: 'subtract)]
             term (expr-val: compose [(expr-op) (expr-val) (term-val)])
         ]
+        end
     ])
 
     term-val (_)

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -235,6 +235,7 @@ reword: function [
             parse delimiters [
                 set prefix delimiter-types
                 set suffix opt delimiter-types
+                end
             ] or [
                 fail ["Invalid /ESCAPE delimiter block" delimiters]
             ]
@@ -430,7 +431,7 @@ extract: func [
     ]
     if not index [pos: 1]
     if block? pos [
-        parse pos [some [any-number! | logic!]] or [
+        parse pos [some [any-number! | logic!] end] or [
             cause-error 'Script 'invalid-arg reduce [pos]
         ]
         out: make (type of series) len * length of pos
@@ -638,7 +639,7 @@ split: function [
         [block! integer! char! bitset! text! tag!]
     /into "If dlm is integer, split in n pieces (vs. pieces of length n)"
 ][
-    if block? dlm and [parse dlm [some integer!]] [
+    if block? dlm and [parse dlm [some integer! end]] [
         return map-each len dlm [
             if len <= 0 [
                 series: skip series negate len
@@ -665,7 +666,7 @@ split: function [
                     copy series to end (keep/only series)
                 ]
             ] else [
-                [any [copy series 1 size skip (keep/only series)]]
+                [any [copy series 1 size skip (keep/only series)] end]
             ]
         ] else [
             ; A block that is not all integers, e.g. not `[1 1 1]`, acts as a
@@ -677,6 +678,7 @@ split: function [
                 any [mk1: some [mk2: dlm break | skip] (
                     keep/only copy/part mk1 mk2
                 )]
+                end
             ]
         ]
     ]

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -274,6 +274,7 @@ parse-write-dialect: func [port block <local> spec debug] [
             set block [any-string! | binary!] (spec/content: block)
             | (spec/content: blank)
         ]
+        end
     ]
 ]
 
@@ -380,6 +381,7 @@ check-response: function [port] [
                 ]
                 | (throw 'version-not-supported)
             ]
+            end
         ]
     ]
 

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -377,7 +377,7 @@ client-hello: function [
         not set? 'ver [[1.0 1.2]]
         decimal? ver [reduce [ver ver]]
         block? ver [
-            parse ver [decimal! decimal!] or [
+            parse ver [decimal! decimal! end] or [
                 fail "BLOCK! /VERSION must be two DECIMAL! (min ver, max ver)"
             ]
             ver
@@ -1362,6 +1362,7 @@ do-commands: function [
                 update-write-state ctx cmd
             )
         ]
+        end
     ]
     debug ["writing bytes:" length of ctx/msg]
     ctx/resp: copy []

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -480,6 +480,7 @@ do-needs: function [
             set hash opt binary!
             (join mods [name vers hash])
         ]
+        end
     ] or [
         cause-error 'script 'invalid-arg here
     ]
@@ -646,6 +647,7 @@ load-module: function [
                         join data [mod ver if name [to word! name]]
                     )
                 ]
+                end
             ] or [
                 cause-error 'script 'invalid-arg tmp
             ]

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -158,6 +158,8 @@ make-port*: function [
 
         ; optional bookmark
         opt ["#" copy s1 some path-char (emit tag s1)]
+
+        end
     ]
 
     decode-url: func ["Decode a URL according to rules of sys/*parse-url." url] [

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -253,6 +253,7 @@ elf-format: context [
                     index: index + 1
                 )
             ]
+            end
         ]
         return blank
     ]
@@ -369,6 +370,7 @@ elf-format: context [
             parse skip executable e_shoff + (section-index * e_shentsize) [
                 (sh_size: new-size)
                 (mode: 'write) section-header-rule
+                end
             ]
 
             ; Adjust all the program and section header offsets that are
@@ -612,23 +614,19 @@ pe-format: context [
 
         def: make block! 1
         group-rule: [
-            any [
-                set word set-word!
-                (find-a-word word)
-                | and block! into block-rule ;recursively look into the array
-                | skip
-            ]
+            set word set-word!
+            (find-a-word word)
+            | and block! into block-rule ;recursively look into the array
+            | skip
         ]
         block-rule: [
-            any [
-                and group! into group-rule
-                | and block! into block-rule
-                | ['copy | 'set] set word word! (find-a-word word)
-                | skip
-            ]
+            and group! into [any group-rule]
+            | and block! into [any block-rule]
+            | ['copy | 'set] set word word! (find-a-word word)
+            | skip
         ]
 
-        parse rule block-rule
+        parse rule [any block-rule end]
 
         ;dump def
         set name make object! append def _
@@ -785,6 +783,8 @@ pe-format: context [
         start-of-section-header:
         COFF-header/number-of-sections section-rule
         end-of-section-header:
+
+        ;-- !!! stop here, no END ?
     ]
     size-of-section-header: 40 ;size of one entry
 

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -71,6 +71,7 @@ make-banner: function [
             ]
             (append append str s newline)
         ]
+        end
     ]
     return str
 ]

--- a/tests/comparison/sameq.test.reb
+++ b/tests/comparison/sameq.test.reb
@@ -113,13 +113,13 @@
 )
 [#1068 #1066 (
     a-value: first ['a/b]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     same? :a-value :b-value
 )]
 ; symmetry
 (
     a-value: first ['a/b]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     equal? same? :a-value :b-value same? :b-value :a-value
 )
 (not same? [] blank)
@@ -127,35 +127,35 @@
 (equal? same? [] blank same? blank [])
 [#1068 #1066 (
     a-value: first [()]
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     same? a-value b-value
 )]
 ; symmetry
 (
     a-value: first [()]
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     equal? same? a-value b-value same? b-value a-value
 )
 [#1068 #1066 (
     a-value: 'a/b
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     same? :a-value :b-value
 )]
 ; symmetry
 (
     a-value: 'a/b
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     equal? same? :a-value :b-value same? :b-value :a-value
 )
 [#1068 #1066 (
     a-value: first [a/b:]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     same? :a-value :b-value
 )]
 ; symmetry
 (
     a-value: first [a/b:]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     equal? same? :a-value :b-value same? :b-value :a-value
 )
 (not same? any-number! integer!)

--- a/tests/comparison/strict-equalq.test.reb
+++ b/tests/comparison/strict-equalq.test.reb
@@ -113,13 +113,13 @@
 )]
 [#1068 #1066 (
     a-value: first ['a/b]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     strict-equal? :a-value :b-value
 )]
 ; symmetry
 (
     a-value: first ['a/b]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     equal? strict-equal? :a-value :b-value strict-equal? :b-value :a-value
 )
 (not strict-equal? [] blank)
@@ -127,35 +127,35 @@
 (equal? strict-equal? [] blank strict-equal? blank [])
 [#1068 #1066 (
     a-value: first [()]
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     strict-equal? a-value b-value
 )]
 ; symmetry
 (
     a-value: first [()]
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     equal? strict-equal? a-value b-value strict-equal? b-value a-value
 )
 [#1068 #1066 (
     a-value: 'a/b
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     strict-equal? :a-value :b-value
 )]
 ; symmetry
 (
     a-value: 'a/b
-    parse a-value [b-value:]
+    parse a-value [b-value: end]
     equal? strict-equal? :a-value :b-value strict-equal? :b-value :a-value
 )
 [#1068 #1066 (
     a-value: first [a/b:]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     strict-equal? :a-value :b-value
 )]
 ; symmetry
 (
     a-value: first [a/b:]
-    parse :a-value [b-value:]
+    parse :a-value [b-value: end]
     equal? strict-equal? :a-value :b-value strict-equal? :b-value :a-value
 )
 (not strict-equal? any-number! integer!)

--- a/tests/control/match.test.reb
+++ b/tests/control/match.test.reb
@@ -7,8 +7,8 @@
 ; https://github.com/metaeducation/ren-c/pull/730
 ;
 
-("aaa" = match parse "aaa" [some "a"])
-(null = match parse "aaa" [some "b"])
+("aaa" = match parse "aaa" [some "a" end])
+(null = match parse "aaa" [some "b" end])
 
 (10 = match integer! 10)
 (null = match integer! "ten")

--- a/tests/line-numberq.r
+++ b/tests/line-numberq.r
@@ -24,5 +24,6 @@ line-number?: func [
             (if greater-or-equal? index? t index? s [return line-number])
             [[CR LF | CR | LF] (line-number: me + 1) | skip] t:
         ]
+        end
     ]
 ]

--- a/tests/misc/shttpd.r
+++ b/tests/misc/shttpd.r
@@ -44,7 +44,7 @@ send-chunk: func [port] [
 ]
 
 handle-request: function [config req] [
-    parse to-text req ["get " ["/ " | copy uri: to " "]]
+    parse to-text req ["get " ["/ " | copy uri: to " "] end]
     uri: default ["index.html"]
     print ["URI:" uri]
     parse uri [some [thru "."] copy ext to end (type: mime-map/:ext)]

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -101,6 +101,7 @@ make object! compose [
                     set 'dialect-failures (dialect-failures + 1)
                 )
             ]
+            end
         ]
     ]
 
@@ -201,7 +202,9 @@ make object! compose [
                             |
                         :position
                     ]
-                    end | (fail "do-recover log file parsing problem")
+                    end
+                ] or [
+                    fail "do-recover log file parsing problem"
                 ]
                 last-vector
                 test-sources: find/last/tail test-sources last-vector

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -201,7 +201,7 @@ make object! [
             position: (type: value: _)
         ]
 
-        rule: [any token]
+        rule: [any token end]
 
         parse test-sources rule or [
             append collected-tests reduce [
@@ -273,6 +273,7 @@ make object! [
                     |
                 :position
             ]
+            end
         ]
     ]
 ]


### PR DESCRIPTION
This changes parse's return result contract so that it returns the
last matching position:

    >> parse "aaabbb" [some "a"]
    == "bbb"

It still returns NULL if matching fails:

    >> parse "aaabbb" [some "c"]
    // null

To get a conditionally true/false result based on whether there was a
complete match, END can be incorporated into the rule, which forces
a match to fail if it is only partial:

    >> parse "aaabbb" [some "a" end]
    // null

Alternately one can test to see if a result is returned and if so, if
it is at the `TAIL?`  (This currently can't be done in one step as
TAIL? TRY PARSE... would feed a blank into TAIL? on failure, and there
is not clear guidance on TAIL? of a blank being false yet.)

In accordance with the change, this also removes the RETURN keyword
from PARSE.  Returning an "out of band" value from the parse should be
done with THROW and CATCH, or a plain RETURN from a GROUP! in the parse
to an enclosing function.