### PR TITLE
Added a new "output" config setting

### DIFF
--- a/make/configs/emscripten.r
+++ b/make/configs/emscripten.r
@@ -48,6 +48,8 @@ debug-javascript-extension: true
 ;
 top: 'library
 
+output: %libr3
+
 os-id: default [0.16.2]
 
 gcc-path:

--- a/make/default-config.r
+++ b/make/default-config.r
@@ -96,3 +96,5 @@ ldflags: _
 main: _
 
 top: _
+
+output: _

--- a/make/make.r
+++ b/make/make.r
@@ -553,6 +553,7 @@ app-config: make object! [
     definitions: copy []
     includes: reduce [src-dir/include %prep/include]
     searches: make block! 8
+    output: make file! %r3
 ]
 
 cfg-sanitize: false
@@ -1026,6 +1027,7 @@ print ["cflags:" mold app-config/cflags]
 print ["ldflags:" mold app-config/ldflags]
 print ["debug:" mold app-config/debug]
 print ["optimization:" mold app-config/optimization]
+print ["output:" mold app-config/output]
 
 append app-config/definitions reduce [
     unspaced ["TO_" uppercase to-text system-config/os-base]
@@ -1039,6 +1041,8 @@ append app-config/includes opt user-config/includes
 append app-config/cflags opt user-config/cflags
 append app-config/libraries opt user-config/libraries
 append app-config/ldflags opt user-config/ldflags
+
+if user-config/output [app-config/output: user-config/output]
 
 libr3-core: make rebmake/object-library-class [
     name: 'libr3-core
@@ -1484,7 +1488,7 @@ add-new-obj-folders ext-objs folders
 
 app: make rebmake/application-class [
     name: 'r3-exe
-    output: %r3 ;no suffix
+    output: app-config/output
     depends: compose [
         (libr3-core)
         (libr3-os)


### PR DESCRIPTION
replpad-js requires a ../ren-c/make/libr3.js file to exist when running on localhost. This update adds a new "output" setting that lets you configure the name of the binary generated by Ren-C. This allows us to specify the %libr3 file name, instead of it generating the default %r3 one, when building Emscripten.

If you don't want to add a new config setting to Ren-C, then another alternative is to update replpad-js and have it look for %r3.js instead.