### PR TITLE
Immutable Paths, of minimum length 2

### DIFF
--- a/make/tools/native-emitters.r
+++ b/make/tools/native-emitters.r
@@ -81,10 +81,10 @@ emit-include-params-macro: function [
     n: 1
     items: try collect [
         for-each item paramlist [
-            if any [
+            any [
                 not match [any-word! lit-word!] item
                 set-word? item
-            ][
+            ] then [
                 continue
             ]
 

--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -90,10 +90,16 @@ REBOL [
             ANY_SCALAR_KIND(KIND_BYTE(v))
 
         inline static bool ANY_SERIES_KIND(REBYTE k)
-           { return k >= REB_GET_PATH and k <= REB_VECTOR; }
+           { return k >= REB_GET_GROUP and k <= REB_VECTOR; }
 
         #define ANY_SERIES(v) \
             ANY_SERIES_KIND(KIND_BYTE(v))
+
+        inline static bool ANY_SERIES_OR_PATH_KIND(REBYTE k)
+           { return k >= REB_GET_PATH and k <= REB_VECTOR; }
+
+        #define ANY_SERIES_OR_PATH(v) \
+            ANY_SERIES_OR_PATH_KIND(KIND_BYTE(v))
 
         inline static bool ANY_STRING_KIND(REBYTE k)
             { return k >= REB_TEXT and k <= REB_TAG; }
@@ -107,8 +113,14 @@ REBOL [
         #define ANY_BINSTR(v) \
             ANY_BINSTR_KIND(KIND_BYTE(v))
 
-        inline static bool ANY_ARRAY_KIND(REBYTE k)
+        inline static bool ANY_ARRAY_OR_PATH_KIND(REBYTE k)
             { return k >= REB_GET_PATH and k <= REB_BLOCK; }
+
+        #define ANY_ARRAY_OR_PATH(v) \
+            ANY_ARRAY_OR_PATH_KIND(KIND_BYTE(v))
+
+        inline static bool ANY_ARRAY_KIND(REBYTE k)
+            { return k >= REB_GET_GROUP and k <= REB_BLOCK; }
 
         #define ANY_ARRAY(v) \
             ANY_ARRAY_KIND(KIND_BYTE(v))
@@ -304,14 +316,20 @@ issue       "identifying marker word"
 ;         order matters, contiguous with ANY-SERIES! below matters
 ;         + 2 will UNSETIFY_ANY_GET_KIND(), + 1 will UNSETIFY_ANY_SET_KIND()
 
+; ===========================================================================
+; ANY-PATH!, order matters (contiguous with ANY-ARRAY below matters!)
+
 get-path    "the value of a path"
-            array       *       *       *       [path array series]
+            path        *       *       *       [path]
 
 set-path    "definition of a path's value"
-            array       *       *       *       [path array series]
+            path        *       *       *       [path]
 
 path        "refinements to functions, objects, files"
-            array       *       *       *       [path array series]
+            path        *       *       *       [path]
+
+; ===========================================================================
+; ANY-ARRAY!, order matters (contiguous with ANY-SERIES below matters!)
 
 get-group   "array that evaluates and runs GET on the resulting word/path"
             array       *       *       *       [group array series]

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -85,7 +85,10 @@ void Bind_Values_Inner_Loop(
                 Quotify(head, depth); // new cell made for higher escapes
             }
         }
-        else if (ANY_ARRAY_KIND(kind) and (flags & BIND_DEEP)) {
+        else if (
+            (ANY_ARRAY_OR_PATH_KIND(kind))
+            and (flags & BIND_DEEP)
+        ){
             Bind_Values_Inner_Loop(
                 binder,
                 VAL_ARRAY_AT(cell),
@@ -161,7 +164,7 @@ void Unbind_Values_Core(RELVAL *head, REBCTX *context, bool deep)
         ){
             Unbind_Any_Word(v);
         }
-        else if (ANY_ARRAY(v) and deep)
+        else if (ANY_ARRAY_OR_PATH(v) and deep)
             Unbind_Values_Core(VAL_ARRAY_AT(v), context, true);
     }
 }
@@ -196,7 +199,7 @@ static void Bind_Relative_Inner_Loop(
     RELVAL *head,
     REBARR *paramlist,
     REBU64 bind_types
-) {
+){
     for (; NOT_END(head); ++head) {
         //
         // The two-pass copy-and-then-bind should have gotten rid of all the
@@ -226,7 +229,7 @@ static void Bind_Relative_Inner_Loop(
                 Quotify(head, depth); // new cell made for higher escapes
             }
         }
-        else if (ANY_ARRAY_KIND(kind)) {
+        else if (ANY_ARRAY_OR_PATH_KIND(kind)) {
 
             Bind_Relative_Inner_Loop(
                 binder, VAL_ARRAY_AT(cell), paramlist, bind_types
@@ -274,7 +277,7 @@ REBARR *Copy_And_Bind_Relative_Deep_Managed(
         VAL_LEN_AT(body), // tail
         0, // extra
         ARRAY_FLAG_FILE_LINE, // ask to preserve file and line info
-        TS_SERIES & ~TS_NOT_COPIED // types to copy deeply
+        (TS_SERIES | TS_PATH) & ~TS_NOT_COPIED // types to copy deeply
     );
 
     struct Reb_Binder binder;
@@ -314,7 +317,7 @@ void Rebind_Values_Deep(
 ) {
     RELVAL *v = head;
     for (; NOT_END(v); ++v) {
-        if (ANY_ARRAY(v)) {
+        if (ANY_ARRAY_OR_PATH(v)) {
             Rebind_Values_Deep(src, dst, VAL_ARRAY_AT(v), opt_binder);
         }
         else if (ANY_WORD(v) and VAL_BINDING(v) == NOD(src)) {
@@ -469,7 +472,7 @@ void Virtual_Bind_Deep_To_New_Context(
                 ARR_LEN(VAL_ARRAY(body_in_out)), // tail
                 0, // extra
                 ARRAY_FLAG_FILE_LINE, // flags
-                TS_ARRAY // types to copy deeply
+                TS_ARRAY | TS_PATH // types to copy deeply
             )
         );
     }

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -2653,7 +2653,9 @@ bool Eval_Core_Throws(REBFRM * const f)
     if (kind.byte == REB_PATH) {
         if (
             Dampen_Lookahead(f)
-            or VAL_LEN_AT(f->value) != 0
+            or VAL_LEN_AT(f->value) != 2
+            or not IS_BLANK(ARR_AT(VAL_ARRAY(f->value), 0))
+            or not IS_BLANK(ARR_AT(VAL_ARRAY(f->value), 1))
             or not EVALUATING(f->value)
         ){
             if (not (f->flags.bits & DO_FLAG_TO_END))

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -212,7 +212,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
     const REBVAL *spec,
     REBFLGS flags
 ) {
-    assert(ANY_ARRAY(spec));
+    assert(IS_BLOCK(spec));
 
     uintptr_t header_bits = 0;
 

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -349,7 +349,7 @@ REBARR *Copy_Rerelativized_Array_Deep_Managed(
 
         Move_Value_Header(dest, src);
 
-        if (ANY_ARRAY(src)) {
+        if (ANY_ARRAY_OR_PATH(src)) {
             dest->payload.any_series.series = SER(
                 Copy_Rerelativized_Array_Deep_Managed(
                     VAL_ARRAY(src), before, after
@@ -404,7 +404,7 @@ void Uncolor_Array(REBARR *a)
 
     RELVAL *val;
     for (val = ARR_HEAD(a); NOT_END(val); ++val)
-        if (ANY_ARRAY(val) or IS_MAP(val) or ANY_CONTEXT(val))
+        if (ANY_ARRAY_OR_PATH(val) or IS_MAP(val) or ANY_CONTEXT(val))
             Uncolor(val);
 }
 
@@ -418,7 +418,7 @@ void Uncolor(RELVAL *v)
 {
     REBARR *array;
 
-    if (ANY_ARRAY(v))
+    if (ANY_ARRAY_OR_PATH(v))
         array = VAL_ARRAY(v);
     else if (IS_MAP(v))
         array = MAP_PAIRLIST(VAL_MAP(v));

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -284,11 +284,11 @@ REBINT Get_System_Int(REBCNT i1, REBCNT i2, REBINT default_int)
 REBVAL *Init_Any_Series_At_Core(
     RELVAL *out, // allows RELVAL slot as input, but will be filled w/REBVAL
     enum Reb_Kind type,
-    REBSER *series,
+    REBSER *s,
     REBCNT index,
     REBNOD *binding
 ) {
-    ENSURE_SERIES_MANAGED(series);
+    ENSURE_SERIES_MANAGED(s);
 
     if (type != REB_IMAGE and type != REB_VECTOR) {
         // Code in various places seemed to have different opinions of
@@ -304,21 +304,26 @@ REBVAL *Init_Any_Series_At_Core(
         //
         // Until that is consciously overturned, check the REB_BINARY too
 
-        ASSERT_SERIES_TERM(series); // doesn't apply to image/vector
+        ASSERT_SERIES_TERM(s); // doesn't apply to image/vector
     }
 
     RESET_CELL(out, type);
-    out->payload.any_series.series = series;
+    out->payload.any_series.series = s;
     VAL_INDEX(out) = index;
     INIT_BINDING(out, binding);
 
   #if !defined(NDEBUG)
-    if (ANY_STRING(out)) {
-        if (SER_WIDE(series) != 2)
-            panic(series);
-    } else if (IS_BINARY(out)) {
-        if (SER_WIDE(series) != 1)
-            panic(series);
+    if (ANY_STRING_KIND(type)) {
+        if (SER_WIDE(s) != 2)
+            panic (s);
+    }
+    else if (type == REB_BINARY) {
+        if (SER_WIDE(s) != 1)
+            panic (s);
+    }
+    else if (ANY_PATH_KIND(type)) {
+        if (ARR_LEN(ARR(s)) < 2)
+            panic (s);
     }
   #endif
 
@@ -484,7 +489,7 @@ static REBCNT Part_Len_Core(
 // subsetted range and gives back a length to the end of that subset.
 //
 REBCNT Part_Len_May_Modify_Index(REBVAL *series, const REBVAL *limit) {
-    assert(ANY_SERIES(series));
+    assert(ANY_SERIES(series) or ANY_PATH(series));
     return Part_Len_Core(series, limit);
 }
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -205,7 +205,7 @@ REBNATIVE(bind)
         return D_OUT;
     }
 
-    if (not ANY_ARRAY(v))
+    if (not ANY_ARRAY_OR_PATH(v))
         fail (Error_Invalid(v)); // QUOTED! could have been any type
 
     RELVAL *at;
@@ -1072,11 +1072,11 @@ REBNATIVE(free_q)
 //
 //  as: native [
 //
-//  {Aliases underlying data of one series to act as another of same class}
+//  {Aliases underlying data of one value to act as another of same class}
 //
-//      return: [<opt> any-series! any-word! quoted!]
+//      return: [<opt> any-path! any-series! any-word! quoted!]
 //      type [datatype! quoted!]
-//      value [<blank> any-series! any-word! quoted!]
+//      value [<blank> any-path! any-series! any-word! quoted!]
 //  ]
 //
 REBNATIVE(as)
@@ -1085,7 +1085,7 @@ REBNATIVE(as)
 
     REBVAL *v = ARG(value);
     Dequotify(v); // number of incoming quotes not relevant
-    if (not ANY_SERIES(v) and not ANY_WORD(v))
+    if (not ANY_SERIES(v) and not ANY_WORD(v) and not ANY_PATH(v))
         fail (Error_Invalid(v));
 
     REBVAL *t = ARG(type);
@@ -1095,16 +1095,46 @@ REBNATIVE(as)
         fail (Error_Invalid(t));
 
     enum Reb_Kind new_kind = VAL_TYPE_KIND(t);
+    if (new_kind == VAL_TYPE(v))
+        RETURN (Quotify(v, quotes)); // just may change quotes
 
     switch (new_kind) {
       case REB_BLOCK:
       case REB_GROUP:
-      case REB_PATH:
-      case REB_GET_PATH:
-        if (new_kind == VAL_TYPE(v))
-            RETURN (Quotify(v, quotes)); // just may change quotes
+        if (ANY_PATH(v)) {
+            //
+            // This forces the freezing of the path's array; otherwise the
+            // BLOCK! or GROUP! would be able to mutate the immutable path.
+            // There is currently no such thing as a shallow non-removable
+            // bit, though we could use SERIES_INFO_HOLD for that.  For now,
+            // freeze deeply and anyone who doesn't like the effect can use
+            // TO PATH! and accept the copying.
+            //
+            Deep_Freeze_Array(VAL_ARRAY(v));
+            break;
+        }
 
         if (not ANY_ARRAY(v))
+            goto bad_cast;
+        break;
+
+      case REB_PATH:
+      case REB_GET_PATH:
+      case REB_SET_PATH:
+        //
+        // !!! If AS aliasing were to be permitted, it gets pretty complex.
+        // See notes above in aliasing paths as group or block.  We can
+        // only alias it if we ensure it is frozen.  Not only that, a path
+        // may be optimized to not have an array, hence we may have to
+        // fabricate one.  It would create some complexity with arrays not
+        // at their head, because paths would wind up having an index that
+        // they heeded but could not change.  Also, the array would have
+        // to be checked for validity, e.g. not containing any PATH! or
+        // FILE! or types that wouldn't be allowed.  There's less flexibility
+        // than in a TO conversion to do adjustments.  Long story short: it
+        // is probably not worth it...and TO should be used instead.
+
+        if (not ANY_PATH(v))
             goto bad_cast;
         break;
 
@@ -1113,9 +1143,7 @@ REBNATIVE(as)
       case REB_FILE:
       case REB_URL:
       case REB_EMAIL: {
-        if (new_kind == VAL_TYPE(v))
-            RETURN (Quotify(v, quotes)); // just may change quotes
-
+        //
         // !!! Until UTF-8 Everywhere, turning ANY-WORD! into an ANY-STRING!
         // means it has to be UTF-8 decoded into REBUNI (UCS-2).  We do that
         // but make sure it is locked, so that when it does give access to
@@ -1169,9 +1197,7 @@ REBNATIVE(as)
       case REB_SET_WORD:
       case REB_ISSUE:
       case REB_REFINEMENT: {
-        if (new_kind == VAL_TYPE(v))
-            RETURN (Quotify(v, quotes)); // just may change quotes
-
+        //
         // !!! Until UTF-8 Everywhere, turning ANY-STRING! into an ANY-WORD!
         // means you have to have an interning of it.
         //
@@ -1223,9 +1249,7 @@ REBNATIVE(as)
         break; }
 
       case REB_BINARY: {
-        if (new_kind == VAL_TYPE(v))
-            RETURN (Quotify(v, quotes)); // just may change quotes
-
+        //
         // !!! A locked BINARY! shouldn't (?) complain if it exposes a
         // REBSTR holding UTF-8 data, even prior to the UTF-8 conversion.
         //
@@ -1263,6 +1287,9 @@ REBNATIVE(as)
         fail (Error_Bad_Cast_Raw(v, ARG(type)));
     }
 
+    // Fallthrough for cases where changing the type byte and potentially
+    // updating the quotes is enough.
+    //
     Move_Value(D_OUT, v);
     mutable_KIND_BYTE(D_OUT) = new_kind;
     return Trust_Const(Quotify(D_OUT, quotes));

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -186,7 +186,7 @@ REB_R Compose_To_Stack_Core(
         const REBCEL *cell = VAL_UNESCAPED(f->value);
         enum Reb_Kind kind = CELL_KIND(cell); // notice `\\(...)`
 
-        if (not ANY_ARRAY_KIND(kind)) { // won't substitute/recurse
+        if (not ANY_ARRAY_OR_PATH_KIND(kind)) { // won't substitute/recurse
             Derelativize(DS_PUSH(), f->value, specifier); // keep newline flag
             continue;
         }
@@ -358,11 +358,11 @@ REB_R Compose_To_Stack_Core(
 //
 //  {Evaluates only contents of GROUP!-delimited expressions in an array}
 //
-//      return: [any-array!]
+//      return: [any-array! any-path!]
 //      :label "Distinguish compose groups, e.g. [(plain) (<*> composed)]"
 //          [<skip> tag!]
 //      value "Array to use as the template for substitution"
-//          [any-array!]
+//          [any-array! any-path!]
 //      /deep "Compose deeply into nested arrays"
 //      /only "Insert arrays as single value (not as contents of array)"
 //  ]

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -355,7 +355,7 @@ void Mold_Array_At(
 
     bool indented = false;
 
-    if (sep[1])
+    if (sep[0])
         Append_Utf8_Codepoint(mo->series, sep[0]);
 
     RELVAL *item = ARR_AT(a, index);
@@ -375,9 +375,7 @@ void Mold_Array_At(
         if (IS_END(item))
             break;
 
-        if (sep[0] == '/')
-            Append_Utf8_Codepoint(mo->series, '/'); // !!! ignores newline
-        else if (NOT_CELL_FLAG(item, NEWLINE_BEFORE))
+        if (NOT_CELL_FLAG(item, NEWLINE_BEFORE))
             Append_Utf8_Codepoint(mo->series, ' ');
     }
 

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -473,7 +473,11 @@ inline static void INIT_VAL_ARRAY(RELVAL *v, REBARR *a) {
 // account; they strictly operate on the array series
 //
 inline static REBARR *VAL_ARRAY(const REBCEL *v) {
-    assert(ANY_ARRAY_KIND(CELL_KIND(v)));
+    if (ANY_PATH_KIND(CELL_KIND(v)))
+        assert(v->payload.any_series.index == 0);
+    else
+        assert(ANY_ARRAY_KIND(CELL_KIND(v)));
+
     REBSER *s = v->payload.any_series.series;
     if (s->info.bits & SERIES_INFO_INACCESSIBLE)
         fail (Error_Series_Data_Freed_Raw());

--- a/src/include/sys-bind.h
+++ b/src/include/sys-bind.h
@@ -71,7 +71,11 @@
     }
 
     inline static REBSPC *VAL_SPECIFIER(const REBCEL *v) {
-        assert(ANY_ARRAY_KIND(CELL_KIND(v)));
+        if (ANY_PATH_KIND(CELL_KIND(v)))
+            assert(v->payload.any_series.index == 0);
+        else
+            assert(ANY_ARRAY_KIND(CELL_KIND(v)));
+
         if (not v->extra.binding)
             return SPECIFIED;
 
@@ -633,7 +637,7 @@ inline static REBVAL *Derelativize(
 
       #if !defined(NDEBUG)
         enum Reb_Kind kind = CELL_KIND(VAL_UNESCAPED(v));
-        assert(ANY_WORD_KIND(kind) or ANY_ARRAY_KIND(kind));
+        assert(ANY_WORD_KIND(kind) or ANY_ARRAY_OR_PATH_KIND(kind));
 
         if (not specifier) {
             printf("Relative item used with SPECIFIED\n");

--- a/src/include/sys-protect.h
+++ b/src/include/sys-protect.h
@@ -86,11 +86,23 @@ inline static void FAIL_IF_READ_ONLY_ARRAY_CORE(
     FAIL_IF_READ_ONLY_ARRAY_CORE((array), SPECIFIED)
 
 
-inline static void FAIL_IF_READ_ONLY_CONTEXT(REBVAL *context) {
+inline static void FAIL_IF_READ_ONLY_CONTEXT(RELVAL *context) {
     assert(ANY_CONTEXT(context));
     REBARR *varlist = context->payload.any_context.varlist;
     FAIL_IF_READ_ONLY_SER(SER(varlist));
 
     // !!! CONST is a work in progress, experimental, but would need handling
     // here too...
+}
+
+
+inline static void FAIL_IF_READ_ONLY_VALUE(RELVAL *v) {
+    if (ANY_SERIES(v))
+        FAIL_IF_READ_ONLY_SERIES(v);
+    else if (ANY_CONTEXT(v))
+        FAIL_IF_READ_ONLY_CONTEXT(v);
+    else if (ANY_SCALAR(v) or IS_BLANK(v))
+        fail ("Scalars are immutable");
+    else if (ANY_PATH(v))
+        fail ("Paths are immutable");
 }

--- a/src/include/sys-rebser.h
+++ b/src/include/sys-rebser.h
@@ -229,6 +229,9 @@
 
 //=//// ARRAY_FLAG_NULLEDS_LEGAL //////////////////////////////////////////=//
 //
+// Note: This is not a debug-only flag at this time, as passing it in has
+// semantic implications (e.g. preserve VALUE_FLAG_EVAL_FLIP on copy).
+//
 // Identifies arrays in which it is legal to have nulled elements.  This is
 // true for reified C va_list()s which treated slots as if they had already
 // abeen evaluated.  (See CELL_FLAG_EVAL_FLIP).  When those va_lists need to

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -408,13 +408,7 @@ struct Reb_Quoted_Payload {
 
 
 struct Reb_Series_Payload {
-    //
-    // `series` represents the actual physical underlying data, which is
-    // essentially a vector of equal-sized items.  The length of the item
-    // (the series "width") is kept within the REBSER abstraction.  See the
-    // file %sys-series.h for notes.
-    //
-    REBSER *series;
+    REBSER *series; // vector of equal-sized items, see %sys-series.h
 
     // `index` is the 0-based position into the series represented by this
     // ANY-VALUE! (so if it is 0 then that means a Rebol index of 1).

--- a/src/include/sys-series.h
+++ b/src/include/sys-series.h
@@ -495,7 +495,7 @@ inline static void FAIL_IF_READ_ONLY_SER(REBSER *s) {
 
 inline static REBSER *VAL_SERIES(const REBCEL *v) {
     assert(
-        ANY_SERIES_KIND(CELL_KIND(v))
+        ANY_SERIES_KIND(CELL_KIND(v)) or ANY_PATH_KIND(CELL_KIND(v))
         or CELL_KIND(v) == REB_MAP
         or CELL_KIND(v) == REB_IMAGE
     ); // !!! Note: there was a problem here once, with a gcc 5.4 -O2 bug
@@ -518,10 +518,14 @@ inline static void INIT_VAL_SERIES(RELVAL *v, REBSER *s) {
     // allows an assert, but also lvalue: `VAL_INDEX(v) = xxx`
     //
     inline static REBCNT & VAL_INDEX(REBCEL *v) { // C++ reference type
-        assert(ANY_SERIES_KIND(CELL_KIND(v)));
+        assert(ANY_SERIES_KIND(CELL_KIND(v)) or ANY_PATH_KIND(CELL_KIND(v)));
         return v->payload.any_series.index;
     }
     inline static REBCNT VAL_INDEX(const REBCEL *v) {
+        if (ANY_PATH_KIND(CELL_KIND(v))) {
+            assert(v->payload.any_series.index == 0);
+            return 0;
+        }
         assert(ANY_SERIES_KIND(CELL_KIND(v)));
         return v->payload.any_series.index;
     }

--- a/src/include/sys-typeset.h
+++ b/src/include/sys-typeset.h
@@ -102,10 +102,10 @@ inline static REBSTR *Get_Type_Name(const RELVAL *value)
     (TS_SERIES & ~TS_NOT_COPIED)
 
 #define TS_SERIES_OBJ \
-    ((TS_SERIES | TS_CONTEXT) & ~TS_NOT_COPIED)
+    ((TS_SERIES | TS_CONTEXT | TS_PATH) & ~TS_NOT_COPIED)
 
 #define TS_ARRAYS_OBJ \
-    ((TS_ARRAY | TS_CONTEXT) & ~TS_NOT_COPIED)
+    ((TS_ARRAY | TS_CONTEXT | TS_PATH) & ~TS_NOT_COPIED)
 
 #define TS_CLONE \
     (TS_SERIES & ~TS_NOT_COPIED) // currently same as TS_NOT_COPIED

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -49,7 +49,7 @@ extend: func [
 
 join-all: function [
     "Reduces and appends a block of values together."
-    return: [<opt> any-series!]
+    return: [<opt> any-path! any-series! quoted!]
         "Will be the type of the first non-null series produced by evaluation"
     block [block!]
         "Values to join together"

--- a/tests/control/for-each.test.reb
+++ b/tests/control/for-each.test.reb
@@ -188,3 +188,10 @@
     ]
 )
 
+;; paths are immutable, but for-each is legal on them
+
+(
+    [a b c] = collect [for-each x 'a/b/c [keep x]]
+)(
+    [_ _] = collect [for-each x '/ [keep x]]
+)

--- a/tests/control/map-each.test.reb
+++ b/tests/control/map-each.test.reb
@@ -3,3 +3,9 @@
 (
     integer? eval does [map-each v [] [] 1]
 )
+
+; PATH! is immutable, but MAP-EACH should work on it
+
+(
+     [[a 1] [b 1] [c 1]] = map-each x 'a/b/c [reduce [x 1]]
+)

--- a/tests/convert/to.test.reb
+++ b/tests/convert/to.test.reb
@@ -10,8 +10,8 @@
 
 ; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
 ;
-([a/b/c] = to block! 'a/b/c)
-(lit (a/b/c) = to group! 'a/b/c)
+([a b c] = to block! 'a/b/c)
+(lit (a b c) = to group! 'a/b/c)
 ([a b c] = to block! lit (a b c))
 (lit (a b c) = to group! [a b c])
 (lit a/b/c = to path! [a b c])

--- a/tests/datatypes/get-path.test.reb
+++ b/tests/datatypes/get-path.test.reb
@@ -4,9 +4,12 @@
 [#1947
     (get-path? load "#[get-path! [[a] 1]]")
 ]
-(
-    all [
-        get-path? a: load "#[get-path! [[a b c] 2]]"
-        2 == index? a
-    ]
-)
+
+;; ANY-PATH! are no longer positional
+;;
+;;(
+;;    all [
+;;        get-path? a: load "#[get-path! [[a b c] 2]]"
+;;        2 == index? a
+;;    ]
+;;)

--- a/tests/datatypes/lit-path.test.reb
+++ b/tests/datatypes/lit-path.test.reb
@@ -1,17 +1,18 @@
-; datatypes/lit-path.r
+; Note: LIT-PATH! no longer exists as a distinct datatype.  It is defined for
+; compatibility purposes under the mechanisms of fully generalized quoting:
+;
+; https://forum.rebol.info/t/quoted-arrives-formerly-known-as-lit-bit/995
+
 (lit-path? first ['a/b])
 (not lit-path? 1)
 ((uneval path!) = type of first ['a/b])
+
 ; minimum
+
 [#1947
     (lit-path? uneval load "#[path! [[a] 1]]")
 ]
-(
-    all [
-        lit-path? a: uneval load "#[path! [[a b c] 2]]"
-        2 == index? a
-    ]
-)
+
 ; lit-paths are active
 (
     a-value: first ['a/b]

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -7,12 +7,15 @@
 [#1947
     (path? load "#[path! [[a] 1]]")
 ]
-(
-    all [
-        path? a: load "#[path! [[a b c] 2]]"
-        2 == index? a
-    ]
-)
+
+;; ANY-PATH! are no longer positional
+;;(
+;;    all [
+;;        path? a: load "#[path! [[a b c] 2]]"
+;;        2 == index? a
+;;    ]
+;;)
+
 ("a/b" = mold 'a/b)
 (
     a-word: 1
@@ -29,7 +32,7 @@
 )
 (
     blk: reduce [charset "a" 3]
-    3 == do reduce [as path! reduce ['blk charset "a"]]
+    3 == do reduce [to path! reduce ['blk charset "a"]]
 )
 (
     blk: [[] 3]
@@ -134,13 +137,10 @@
     b: [b 1]
     1 = b/b
 )]
-; recursive path
+
+; Paths are immutable
 (
-    a: make object! []
-    path: mutable 'a/a
-    change/only back tail of path path
-    error? trap [do path]
-    true
+    did trap [mutable 'a/a]
 )
 
 [#71 (
@@ -171,18 +171,18 @@
 ; PATH! beginning with an inert item will itself be inert
 ;
 [
-    (/ref/inement/path = as path! [/ref inement path])
-    (/refinement/3 = as path! [/refinement 3])
+    (/ref/inement/path = to path! [/ref inement path])
+    (/refinement/3 = to path! [/refinement 3])
     ((/refinement)/3 = #"f")
     (r: /refinement | r/3 = #"f")
 ][
-    (#iss/ue/path = as path! [#iss ue path])
-    (#issue/3 = as path! [#issue 3])
+    (#iss/ue/path = to path! [#iss ue path])
+    (#issue/3 = to path! [#issue 3])
     ((#issue)/3 = #"s")
     (i: #issue | i/3 = #"s")
 ][
-    ("te"/xt/path = as path! ["te" xt path])
-    ("text"/3 = as path! ["text" 3])
+    ("te"/xt/path = to path! ["te" xt path])
+    ("text"/3 = to path! ["text" 3])
     (("text")/3 = #"x")
     (t: "text" | t/3 = #"x")
 ]
@@ -194,16 +194,22 @@
     all [
         1 = bl/a
         [e/r 42] = bl/('q/w)
-        [e/r 42] = reduce to-path [bl q/w]
+        [e/r 42] = reduce to-path [bl ('q/w)]
         42 = bl/('q/w)/('e/r)
-        42 = reduce to-path [bl q/w e/r]
+        42 = reduce to-path [bl ('q/w) ('e/r)]
     ]
 )
 
-; / is a length 0 PATH! in Ren-C
+; / is a length 2 PATH! in Ren-C
 (path! = type of lit /)
-(0 = length of lit /)
+(2 = length of lit /)
+(lit / = to path! [_ _])
 
 ; foo/ is a length 1 PATH! in Ren-C
 (path! = type of lit foo/ )
-(1 = length of lit foo/ )
+(2 = length of lit foo/ )
+(lit foo/ = to path! [foo _])
+
+; Not currently true, TO BLOCK! is acting like BLOCKIFY, review
+; ([_ _] = to block! lit /)
+; ([foo _] = to block! lit foo/ )  ; !!! low priority scanner bug on /)

--- a/tests/datatypes/quoted.test.reb
+++ b/tests/datatypes/quoted.test.reb
@@ -160,10 +160,10 @@
 (did lit '''''''')
 
 
-;; Spliced-oriented processing should "see through" the quote of the appended
-;; item, but preserve the quoting level of the appended-to item:
+; Spliced-oriented processing should "see through" the quote of the appended
+; item, but preserve the quoting level of the appended-to item:
 
-('''a/b/c/d/e/f = append copy lit '''a/b/c 'd/e/f)
+('''a/b/c/d/e/f = join lit '''a/b/c 'd/e/f)
 
 
 ;; An escaped word that can't fit in a cell and has to do an additional

--- a/tests/datatypes/set-path.test.reb
+++ b/tests/datatypes/set-path.test.reb
@@ -6,12 +6,16 @@
 [#1947
     (set-path? load "#[set-path! [[a] 1]]")
 ]
-(
-    all [
-        set-path? a: load "#[set-path! [[a b c] 2]]"
-        2 == index? a
-    ]
-)
+
+;; ANY-PATH! are no longer positional
+;;
+;;(
+;;    all [
+;;        set-path? a: load "#[set-path! [[a b c] 2]]"
+;;        2 == index? a
+;;    ]
+;;)
+
 ("a/b:" = mold first [a/b:])
 ; set-paths are active
 (

--- a/tests/series/append.test.reb
+++ b/tests/series/append.test.reb
@@ -33,7 +33,7 @@
 ; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
 ;
 ([a b c d/e/f] = append copy [a b c] 'd/e/f)
-('a/b/c/d/e/f = append copy 'a/b/c [d e f])
+('a/b/c/d/e/f = join 'a/b/c ['d 'e 'f])
 ('(a b c d/e/f) = append copy '(a b c) 'd/e/f)
-('a/b/c/d/e/f = append copy 'a/b/c '(d e f))
-('a/b/c/d/e/f = append copy 'a/b/c 'd/e/f)
+(did trap ['a/b/c/d/e/f = join 'a/b/c '('d 'e 'f)])
+('a/b/c/d/e/f = join 'a/b/c 'd/e/f)

--- a/tests/series/as.test.reb
+++ b/tests/series/as.test.reb
@@ -1,8 +1,8 @@
 (
     block: copy [a b c]
-    path: as path! block
+    path: to path! block
     append block 'd
-    path = 'a/b/c/d
+    path = 'a/b/c  ; AS was not legal
 )
 (
     block: copy [a b c]

--- a/tests/series/back.test.reb
+++ b/tests/series/back.test.reb
@@ -7,15 +7,6 @@
     a: tail of [1]
     same? head of a back a
 )
-; path
-(
-    a: 'b/c
-    null? back a
-)
-(
-    a: tail of 'b/c
-    same? head of a back back a
-)
 ; string
 (
     a: tail of "1"

--- a/tests/series/insert.test.reb
+++ b/tests/series/insert.test.reb
@@ -34,60 +34,6 @@
     insert b a
     a == b
 )
-; path
-(
-    a: make path! 0
-    insert a 0
-    a == as path! [0]
-)
-(
-    a: copy as path! [0]
-    b: make path! 0
-    insert b first a
-    a == b
-)
-(
-    a: copy as path! [0]
-    b: make path! 0
-    insert :b a
-    a == b
-)
-; lit-path
-(
-    a: uneval make path! 0
-    insert :a 0
-    :a == uneval to path! [0]
-)
-(
-    a: uneval to path! [0]
-    b: uneval make path! 0
-    insert :b first :a
-    :a == :b
-)
-(
-    a: uneval to path! [0]
-    b: uneval make path! 0
-    insert :b :a
-    :a == :b
-)
-; set-path
-(
-    a: make set-path! 0
-    insert :a 0
-    :a == to set-path! [0]
-)
-(
-    a: to set-path! [0]
-    b: make set-path! 0
-    insert :b first :a
-    :a == :b
-)
-(
-    a: to set-path! [0]
-    b: make set-path! 0
-    insert :b :a
-    :a == :b
-)
 ; text
 (
     a: make text! 0

--- a/tests/series/rejoin.test.reb
+++ b/tests/series/rejoin.test.reb
@@ -1,4 +1,9 @@
 ; series/rejoin.test.reb
+;
+; REJOIN is deprecated in Ren-C in favor of JOIN-ALL:
+;
+; https://forum.rebol.info/t/rejoin-ugliness-and-the-usefulness-of-tests/248
+
 (
     [] = rejoin []
 )
@@ -25,10 +30,10 @@
     [1] = rejoin [[] 1]
 )
 (
-    'a/b/c = rejoin ['a/b 'c]
+    'a/b/c = join-all ['a/b 'c]
 )
 (
-    'a/b/c/d = rejoin ['a/b 'c 'd]
+    'a/b/c/d = join-all ['a/b 'c 'd]
 )
 (
     "" = rejoin [{}]

--- a/tests/series/replace.test.reb
+++ b/tests/series/replace.test.reb
@@ -15,21 +15,20 @@
 ([1 2 8 5] = replace mutable [1 2 3 4 5] [3 4] 8)
 ([1 2 a 5] = replace mutable [1 2 3 4 5] [3 4] 'a)
 ([a g c d] = replace mutable [a b c d] 'b 'g)
-('a/b/g/d/e = replace mutable 'a/b/c/d/e 'c 'g)
-('a/b/g/h/i/d/e = replace mutable 'a/b/c/d/e 'c 'g/h/i)
 (#{006400} = replace mutable #{000100} #{01} 100)
 (%file.ext = replace mutable %file.sub.ext ".sub." #".")
 ("abra-abra" = replace mutable "abracadabra" "cad" #"-")
 ("abra-c-adabra" = replace mutable "abracadabra" #"c" "-c-")
 
-; Red has a bizarre behavior for this which is in the tests:
+; Red has a bizarre behavior for this which is in their tests:
 ; https://github.com/red/red/blob/12ad56be0fc474f7738c0ef891725e49f9738010/tests/source/units/replace-test.red#L24
 ;
 ;    ('a/b/c/h/i/d/e = replace 'a/b/g/h/i/d/e 'g/h/i 'c)
 ;
 ; That's not what Rebol2 does, and not consistent with BLOCK! replacement
-;
-('a/b/c/d/e = replace mutable 'a/b/g/h/i/d/e 'g/h/i 'c)
+; Ren-C doesn't allow REPLACE on paths in any case--they are immutable, one
+; must convert to a block and back (the conversion may fail as not all blocks
+; can become paths)
 
 ; REPLACE/ALL
 
@@ -37,8 +36,6 @@
 ([1 4 5 3 4 5] = replace/all mutable [1 2 3 2] 2 [4 5])
 ([1 8 9 8 9] = replace/all mutable [1 2 3 2 3] [2 3] [8 9])
 ([1 8 8] = replace/all mutable [1 2 3 2 3] [2 3] 8)
-('a/b/g/d/g = replace/all mutable 'a/b/c/d/c 'c 'g)
-('a/b/g/h/d/g/h = replace/all mutable 'a/b/c/d/c 'c 'g/h)
 (#{640164} = replace/all mutable #{000100} #{00} #{64})
 (%file.sub.ext = replace/all mutable %file!sub!ext #"!" #".")
 (<tag body end> = replace/all mutable <tag_body_end> "_" " ")
@@ -53,10 +50,7 @@
 (%file.txt = replace/case/all mutable %file.TXT.txt.TXT %.TXT "")
 (<tag xyXx> = replace/case mutable <tag xXXx> "X" "y")
 (<tag xyyx> = replace/case/all mutable <tag xXXx> "X" "y")
-('a/X/o/X = replace/case mutable 'a/X/x/X 'x 'o)
-('a/o/x/o = replace/case/all mutable 'a/X/x/X 'X 'o)
 (["a" "B" "x"] = replace/case/all mutable ["a" "B" "a" "b"] ["a" "b"] "x")
-((lit :x/b/A/x/B) = replace/case/all mutable lit :a/b/A/a/B [a] 'x)
 ((lit (x A x)) = replace/case/all mutable lit (a A a) 'a 'x)
 
 ;((make hash! [x a b [a B]]) = replace/case make hash! [a B a b [a B]] [a B] 'x)


### PR DESCRIPTION
This changes PATH! to no longer be an ANY-SERIES! type.  This means it
cannot be operated on with series operations like APPEND, and it can't
be traversed to give new positions into paths with things like NEXT
or SKIP.  However, other operations like LENGTH OF, PICK, and FOR-EACH
continue to work.  JOIN works as well, for creating a new path with more
material (but does not modify the old one).

Because there's no way to change them, ANY-PATH! is also immutable.
This means that a path can be checked at the time of its creation for
properties which cannot be violated by future mutations.

The new rules are:

* Paths must contain at least 2 elements.  The minimum path is `/`,
  which is the path form of [_ _]...two blanks.

* Paths may not directly contain other paths.  This prevents various
  ambiguity problems like [a/b c] and [a b/c] both being possible
  interpretations of a/b/c.  Indirect inclusion of other paths is
  legal, such as `a/(b/c)/d`

It is believed that this change eliminates harmful degrees of freedom,
without really sacrificing any behaviors people found that interesting.
Additionally, being able to promise paths are immutable open doors to
being able to create optimized representations of things like `/` or
`/a`, which could be packed into a single cell with no array node.

It's possible to use JOIN to create a new path which adds to another.
But if one wishes to do arbitrary surgery on path content, the way to
do that is to convert it to a BLOCK! or GROUP! and use series
operations on that, and then change it back to a PATH!.