### PR TITLE
Large number of usability improvements to CALL

### DIFF
--- a/make/tools/bootstrap-shim.r
+++ b/make/tools/bootstrap-shim.r
@@ -153,3 +153,6 @@ has: null
 ]
 
 const?: func [x] [return false]
+
+call*: :call
+call: specialize 'call* [wait: true]

--- a/make/tools/rebmake.r
+++ b/make/tools/rebmake.r
@@ -89,7 +89,7 @@ run-command: function [
     cmd [block! text!]
 ][
     x: copy ""
-    call/wait/shell/output cmd x
+    call/shell/output cmd x
     trim/with x "^/^M"
 ]
 
@@ -1493,12 +1493,12 @@ Execution: make generator-class [
                     for-each cmd target/commands [
                         cmd: reify cmd
                         print ["Running:" cmd]
-                        call/wait/shell cmd
+                        call/shell cmd
                     ]
                 ][
                     cmd: reify target/commands
                     print ["Running:" cmd]
-                    call/wait/shell cmd
+                    call/shell cmd
                 ]
             ]
             default [

--- a/scripts/changes-file/changes-file.reb
+++ b/scripts/changes-file/changes-file.reb
@@ -57,7 +57,7 @@ get-git-log: function [
     {Return Rebolised block of Ren/C `git log`}
 ][
     git-log: make text! 0
-    call/shell/wait/output "git log --pretty=format:'[commit: {%h} author: {%an} email: {%ae} date-string: {%ai} summary: {%s}]'" git-log
+    call/shell/output "git log --pretty=format:'[commit: {%h} author: {%an} email: {%ae} date-string: {%ai} summary: {%s}]'" git-log
     split git-log newline
 
 ]

--- a/src/extensions/process/ext-process-init.reb
+++ b/src/extensions/process/ext-process-init.reb
@@ -7,6 +7,108 @@ REBOL [
     License: {Apache 2.0}
 ]
 
+; It's desirable to do as much usermode logic as possible, to reduce the
+; amount of C code that CALL has to run.  So things like transforming any
+; FILE! into local paths are done here.
+;
+call*: adapt 'call-internal* [
+    command: switch type of command [
+        text! [
+            ; A TEXT! is passed through as-is, and will be interpreted by
+            ; the shell (e.g. `sh -c your text` or `cmd.exe /C your text`) 
+            ;
+            command
+        ]
+        file! [
+            ; We change a FILE! to a TEXT! of its local form -but- enclose it
+            ; in a length-1 argv[] block.  That's because CALL-INTERNAL* will
+            ; treat a TEXT! as a line to pass and be interpreted by the shell.
+            ; Hence if the filename contained spaces, it would be broken up.
+            ; Making it an element of an argv[] array keeps it atomic.
+            ;
+            reduce [file-to-local command]
+        ]
+        block! [
+            if empty? command [  ; !!! should this be a no-op?
+                fail "Empty argv[] block passed to CALL"
+            ]
+            map-each arg command [
+                switch type of arg [
+                    text! [arg]  ; pass through as is
+                    file! [file-to-local arg]
+
+                    fail ["invalid item in argv[] block for CALL:" arg]
+                ]
+            ]
+        ]
+        fail  ; unreachable (parameter was typechecked)
+    ]
+]
+
+; The Atronix CALL implementation was asynchronous by default, launching a
+; process and returning immediately.  However, use of parameters that would
+; feed it input or output could make it /WAIT implicitly.
+;
+; The long term goal would be to have some kind of call PORT! which could be
+; generated, and then spoken to to feed I/O programmatically a bit at a time.
+; (Similar to Tcl's EXPECT, for instance.)  In lieu of that design, this goes
+; ahead and keeps the asynchronous behavior in a lower level and chooses to
+; /WAIT by default.
+;
+call: specialize 'call* [wait: true]
+
+parse-command-to-argv*: function [
+    {Helper for when POSIX gets a TEXT! and the /SHELL refinement not used}
+
+    return: [block!]
+    command [text!]
+][
+    quoted-shell-item-rule: [  ; Note: ANY because "" is legal as an arg
+        any [{\"} | not {"} skip]  ; escaped quotes and nonquotes
+    ]
+    unquoted-shell-item-rule: [some [not space skip]]
+
+    parse command [
+        collect result: [any [
+            any space
+            [
+                {"} keep quoted-shell-item-rule {"}
+                | keep unquoted-shell-item-rule
+            ]
+        ]
+        any space end]
+    ] else [
+        fail [
+            "Could not parse command line into argv[] block." LF
+            "Use CALL/SHELL to defer the shell to parse, or if you believe"
+            "the command line is valid then help fix PARSE-COMMAND-TO-ARGV*"
+        ]
+    ]
+    return result
+]
+
+
+argv-block-to-command*: function [
+    {Helper for when Windows gets an argv BLOCK! and needs a command line}
+
+    return: [text!]
+    argv [block!]
+][
+    return spaced map-each arg argv [
+        any [
+            find arg space
+            find arg {"}
+        ] then [  ; have to put it in quotes, but also escape any quotes
+            arg: copy arg
+            replace/all arg {"} {\"}
+            insert arg {"}
+            append arg {"}
+        ]
+        arg
+    ]
+]
+
+
 ; CALL is a native built by the C code, BROWSE depends on using that, as well
 ; as some potentially OS-specific detection on how to launch URLs (e.g. looks
 ; at registry keys on Windows)
@@ -30,7 +132,7 @@ browse*: function [
             location
         ]
         trap [
-            call/shell command  ; don't use /WAIT
+            call/shell command  ; open with no /WAIT, so don't use CALL*
             return
         ] then [
             ; Just keep trying
@@ -40,3 +142,5 @@ browse*: function [
 ]
 
 hijack 'browse :browse*
+
+sys/export [call call*]

--- a/src/extensions/process/mod-process.c
+++ b/src/extensions/process/mod-process.c
@@ -72,9 +72,9 @@
 
 
 //
-//  export call: native [
+//  export call-internal*: native [
 //
-//  {Run another program; return immediately (unless /WAIT)}
+//  {Run another program by spawning a new process}
 //
 //      command "OS-local command line, block with arguments, executable file"
 //          [text! block! file!]
@@ -90,7 +90,7 @@
 //      err [text! binary! file! blank!]
 //  ]
 //
-REBNATIVE(call)
+REBNATIVE(call_internal_p)
 //
 // !!! Parameter usage may require WAIT mode even if not explicitly requested.
 // /WAIT should be default, with /ASYNC (or otherwise) as exception!

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -21,7 +21,7 @@ launch: func [
     if file? script [script: file-to-local clean-path script]
     args: reduce [file-to-local system/options/boot script]
     if set? 'arg [append args arg]
-    either wait [call/wait args] [call args]
+    call*/(wait) args
 ]
 
 wrap: func [

--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -9,7 +9,7 @@
 (
     ; small - note Windows doesn't do BLOCK! arg to CALL (argv style) yet
 
-    call/shell/wait/output spaced [
+    call/shell/output spaced [
         (file-to-local system/options/boot)
         {--suppress "*" call/print.reb 100}
     ] data: {}
@@ -19,7 +19,7 @@
 (
     ; medium - note Windows doesn't do BLOCK! arg to CALL (argv style) yet
 
-    call/shell/wait/output spaced [
+    call/shell/output spaced [
         (file-to-local system/options/boot)
         {--suppress "*" call/print.reb 9000}
     ] data: {}
@@ -29,7 +29,7 @@
 (
     ; large - note Windows doesn't do BLOCK! arg to CALL (argv style) yet
 
-    call/shell/wait/output spaced [
+    call/shell/output spaced [
         (file-to-local system/options/boot)
         {--suppress "*" call/print.reb 80000}
     ] data: {}
@@ -41,7 +41,7 @@
 (
     (not exists? %/usr/bin/git) or [
         data: {}
-        call/wait/output compose [
+        call/output compose [
             %/usr/bin/git "log" (spaced [
                 "--pretty=format:'["
                     "commit: {%h}"
@@ -60,14 +60,14 @@
 
 ; Tests feeding input and taking output from various sources
 [
-    (did echoer: enclose specialize 'call/shell/wait/input/output [
+    (did echoer: enclose specialize 'call/input/output [
         command: spaced [
-          file-to-local system/options/boot
-          {--suppress "*"} {-qs} {--do} {"write-stdout input quit"}
+            file-to-local system/options/boot {--suppress "*"} {-qs}
+            {--do} {"write-stdout read system/ports/input"}
         ]
-    ] function [f [frame!]] [
-        out: f/out
-        do f
+    ] function [frame [frame!]] [
+        out: frame/out
+        do frame
         return out
     ])
 
@@ -78,4 +78,16 @@
     (#{466F6F} = echoer #{466F6F} #{})
     ("Foo" = echoer #{466F6F} "")
     (#{466F6F} = echoer "Foo" #{})
+    (#{DECAFBAD} = echoer #{DECAFBAD} #{})
+    (error? trap [#{DECAFBAD} = echoer #{DECAFBAD} ""])
 ]
+
+; Both unix and windows echo text back, so this is a good test of the shell
+; But line endings will vary because it's not redirected.  :-/
+(
+    call/shell/output "echo test" out: ""
+    did any [
+        "test^M^/" = out
+        "test^/" = out
+    ]
+)


### PR DESCRIPTION
R3-Alpha had a very primitive call, with /WAIT as the only refinement.
Atronix updated this to add the input/output/error features for
redirection on Windows and POSIX, but preserved the /WAIT behavior,
which seems to run counter to Rebol's ease of use defaults.

Several oddities of the difference between Windows and POSIX--as well
as the differentiation between direct process execution and shell
execution--leaked through in the implementation to where a seemingly
simple idea like `call {my.exe an-arg}` was not running it in the way
one would expect.  For a summary of the reasons that convenience was
not favored, see these notes:

https://github.com/rebol/rebol-issues/issues/2225

This commit is a reimagination that tries to "fix all the problems":

* Text strings passed are parsed and spacing heeded, regardless of
  platform.  On POSIX, a usermode PARSE-based helper does this unless
  the /SHELL refinement is used, in which case it is deferred to the
  shell for processing.  If bugs are found, they can feed back into
  improving that Rebol parser.

* Blocks are heeded as argv[] arrays, regardless of platform.  On
  Windows, a usermode based DELIMIT and MAP-EACH helper does this.

* This means that process invocation is always direct, unless the
  /SHELL refinement is used.  That's more efficient, and should be
  preferred unless you explicitly want the child process to have its
  own environment, or if you want to run shell substitutions in the
  command, or if you want to use something like "echo" or "dir" which
  aren't actual on-disk executables and are only available if you
  are running via an intermediary CMD.EXE or SH/BASH.

* Waiting is done by default.  If you do not want to wait, the lower
  level CALL* primitive offers a /WAIT refinement (CALL specializes
  CALL* with wait).  This is a placeholder for a more complex
  implementation which would be PORT!-based and allow asynchronous
  communication with the port as if it were talking over a network pipe

The usermode helpers which enable the bridging may not be perfect, but
they seem to work and are short.  Using /SHELL will bypass these as
a workaround in case they turn out to be broken--but users should be
able to identify and submit Rebol-coded patches to them.