### PR TITLE
Restore "One Expression" Left Normal Enfix Rule

### DIFF
--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -434,13 +434,13 @@ try: emulate [
     ][
         trap [
             result: do block
-        ] then err => [
+        ] then (err => [
             case [
                 null? :code [err]
                 block? :code [do code]
                 action? :code [code err]
             ]
-        ] else [
+        ]) else [
             result
         ]
     ]

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -406,6 +406,34 @@ inline static void Expire_Out_Cell_Unless_Invisible(REBFRM *f) {
 }
 
 
+// Factored out code for entering a child frame with an already evaluated
+// value in order to reuse the post-switch enfix code.
+//
+static inline bool Eval_Post_Switch_Throws(REBFRM *f, REBVAL *preload) {
+    REBFLGS flags =
+        (DO_MASK_DEFAULT & ~DO_FLAG_CONST)
+        | DO_FLAG_FULFILLING_ARG
+        | (f->flags.bits & DO_FLAG_EXPLICIT_EVALUATE)
+        | (f->flags.bits & DO_FLAG_CONST);
+
+    DECLARE_SUBFRAME (child, f); // capture DSP *now*
+
+    if (Is_Frame_Gotten_Shoved(f)) {
+        Prep_Stack_Cell(FRM_SHOVE(child));
+        Move_Value(FRM_SHOVE(child), f->gotten);
+        SET_VAL_FLAG(FRM_SHOVE(child), VALUE_FLAG_ENFIXED);
+        f->gotten = FRM_SHOVE(child);
+    }
+
+    return Eval_Step_In_Subframe_Throws(
+        preload, // preload previous f->arg as left enfix
+        f,
+        flags | DO_FLAG_POST_SWITCH,
+        child
+    );
+}
+
+
 //
 //  Eval_Core_Throws: C
 //
