### PR TITLE
Add platform Macintosh

### DIFF
--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -1528,7 +1528,7 @@ Execution: make generator-class [
     host: switch system/platform/1 [
         'Windows [windows]
         'Linux [linux]
-        'OSX [osx]
+        'OSX 'Macintosh [osx]
         'Android [android]
 
         default [


### PR DESCRIPTION
Minor addition of platform 'Macintosh as osx is called in R3 console on my Mac.