### PR TITLE
Beginning of a RESKIN technique for parameter conventions

### DIFF
--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -398,6 +398,9 @@ e-types/emit {
         PSEUDOTYPE_SEVEN,
         REB_TS_QUOTED_PATH = PSEUDOTYPE_SEVEN, /* !!! temp compatibility */
 
+        PSEUDOTYPE_EIGHT,
+        REB_TS_SKIN_EXPANDED = PSEUDOTYPE_EIGHT,
+
         REB_MAX_PLUS_MAX
     };
 

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -90,6 +90,12 @@ Script: [
     no-arg:             [:arg1 {is missing its} :arg2 {argument}]
     expect-arg:         [:arg1 {does not allow} :arg2 {for its} :arg3 {argument}]
     arg-required:       [:arg1 {requires} :arg2 {argument to not be null}]
+    
+    phase-bad-arg-type:
+        [:arg1 {internal phase disallows} :arg2 {for its} :arg3 {argument}]
+    phase-no-arg:
+        [:arg1 {internal phase requres} :arg2 {argument to not be null}]
+
     expect-val:         [{expected} :arg1 {not} :arg2]
     expect-type:        [:arg1 :arg2 {field must be of type} :arg3]
     cannot-use:         [{cannot use} :arg1 {on} :arg2 {value}]

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -337,7 +337,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
 
             // Save the block for parameter types.
             //
-            REBVAL *typeset;
+            REBVAL *param;
             if (IS_PARAM(DS_TOP)) {
                 REBSPC *derived = Derive_Specifier(VAL_SPECIFIER(spec), item);
                 Init_Block(
@@ -349,7 +349,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                     )
                 );
 
-                typeset = DS_TOP - 1; // volatile if you DS_PUSH()!
+                param = DS_TOP - 1; // volatile if you DS_PUSH()!
             }
             else {
                 assert(IS_TEXT(DS_TOP)); // !!! are blocks after notes good?
@@ -362,7 +362,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                 }
 
                 assert(IS_PARAM(DS_TOP - 2));
-                typeset = DS_TOP - 2;
+                param = DS_TOP - 2;
 
                 assert(IS_BLOCK(DS_TOP - 1));
                 if (VAL_ARRAY(DS_TOP - 1) != EMPTY_ARRAY)
@@ -383,8 +383,9 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             // Leaves VAL_TYPESET_SYM as-is.
             //
             REBSPC *derived = Derive_Specifier(VAL_SPECIFIER(spec), item);