@@ -492,7 +520,14 @@ bool Eval_Core_Throws(REBFRM * const f)
         | DO_FLAG_REEVALUATE_CELL
     )){
         if (f->flags.bits & DO_FLAG_POST_SWITCH) {
-            assert(f->prior->u.defer.arg); // !!! EVAL-ENFIX crudely preserves
+            //
+            // !!! Previously this was only used for enfix deferral on normal
+            // arguments, but support was added for soft and hard quoted args.
+            // They run through the same procedure, even though they are not
+            // re-entering a frame after an evaluation (they directly quote
+            // the value without a recursion).  Likely could be improved.
+            //
+            /* assert(f->prior->u.defer.arg); */
             assert(NOT_END(f->out));
 
             f->flags.bits &= ~DO_FLAG_POST_SWITCH;
@@ -1332,27 +1367,7 @@ bool Eval_Core_Throws(REBFRM * const f)
             // put off before, this time using the 10 as AND's left-hand arg.
             //
             if (f->u.defer.arg) {
-                REBFLGS flags =
-                    (DO_MASK_DEFAULT & ~DO_FLAG_CONST)
-                    | DO_FLAG_FULFILLING_ARG
-                    | (f->flags.bits & DO_FLAG_EXPLICIT_EVALUATE)
-                    | (f->flags.bits & DO_FLAG_CONST);
-
-                DECLARE_SUBFRAME (child, f); // capture DSP *now*
-
-                if (Is_Frame_Gotten_Shoved(f)) {
-                    Prep_Stack_Cell(FRM_SHOVE(child));
-                    Move_Value(FRM_SHOVE(child), f->gotten);
-                    SET_VAL_FLAG(FRM_SHOVE(child), VALUE_FLAG_ENFIXED);
-                    f->gotten = FRM_SHOVE(child);
-                }
-
-                if (Eval_Step_In_Subframe_Throws(
-                    f->u.defer.arg, // preload previous f->arg as left enfix
-                    f,
-                    flags | DO_FLAG_POST_SWITCH,
-                    child
-                )){
+                if (Eval_Post_Switch_Throws(f, f->u.defer.arg)) {
                     Move_Value(f->out, f->u.defer.arg);
                     goto abort_action;
                 }
@@ -1424,7 +1439,9 @@ bool Eval_Core_Throws(REBFRM * const f)
     //=//// HARD QUOTED ARG-OR-REFINEMENT-ARG /////////////////////////////=//
 
               case REB_P_HARD_QUOTE:
-                if (Is_Param_Skippable(f->param)) {
+                if (not Is_Param_Skippable(f->param))
+                    Quote_Next_In_Frame(f->arg, f); // VALUE_FLAG_UNEVALUATED
+                else {
                     if (not Typecheck_Including_Quoteds(f->param, f->value)) {
                         assert(Is_Param_Endable(f->param));
                         Init_Endish_Nulled(f->arg); // not DO_FLAG_BARRIER_HIT
@@ -1436,9 +1453,25 @@ bool Eval_Core_Throws(REBFRM * const f)
                         f->arg,
                         ARG_MARKED_CHECKED | VALUE_FLAG_UNEVALUATED
                     );
-                    goto continue_arg_loop;
                 }
-                Quote_Next_In_Frame(f->arg, f); // has VALUE_FLAG_UNEVALUATED
+
+                // Have to account for enfix deferrals in cases like:
+                //
+                //     return quote 1 then (x => [x + 1])
+                //
+                // !!! This is likely inefficient, but it's brief to reuse.
+                //
+                assert(f->u.defer.arg == nullptr);
+                if (NOT_SER_FLAG(f->original, PARAMLIST_FLAG_INVISIBLE)) {
+                    if (Eval_Post_Switch_Throws(f, f->arg)) {
+                        Move_Value(f->out, f->arg);
+                        goto abort_action;
+                    }
+                }
+
+                if (GET_VAL_FLAG(f->arg, ARG_MARKED_CHECKED))
+                    goto continue_arg_loop;
+
                 break;
 
     //=//// SOFT QUOTED ARG-OR-REFINEMENT-ARG  ////////////////////////////=//
@@ -1454,16 +1487,32 @@ bool Eval_Core_Throws(REBFRM * const f)
 
                 if (not IS_QUOTABLY_SOFT(f->value)) {
                     Quote_Next_In_Frame(f->arg, f); // VALUE_FLAG_UNEVALUATED
-                    Finalize_Current_Arg(f);
-                    goto continue_arg_loop;
+                }
+                else {
+                    if (Eval_Value_Core_Throws(
+                        f->arg,
+                        f->value,
+                        f->specifier
+                    )){
+                        Move_Value(f->out, f->arg);
+                        goto abort_action;
+                    }
+                    Fetch_Next_In_Frame(nullptr, f);
                 }
 
-                if (Eval_Value_Core_Throws(f->arg, f->value, f->specifier)) {
-                    Move_Value(f->out, f->arg);
-                    goto abort_action;
+                // Have to account for enfix deferrals in cases like:
+                //
+                //     return if false '[foo] else '[bar]
+                //
+                // !!! This is likely inefficient, but it's brief to reuse.
+                //
+                assert(f->u.defer.arg == nullptr);
+                if (NOT_SER_FLAG(f->original, PARAMLIST_FLAG_INVISIBLE)) {
+                    if (Eval_Post_Switch_Throws(f, f->arg)) {
+                        Move_Value(f->out, f->arg);
+                        goto abort_action;
+                    }
                 }
-
-                Fetch_Next_In_Frame(nullptr, f);
                 break;
 
               default:
@@ -1590,10 +1639,8 @@ bool Eval_Core_Throws(REBFRM * const f)
                 // it appears as a step above it.
                 //
                 Reb_Param_Class dclass = VAL_PARAM_CLASS(f->u.defer.param);
-                if (dclass == REB_P_NORMAL)
+                if (dclass != REB_P_TIGHT)
                     f->flags.bits |= DO_FLAG_ALREADY_DEFERRED_ENFIX;
-                else
-                    assert(dclass == REB_P_TIGHT);
 
                 TRASH_POINTER_IF_DEBUG(f->u.defer.param);
                 TRASH_POINTER_IF_DEBUG(f->u.defer.refine);

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1569,6 +1569,32 @@ bool Eval_Core_Throws(REBFRM * const f)
                     f->u.defer.arg,
                     f->u.defer.refine
                 );
+
+                // If we had found another argument, we would have jumped the
+                // evaluator back into the post-switch and forced the deferred
+                // enfix to go ahead and run so the next argument could be
+                // fetched.  We didn't find one, and are going ahead and
+                // running the function.  Usually this means we want to signal
+                // not to defer again, e.g. the ELSE here should run after IF
+                //
+                //     return if condition [...] else [...]
+                //
+                // But if something says it takes its argument tightly, then
+                // we should allow another deferral.  Notable case:
+                //
+                //     if condition [...] then x => [...] else [...]
+                //
+                // The lambda => wants to be an argument to THEN, ignoring
+                // the else.  Hence it declares its argument tight.  That
+                // means the ELSE waits and lets the THEN run, even though
+                // it appears as a step above it.
+                //
+                Reb_Param_Class dclass = VAL_PARAM_CLASS(f->u.defer.param);
+                if (dclass == REB_P_NORMAL)
+                    f->flags.bits |= DO_FLAG_ALREADY_DEFERRED_ENFIX;
+                else
+                    assert(dclass == REB_P_TIGHT);
+
                 TRASH_POINTER_IF_DEBUG(f->u.defer.param);
                 TRASH_POINTER_IF_DEBUG(f->u.defer.refine);
             }
@@ -2370,10 +2396,10 @@ bool Eval_Core_Throws(REBFRM * const f)
 //
 //==//////////////////////////////////////////////////////////////////////==//
 
-      default: {
+      default:
         Derelativize(f->out, current, f->specifier);
         Unquotify_In_Situ(f->out, 1); // checks for illegal REB_XXX bytes
-        break; }
+        break;
     }
 
     //==////////////////////////////////////////////////////////////////==//
@@ -2596,25 +2622,24 @@ bool Eval_Core_Throws(REBFRM * const f)
         goto finished;
     }
 
-    // !!! Once checked `not f->deferred` because it only deferred once:
+    // A deferral occurs, e.g. with:
     //
-    //    "If we get there and there's a deferral, it doesn't matter if it
-    //     was this frame or the parent frame who deferred it...it's the
-    //     same enfix function in the same spot, and it's only willing to
-    //     give up *one* of its chances to run."
+    //     return if condition [...] else [...]
     //
-    // But it now defers indefinitely so long as it is fulfilling arguments,
-    // until it finds an <end>able one...which <- (identity) is.  Having
-    // endability control this may not be the best idea, but it keeps from
-    // introducing a new parameter convention or recognizing the specific
-    // function.  It's a rare enough property that one might imagine it to be
-    // unlikely such functions would want to run before deferred enfix.
+    // The first time the ELSE is seen, IF is fulfilling its branch argument
+    // and doesn't know if its done or not.  So this code senses that and
+    // runs, returning the output without running ELSE.  Then, the IF does
+    // not need to force the ELSE to run in order to fulfill another argument.
+    // So it concludes the typechecking on the block argument, and sets the
+    // DO_FLAG_ALREADY_DEFERRED_ENFIX flag.  That means after the IF runs
+    // its code, it will get here and run the ELSE *before* yielding the
+    // argument fulfillment to the RETURN above it.
     //
     if (
         GET_SER_FLAG(VAL_ACTION(f->gotten), PARAMLIST_FLAG_DEFERS_LOOKBACK)
         and (f->flags.bits & DO_FLAG_FULFILLING_ARG)
         and not f->prior->u.defer.arg
-        and not Is_Param_Endable(f->prior->param)
+        and not (f->flags.bits & DO_FLAG_ALREADY_DEFERRED_ENFIX)
     ){
         assert(not (f->flags.bits & DO_FLAG_TO_END));
         assert(Is_Action_Frame_Fulfilling(f->prior));
@@ -2642,6 +2667,8 @@ bool Eval_Core_Throws(REBFRM * const f)
         //
         goto finished;
     }
+
+    f->flags.bits &= ~DO_FLAG_ALREADY_DEFERRED_ENFIX;
 
     // This is a case for an evaluative lookback argument we don't want to
     // defer, e.g. a #tight argument or a normal one which is not being

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -981,7 +981,6 @@ REBNATIVE(semiquoted_q)
 //
 //      return: [<opt> any-value!]
 //      value [<end> <opt> any-value!]
-//          {!!! <end> flag is hack to limit enfix reach to the left}
 //      /quote
 //          {Make it seem that the return result was quoted}
 //  ]
@@ -994,8 +993,7 @@ REBNATIVE(identity)
 // !!! Quoting version is currently specialized as SEMIQUOTE, for convenience.
 //
 // This is assigned to <- for convenience, but cannot be used under that name
-// in bootstrap with R3-Alpha.  It uses the <end>-ability to stop left reach,
-// since there is no specific flag for that.
+// in bootstrap with R3-Alpha.
 {
     INCLUDE_PARAMS_OF_IDENTITY;
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -204,8 +204,7 @@ static bool Subparse_Throws(
     f->source->index = VAL_INDEX(rules) + 1;
     f->source->pending = f->value + 1;
 
-    f->flags.bits = DO_MASK_DEFAULT // terminates f->cell
-        | DO_FLAG_PARSE_FRAME;
+    f->flags.bits = DO_MASK_DEFAULT; // terminates f->cell
 
     Push_Frame_Core(f); // checks for C stack overflow
     Reuse_Varlist_If_Available(f);

--- a/src/extensions/console/ext-console-init.reb
+++ b/src/extensions/console/ext-console-init.reb
@@ -286,10 +286,10 @@ start-console: function [
             proto-skin/name: default ["loaded"]
             append o/loaded skin-file
 
-        ] then lambda e [
+        ] then (lambda e [
             skin-error: e       ;; show error later if --verbose
             proto-skin/name: "error"
-        ]
+        ])
     ]
 
     proto-skin/name: default ["default"]
@@ -648,7 +648,7 @@ ext-console-impl: function [
         code: load/all delimit newline result
         assert [block? code]
 
-    ] then lambda error [
+    ] then (lambda error [
         ;
         ; If loading the string gave back an error, check to see if it
         ; was the kind of error that comes from having partial input
@@ -665,7 +665,7 @@ ext-console-impl: function [
                 "}" ["{"]
                 ")" ["("]
                 "]" ["["]
-            ] also lambda unclosed [
+            ] also (lambda unclosed [
                 ;
                 ; Backslash is used in the second column to help make a
                 ; pattern that isn't legal in Rebol code, which is also
@@ -680,7 +680,7 @@ ext-console-impl: function [
                 ]]
 
                 return block!
-            ]
+            ])
         ]
 
         ; Could be an unclosed double quote (unclosed tag?) which more input
@@ -688,7 +688,7 @@ ext-console-impl: function [
         ;
         emit [system/console/print-error (<*> error)]
         return <prompt>
-    ]
+    ])
 
     if shortcut: select system/console/shortcuts try first code [
         ;

--- a/src/extensions/ffi/ext-ffi-init.reb
+++ b/src/extensions/ffi/ext-ffi-init.reb
@@ -95,12 +95,12 @@ make-callback: function [
 
     safe: function r-args
         <- (if fallback [
-            compose/deep/only [
-                trap [return (as group! body)] then error => [
+            compose/deep <$> [
+                trap [return ((<$> as group! body))] then (error => [
                     print "** TRAPPED CRITICAL ERROR DURING FFI CALLBACK:"
                     print mold error
-                    (fallback-value)
-                ]
+                    ((<$> fallback-value))
+                ])
             ]
         ] else [
             body

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -159,6 +159,11 @@ inline static bool Do_Branch_Core_Throws(
 ){
     assert(branch != out and condition != out);
 
+    if (IS_QUOTED(branch)) {
+        Unquotify(Move_Value(out, branch), 1);
+        return false;
+    }
+
     if (IS_BLOCK(branch))
         return Do_Any_Array_At_Throws(out, branch);
 

--- a/src/include/sys-eval.h
+++ b/src/include/sys-eval.h
@@ -861,6 +861,7 @@ inline static bool Eval_Step_In_Subframe_Throws(
         or FRM_IS_VALIST(child)
         or old_index != child->source->index
         or (flags & DO_FLAG_REEVALUATE_CELL)
+        or (flags & DO_FLAG_POST_SWITCH)
         or Is_Evaluator_Throwing_Debug()
     );
 

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -260,17 +260,6 @@ STATIC_ASSERT(DO_FLAG_7_IS_FALSE == NODE_FLAG_CELL);
 STATIC_ASSERT(DO_FLAG_EXPLICIT_EVALUATE == VALUE_FLAG_EVAL_FLIP);
 
 
-//=//// DO_FLAG_PARSE_FRAME ///////////////////////////////////////////////=//
-//
-// This flag is set when a REBFRM* is being used to hold the state of the
-// PARSE stack.  One application of knowing this is that PARSE wasn't really
-// written to use frames, and doesn't follow the same rules as the evaluator;
-// so the debugging checks have to be more lax;
-//
-#define DO_FLAG_PARSE_FRAME \
-    FLAG_LEFT_BIT(22)
-
-
 //=//// DO_FLAG_CONST /////////////////////////////////////////////////////=//
 //
 // The user is able to flip the constness flag explicitly with the CONST and
@@ -287,6 +276,20 @@ STATIC_ASSERT(DO_FLAG_EXPLICIT_EVALUATE == VALUE_FLAG_EVAL_FLIP);
 #define DO_FLAG_CONST \
     FLAG_LEFT_BIT(22)
 STATIC_ASSERT(DO_FLAG_CONST == VALUE_FLAG_CONST);
+
+
+//=//// DO_FLAG_ALREADY_DEFERRED_ENFIX ////////////////////////////////////=//
+//
+// Ren-C introduced evaluative left hand sides that looked at more than one
+// argument.  (Otherwise `IF CONDITION [...] ELSE [...]` would force ELSE to
+// produce a result solely on seeing a block on its left.)  These evaluations
+// only allow up to one function to run on their left, otherwise there would
+// be problems e.g. with `RETURN IF CONDITION [...] ELSE [...]`, which then
+// interprets as `(RETURN IF CONDITION [...]) ELSE [...]`.  This flag tracks
+// the case that e.g. ELSE already yielded to IF, and shouldn't yield again.
+//
+#define DO_FLAG_ALREADY_DEFERRED_ENFIX \
+    FLAG_LEFT_BIT(23)
 
 
 //=//// DO_FLAG_BARRIER_HIT ///////////////////////////////////////////////=//

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -139,10 +139,10 @@ make-dir: func [
     for-each dir dirs [
         path: either empty? path [dir][path/:dir]
         append path slash
-        trap [make-dir path] then lambda e [
+        trap [make-dir path] then (lambda e [
             for-each dir created [attempt [delete dir]]
             fail e
-        ]
+        ])
         insert created path
     ]
     path

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -653,18 +653,12 @@ lambda: function [
     return: [action!]
     :args [<end> word! block!]
         {Block of argument words, or a single word (if only one argument)}
-    :body [any-value! <...>]
+    body [block!]
         {Block that serves as the body or variadic elements for the body}
 ][
-    make action! compose/deep [
-        [(:args then [to block! args])]
-        [(
-            if block? first body [
-                take body
-            ] else [
-                make block! body
-            ]
-        )]
+    make action! compose [
+        ((blockify :args))
+        ((body))
     ]
 ]
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -591,10 +591,10 @@ iterate-skip: redescribe [
 
         ; !!! https://github.com/rebol/rebol-issues/issues/2331
         comment [
-            trap [set* lit result: do f] then lambda e [
+            trap [set* lit result: do f] then (lambda e [
                 set* word saved
                 fail e
-            ]
+            ])
             set* word saved
             :result
         ]

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -164,6 +164,10 @@ my: enfix func [
 ;
 ;     if condition [code] then (x => [code w/x] else [stuff])
 ;
+; !!! This property is not relevant for the moment with soft-quoted branches,
+; which is done to allow `if condition '[block by value]`, hence a lambda
+; must be in a GROUP! anyway.
+;
 set/enfix (r3-alpha-lit "=>") tighten :lambda
 set (r3-alpha-lit "<-") :identity ;-- not enfix, just affects enfix
 set/enfix (r3-alpha-lit "->") :shove

--- a/src/mezz/base-infix.r
+++ b/src/mezz/base-infix.r
@@ -155,9 +155,16 @@ my: enfix func [
 
 
 ; Lambdas are experimental quick function generators via a symbol.  The
-; identity is used to shake up enfix ordering.
+; identity is used to shake up enfix ordering.  They have to be tight (on
+; their right hand side) when enfixed, otherwise this will break:
 ;
-set/enfix (r3-alpha-lit "=>") :lambda
+;     if condition [code] then x => [code w/x] else [stuff]
+;
+; The problem is, if => wasn't right tight then ELSE would process this as:
+;
+;     if condition [code] then (x => [code w/x] else [stuff])
+;
+set/enfix (r3-alpha-lit "=>") tighten :lambda
 set (r3-alpha-lit "<-") :identity ;-- not enfix, just affects enfix
 set/enfix (r3-alpha-lit "->") :shove
 

--- a/src/mezz/mezz-dump.r
+++ b/src/mezz/mezz-dump.r
@@ -285,7 +285,7 @@ dump-obj: function [
         [<opt> <end> any-value!]
     :args [any-value! <...>]
 ][
-    while [not new-line? args and [value: take* args]] [
+    while [(not new-line? args) and [value: take* args]] [
         if any-array? :value and [contains-newline :value] [
             return
         ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -345,12 +345,12 @@ help: function [
     ;
     meta: try meta-of :value
 
-    original-name: try <- ensure [<opt> word!] any [
+    original-name: try ensure [<opt> word!] any [
         select meta 'specializee-name
         select meta 'adaptee-name
-    ] also lambda name [
-        uppercase mold name
-    ]
+    ] also (lambda name [
+        as word! uppercase mold name
+    ])
 
     specializee: try ensure [<opt> action!] select meta 'specializee
     adaptee: try ensure [<opt> action!] select meta 'adaptee

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -1004,10 +1004,10 @@ pe-format: context [
     ][
         trap [
             parse-exe exe-data
-        ] then lambda err [
+        ] then (lambda err [
             ;print ["Failed to parse exe:" err]
             return null
-        ]
+        ])
 
         ;check if there's section name conflicts
 
@@ -1334,11 +1334,11 @@ get-encap: function [
 ][
     trap [
         read/part rebol-path 1
-    ] then func [e <with> return] [
+    ] then (func [e <with> return] [
         print [e]
         print ["Can't check for embedded code in Rebol path:" rebol-path]
         return blank
-    ]
+    ])
 
     compressed-data: any [
         elf-format/get-embedding rebol-path

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -748,9 +748,9 @@ comment [
             do o/bin/rebol.reb
             append o/loaded o/bin/rebol.reb
             loud-print ["Finished evaluating script:" o/bin/rebol.reb]
-        ] then lambda e [
+        ] then (lambda e [
             die/error "Error found in rebol.reb script" e
-        ]
+        ])
     ]
 
     ; Evaluate user.reb script:
@@ -766,9 +766,9 @@ comment [
             do o/resources/user.reb
             append o/loaded o/resources/user.reb
             loud-print ["Finished evaluating script:" o/resources/user.reb]
-        ] then lambda e [
+        ] then (lambda e [
             die/error "Error found in user.reb script" e
-        ]
+        ])
     ]
 
     switch type of boot-embedded [

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -20,12 +20,12 @@
 )
 (
     success: <bad>
-    if true does [success: true]
+    if true (does [success: true])
     success
 )
 (
     success: true
-    if false does [success: false]
+    if false (does [success: false])
     success
 )
 

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -31,14 +31,6 @@
 
 (
     ; https://github.com/metaeducation/ren-c/issues/510
-    ;
-    ; !!! RETURN has been changed to being <end>-able, where endability is
-    ; currently the very hack by which <- assumes you want "to the end".
-    ; It's curious that RETURN would turn out to purposefully need the very
-    ; feature that was chosen as the "hack" to signal overriding eager
-    ; left completion...which may indicate the hack has merit.  The issue
-    ; is being left open to explore, but for the moment the quirk is "fixed"
-    ; for the case of RETURN.
 
     c: func [i] [
         return if i < 15 [30] else [4]
@@ -50,7 +42,7 @@
 
     did all [
         30 = c 10
-        4 = c 20 ;-- !!! was () = c 20
+        4 = c 20
         30 = d 10
         4 = d 20
     ]

--- a/tests/control/else.test.reb
+++ b/tests/control/else.test.reb
@@ -47,3 +47,13 @@
         4 = d 20
     ]
 )
+
+; Hard quotes need to account for enfix deferral
+(
+    foo: func [y] [return lit 1 then (x => [x + y])]
+    bar: func [y] [return 1 then (x => [x + y])]
+    did all [
+        foo 10 = 11
+        bar 10 = 1
+    ]
+)

--- a/tests/control/try.test.reb
+++ b/tests/control/try.test.reb
@@ -25,8 +25,8 @@
 ]
 (trap [fail make error! ""] then [true])
 (trap [1 / 0] then :error?)
-(trap [1 / 0] then func [e] [error? e])
-(trap [] then func [e] [<handler-not-run>] else [true])
+(trap [1 / 0] then (func [e] [error? e]))
+(trap [] then (func [e] [<handler-not-run>]) else [true])
 [#1514
     (error? trap [trap [1 / 0] then :add])
 ]

--- a/tests/convert/load.test.reb
+++ b/tests/convert/load.test.reb
@@ -3,7 +3,7 @@
     (block? load/all "1")
 ]
 [#22 ; a
-    (uneval lit :a = load "':a")
+    ((uneval lit :a) = load "':a")
 ]
 [#22 ; b
     (error? trap [load "':a:"])

--- a/tests/convert/mold.test.reb
+++ b/tests/convert/mold.test.reb
@@ -53,15 +53,15 @@
     (did block: copy [a b c])
 
     (
-        mold block = {[a b c]}
+        {[a b c]} = mold block
     )(
         new-line block true
-        mold block = {[^/    a b c]}
+        {[^/    a b c]} = mold block
     )(
         new-line tail block true
-        mold block = {[^/    a b c^/]}
+        {[^/    a b c^/]} = mold block
     )(
-        mold tail block = {[^/]}
+        {[^/]} = mold tail block
     )
 ]
 

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -201,9 +201,9 @@
 )
 
 ; / is a length 0 PATH! in Ren-C
-(type of lit / = path!)
-(length of lit / = 0)
+(path! = type of lit /)
+(0 = length of lit /)
 
 ; foo/ is a length 1 PATH! in Ren-C
-(type of lit foo/ = path!)
-(length of lit foo/ = 1)
+(path! = type of lit foo/ )
+(1 = length of lit foo/ )

--- a/tests/datatypes/quoted.test.reb
+++ b/tests/datatypes/quoted.test.reb
@@ -116,9 +116,9 @@
 ('''[a b c] = '''''[a b c])
 
 
-(kind of lit 'foo = quoted!) ;; low level "KIND"
-(type of lit 'foo = uneval word!) ;; higher-level "TYPE"
-(type of lit ''[a b c] = uneval/depth block! 2)
+(quoted! = kind of lit 'foo) ;; low level "KIND"
+(uneval word! = type of lit 'foo) ;; higher-level "TYPE"
+((type of lit ''[a b c]) = uneval/depth block! 2)
 
 
 ;; Some generic actions have been tweaked to know to extend their

--- a/tests/misc/help.test.reb
+++ b/tests/misc/help.test.reb
@@ -28,7 +28,7 @@
         dump w
         if not set? w [continue]
         if action? get w
-            compose [help (w)]
+            (compose [help (w)])
         else [
             help (get w)
         ]
@@ -38,6 +38,6 @@
     for-each w words of lib [
         dump w
         if action? get w
-            compose [source (w)]
+            (compose [source (w)])
     ]
 ])

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -72,10 +72,10 @@ make object! compose [
             not :result [
                 "test returned #[false]"
             ]
-        ] then message => [
+        ] then (message => [
             test-failures: me + 1
             log reduce [space {"failed, } message {"} newline]
-        ] else [
+        ]) else [
             successes: me + 1
             log reduce [space {"succeeded"} newline]
         ]

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -93,14 +93,14 @@ make object! [
                 change-dir first split-path test-file
             ]
             test-sources: get in load-testfile test-file 'contents
-        ] then err => [
+        ] then (err => [
             ; probe err
             append collected-tests reduce [
                 test-file 'dialect {^/"failed, cannot read the file"^/}
             ]
             change-dir current-dir
             return
-        ] else [
+        ]) else [
             change-dir current-dir
             append collected-tests test-file
         ]


### PR DESCRIPTION
R3-Alpha only evaluated one left-hand side element for infix operators.
Ren-C needed to allow for more evaluation in order to implement various
ideas like ELSE:

     if condition [...] else [...]

The ELSE required some verdict from IF about whether the condition was
true and the branch ran or not.  But if it were limited to only seeing
one block on the left, it couldn't learn anything from the IF.

Argument conventions for the left enfix were decided to be NORMAL,
TIGHT, SOFT QUOTED, and HARD QUOTED.  The only one of these conventions
obeyed by R3-Alpha for infix "OP!s" was the one called TIGHT...which
took one unit of value cell and evaluated it (something like a hard
quoted operator that ran one unit of evaluation).  The question arose
as to how much more evaluation than that a NORMAL argument would do.
Initially it would evaluate as much of the left as it could.

This ran up against a "dark corner", e.g.

    return if condition [...] else [...]

With the interpretation of maximal evaluation, you would get precedence
equivalent to:

    (return if condition [...]) else [...]

The ELSE would never be able to run, because the RETURN was fulfilled,
and would jump out of the routine.  This led to a modificiation of the
rule to be "one expression's worth of evaluation".

This was used for a while, but some concern arose over whether it was
the harder rule to learn in the long run.  Some operators were
introduced to try mitigating concerns about dealing with injecting new
points into the evaluation without using parentheses.  It was theorized
that maybe the operator or mitigating RETURN's problem was an easier
operator to learn.

Switching back to full left completion did not offer the benefits that
were hoped, and raised the need or ugly operators.  This switches
back, with an enhancement to cover one pattern that became common that
previously relied on left completion:

    if condition [10] then x => [print [x]] else [print "boo"]

This was intended to let you use a lambda function as the argument to
the THEN.  However, if the "one expression" rule is in effect, what
happens here is that the ELSE defers the [print [x]] block, but then
acts after the lambda and before the THEN:

    if condition [10] then ((x => [print [x]]) else [print "boo"])

Since lambdas make ACTION!s that are truthy, the ELSE gets thrown
away.  To address this, lambdas were changed to have a TIGHT right-hand
argument, and the rules of deferment do not count tight deferments as
having done the "one deferment" yet.  Hence the first deferment ELSE
counts is the one on lambda itself, allowing it to pin its execution
to after the THEN's completion.