### PR TITLE
Fixed a quoting issue with emcc on Windows

### DIFF
--- a/make/configs/emscripten.r
+++ b/make/configs/emscripten.r
@@ -221,7 +221,7 @@ ldflags: compose [
     ; that doesn't seem to be the case for %reb-lib.js or things called from
     ; EM_ASM() in the C...so do it explicitly.
     ;
-    {-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap", "allocateUTF8"]'}
+    {-s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'cwrap', 'allocateUTF8']"}
 
     ; WASM does not have source maps, so disabling it can aid in debugging
     ; But emcc WASM=0 does not work in VirtualBox shared folders by default


### PR DESCRIPTION
I updated the quoting so that emcc won't crash on Windows when building Emscripten. This update has been tested on both Linux and Windows, and it works on both.