-            Update_Typeset_Bits_Core(
-                typeset,
+            param->payload.typeset.bits = 0;
+            Add_Typeset_Bits_Core(
+                param,
                 VAL_ARRAY_HEAD(item),
                 derived
             );
@@ -394,7 +395,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             // not "passed in" that way...the refinement is inactive.
             //
             if (refinement_seen) {
-                if (TYPE_CHECK(typeset, REB_MAX_NULLED))
+                if (TYPE_CHECK(param, REB_MAX_NULLED))
                     fail (Error_Refinement_Arg_Opt_Raw());
             }
 
@@ -984,9 +985,9 @@ REBACT *Make_Action(
     // uses it as well).
 
     if (GET_SER_FLAG(act, PARAMLIST_FLAG_RETURN)) {
-        REBVAL *typeset = ACT_PARAM(act, ACT_NUM_PARAMS(act));
-        assert(VAL_PARAM_SYM(typeset) == SYM_RETURN);
-        if (VAL_TYPESET_BITS(typeset) == 0) // e.g. `return []`, invisible
+        REBVAL *param = ACT_PARAM(act, ACT_NUM_PARAMS(act));
+        assert(VAL_PARAM_SYM(param) == SYM_RETURN);
+        if (VAL_TYPESET_BITS(param) == 0) // e.g. `return []`, invisible
             SET_SER_FLAG(act, PARAMLIST_FLAG_INVISIBLE);
     }
 
@@ -1797,4 +1798,3 @@ bool Get_If_Word_Or_Path_Throws(
 
     return false;
 }
-

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -116,7 +116,7 @@ void Shutdown_Typesets(void)
 
 
 //
-//  Update_Typeset_Bits_Core: C
+//  Add_Typeset_Bits_Core: C
 //
 // This sets the bits in a bitset according to a block of datatypes.  There
 // is special handling by which BAR! will set the "variadic" bit on the
@@ -128,13 +128,14 @@ void Shutdown_Typesets(void)
 // will act as WORD!.  Also, is essentially having "keywords" and should be
 // reviewed to see if anything actually used it.
 //
-bool Update_Typeset_Bits_Core(
+bool Add_Typeset_Bits_Core(
     RELVAL *typeset,
     const RELVAL *head,
     REBSPC *specifier
 ) {
     assert(IS_TYPESET(typeset) or IS_PARAM(typeset));
-    VAL_TYPESET_BITS(typeset) = 0;
+    if (VAL_TYPESET_BITS(typeset) != 0)
+        head = head;
 
     const RELVAL *maybe_word = head;
     for (; NOT_END(maybe_word); ++maybe_word) {
@@ -237,7 +238,7 @@ REB_R MAKE_Typeset(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
     if (!IS_BLOCK(arg)) goto bad_make;
 
     Init_Typeset(out, 0);
-    Update_Typeset_Bits_Core(out, VAL_ARRAY_AT(arg), VAL_SPECIFIER(arg));
+    Add_Typeset_Bits_Core(out, VAL_ARRAY_AT(arg), VAL_SPECIFIER(arg));
     return out;
 
   bad_make:

--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -807,6 +807,26 @@ inline static RELVAL *Prep_Stack_Cell_Core(
 inline static bool IS_RELATIVE(const REBCEL *v) {
     if (Not_Bindable(v) or not v->extra.binding)
         return false; // INTEGER! and other types are inherently "specific"
+
+  #if !defined(NDEBUG)
+    //
+    // !!! A trick used by RESKINNED for checking return types after its
+    // dispatcher is no longer on a stack uses CHAIN's mechanics to run a
+    // single argument function that does the test.  To avoid creating a new
+    // ACTION! for each such scenario, it makes the value it queues distinct
+    // by putting the paramlist that has the return to check in the binding.
+    // Ordinarily this would make it a "relative value" which actions never
+    // should be, but it's a pretty good trick so it subverts debug checks.
+    // Review if this category of trick can be checked for more cleanly.
+    if (
+        KIND_BYTE_UNCHECKED(v) == REB_ACTION
+        and Natives[N_skinner_return_helper_ID].payload.action.paramlist
+            == v->payload.action.paramlist
+    ){
+        return false;
+    }
+  #endif
+
     return GET_SER_FLAG(v->extra.binding, ARRAY_FLAG_PARAMLIST);
 }
 

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -152,6 +152,7 @@
 %functions/hijack.test.reb
 %functions/invisible.test.reb
 %functions/oneshot.test.reb
+%functions/redescribe.test.reb
 %functions/redo.test.reb
 %functions/specialize.test.reb
 %math/absolute.test.reb

--- a/tests/functions/redescribe.test.reb
+++ b/tests/functions/redescribe.test.reb
@@ -1,0 +1,98 @@
+; RESKINNED is an early concept of a native that rewrites parameter
+; conventions.  Would need a bigger plan to be integrated with REDESCRIBE,
+; as a general mechanism for updating HELP.  (The native does not mess with
+; the HELP, which is structured information that has been pushed out to a
+; mostly userspace protocol.)
+
+; Test return type expansion and contraction
+(
+    returns-int: func [return: [integer!] x] [x]
+
+    returns-text: enclose 'returns-int func [f] [f/x: -> + 1 to text! do f]
+    returns-text-check: reskinned [return: [integer!]] :returns-text
+
+    skin: reskinned [return: [integer! text!]] :returns-text-check
+
+    did all [
+        "11" = returns-text 10
+        (trap [returns-text-check 10])/id = 'bad-return-type
+        "11" = skin 10
+    ]
+)
+
+(
+    no-decimal-add: reskinned [return: #remove [decimal!]] adapt :add []
+    did all [
+        10 = no-decimal-add 5 5
+        (trap [no-decimal-add 5.0 5.0])/id = 'bad-return-type
+    ]
+)
+
+; The #add instruction adds an accepted type, leaving the old
+(
+    foo: func [x [integer!]] [x]
+    skin: reskinned [x #add [text!]] (adapt :foo [x: to integer! x])
+
+    did all [
+        10 = skin "10"
+        10 = skin 10
+    ]
+)
+
+; No instruction overwrites completely with the new types
+(
+    foo: func [x [integer!]] [x]
+    skin: reskinned [x [text!]] (adapt :foo [x: to integer! x])
+
+    did all [
+        10 = skin "10"
+        (trap [skin 10])/id = 'expect-arg
+    ]
+)
+
+; #remove takes away types; doesn't need to be ADAPT-ed or ENCLOSE'd to do so
+
+(
+    foo: func [x [integer! text!]] [x]
+    skin: reskinned [x #remove [integer!]] :foo
+
+    did all [
+        "10" = skin "10"
+        (trap [skin 10])/id = 'expect-arg
+    ]
+)
+
+; You can change the conventions of a function from quoting to non, etc.
+
+(
+    skin: reskinned [#change value] :lit
+    3 = skin 1 + 2
+)
+
+(
+    append-lit: reskinned [#change :value] :append
+    [a b c d] = append-lit mutable [a b c] d
+)
+
+; Ordinarily, when you ADAPT or ENCLOSE a function, the frame filling that is
+; done for the adaptation or enclosure does good enough type checking for the
+; inner function.  The only parameters it has to worry about rechecking are
+; those changed by the code.  Such changes disrupt the ARG_MARKED_CHECKED bit
+; that was put on the frame when it was filled.
+;
+; But if RESKINNED is used to expand the type conventions, then the type
+; checking on the original frame filling is no longer trustable.  If it is
+; not rechecked on a second pass, then the underlying function will get types
+; it did not expect.  If that underlying action is native code, it will crash.
+;
+; This checks that the type expansion doesn't allow those stale types to
+; sneak through unchecked.
+
+(
+    skin: reskinned [series #add [integer!]] (adapt :append [])
+
+    e: trap [
+        skin 10 "this would crash if there wasn't a recheck"
+    ]
+    e/id = 'phase-bad-arg-type
+)


### PR DESCRIPTION
This is a proof of concept for changing the parameter conventions of
functions.  Right now all it allows is to change the return type to
return any value:

    returns-int: func [return: [integer!] x] [x * 10]
    returns-text: enclose 'returns-int func [f] [
        f/x: f/x + 1
        to text! do f
    ]

    >> returns-text 10
    ** Script Error: returns-text doesn't have RETURN: enabled for text!
    
    >> skin: reskinned [return: [<opt> any-value!]] :returns-text 
    
    >> skin 10
    == 10

But it only does *exactly that*.  So the question is how this fits in
with REDESCRIBE; what does the native do, what does the usermode code
do, and how they fit together.  This is to start that conversation,
based on what can be done that gets @giuliolunati the most leverage
in the near term.