### PR TITLE
Fixed an Emscripten crashing issue by setting Module["noInitialRun"] during preload

### DIFF
--- a/make/configs/emscripten.r
+++ b/make/configs/emscripten.r
@@ -159,6 +159,8 @@ ldflags: compose [
     ;
     (if (javascript-environment = #node) and [use-emterpreter] [
         {--pre-js prep/include/node-preload.js}
+    ] else [
+        {--pre-js prep/include/web-preload.js}
     ])
 
     (if debug-javascript-extension [

--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -1146,3 +1146,15 @@ e-node-preload/emit {
 }
 
 e-node-preload/write-emitted
+
+=== GENERATE %WEB-PRELOAD.JS ===
+
+e-web-preload: (make-emitter
+    "Module Preload for Web" output-dir/web-preload.js
+)
+
+e-web-preload/emit {
+    Module["noInitialRun"] = true;
+}
+
+e-web-preload/write-emitted


### PR DESCRIPTION
This fixes an issue where Emscripten would crash with the following error.

This issue is being caused by the latest version of emcc inserting a new Module["_main"] method. I don't understand it fully, but this new method breaks compatibility with Ren-C, and so I have disabled it by preloading: Module["noInitialRun"] = true;

** Access Error: cannot open: %/this.program reason: make error! [ libr3.js:1507:5
    type: _ libr3.js:1507:5
    id: _ libr3.js:1507:5
    message: "No such file or directory" libr3.js:1507:5
    near: [fail make error! [...] ~~] libr3.js:1507:5
    where: [fail read trap get-encap _ entrap] libr3.js:1507:5
    file: 'tmp-host-start.inc libr3.js:1507:5
    line: 3032 libr3.js:1507:5
] libr3.js:1507:5
** Where: read trap get-encap _ entrap libr3.js:1507:5
** Near: [ libr3.js:1507:5
    read/part rebol-path 1 ~~] libr3.js:1507:5
** File: tmp-host-start.inc libr3.js:1507:5
** Line: 3032 libr3.js:1507:5
Can't check for embedded code in Rebol path: /this.program