### PR TITLE
New COMPOSE rule: splice only if ((...))

### DIFF
--- a/make/configs/emscripten.r
+++ b/make/configs/emscripten.r
@@ -101,15 +101,15 @@ cflags: compose [
     ;
     {-DDEBUG_STDIO_OK}
 
-    (if debug-javascript-extension [[
+    ((if debug-javascript-extension [[
         {-DDEBUG_JAVASCRIPT_EXTENSION}
 
         ; {-DDEBUG_STDIO_OK}  ; !!! see above
         {-DDEBUG_HAS_PROBE}
         {-DDEBUG_COUNT_TICKS}
-    ]])
+    ]]))
 
-    (if use-emterpreter [[
+    ((if use-emterpreter [[
         {-DUSE_EMTERPRETER}  ; affects rebPromise() methodology
     ]] else [[
         ; Instruction to emcc (via -s) to include pthread functionalitys
@@ -117,7 +117,7 @@ cflags: compose [
 
         ; Instruction to compiler front end (via -D) to do a #define
         {-DUSE_PTHREADS=1}  ; clearer than `#if !defined(USE_EMSCRIPTEN)`
-    ]])
+    ]]))
 ]
 
 ldflags: compose [
@@ -167,7 +167,7 @@ ldflags: compose [
         {-s ASSERTIONS=0}
     ])
 
-    (if false [[
+    ((if false [[
         ; In theory, using the closure compiler will reduce the amount of
         ; unused support code in %libr3.js, at the cost of slower compilation. 
         ; Level 2 is also available, but is not recommended as it impedes
@@ -189,7 +189,7 @@ ldflags: compose [
         {--closure 1}
     ]] else [[
         {--closure 0}
-    ]])
+    ]]))
 
     ; Minification usually tied to optimization, but can be set separately.
     ;
@@ -237,7 +237,7 @@ ldflags: compose [
     ;
     ;{-s ALLOW_MEMORY_GROWTH=0}
 
-    (if use-emterpreter [[
+    ((if use-emterpreter [[
         {-s EMTERPRETIFY=1}
         {-s EMTERPRETIFY_ASYNC=1}
         {-s EMTERPRETIFY_FILE="libr3.bytecode"}
@@ -271,7 +271,7 @@ ldflags: compose [
         ; https://emscripten.org/docs/porting/pthreads.html
         ;
         {-s PTHREAD_POOL_SIZE=1}
-    ]])
+    ]]))
 
     ; When debugging in the emterpreter, stack frames all appear to have the
     ; function name `emterpret`.  Asking to turn on profiling will inject an

--- a/make/make.r
+++ b/make/make.r
@@ -685,7 +685,7 @@ append app-config/cflags opt switch user-config/standard [
             ; when building as pre-C++11 where it was introduced, unless you
             ; disable that warning.
             ;
-            (if user-config/standard = 'c++98 [<gnu:-Wno-c++0x-compat>])
+            ((if user-config/standard = 'c++98 [<gnu:-Wno-c++0x-compat>]))
 
             ; Note: The C and C++ user-config/standards do not dictate if
             ; `char` is signed or unsigned.  Lest anyone think environments
@@ -1488,8 +1488,8 @@ app: make rebmake/application-class [
     depends: compose [
         (libr3-core)
         (libr3-os)
-        (ext-objs)
-        (app-config/libraries)
+        ((ext-objs))
+        ((app-config/libraries))
         (main)
     ]
     post-build-commands: either cfg-symbols [
@@ -1516,9 +1516,9 @@ library: make rebmake/dynamic-library-class [
     output: %libr3 ;no suffix
     depends: compose [
         (libr3-core)
-        (libr3-os)
-        (ext-objs)
-        (app-config/libraries)
+        ((libr3-os))
+        ((ext-objs))
+        ((app-config/libraries))
     ]
     searches: app-config/searches
     ldflags: app-config/ldflags
@@ -1567,11 +1567,12 @@ for-each ext dynamic-extensions [
         name: join either system-config/os-base = 'windows ["r3-"]["libr3-"]
             lowercase to text! ext/name
         output: to file! name
-        depends: append compose [
-            (mod-objs)
+        depends: compose [
+            ((mod-objs))
             (app) ;all dynamic extensions depend on r3
-            (app-config/libraries)
-        ] ext-libs
+            ((app-config/libraries))
+            ((ext-libs))
+        ]
 
         post-build-commands: either cfg-symbols [
             _
@@ -1583,7 +1584,7 @@ for-each ext dynamic-extensions [
             ]
         ]
 
-        ldflags: compose [(ext-ldflags) <gnu:-Wl,--as-needed>]
+        ldflags: compose [((ext-ldflags)) <gnu:-Wl,--as-needed>]
     ]
 
     add-project-flags/I/D/c/O/g ext-proj

--- a/make/tools/bootstrap-shim.r
+++ b/make/tools/bootstrap-shim.r
@@ -89,7 +89,7 @@ modernize-action: function [
         ]
     ]
     body: compose [
-        (blankers)
+        ((blankers))
         (as group! body)
     ]
     return reduce [spec body]

--- a/make/tools/common-emitter.r
+++ b/make/tools/common-emitter.r
@@ -109,7 +109,7 @@ cscape: function [
             if with [
                 if lit-word? context [context: to word! context]
 
-                context: compose [(context)]  ; convert to block
+                context: compose [((context))]  ; convert to block
                 for-each item context [
                     bind code item
                 ]

--- a/make/tools/make-zlib.r
+++ b/make/tools/make-zlib.r
@@ -63,9 +63,9 @@ disable-user-includes: function [
     close-include (charset {">})
 ] [
     include-rule: compose [
-        (if stdio [
+        ((if stdio [
             [open-include copy name "stdio.h" close-include |]
-        ])
+        ]))
         {"} copy name to {"}
     ]
 

--- a/make/tools/parsing-tools.reb
+++ b/make/tools/parsing-tools.reb
@@ -29,9 +29,11 @@ parsing-at: func [
     use [result position][
         block: compose/only [try (as group! block)]
         if not end [
-            block: compose/deep [try if not tail? (word) [(block)]]
+            block: compose/deep [try if not tail? (word) [((block))]]
         ]
-        block: compose/deep [result: either position: (block) [[:position]] [[end skip]]]
+        block: compose/deep [
+            result: either position: ((block)) [[:position]] [[end skip]]
+        ]
         use compose [(word)] compose/deep [
             [(as set-word! :word) (as group! block) result]
         ]

--- a/make/tools/r2r3-future.r
+++ b/make/tools/r2r3-future.r
@@ -393,7 +393,7 @@ actionmaker: lib/function [
         body: compose [
             real-return: :return
             return: does [real-return void]
-            (body)
+            ((body))
         ]
         chain [
             either gather-locals [:lib/function] [:lib/func]
@@ -438,7 +438,7 @@ method: enfix func [
         fail [member "must be bound to an ANY-CONTEXT! to use METHOD"]
     ]
     ;-- Older Ren-C don't take OBJECT! literally with <in>
-    set member (function compose [(spec) <in> context] body)
+    set member (function compose [((spec)) <in> context] body)
 ]
 
 meth: :func ;-- suitable enough synonym in the older Ren-C

--- a/make/tools/read-deep.reb
+++ b/make/tools/read-deep.reb
@@ -51,7 +51,7 @@ read-deep: function [
 
     result: copy []
 
-    queue: compose [(root)]
+    queue: compose [((root))]
 
     while [not tail? queue] [
         append result taker queue ;-- Possible null

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -994,9 +994,9 @@ object-file-class: make object! [
     ][
         cc: any [compiler default-compiler]
         cc/command/I/D/F/O/g/(PIC)/(E) output source
-            compose [(opt includes) (if I [ex-includes])]
-            compose [(opt definitions) (if D [ex-definitions])]
-            compose [(if F [ex-cflags]) (opt cflags)] ;; ex-cflags override
+            compose [((opt includes)) ((if I [ex-includes]))]
+            compose [((opt definitions)) ((if D [ex-definitions]))]
+            compose [((if F [ex-cflags])) ((opt cflags))] ; ex-cflags override
 
             ; current setting overwrites /refinement
             ; because the refinements are inherited from the parent
@@ -2075,7 +2075,7 @@ visual-studio: make generator-class [
                                 {        <AdditionalOptions>}
                                 spaced compose [
                                     {%(AdditionalOptions)}
-                                    (collected)
+                                    ((collected))
                                 ]
                                 {</AdditionalOptions>^/}
                             ]

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -533,10 +533,10 @@ use [
     ]
 
     unused-flags: exclude compose [
-        (words-of compiler-flags)
-        (words-of linker-flags)
-        (words-of system-definitions)
-        (words-of system-libraries)
+        ((words-of compiler-flags))
+        ((words-of linker-flags))
+        ((words-of system-definitions))
+        ((words-of system-libraries))
     ] used-flags
 
     if not empty? unused-flags [

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -173,11 +173,11 @@ func: emulate [
         body [block!]
     ][
         func compose [
-           (optify spec) <local> exit
+           ((optify spec)) <local> exit
         ] compose [
             blankify-refinement-args binding of 'return
             exit: make action! [[] [unwind binding of 'return]]
-            (body)
+            ((body))
         ]
     ]
 ]
@@ -196,14 +196,14 @@ function: emulate [
         ; put everything into the spec...marked with <tags>
         ;
         function compose [
-            (optify spec)
-            (if with [<in>]) (:object) ;-- <in> replaces /WITH
-            (if extern [<with>]) (:words) ;-- <with> replaces /EXTERN
-            ;-- <local> exit, picked up since using FUNCTION as generator
+            ((optify spec))
+            (if with [<in>]) (:object)  ; <in> replaces /WITH
+            (if extern [<with>]) ((:words))  ; <with> replaces /EXTERN
+            ; <local> exit, picked up since using FUNCTION as generator
         ] compose [
             blankify-refinement-args binding of 'return
             exit: make action! [[] [unwind binding of 'return]]
-            (body)
+            ((body))
         ]
     ]
 ]
@@ -849,7 +849,7 @@ foreach: emulate [
         use :vars [
             position: data
             while [not tail? position] compose [
-                (collect [
+                ((collect [
                     for-each item vars [
                         case [
                             set-word? item [
@@ -864,8 +864,8 @@ foreach: emulate [
                             fail "non SET-WORD?/WORD? in FOREACH vars"
                         ]
                     ]
-                ])
-                (body)
+                ]))
+                ((body))
             ]
         ]
     ]

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -116,7 +116,7 @@ REB_R MAKE_Array(
         //     == a/b/c
         //
         //     >> block: [a b c]
-        //     >> p2: make path! compose [(block) 2]
+        //     >> p2: make path! compose [((block)) 2]
         //     == b/c
         //
         //     >> append block 'd

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -168,6 +168,7 @@ bool Add_Typeset_Bits_Core(
 
                 TYPE_SET(typeset, REB_TS_SKIPPABLE);
                 TYPE_SET(typeset, REB_TS_ENDABLE); // skip => null
+                TYPE_SET(typeset, REB_NULLED);  // null if specialized
             }
             else if (0 == Compare_String_Vals(item, Root_Dequote_Tag, true)) {
                 TYPE_SET(typeset, REB_TS_DEQUOTE_REQUOTE);

--- a/src/extensions/console/ext-console-init.reb
+++ b/src/extensions/console/ext-console-init.reb
@@ -451,7 +451,7 @@ ext-console-impl: function [
             <bad> [
                 emit #no-unskin-if-error
                 emit [print (<*> mold uneval prior)]
-                emit [fail ["Bad REPL continuation:" ((<*> result))]]
+                emit [fail ["Bad REPL continuation:" (<*> result)]]
             ]
         ] then [
             return-to-c instruction
@@ -643,7 +643,7 @@ ext-console-impl: function [
     === HANDLE RESULT FROM EXECUTION OF CODE ON USER'S BEHALF ===
 
     if group? prior [
-        emit [system/console/print-result ((<*> result))]
+        emit [system/console/print-result (<*> result)]
         return <prompt>
     ]
 
@@ -762,7 +762,7 @@ ext-console-impl: function [
     emit #unskin-if-halt  ; Ctrl-C during dialect hook is a problem
     emit [
         comment {not all users may want CONST result, review configurability}
-        as group! system/console/dialect-hook ((<*> code))
+        as group! system/console/dialect-hook (<*> code)
     ]
     return group!  ; a group RESULT should come back to HOST-CONSOLE
 ]

--- a/src/extensions/tcc/ext-tcc-init.reb
+++ b/src/extensions/tcc/ext-tcc-init.reb
@@ -29,7 +29,7 @@ REBOL [
         * Extract embedded header files and library files to the local file
           system.  These allow a Rebol executable that is distributed as a
           single EXE to function as a "standalone" compiler.
-          
+
           !!! ^-- Planned future feature: See README.md.
 
         These features could become more imaginative, considering COMPILE as

--- a/src/extensions/tcc/prep-librebol-table.r
+++ b/src/extensions/tcc/prep-librebol-table.r
@@ -88,7 +88,7 @@ exists? top-dir or [
 encap: compose [
     (top-dir/make/prep/include/rebol.h)
 
-    (switch system-config/os-base [
+    ((switch system-config/os-base [
         ;
         ; https://repo.or.cz/tinycc.git/blob/HEAD:/win32/tcc-win32.txt
         ;
@@ -120,9 +120,9 @@ encap: compose [
                 "(OS X looks to be possible, but it just hasn't been tried)"
             ]
         ]
-    ])
+    ]))
 
-    (tcc-libtcc1-file) ;; See README.md for an explanation of %libtcc1.a
+    (tcc-libtcc1-file)  ; See README.md for an explanation of %libtcc1.a
 ]
 
 print "== IF TCC EXTENSION ENCAPPING WERE IMPLEMENTED, IT WOULD STORE THIS =="

--- a/src/include/sys-eval.h
+++ b/src/include/sys-eval.h
@@ -55,7 +55,15 @@
 //
 
 
-// Simple and short variant of Eval_Core() that clears off OUT_MARKED_STALE.
+// Simple helper solving two problems that Eval_Internal_Maybe_Stale_Throws()
+// has such a long name to warn about:
+//
+//    (1) It calls through a function pointer, so that if there is a hook
+//    for tracing or debug stepping it won't be skipped.
+//
+//    (2) Clears off OUT_MARKED_STALE--an alias for NODE_FLAG_MARKED that
+//    is used for generic purposes and may be misinterpreted if it leaked.
+//
 // (Note that it is wasteful to clear the stale flag if running in a loop,
 // so the Do_XXX() versions don't use this.)
 //

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -469,7 +469,7 @@ so: enfix func [
         fail 'condition make error! [
             type: 'Script
             id: 'assertion-failure
-            arg1: compose [(:condition) so]
+            arg1: compose [((:condition)) so]
         ]
     ]
     if tail? feed [return void]
@@ -721,8 +721,8 @@ lambda: function [
         {Block that serves as the body or variadic elements for the body}
 ][
     make action! compose [
-        ((blockify :args))
-        ((const if block? first body [take body] else [make block! body]))
+        (blockify :args)
+        (const if block? first body [take body] else [make block! body])
     ]
 ]
 
@@ -772,7 +772,7 @@ method: enfix func [
     context: binding of member else [
         fail [member "must be bound to an ANY-CONTEXT! to use METHOD"]
     ]
-    set member bind (function compose [(spec) <in> (context)] body) context
+    set member bind (function compose [((spec)) <in> ((context))] body) context
 ]
 
 meth: enfix func [
@@ -858,7 +858,7 @@ module: func [
         spec/version [tuple! blank!]
         spec/options [block! blank!]
     ][
-        do compose [ensure ((types)) (var)] ;-- names to show if fails
+        do compose [ensure (types) (var)]  ; names to show if fails
     ]
 
     ; In Ren-C, MAKE MODULE! acts just like MAKE OBJECT! due to the generic
@@ -965,8 +965,7 @@ cause-error: func [
     err-id [word!]
     args
 ][
-    ; Make sure it's a block:
-    args: compose [(:args)]
+    args: blockify :args  ; make sure it's a block
 
     ; Filter out functional values:
     iterate args [
@@ -1034,7 +1033,7 @@ fail: function [
     ] else [
         not set? 'reason so make error! compose [
             Type: 'Script
-            (case [
+            ((case [
                 frame and [set? blame] [[
                     id: 'invalid-arg
                     arg1: label of frame
@@ -1053,7 +1052,7 @@ fail: function [
                 default [[
                     id: 'unknown-error
                 ]]
-            ])
+            ]))
         ]
     ]
 
@@ -1096,11 +1095,11 @@ generate: function [ "Make a generator."
             return do result
         ]
         count: me + 1
-        result: (to group! (iteration))
-        (either empty? condition
+        result: (to group! iteration)
+        ((either empty? condition
             [[ return result ]]
-            [compose [ return either (to group! (condition)) [result] [null] ]]
-        )
+            [compose [ return if (to group! condition) [result] ]]
+        ))
     ]
     f: function spec body
     f/reset init

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -284,7 +284,7 @@ trim: function [
     ]
 
     line-start-rule: compose/deep [
-        remove [(if indent [[1 indent]] else ['any]) rule]
+        remove [((if indent [[1 indent]] else ['any])) rule]
     ]
 
     parse series [

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -30,7 +30,7 @@ verify: function [
                 type: 'Script
                 id: 'assertion-failure
                 arg1: compose [
-                    (copy/part conditions pos) ** (case [
+                    ((copy/part conditions pos)) ** (case [
                         unset? 'result ['null]
                         void? result ['void]
                         blank? result ['blank]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -43,7 +43,7 @@ spec-of: function [
         ]
         if any [return-type return-note] [
             keep compose [
-                return: ((opt return-type)) (opt return-note)
+                return: (opt return-type) (opt return-note)
             ]
         ]
 
@@ -58,7 +58,7 @@ spec-of: function [
 
         for-each param parameters of :action [
             keep compose [
-                (param) ((select types param)) (select notes param)
+                (param) (select types param) (select notes param)
             ]
         ]
     ]

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -91,7 +91,7 @@ save: function [
                     remove find to-value select header-data 'options 'compress
                 ]
                 not block? select header-data 'options [
-                    append header-data compose [options: ((copy [compress]))]
+                    append header-data compose [options: (copy [compress])]
                 ]
                 not find header-data/options 'compress [
                     append header-data/options 'compress

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -492,7 +492,7 @@ collect-lines: redescribe [
         keep: adapt specialize 'keep [
             line: true | only: false | part: false
         ] [value: spaced try :value]
-        ((as group! body))
+        (as group! body)
     ]
 ]
 
@@ -507,7 +507,7 @@ collect-text: redescribe [
             ][
                 value: unspaced try :value
             ]
-            ((as group! body))
+            (as group! body)
         ]
     ]
     :spaced

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -42,7 +42,7 @@ register-codec*: func [
         ; IMAGE!.  Should the argument types of the encode function be cached
         ; here, or be another parameter, or...?
 
-        suffixes: ((suffixes))
+        suffixes: (suffixes)
         identify?: lit (:identify?)
         decode: lit (:decode)
         encode: lit (:encode)

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -810,7 +810,7 @@ load-module: function [
 
         if exports [
             if null? select hdr 'exports [
-                append hdr compose [exports: ((export-list))]
+                append hdr compose [exports: (export-list)]
             ] else [
                 append exports hdr/exports
                 hdr/exports: export-list

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -277,7 +277,7 @@ host-start: function [
             <bad> [
                 emit #no-unskin-if-error
                 emit [print (<*> mold uneval prior)]
-                emit [fail ["Bad REPL continuation:" ((<*> uneval result))]]
+                emit [fail ["Bad REPL continuation:" (<*> uneval result)]]
             ]
         ] then [
             return-to-c instruction
@@ -297,7 +297,7 @@ host-start: function [
                 state
             ]
             default [
-                emit [fail [{Bad console instruction:} ((<*> mold state))]]
+                emit [fail [{Bad console instruction:} (<*> mold state)]]
             ]
         ]
     ]
@@ -518,7 +518,7 @@ host-start: function [
                 quit-when-done: default [true] ;-- override blank, not false
 
                 emit {Use /ONLY so that QUIT/WITH quits, vs. return DO value}
-                emit [do/only ((<*> param-or-die "DO"))]
+                emit [do/only (<*> param-or-die "DO")]
             )
         |
             ["--halt" | "-h"] end (
@@ -805,7 +805,7 @@ comment [
     ;
     if file? o/script [
         emit {Use DO/ONLY so QUIT/WITH exits vs. being DO's return value}
-        emit [do/only/args ((<*> o/script)) ((<*> script-args))]
+        emit [do/only/args (<*> o/script) (<*> script-args)]
     ]
 
     host-start: 'done

--- a/tests/atronix/test-libs.r
+++ b/tests/atronix/test-libs.r
@@ -76,7 +76,7 @@ cycle [
                 ]
             ]
         ]
-        (libs) "read_s10"
+        ((libs)) "read_s10"
     ]
 
     a: make struct! [

--- a/tests/control/compose.test.reb
+++ b/tests/control/compose.test.reb
@@ -30,7 +30,7 @@
 )
 (
     blk: []
-    same? blk first compose [(reduce [blk])]
+    same? blk first compose [((reduce [blk]))]
 )
 (
     blk: []
@@ -39,7 +39,7 @@
 ; recursion
 (
     num: 1
-    [num 1] = compose [num (compose [(num)])]
+    [num 1] = compose [num ((compose [(num)]))]
 )
 ; infinite recursion
 (
@@ -59,7 +59,7 @@
 
 (
     block: [a b c]
-    [plain: a b c only: [a b c]] = compose [plain: (block) only: ((block))]
+    [splice: a b c only: [a b c]] = compose [splice: ((block)) only: (block)]
 )
 
 ; COMPOSE with pattern, beginning tests
@@ -77,7 +77,7 @@
 (
     [(left alone) [c b a] c b a ((left alone))]
     = compose <$> [
-        (left alone) ((<$> reverse copy [a b c])) (<$> reverse copy [a b c])
+        (left alone) (<$> reverse copy [a b c]) ((<$> reverse copy [a b c]))
         ((left alone))
     ]
 )
@@ -103,20 +103,17 @@
 ([x:] = compose [(#x):])
 ([x:] = compose [("x"):])
 
-([x/y:] = compose [('x/y):])
-([x/y:] = compose [('x/y:):])
-([x/y:] = compose [(':x/y):])
+([x/y:] = compose [( 'x/y ):])
+([x/y:] = compose [( 'x/y: ):])
+([x/y:] = compose [( ':x/y ):])
 
-([(x y):] = compose [(('(x y))):])
-([(x y):] = compose [(('(x y):)):])
-([(x y):] = compose [((':(x y))):])
+([(x y):] = compose [( '(x y) ):])
+([(x y):] = compose [( '(x y): ):])
+([(x y):] = compose [( ':(x y) ):])
 
-; !!! Hopefully temporary: block splicing throws a wrench in this.  Better
-; to make (( )) the splicing operator
-
-([[x y]:] = compose [(('[x y])):])
-([[x y]:] = compose [(('[x y]:)):])
-([[x y]:] = compose [((':[x y])):])
+([[x y]:] = compose [( '[x y] ):])
+([[x y]:] = compose [( '[x y]: ):])
+([[x y]:] = compose [( ':[x y] ):])
 
 
 ; Using a GET-GROUP! will *try* to convert the composed value to a get form
@@ -127,17 +124,14 @@
 ([:x] = compose [:(#x)])
 ([:x] = compose [:("x")])
 
-([:x/y] = compose [:('x/y)])
-([:x/y] = compose [:('x/y:)])
-([:x/y] = compose [:(':x/y)])
+([:x/y] = compose [:( 'x/y )])
+([:x/y] = compose [:( 'x/y: )])
+([:x/y] = compose [:( ':x/y )])
 
-([:(x y)] = compose [:(('(x y)))])
-([:(x y)] = compose [:(('(x y):))])
-([:(x y)] = compose [:((':(x y)))])
+([:(x y)] = compose [:( '(x y) )])
+([:(x y)] = compose [:( '(x y): )])
+([:(x y)] = compose [:( ':(x y) )])
 
-; !!! Hopefully temporary: block splicing throws a wrench in this.  Better
-; to make (( )) the splicing operator
-
-([:[x y]] = compose [:(('[x y]))])
-([:[x y]] = compose [:(('[x y]:))])
-([:[x y]] = compose [:((':[x y]))])
+([:[x y]] = compose [:( '[x y] )])
+([:[x y]] = compose [:( '[x y]: )])
+([:[x y]] = compose [:( ':[x y] )])

--- a/tests/datatypes/object.test.reb
+++ b/tests/datatypes/object.test.reb
@@ -121,7 +121,7 @@
             ; var-256: 256
             ;
             keep compose [
-                (to set-word! unspaced ["var-" n]) (n)
+                (to word! unspaced ["var-" n]): (n)
             ]
         ]
         repeat n 256 [
@@ -132,14 +132,14 @@
             ; fun-256: method [] [var-1 + var-2 ... + var-256]
             ;
             keep compose [
-                (to set-word! unspaced ["meth-" n]) method [] ((collect [
+                (to word! unspaced ["meth-" n]): method [] (collect [
                     keep 'var-1
                     repeat i n - 1 [
                         keep compose [
                             + (to word! unspaced ["var-" i + 1])
                         ]
                     ]
-                ]))
+                ])
             ]
         ]
     ]

--- a/tests/secure/const.test.reb
+++ b/tests/secure/const.test.reb
@@ -67,12 +67,12 @@
 )(
     block: []
     e: trap [
-        do compose/deep [loop 2 [append ((block)) <fail>]]
+        do compose/deep [loop 2 [append (block) <fail>]]
     ]
     e/id = 'const-value
 )(
     block: mutable []
-    do compose/deep [loop 2 [append ((block)) <legal>]]
+    do compose/deep [loop 2 [append (block) <legal>]]
     block = [<legal> <legal>]
 )
 
@@ -98,7 +98,7 @@
     data = [a [b [c <success>] <success>] <success>]
 )(
     loop 1 [sub: copy/deep [b [c]]]
-    data: copy compose [a ((sub))]
+    data: copy compose [a (sub)]
     append data <success>
     append data/2 <success>
     append data/2/2 <success>
@@ -149,11 +149,9 @@
 
 ; COMPOSE should splice with awareness of const/mutability
 (
-    e: trap [loop 2 compose [append (([1 2 3])) <bad>]]
+    e: trap [loop 2 compose [append ([1 2 3]) <bad>]]
     e/id = 'const-value
 )(
-    block: loop 2 compose [append ((mutable [1 2 3])) <legal>]
+    block: loop 2 compose [append (mutable [1 2 3]) <legal>]
     block = [1 2 3 <legal> <legal>]
 )
-
-


### PR DESCRIPTION
> **NOTE:** This was merged with some new features, and a slightly different implementation.  It no longer has a /splice refinement, but similar behavior is accomplished using a more general means.  The premise of splicing only ((...)) remains: https://github.com/metaeducation/ren-c/commit/31aa9be604fd6738e5e6b501087c18aa94ae0e6a

This is a fundamental change (on par with evaluative SWITCH) which
makes COMPOSE not splice generated blocks until they are doubled up.

    >> block: [a b c]
    >> compose [normal: (block) spliced: ((block))]
    == [normal: [a b c] spliced: a b c]

It was a desirable option when the idea of doubled groups came up, as
the fatter appearance suggests some sort of multiplicity.  But the
first run of the idea was to let it be fatter to suggest "protection"
against splicing.

Yet pushing the desirability over the edge is the new semantics of
quoting in compose, where a quoted group means quoting that thing:

    >> var: first [foo]
    >> compose [word: '(var)]
    == [word: 'foo]

This concept of merging the quote onto the material is powerful, and
does not go along with the idea of single-parentheses associating with
a splice.

    >> block: [a b c]
    >> compose ['(block) (block): :(block)]
    == ['[a b c] [a b c]: :[a b c]]

In practice, the change of making it clear where the splices are is
extremely clarifying when reading code.  It might look a little bit
"cluttered" if you have to double up both your blocks and your groups
wen writing things out literally:

    compose [
       "item one"
       ((if condition [[
           "item two"
           "item three"
       ]]))
       "item four"
    ]

But I'd argue that helps you viscerally notice that that the block of the
branch is being spliced...not a block that is calculated by the branch as
a result.  In the cases I've looked at, I think it reduces the confusion.

There is also a /splice refinement which could be used if one wanted
to do multiple splices:

    compose/splice [
       "item one"
       (if condition [[
           "item two"
           "item three"
       ]])
       "item four"
    ]

The meaning of /ONLY is changed to mean "do not interpret ((...))" as
a splicing override.  This could technically come in handy if you have
groups that wind up being generated from expressions and you are
doing some kind of compose-of-a-compose, and you don't want that
pattern appearing indavertently to splice.

     >> items: [(1 + 2) "hi" ...]
     ; time passes

     >> splicers: map-each i items [
         as group! reduce [i]
     ]
     == [((1 + 2)) ("hi") ...]

     >> block: reduce ['x: splicers/1]
     == [x: ((1 + 2))]
 
     >> compose/only block
     == [x: 3]

But the more important reason to keep /ONLY on the interface in the
near term is so that old compose has the parameter to be used in a
fast emulation:

    compose-redbol: specialize (adapt 'compose [
        if only [splice: false]
    ])[
        splice: true
    ]

This makes an adaptation of compose which disables splicing when the
only switch is used.  Then it specializes the splice refinement out
of the interface by defaulting it to true, leaving /only on the
interface to control both properties.

So that will be used to implement COMPOSE in the Redbol emulation.