### PR TITLE
Reimagine REFINEMENT! as a 2-element PATH!

### DIFF
--- a/make/tools/bootstrap-shim.r
+++ b/make/tools/bootstrap-shim.r
@@ -43,6 +43,7 @@ REBOL [
 trap [
     func [i [<blank> integer!]] [...]
 ] else [
+    refinement-second: :second  ; Refinements aren't PATH! in older Ren-CC
     QUIT
 ]
 
@@ -133,3 +134,5 @@ join-of: func [] [
         https://forum.rebol.info/t/its-time-to-join-together/1030
     ]
 ]
+
+refinement-second: func [v [refinement!]] [as word! v]

--- a/make/tools/native-emitters.r
+++ b/make/tools/native-emitters.r
@@ -82,16 +82,19 @@ emit-include-params-macro: function [
     items: try collect [
         for-each item paramlist [
             any [
-                not match [any-word! lit-word!] item
+                not match [any-word! refinement! lit-word!] item
                 set-word? item
             ] then [
                 continue
             ]
 
-            param-name: copy as text! item
             either refinement? item [
+                param-name: copy as text! refinement-second item
+
                 keep cscape/with {REFINE($<n>, ${param-name})} [n param-name]
             ][
+                param-name: copy as text! item
+
                 keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
             ]
             n: n + 1

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -468,7 +468,7 @@ for-each-system: function [
                 cflags: map-each x cflags [to-word to-text x]
             )
             copy ldflags [any refinement!] (
-                ldflags: map-each x ldflags [to-word x]
+                ldflags: map-each x ldflags [refinement-second x]
             )
             copy libraries [any file!] (
                 libraries: map-each x libraries [to-word to-text x]

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -121,8 +121,9 @@ blankify-refinement-args: helper [
             case [
                 refinement? w [
                     seen-refinement: true
-                    if f/(to-word w) [
-                        f/(to-word w): true ;-- turn REFINEMENT! into #[true]
+                    w: ensure word! second w
+                    if f/(w) [
+                        f/(w): true ;-- turn refinement PATH! into #[true]
                     ]
                 ]
                 seen-refinement [ ;-- turn any null args into BLANK!s

--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -185,14 +185,14 @@ REBOL [
             ANY_NUMBER_KIND(KIND_BYTE(v))
 
         /* !!! Being able to locate inert types based on range *almost* works,
-         * but REB_ISSUE and REB_REFINEMENT want to be picked up as ANY-WORD!.
-         * This trick will have to be rethought, esp if words and strings
-         * get unified, but it's here to show how choosing these values
-         * carefully can help with speeding up tests.
+         * but REB_ISSUE wants to be picked up as ANY-WORD!.  This trick will
+         * have to be rethought, esp if words and strings get unified, but
+         * it's here to show how choosing these values carefully can help with
+         * speeding up tests.
          */
         inline static bool ANY_INERT_KIND(REBYTE k) {
             return (k >= REB_BLOCK and k <= REB_BLANK)
-                or k == REB_ISSUE or k == REB_REFINEMENT;
+                or k == REB_ISSUE;
         }
 
         #define ANY_INERT(v) \
@@ -301,9 +301,6 @@ set-word    "definition of a word's value"
             word        *       *       +       [word]
 
 word        "word (symbol or variable)"
-            word        *       *       +       [word]
-
-refinement  "variation of meaning or location"
             word        *       *       +       [word]
 
 issue       "identifying marker word"

--- a/src/boot/typespec.r
+++ b/src/boot/typespec.r
@@ -1,0 +1,67 @@
+REBOL [
+    System: "REBOL [R3] Language Interpreter and Run-time Environment"
+    Title: "Datatype help spec"
+    Rights: {
+        Copyright 2012 REBOL Technologies
+        REBOL is a trademark of REBOL Technologies
+    }
+    License: {
+        Licensed under the Apache License, Version 2.0
+        See: http://www.apache.org/licenses/LICENSE-2.0
+    }
+    Purpose: {
+        Provides useful information about datatypes.
+        Can be expanded to include info like min-max ranges.
+    }
+]
+
+action      ["an invokable Rebol subroutine" action]
+bar         ["expression evaluation barrier" internal]
+binary      ["string series of bytes" string]
+bitset      ["set of bit flags" string]
+blank       ["placeholder unit type which also is conditionally FALSE?" scalar]
+block       ["array of values that blocks evaluation unless DO is used" block]
+char        ["8bit and 16bit character" scalar]
+datatype    ["type of datatype" symbol]
+date        ["day, month, year, time of day, and timezone" scalar]
+decimal     ["64bit floating point number (IEEE standard)" scalar]
+email       ["email address" string]
+error       ["errors and throws" context]
+event       ["user interface event (efficiently sized)" opt-object]
+file        ["file name or path" string]
+frame       ["arguments and locals of a specific action invocation" context]
+get-path    ["the value of a path" block]
+get-word    ["the value of a word (variable)" word]
+gob         ["graphical object" opt-object]
+handle      ["arbitrary internal object or value" internal]
+image       ["RGB image with alpha channel" vector]
+integer     ["64 bit integer" scalar]
+issue       ["identifying marker word" word]
+library     ["external library reference" internal]
+lit-path    ["literal path value" block]
+lit-word    ["literal word value" word]
+logic       ["boolean true or false" scalar]
+map         ["name-value pairs (hash associative)" block]
+module      ["loadable context of code and data" context]
+money       ["high precision decimals with denomination (opt)" scalar]
+object      ["context of names with values" context]
+pair        ["two dimensional point or size" scalar]
+group       ["array that evaluates expressions as an isolated group" block]
+path        ["refinements to functions, objects, files" block]
+percent     ["special form of decimals (used mainly for layout)" scalar]
+port        ["external series, an I/O channel" context]
+quoted      ["quoted container" quoted]
+set-path    ["definition of a path's value" block]
+set-word    ["definition of a word's value" word]
+struct      ["native structure definition" block]
+tag         ["markup string (HTML or XML)" string]
+text        ["text string series of characters" string]
+time        ["time of day or duration" scalar]
+tuple       ["sequence of small integers (colors, versions, IP)" scalar]
+typeset     ["set of datatypes" opt-object]
+unicode     ["string of unicoded characters" string]
+url         ["uniform resource locator or identifier" string]
+varargs     ["evaluator position for variable numbers of arguments" internal]
+vector      ["high performance arrays (single datatype)" vector]
+void        ["signal returned by actions that have no result" void]
+word        ["word (symbol or variable)" word]

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -199,6 +199,7 @@ literal ;-- should both LIT and LITERAL be supported, or just LIT?
 lit
 lit-word! ;-- !!! compatibility hack; not a DATATYPE!, so parse keyword
 lit-path! ;-- !!! compatibility hack; not a DATATYPE!, so parse keyword
+refinement! ;-- !!! compatibility hack; not a DATATYPE!, so parse keyword
 match
 do
 into

--- a/src/core/a-constants.c
+++ b/src/core/a-constants.c
@@ -123,13 +123,13 @@ const char * const Token_Names[] = {
     "integer",
     "decimal",
     "percent",
-    "money",
     "get-group-begin",
     "group-end",
     "group-begin",
     "get-block-begin",
     "block-end",
     "block-begin",
+    "money",
     "time",
     "date",
     "char",
@@ -144,7 +144,6 @@ const char * const Token_Names[] = {
     "issue",
     "tag",
     "path",
-    "refine",
     "construct",
     NULL
 };

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -289,6 +289,13 @@ static REBARR *Startup_Datatypes(REBARR *boot_types, REBARR *boot_typespecs)
     Init_Datatype(lit_path, REB_PATH);
     Quotify(lit_path, 1);
 
+    REBVAL *refinement = Append_Context(
+        Lib_Context,
+        nullptr,
+        Canon(SYM_REFINEMENT_X)
+    );
+    Init_Datatype(refinement, REB_PATH); // imprecise, paths not all refines
+
     return catalog;
 }
 

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -1159,7 +1159,7 @@ REBCTX *Error_Bad_Refine_Revoke(const RELVAL *param, const REBVAL *arg)
         --param;
 
     DECLARE_LOCAL (refine_name);
-    Init_Refinement(refine_name, VAL_PARAM_SPELLING(param));
+    Refinify(Init_Word(refine_name, VAL_PARAM_SPELLING(param)));
 
     if (IS_NULLED(arg)) // was void and shouldn't have been
         return Error_Bad_Refine_Revoke_Raw(refine_name, param_name);

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1004,7 +1004,7 @@ bool Eval_Core_Throws(REBFRM * const f)
 
                 if (IS_REFINEMENT(f->special)) {
                     assert(
-                        VAL_WORD_SPELLING(f->special)
+                        VAL_REFINEMENT_SPELLING(f->special)
                         == VAL_PARAM_SPELLING(f->param)
                     ); // !!! Maybe not, if REDESCRIBE renamed args, but...
                     f->refine = f->arg;
@@ -1087,7 +1087,7 @@ bool Eval_Core_Throws(REBFRM * const f)
               used_refinement:;
 
                 assert(not IS_POINTER_TRASH_DEBUG(f->refine)); // must be set
-                Init_Refinement(f->arg, VAL_PARAM_SPELLING(f->param));
+                Refinify(Init_Word(f->arg, VAL_PARAM_SPELLING(f->param)));
                 SET_CELL_FLAG(f->arg, ARG_MARKED_CHECKED);
                 goto continue_arg_loop;
             }
@@ -1576,7 +1576,7 @@ bool Eval_Core_Throws(REBFRM * const f)
             assert(IS_ISSUE(DS_TOP));
 
             if (not IS_WORD_BOUND(DS_TOP)) { // the loop didn't index it
-                mutable_KIND_BYTE(DS_TOP) = REB_REFINEMENT;
+                mutable_KIND_BYTE(DS_TOP) = REB_WORD;
                 fail (Error_Bad_Refine_Raw(DS_TOP)); // so duplicate or junk
             }
 
@@ -1593,7 +1593,7 @@ bool Eval_Core_Throws(REBFRM * const f)
             assert(
                 IS_REFINEMENT(f->refine)
                 and (
-                    VAL_WORD_SPELLING(f->refine)
+                    VAL_REFINEMENT_SPELLING(f->refine)
                     == VAL_PARAM_SPELLING(f->param - 1)
                 )
             );
@@ -2002,7 +2002,6 @@ bool Eval_Core_Throws(REBFRM * const f)
 
 //==//// INERT WORD AND STRING TYPES /////////////////////////////////////==//
 
-    case REB_REFINEMENT:
     case REB_ISSUE:
         // ^-- ANY-WORD!
         goto inert;

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -182,7 +182,7 @@ REBCTX *Make_Context_For_Action_Int_Partials(
         }
 
         if (IS_REFINEMENT(special)) { // specialized REFINEMENT! => "in use"
-            Init_Refinement(arg, VAL_PARAM_SPELLING(param));
+            Refinify(Init_Word(arg, VAL_PARAM_SPELLING(param)));
             SET_CELL_FLAG(arg, ARG_MARKED_CHECKED);
             goto continue_specialized;
         }
@@ -534,14 +534,14 @@ bool Specialize_Action_Throws(
                 or (
                     IS_REFINEMENT(refine)
                     and (
-                        VAL_WORD_SPELLING(refine)
+                        VAL_REFINEMENT_SPELLING(refine)
                         == VAL_PARAM_SPELLING(param)
                     )
                 )
             );
 
             if (IS_TRUTHY(refine))
-                Init_Refinement(refine, VAL_PARAM_SPELLING(param));
+                Refinify(Init_Word(refine, VAL_PARAM_SPELLING(param)));
             else
                 Init_Blank(arg);
 
@@ -746,14 +746,14 @@ bool Specialize_Action_Throws(
         }
 
         if (KIND_BYTE(partial) != REB_X_PARTIAL_SAW_NULL_ARG) { // filled
-            Init_Refinement(
+            Refinify(Init_Word(
                 partial,
                 VAL_PARAM_SPELLING(
                     rootkey + ((PAYLOAD(Partial, partial).signed_index > 0)
                             ? PAYLOAD(Partial, partial).signed_index
                             : -(PAYLOAD(Partial, partial).signed_index))
                 )
-            );
+            ));
             SET_CELL_FLAG(partial, ARG_MARKED_CHECKED);
             goto continue_loop;
         }

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -429,7 +429,6 @@ REBINT Cmp_Value(const RELVAL *sval, const RELVAL *tval, bool is_case)
       case REB_WORD:
       case REB_SET_WORD:
       case REB_GET_WORD:
-      case REB_REFINEMENT:
       case REB_ISSUE:
         return Compare_Word(s,t,is_case);
 

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -289,7 +289,8 @@ REBVAL *Init_Any_Series_At_Core(
     REBSER *s,
     REBCNT index,
     REBNOD *binding
-) {
+){
+    assert(ANY_SERIES_KIND(type));
     ENSURE_SERIES_MANAGED(s);
 
     if (type != REB_IMAGE and type != REB_VECTOR) {
@@ -321,10 +322,6 @@ REBVAL *Init_Any_Series_At_Core(
     }
     else if (type == REB_BINARY) {
         if (SER_WIDE(s) != 1)
-            panic (s);
-    }
-    else if (ANY_PATH_KIND(type)) {
-        if (ARR_LEN(ARR(s)) < 2)
             panic (s);
     }
   #endif

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1153,35 +1153,6 @@ acquisition_loop:
         case LEX_DELIMIT_SLASH:
             assert(*cp == '/');
             ++cp;
-            if (
-                IS_LEX_WORD_OR_NUMBER(*cp)
-                or *cp == '+'
-                or *cp == '-'
-                or *cp == '.'
-                or *cp == '|'
-                or *cp == '_'
-            ){
-                // ///refine not allowed
-                if (ss->begin + 1 != cp) {
-                    ss->end = cp;
-                    ss->token = TOKEN_REFINE;
-                    fail (Error_Syntax(ss));
-                }
-                ss->begin = cp;
-                TRASH_POINTER_IF_DEBUG(ss->end);
-                flags = Prescan_Token(ss);
-                ss->begin--;
-                ss->token = TOKEN_REFINE;
-                // Fast easy case:
-                if (ONLY_LEX_FLAG(flags, LEX_SPECIAL_WORD))
-                    return;
-                goto scanword;
-            }
-            if (cp[0] == '<' or cp[0] == '>') {
-                ss->end = cp + 1;
-                ss->token = TOKEN_REFINE;
-                fail (Error_Syntax(ss));
-            }
             ss->end = cp;
             ss->token = TOKEN_PATH;
             return;
@@ -1927,11 +1898,6 @@ REBVAL *Scan_To_Stack(SCAN_STATE *ss) {
             );
             break;
 
-          case TOKEN_REFINE: {
-            REBSTR *spelling = Intern_UTF8_Managed(bp + 1, len - 1);
-            Init_Refinement(DS_PUSH(), spelling);
-            break; }
-
           case TOKEN_ISSUE:
             if (ep != Scan_Issue(DS_PUSH(), bp + 1, len - 1))
                 fail (Error_Syntax(ss));
@@ -1991,17 +1957,50 @@ REBVAL *Scan_To_Stack(SCAN_STATE *ss) {
             break; }
 
         case TOKEN_PATH:
-            if (ss->mode_char != '/') { // saw slash while not scanning path
-                REBARR *a = Make_Arr(2); // meaning is actually BLANK!/BLANK!
-                Init_Blank(Alloc_Tail_Array(a));
-                Init_Blank(Alloc_Tail_Array(a));
-                Init_Path(DS_PUSH(), a); // must be a minimal path (`/`)
+            if (*ss->end == '\0' or IS_LEX_SPACE(*ss->end)) {
+                //
+                // This means you have something like `/`, `foo//`, `///`...
+                // Basically you don't expect to see a TOKEN_PATH while doing
+                // a path scan unless you wind up at the end.
+                //
+                if (ss->mode_char == '/') {
+                    Init_Blank(DS_PUSH());
+                    Init_Blank(DS_PUSH());
+                    goto loop;
+                }
+
+                // Handle the simple `/` case
+
+                REBARR *a = Make_Arr(2);
+                Init_Blank(ARR_AT(a, 0));
+                Init_Blank(ARR_AT(a, 1));
+                TERM_ARRAY_LEN(a, 2);
+                Init_Path(DS_PUSH(), a);
+                break;
             }
-            break;
+
+            Init_Blank(DS_PUSH()); // implicitly imagine blank per slash
+
+            if (*ss->begin == '\0' or IS_LEX_SPACE(*ss->begin)) {
+                Init_Blank(DS_PUSH());
+                break;
+            }
+
+            if (ss->mode_char != '/') // saw slash(es) while not scanning path
+                goto scan_path_head_is_DS_TOP;
+
+            goto loop; // otherwise, we were scanning a path already
 
           case TOKEN_BLOCK_END: {
             if (ss->mode_char == ']')
                 goto array_done;
+
+            if (ss->mode_char == '/') { // implicit end, such as `[lit /]`
+                Init_Blank(DS_PUSH());
+                --ss->begin;
+                --ss->end;
+                goto array_done;
+            }
 
             if (ss->mode_char != '\0') // expected e.g. `)` before the `]`
                 fail (Error_Mismatch(ss, ss->mode_char, ']'));
@@ -2013,6 +2012,13 @@ REBVAL *Scan_To_Stack(SCAN_STATE *ss) {
           case TOKEN_GROUP_END: {
             if (ss->mode_char == ')')
                 goto array_done;
+
+            if (ss->mode_char == '/') { // implicit end, such as `(lit /)`
+                Init_Blank(DS_PUSH());
+                --ss->begin;
+                --ss->end;
+                goto array_done;
+            }
 
             if (ss->mode_char != '\0') // expected e.g. ']' before the ')'
                 fail (Error_Mismatch(ss, ss->mode_char, ')'));
@@ -2287,12 +2293,23 @@ REBVAL *Scan_To_Stack(SCAN_STATE *ss) {
             }
         }
 
-        // Check for end of path:
         if (ss->mode_char == '/') {
-            if (*ep != '/')
+            if (*ep != '/')  // e.g. `a/b`, just finished scanning b
                 goto array_done;
 
-            ep++;
+            ++ep;
+
+            if (*ep == '\0' or IS_LEX_SPACE(*ep)) {  // e.g. `/a/`
+                Init_Blank(DS_PUSH());  // `/a/` is path form of [_ a _]
+                ss->begin = ep;
+                goto array_done;
+            }
+
+            if (*ep == '/') {
+                ss->begin = ep;
+                goto loop;
+            }
+
             if (*ep != '(' and *ep != '[' and IS_LEX_DELIMIT(*ep)) {
                 ss->token = TOKEN_PATH;
                 fail (Error_Syntax(ss));
@@ -2306,37 +2323,29 @@ REBVAL *Scan_To_Stack(SCAN_STATE *ss) {
 
             ++ss->begin;
 
-            REBARR *arr;
+          scan_path_head_is_DS_TOP:;
+
+            REBDSP dsp_path_head = DSP;
+
             if (
                 *ss->begin == '\0' // `foo/`
                 or IS_LEX_ANY_SPACE(*ss->begin) // `foo/ bar`
                 or *ss->begin == ';' // `foo/;--bar`
             ){
-                arr = Make_Arr_Core(
-                    2,
-                    NODE_FLAG_MANAGED | ARRAY_FLAG_HAS_FILE_LINE
-                );
-                Append_Value(arr, DS_TOP);
-                DS_DROP();
-                Init_Blank(Alloc_Tail_Array(arr));
+                // Don't bother scanning recursively if we don't have to.
+                // Note we still might come up empty (e.g. `foo/)`)
             }
             else {
-              #if !defined(NDEBUG)
-                REBDSP dsp_check = DSP;
-              #endif
+                REBYTE saved_mode_char = ss->mode_char;
 
-                // When `mode_char` is '/', the scan needs to steal the last
-                // pushed item from us...as it's the head of the path it
-                // couldn't see coming in the future.
+                ss->mode_char = '/';
+                if (ss->opts & SCAN_FLAG_RELAX)
+                    Scan_To_Stack_Relaxed(ss);
+                else
+                    Scan_To_Stack(ss);
 
-                arr = Scan_Child_Array(ss, '/');
-
-              #if !defined(NDEBUG)
-                assert(DSP == dsp_check - 1); // should only take one!
-              #endif
+                ss->mode_char = saved_mode_char;
             }
-
-            DS_PUSH(); // now push a path to take the stolen token's place
 
             // Any trailing colons should have been left on, because the child
             // scan noticed the mode_char was '/' and that we'd want it for
@@ -2346,25 +2355,69 @@ REBVAL *Scan_To_Stack(SCAN_STATE *ss) {
             // plain XXX! and make this a GET-PATH!, and also check for
             // conflicts if there's a colon at the end and making a SET-PATH!
 
-            RELVAL *head = ARR_HEAD(arr);
-            REBYTE kind_head = KIND_BYTE(head);
+            if (DSP - dsp_path_head == 0) { // nothing more added
+                //
+                // !!! Currently there is no special case optimization for
+                // leading paths with a tail blank.  It could perhaps be
+                // done by cutting out the allowance of escaping levels as
+                // meaning for the kind byte.  Not a priority.
+                //
+                REBARR *a = Make_Arr_Core(2, NODE_FLAG_MANAGED);
+                MISC(a).line = ss->line;
+                LINK(a).file = ss->file;
+                SET_ARRAY_FLAG(a, HAS_FILE_LINE);
 
-            if (ANY_GET_KIND(kind_head)) {
-                if (ss->begin and *ss->end == ':')
-                    fail (Error_Syntax(ss)); // for instance `:a/b/c:`
-
-                RESET_VAL_HEADER(DS_TOP, REB_GET_PATH);
-                mutable_KIND_BYTE(head) = UNGETIFY_ANY_GET_KIND(kind_head);
+                Append_Value(a, DS_TOP); // may be BLANK!
+                Init_Blank(Alloc_Tail_Array(a));
+                Init_Path(DS_TOP, a);
             }
-            else if (ss->begin and *ss->end == ':') {
-                RESET_VAL_HEADER(DS_TOP, REB_SET_PATH);
-                ss->begin = ++ss->end;
-            }
-            else
-                RESET_VAL_HEADER(DS_TOP, REB_PATH);
+            else if (
+                DSP - dsp_path_head == 1 // one more item added
+                and IS_BLANK(DS_AT(dsp_path_head))
+            ){
+                // This is the optimized case where we use a single cell to
+                // represent a path with a blank at the head like /FOO.  So
+                // move the one value we scanned into the position we want
+                // and apply the optimization.
 
-            INIT_VAL_ARRAY(DS_TOP, arr);
-            VAL_INDEX(DS_TOP) = 0;
+                Refinify(Move_Value(DS_TOP - 1, DS_TOP));
+                DS_DROP();
+            }
+            else {
+                REBFLGS flags = NODE_FLAG_MANAGED;
+                if (ss->newline_pending)
+                    flags |= ARRAY_FLAG_NEWLINE_AT_TAIL;
+
+                REBARR *a = Pop_Stack_Values_Core(
+                    dsp_path_head - 1, // stop popping right after head pop
+                    flags
+                );
+                MISC(a).line = ss->line;
+                LINK(a).file = ss->file;
+                SET_ARRAY_FLAG(a, HAS_FILE_LINE);
+
+                DS_PUSH();
+
+                RELVAL *head = ARR_HEAD(a);
+                REBYTE kind_head = KIND_BYTE(head);
+            
+                if (ANY_GET_KIND(kind_head)) {
+                    if (ss->begin and *ss->end == ':')
+                      fail (Error_Syntax(ss)); // for instance `:a/b/c:`
+
+                    RESET_VAL_HEADER(DS_TOP, REB_GET_PATH);
+                    mutable_KIND_BYTE(head) = UNGETIFY_ANY_GET_KIND(kind_head);
+                }
+                else if (ss->begin and *ss->end == ':') {
+                    RESET_VAL_HEADER(DS_TOP, REB_SET_PATH);
+                    ss->begin = ++ss->end;
+                }
+                else
+                    RESET_VAL_HEADER(DS_TOP, REB_PATH);
+
+                INIT_VAL_ARRAY(DS_TOP, a);
+                VAL_INDEX(DS_TOP) = 0;
+            }
 
             ss->token = TOKEN_PATH;
         }

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -365,7 +365,6 @@ static void Queue_Mark_Opt_End_Cell_Deep(const RELVAL *v)
       case REB_WORD:
       case REB_SET_WORD:
       case REB_GET_WORD:
-      case REB_REFINEMENT:
       case REB_ISSUE: {
         REBSTR *spelling = PAYLOAD(Word, v).spelling;
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1133,7 +1133,7 @@ REBNATIVE(default)
                 }
             }
             TERM_ARRAY_LEN(composed, VAL_LEN_AT(target));
-            Init_Any_Array(target, REB_SET_PATH, composed);
+            Init_Any_Path(target, REB_SET_PATH, composed);
         }
 
         if (Eval_Path_Throws_Core(

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -387,7 +387,6 @@ bool Did_Get_Binding_Of(REBVAL *out, const REBVAL *v)
     case REB_WORD:
     case REB_SET_WORD:
     case REB_GET_WORD:
-    case REB_REFINEMENT:
     case REB_ISSUE: {
         if (IS_WORD_UNBOUND(v))
             return false;
@@ -1163,8 +1162,7 @@ REBNATIVE(as)
       case REB_WORD:
       case REB_GET_WORD:
       case REB_SET_WORD:
-      case REB_ISSUE:
-      case REB_REFINEMENT: {
+      case REB_ISSUE: {
         //
         // !!! Until UTF-8 Everywhere, turning ANY-STRING! into an ANY-WORD!
         // means you have to have an interning of it.

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -553,7 +553,6 @@ REBINT Compare_Modify_Values(RELVAL *a, RELVAL *b, REBINT strictness)
           case REB_WORD:
           case REB_SET_WORD:
           case REB_GET_WORD:
-          case REB_REFINEMENT:
           case REB_ISSUE:
             if (ANY_WORD(b)) goto compare;
             break;

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -404,11 +404,11 @@ REBNATIVE(compose)
     if (GET_ARRAY_FLAG(VAL_ARRAY(ARG(value)), NEWLINE_AT_TAIL))
         flags |= ARRAY_FLAG_NEWLINE_AT_TAIL;
 
-    return Init_Any_Array(
-        D_OUT,
-        VAL_TYPE(ARG(value)),
-        Pop_Stack_Values_Core(dsp_orig, flags)
-    );
+    REBARR *popped = Pop_Stack_Values_Core(dsp_orig, flags);
+    if (ANY_PATH(ARG(value)))
+        return Init_Any_Path(D_OUT, VAL_TYPE(ARG(value)), popped);
+
+    return Init_Any_Array(D_OUT, VAL_TYPE(ARG(value)), popped);
 }
 
 

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -321,7 +321,6 @@ uint32_t Hash_Value(const RELVAL *v)
       case REB_WORD:
       case REB_SET_WORD:
       case REB_GET_WORD:
-      case REB_REFINEMENT:
       case REB_ISSUE: {
         //
         // Note that the canon symbol may change for a group of word synonyms

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -352,12 +352,15 @@ REB_R PD_Action(
     // general path mechanic before reaching this dispatch.  So if it's not
     // a word/refinement or or one of those that evaluated it, then error.
     //
-    if (not IS_WORD(picker) and not IS_REFINEMENT(picker))
+    REBSTR *spelling;
+    if (IS_WORD(picker))
+        spelling = VAL_WORD_SPELLING(picker);
+    else if (IS_REFINEMENT(picker))
+        spelling = VAL_REFINEMENT_SPELLING(picker);
+    else
         fail (Error_Bad_Refine_Raw(picker));
 
-    Init_Issue(DS_PUSH(), VAL_WORD_CANON(picker)); // canonize just once
+    Init_Issue(DS_PUSH(), STR_CANON(spelling)); // canonize just once
 
-    // Leave the function value as is in pvs->out
-    //
-    return pvs->out;
+    return pvs->out; // leave ACTION! value in pvs->out, as-is
 }

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -247,10 +247,10 @@ REB_R PD_Word(
             return pvs->out;
         }
 
-        return R_UNHANDLED;
+        fail ("ANY-WORD! picking only supports INTEGER!, currently");
     }
 
-    return R_UNHANDLED;
+    fail ("Can't use ANY-WORD! with SET-PATH");
 }
 
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -620,6 +620,11 @@ static REBIXO Parse_One_Rule(
                     return pos + 1;
                 return END_FLAG;
             }
+            if (VAL_WORD_SYM(rule) == SYM_REFINEMENT_X) { // another hack...
+                if (IS_REFINEMENT(item))
+                    return pos + 1;
+                return END_FLAG;
+            }
             fail (Error_Parse_Rule());
 
           default:
@@ -1871,6 +1876,7 @@ REBNATIVE(subparse)
                 //
                 case SYM_LIT_WORD_X: // lit-word!
                 case SYM_LIT_PATH_X: // lit-path!
+                case SYM_REFINEMENT_X: // refinement!
                     i = Parse_One_Rule(f, P_POS, rule);
                     break;
 
@@ -2361,9 +2367,6 @@ REBNATIVE(subparse)
 REBNATIVE(parse)
 {
     INCLUDE_PARAMS_OF_PARSE;
-
-    if (not ANY_SERIES_OR_PATH_KIND(CELL_KIND(VAL_UNESCAPED(ARG(input)))))
-        fail (PAR(input));
 
     REBVAL *rules = ARG(rules);
 

--- a/src/include/sys-array.h
+++ b/src/include/sys-array.h
@@ -528,9 +528,6 @@ inline static RELVAL *VAL_ARRAY_TAIL(const RELVAL *v) {
 #define Init_Group(v,s) \
     Init_Any_Array((v), REB_GROUP, (s))
 
-#define Init_Path(v,s) \
-    Init_Any_Array((v), REB_PATH, (s))
-
 
 // PATH! types will splice into each other, but not into a BLOCK! or GROUP!.
 // BLOCK! or GROUP! will splice into any other array:

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -52,13 +52,13 @@ enum Reb_Token {
     TOKEN_INTEGER,
     TOKEN_DECIMAL,
     TOKEN_PERCENT,
-    TOKEN_MONEY,
     TOKEN_GET_GROUP_BEGIN, // should equal REB_GET_GROUP
     TOKEN_GROUP_END,
     TOKEN_GROUP_BEGIN, // should equal REB_GROUP
     TOKEN_GET_BLOCK_BEGIN, // should equal REB_GET_BLOCK
     TOKEN_BLOCK_END,
     TOKEN_BLOCK_BEGIN, // should equal REB_BLOCK
+    TOKEN_MONEY,
     TOKEN_TIME,
     TOKEN_DATE,
     TOKEN_CHAR,
@@ -73,7 +73,6 @@ enum Reb_Token {
     TOKEN_ISSUE,
     TOKEN_TAG,
     TOKEN_PATH,
-    TOKEN_REFINE,
     TOKEN_CONSTRUCT,
     TOKEN_MAX
 };

--- a/src/include/sys-word.h
+++ b/src/include/sys-word.h
@@ -133,9 +133,6 @@ inline static REBVAL *Init_Any_Word(
 #define Init_Set_Word(out,spelling) \
     Init_Any_Word((out), REB_SET_WORD, (spelling))
 
-#define Init_Refinement(out,spelling) \
-    Init_Any_Word((out), REB_REFINEMENT, (spelling))
-
 #define Init_Issue(out,spelling) \
     Init_Any_Word((out), REB_ISSUE, (spelling))
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -240,7 +240,6 @@ eval func [
     word?:
     set-word?:
     get-word?:
-    refinement?:
     issue?:
     binary?:
     text?:
@@ -306,6 +305,14 @@ to-lit-path: func [value [any-value!]] [
     uneval to path! dequote :value
 ]
 
+refinement?: func [value [<opt> any-value!]] [
+    did all [
+        path? :value
+        equal? length of value 2 ;; Called by FUNCTION when = not defined yet
+        blank? :value/1
+        word? :value/2
+    ]
+]
 
 print: func [
     {Textually output spaced line (evaluating elements if a block)}

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -146,9 +146,14 @@ function: func [
         <void> (append new-spec <void>)
     |
         ((either var [[
-            set var: match [any-word! 'word!] (
-                append exclusions var ;-- exclude args/refines
+            set var: [
+                match [any-word! 'word!]
+                | ahead path! into [blank! word!]
+            ](
                 append new-spec var
+
+                ;-- exclude args/refines
+                append exclusions either path? var [var/2] [var]
             )
             |
             set other: block! (
@@ -411,7 +416,12 @@ redescribe: function [
             )
         ]
         any [
-            set param: [word! | get-word! | lit-word! | refinement! | set-word!]
+            set param: [
+                word! | get-word! | lit-word! | set-word!
+                | ahead path! into [word! blank!]
+            ](
+                if path? param [param: param/1]
+            )
 
             ; It's legal for the redescribe to name a parameter just to
             ; show it's there for descriptive purposes without adding notes.

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -213,7 +213,7 @@ applique: function [
         ]
 
         if refinement? params/1 [
-            using-args: did set (in frame params/1) :arg
+            using-args: did set (in frame second params/1) :arg
         ] else [
             if using-args [
                 set* (in frame params/1) :arg

--- a/tests/comparison/equalq.test.reb
+++ b/tests/comparison/equalq.test.reb
@@ -451,8 +451,9 @@
 (equal? 'a first ['a])
 ; word! vs. lit-word! symmetry
 (equal? equal? 'a first ['a] equal? first ['a] 'a)
-; word! vs. refinement!
-(equal? 'a /a)
+; word! vs. refinement! (changed in Ren-C)
+(not equal? 'a /a)
+(equal? 'a second /a)
 ; word! vs. refinement! symmetry
 (equal? equal? 'a /a equal? /a 'a)
 ; word! vs. set-word!
@@ -466,7 +467,7 @@
 ; get-word! vs. lit-word! symmetry
 (equal? equal? first [:a] first ['a] equal? first ['a] first [:a])
 ; get-word! vs. refinement!
-(equal? first [:a] /a)
+(not equal? first [:a] /a)
 ; get-word! vs. refinement! symmetry
 (equal? equal? first [:a] /a equal? /a first [:a])
 ; get-word! vs. set-word!
@@ -476,7 +477,7 @@
 ; lit-word! reflexivity
 (equal? first ['a] first ['a])
 ; lit-word! vs. refinement!
-(equal? first ['a] /a)
+(not equal? first ['a] /a)
 ; lit-word! vs. refinement! symmetry
 (equal? equal? first ['a] /a equal? /a first ['a])
 ; lit-word! vs. set-word!
@@ -486,7 +487,7 @@
 ; refinement! reflexivity
 (equal? /a /a)
 ; refinement! vs. set-word!
-(equal? /a first [a:])
+(not equal? /a first [a:])
 ; refinement! vs. set-word! symmetry
 (equal? equal? /a first [a:] equal? first [a:] /a)
 ; set-word! reflexivity

--- a/tests/comparison/sameq.test.reb
+++ b/tests/comparison/sameq.test.reb
@@ -116,12 +116,6 @@
     parse :a-value [b-value: end]
     same? :a-value :b-value
 )]
-; symmetry
-(
-    a-value: first ['a/b]
-    parse :a-value [b-value: end]
-    equal? same? :a-value :b-value same? :b-value :a-value
-)
 (not same? [] blank)
 ; symmetry
 (equal? same? [] blank same? blank [])
@@ -145,17 +139,6 @@
 (
     a-value: 'a/b
     parse a-value [b-value: end]
-    equal? same? :a-value :b-value same? :b-value :a-value
-)
-[#1068 #1066 (
-    a-value: first [a/b:]
-    parse :a-value [b-value: end]
-    same? :a-value :b-value
-)]
-; symmetry
-(
-    a-value: first [a/b:]
-    parse :a-value [b-value: end]
     equal? same? :a-value :b-value same? :b-value :a-value
 )
 (not same? any-number! integer!)

--- a/tests/comparison/strict-equalq.test.reb
+++ b/tests/comparison/strict-equalq.test.reb
@@ -111,17 +111,6 @@
     error? trap [strict-equal? a-value b-value]
     true
 )]
-[#1068 #1066 (
-    a-value: first ['a/b]
-    parse :a-value [b-value: end]
-    strict-equal? :a-value :b-value
-)]
-; symmetry
-(
-    a-value: first ['a/b]
-    parse :a-value [b-value: end]
-    equal? strict-equal? :a-value :b-value strict-equal? :b-value :a-value
-)
 (not strict-equal? [] blank)
 ; symmetry
 (equal? strict-equal? [] blank strict-equal? blank [])
@@ -145,17 +134,6 @@
 (
     a-value: 'a/b
     parse a-value [b-value: end]
-    equal? strict-equal? :a-value :b-value strict-equal? :b-value :a-value
-)
-[#1068 #1066 (
-    a-value: first [a/b:]
-    parse :a-value [b-value: end]
-    strict-equal? :a-value :b-value
-)]
-; symmetry
-(
-    a-value: first [a/b:]
-    parse :a-value [b-value: end]
     equal? strict-equal? :a-value :b-value strict-equal? :b-value :a-value
 )
 (not strict-equal? any-number! integer!)

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -173,9 +173,9 @@
 ;
 [
     (/ref/inement/path = to path! [/ref inement path])
-    (/refinement/3 = to path! [/refinement 3])
-    ((/refinement)/3 = #"f")
-    (r: /refinement | r/3 = #"f")
+    (/refinement/2 = to path! [/refinement 2])
+    ((/refinement)/2 = 'refinement)
+    (r: /refinement | r/2 = 'refinement)
 ][
     (#iss/ue/path = to path! [#iss ue path])
     (#issue/3 = to path! [#issue 3])

--- a/tests/parse-tests.r
+++ b/tests/parse-tests.r
@@ -211,23 +211,14 @@
 
 
 ; Should return the same series type as input (Rebol2 did not do this)
+; PATH! cannot be PARSE'd due to restrictions of the implementation
 (
-    a-value: first ['a/b]
-    parse a-value [b-value: end]
-    same? a-value b-value
+    a-value: first [a/b]
+    parse as block! a-value [b-value: end]
+    a-value = to path! b-value
 )
 (
     a-value: first [()]
-    parse a-value [b-value: end]
-    same? a-value b-value
-)
-(
-    a-value: 'a/b
-    parse a-value [b-value: end]
-    same? a-value b-value
-)
-(
-    a-value: first [a/b:]
     parse a-value [b-value: end]
     same? a-value b-value
 )


### PR DESCRIPTION
This commit does a rethinking of the definition of a REFINEMENT! such
that /word is the parallel to what would be [_ word] as a block.  This
opens up the possibilities for greater expressions of paths in the
pattern `/foo/bar/...`

Similar to how the QUOTED! change generalized what were previously
dedicated types, this adds REFINEMENT! as a parse rule and some
compatibility checks.  Unlike LIT-WORD? and LIT-PATH? however, the
matching of the pattern for REFINEMENT? and the term may be worth
keeping to idiomatically identify this path subclass.

As a first take, this is more inefficient than a refinement, as it
actually does allocate 2-element arrays for each usage (which can't
fit in 2 cell spaces, as it must account for an end as well, so it
requires a full 4 cell-sized array allocation, in addition to a
series node).  This makes a refinement cost roughly the overhead of
6 additional value cells to the one cell it occupied previously.

Near-term efficiency tricks should be able to easily make `/a` fit
into a single cell without an allocation.  Groundwork has been laid
to make arbitrary other values fit, such as `/1.0` or even `a/` to
lean the path the other way.  Longer term this should generalize to
more than paths so that immutable blocks and groups like `(a)` or
`[1.0]` can also fit into a single cell.

This commit also streamlines path scanning to use Scan_To_Stack()
At one point, scanning paths was simplified to ask a recursive call
to generate an array.  This changes to not generate an array, rather
to build the new array on the stack first...so that the decision to
make an array or not can be made when looking at what was scanned.