### PR TITLE
REDUCE turns NULL into BLANK! (leaves VOID! as-is)

### DIFF
--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -64,8 +64,13 @@ bool Reduce_To_Stack_Throws(
             break;
         }
 
-        if (IS_NULLED(out)) // can't put nulls in blocks, so voidify it
-            Init_Void(DS_PUSH());
+        // We can't put nulls into array cells, so we put BLANK!.  This is
+        // compatible with historical behavior of `reduce [if 1 = 2 [<x>]]`
+        // which produced `[#[none]]`, and is generally more useful than
+        // putting VOID!, as more operations skip blanks vs. erroring.
+        //
+        if (IS_NULLED(out))
+            Init_Blank(DS_PUSH());
         else
             Move_Value(DS_PUSH(), out);
 

--- a/src/core/t-word.c
+++ b/src/core/t-word.c
@@ -149,7 +149,7 @@ REB_R TO_Word(REBVAL *out, enum Reb_Kind kind, const REBVAL *arg)
 
         if (NOT_END(ARR_AT(a, index)))
             fail ("Can't MAKE ANY-WORD! from PATH! with > 1 non-BLANK! item");
-        
+
         DECLARE_LOCAL (solo);
         Derelativize(solo, non_blank, VAL_SPECIFIER(arg));
         return MAKE_Word(out, kind, solo);

--- a/tests/context/set.test.reb
+++ b/tests/context/set.test.reb
@@ -2,16 +2,16 @@
 [#1763
     (
         a: <before>
-        [#void] = set [a] reduce [null]
-        void? :a
+        [_] = set [a] reduce [null]
+        blank? :a
     )
 ]
 (
     a: <a-before>
     b: <b-before>
-    [2 #[void]] = set [a b] reduce [2 null]
+    [2 _] = set [a b] reduce [2 null]
     a = 2
-    void? :b
+    blank? :b
 )
 (x: has [a: 1] all [error? trap [set x reduce [()]] x/a = 1])
 (x: has [a: 1 b: 2] all [error? trap [set x reduce [3 ()]] x/a = 1])

--- a/tests/control/reduce.test.reb
+++ b/tests/control/reduce.test.reb
@@ -6,7 +6,7 @@
     success
 )
 ([] = reduce [])
-(void? first reduce [null])
+(blank? first reduce [null])
 ("1 + 1" = reduce "1 + 1")
 (error? first reduce [trap [1 / 0]])
 [#1760 ; unwind functions should stop evaluation
@@ -25,7 +25,7 @@
     error? trap blk
 )
 
-([3 #[void] 300] = reduce [1 + 2 if false [10 + 20] 100 + 200])
+([3 _ 300] = reduce [1 + 2 if false [10 + 20] 100 + 200])
 
 ; Quick flatten test, here for now
 (


### PR DESCRIPTION
Rebol2/R3-Alpha/Red's behaviors work out so that failed conditionals
leave behind #[none] in reduced blocks, while successful conditionals
with empty bodies give #[unset]

    rebol2>> reduce [if 1 = 2 []]
    == [#[none]]  ; In Ren-C, #[none]'s parallel is _ (BLANK!)

    rebol2>> reduce [if 1 = 1 []]
    == [#[unset]]  ; In Ren-C, #[unset]'s parallel is #[void]

This is actually fairly desirable behavior.  However, during the
development of null, Ren-C erred on the side of accuracy in
distinguishing NULL and BLANK!.  This was particularly important when
NULL was "conditionally invisible" in ANY/ALL while BLANK! was
conditionally false.

Those issues have been reconciled, and NULL and BLANK! are both
conditionally false, considered to represent the idea of `NOTHING?`
Given that resolution, there's less to be concerned about by having
REDUCE automatically conflate NULL with BLANK!.

    >> reduce [if 1 = 2 []]
    == [_]

    >> reduce [if 1 = 1 []]
    == [#[void]]

Especially with GET-BLOCK! running a REDUCE, this provides some
cool opportunities, such as being able to say this instead of REFORM:

    >> form :["one is" if 1 <= 2 ["not"] "greater than two"]
    == "one is not greater than two"