### PR TITLE
Return COLLECT to empty block default, chains on COLLECT*

### DIFF
--- a/make/tools/bootstrap-shim.r
+++ b/make/tools/bootstrap-shim.r
@@ -48,6 +48,11 @@ trap [
 
 print "== SHIMMING OLDER R3 TO MODERN LANGUAGE DEFINITIONS =="
 
+; COLLECT was changed back to default to returning an empty block on no
+; collect, but it is built on a null collect lower-level primitive COLLECT*
+;
+collect*: :collect
+collect: :collect-block
 
 modernize-action: function [
     "Account for the <blank> annotation as a usermode feature"
@@ -56,7 +61,7 @@ modernize-action: function [
     body [block!]
 ][
     blankers: copy []
-    spec: collect-block [
+    spec: collect [
         iterate spec [
             ;
             ; Find ANY-WORD!s (args/locals)

--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -51,7 +51,7 @@ cscape: function [
     num: 1
     num-text: to text! num  ; CHANGE won't take GROUP! to evaluate, #1279
 
-    list: collect [
+    list: collect* [
         parse string [(col: 0) start: any [
             [
                 (prefix: _ suffix: _) finish:
@@ -95,7 +95,7 @@ cscape: function [
 
     list: unique/case list
 
-    substitutions: try collect [
+    substitutions: collect [
         for-each item list [
             set [pattern: col: mode: expr: prefix: suffix:] item
 

--- a/make/tools/make-boot.r
+++ b/make/tools/make-boot.r
@@ -604,7 +604,7 @@ make-obj-defs: function [
     depth
     /selfless
 ][
-    items: try collect [
+    items: collect [
         either selfless [
             n: 1
         ][

--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -75,7 +75,7 @@ emit-proto: func [return: <void> proto] [
         fail ["API declaration should be a SET-WORD!, not" (header/1)]
     ]
 
-    paramlist: collect-block [
+    paramlist: collect [
         parse proto [
             copy returns to "RL_" "RL_" copy name to "(" skip
             ["void)" | some [ ;-- C void, or at least one parameter expected
@@ -679,11 +679,11 @@ map-each-api [
         continue
     ]
 
-    js-returns: to-js-type returns else [
+    js-returns: (to-js-type returns) else [
         fail ["No JavaScript return mapping for type" returns]
     ]
 
-    js-param-types: try collect [
+    js-param-types: try collect* [
         for-each [type var] paramlist [
             if type = "intptr_t" [ ;-- e.g. <promise>
                 keep "'number'"

--- a/make/tools/native-emitters.r
+++ b/make/tools/native-emitters.r
@@ -79,7 +79,7 @@ emit-include-params-macro: function [
     /ext ext-name
 ][
     n: 1
-    items: try collect [
+    items: try collect* [
         for-each item paramlist [
             any [
                 not match [any-word! refinement! lit-word!] item

--- a/make/tools/prep-extension.r
+++ b/make/tools/prep-extension.r
@@ -117,7 +117,7 @@ natdef: make object! [
 
 ; === PARSE NATIVES INTO NATIVE-DEFINITION OBJECTS, CHECKING FOR VALIDITY ===
 
-native-defs: try collect [
+native-defs: collect [
     native-rule: [
         (
             n-export: _
@@ -230,7 +230,7 @@ for-each native native-defs [
 specs-compressed: gzip (specs-uncompressed: to-binary mold/only native-list)
 
 
-names: try collect [
+names: collect [
     for-each item native-list [
         if set-word? item [
             item: to word! item
@@ -239,7 +239,7 @@ names: try collect [
     ]
 ]
 
-native-forward-decls: try collect [
+native-forward-decls: collect [
     for-each item native-list [
         if set-word? item [
             item: to word! item

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -811,7 +811,7 @@ switch: emulate [redescribe [
 ](
     chain [
         adapt 'switch [
-            cases: try collect [
+            cases: collect [
                 for-each c cases [
                     keep/only either block? :c [:c] [uneval :c]
                 ]
@@ -823,7 +823,7 @@ switch: emulate [redescribe [
             ]
         ]
             |
-        :to-value ;-- wants blank on failed SWITCH, not null
+        :try  ; wants blank on failed SWITCH, not null
     ]
 )]
 

--- a/src/extensions/console/ext-console-init.reb
+++ b/src/extensions/console/ext-console-init.reb
@@ -464,7 +464,7 @@ ext-console-impl: function [
     ; BLOCK! code execution represents an instruction sent by the console to
     ; itself.  Some #directives may be at the head of these blocks.
     ;
-    directives: try collect [
+    directives: collect [
         if block? prior [
             parse prior [some [set i: issue! (keep i)] end]
         ]

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -162,7 +162,7 @@ trim: function [
         if any [head_TRIM tail_TRIM auto lines all_TRIM with] [
             fail "Invalid refinements for TRIM of ANY-CONTEXT!"
         ]
-        trimmed: make (type of series) collect-block [
+        trimmed: make (type of series) collect [
             for-each [key val] series [
                 if something? :val [keep key]
             ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -27,7 +27,7 @@ spec-of: function [
         meta-of :adaptee
     ]
 
-    return collect-block [
+    return collect [
         keep/line ensure [<opt> text!] any [
             select meta 'description
             select original-meta 'description

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -74,7 +74,7 @@
 ][
     (
         soft: enfix function ['v [any-value! <...>]] [
-            collect-block [
+            collect [
                 while [not tail? v] [
                     keep/only take v
                 ]
@@ -92,7 +92,7 @@
 ][
     (
         hard: enfix function [:v [any-value! <...>]] [
-            collect-block [
+            collect [
                 while [not tail? v] [
                     keep/only take v
                 ]


### PR DESCRIPTION
It is technically desirable for COLLECT to be built on a null-returning
foundation.  It has better performance and memory use characteristics
to not allocate a series node and array memory block if it is not
needed.  Additionally, many clients can benefit from discerning a
"nothing was collected" case, and being null means the result is both
logically false and able to trigger reactions from THEN/ELSE/ALSO.

However, the block form is also useful.  It is also arguable that the
distinct result of "nothing collected" may be usefully discerned from
having a blank input to the collect, to chain out a NULL.

In the balance of both having advantages, this errs on the side of
compatibility (and @rgchris's preference) to give the empty-block
returning COLLECT the primary name--while still building it on the
null-returning form.  The null returning form is tentatively named
COLLECT*, which parallels TAKE* as the "low level take" that returns null
vs. erroring when nothing is available to take.