### PR TITLE
COLLECT and KEEP in PARSE (with backtracking)

### DIFF
--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -167,8 +167,10 @@ subparse ;-- recursions of parse use this for REBNATIVE(subparse) in backtrace
 ; PARSE - These words must not be reserved above!!  The range of consecutive
 ; index numbers are used by PARSE to detect keywords.
 ;
-set ; must be first first (SYM_SET referred to by GET_VAR() in %u-parse.c)
+set  ; must be first first (SYM_SET referred to by GET_VAR() in %u-parse.c)
 copy
+collect  ; proposed as being SET-like, by @rgchris
+keep
 some
 any
 opt

--- a/src/include/sys-roots.h
+++ b/src/include/sys-roots.h
@@ -146,3 +146,16 @@ inline static void Free_Instruction(REBARR *instruction) {
     TRASH_CELL_IF_DEBUG(ARR_SINGLE(instruction));
     Free_Node(SER_POOL, instruction);
 }
+
+
+// If you're going to just fail() anyway, then loose API handles are safe to
+// GC.  It's mildly inefficient to do so compared to generating a local cell:
+//
+//      DECLARE_LOCAL (specific);
+//      Derelativize(specific, relval, specifier);
+//      fail (Error_Something(specific));
+//
+// But assuming errors don't happen that often, it's cleaner to have one call.
+//
+inline static REBVAL *rebSpecific(const RELVAL *v, REBSPC *specifier)
+    { return Derelativize(Alloc_Value(), v, specifier);}


### PR DESCRIPTION
(Note: This is not particularly well tested, and is being committed
due to community demand...where it is expected that the community
will invest in making the tests for it!  Expect bugs, but the gist
seems to work.)

This implements COLLECT and KEEP keywords in PARSE.  They are justified
as features tailored to parse specifically because it is desirable
to have rule failures back out kept items.  For instance, with the
following code:

    parse [1 2 3] [
        collect x [
            keep integer! keep integer! keep text!
            |
            keep integer! keep [some integer!]
        ]
    ]

Without backtracking, this would give x as [1 2 1 2 3], when the likely
intended result was [1 2 3].

In addition to providing the backtracking (that Red did not with its
COLLECT), this changes it to take a variable to set, which is more
like SET and COPY... vs. affecting the overall return result of the
PARSE operation.  The PARSE still returns the series input as far
as it has advanced without failing, or null if it fails.

Following the pattern of existing "refinements" in R3-Alpha, the /ONLY
feature of KEEP is roughly implemented as KEEP ONLY vs. KEEP/ONLY:

    >> parse [1 2 3] [
         collect x [keep only [2 integer!] keep only integer!]
    ]
    == []

    >> x
    == [[1 2] [3]]

If it is desired to add material to what is being collected that does
not originate from the input series, a GET-BLOCK! can be used.  It
will be reduced and inserted (the reducing behavior helps keep it
more parallel to the expectations set in ordinary evaluation of a
GET-BLOCK!)

    >> parse [1 2] [
        collect x [keep integer! keep :['a <b>] keep integer!]]
    ]
    == []

    >> x
    == [1 a <b> 2]

Non-array series may be collected from also:

    >> parse "aaabbbccc" [
        collect x [keep [some "a"] some "b" keep [some "c"]]
    ]
    == ""

    >> x
    == ["aaa" "ccc"]

Nested collects are supported as well:

    >> parse [1 2 3 4] [
         collect a [
             keep integer!
             collect b [keep [2 integer!]]
             keep integer!
         ]
         end
    ]

    >> a
    == [1 4]

    >> b
    == [2 3]