### PR TITLE
make.r: Let unloadable variable values be used as text, e.g. git commits starting with a number

### DIFF
--- a/make/make.r
+++ b/make/make.r
@@ -66,7 +66,7 @@ for-each [name value] options [
         ]
         default [
             set in user-config (to-word replace/all to text! name #"_" #"-")
-                mutable load value
+                mutable attempt [load value] else [value]
         ]
     ]
 ]


### PR DESCRIPTION
Git Commits starting with a number are not loadable, so the make failed. 
I check loading errors, and unloadable values are used as text!.