### PR TITLE
Add configs/emterpreter.r + chain config files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -434,7 +434,7 @@ matrix:
           packages:
             - gcc-multilib  # for cross-compiling
 
-    # [12] Emscripten, Webassembly, release
+    # [12] Emscripten, wasm + pthread, release
     #
     # The job of this build is to create a JavaScript library that can be
     # loaded into a web page or Node.JS.  For an example:
@@ -458,6 +458,28 @@ matrix:
         - EXTENSIONS=-  # requests inclusion of no extensions (default?)
 
 
+    # [13] Emscripten, asm.js + emterpreter, release
+    #
+    # The job of this build is to create a JavaScript library that can be
+    # loaded into a web page or Node.JS.  For an example:
+    #
+    # https://github.com/hostilefork/replpad-js
+    #
+    - os: osx
+      osx_image: xcode10.1  # was originally using xcode9.3beta
+      language: c
+      env:
+        - NUMBER=12
+        - CONFIG=emterpreter.r
+        - OS_ID=0.16.1
+        - DEBUG=none
+        - OPTIMIZE=z
+        - STANDARD=c
+        - RIGOROUS=no
+        - STATIC=no
+        - WITH_FFI=no
+        - ODBC_REQUIRES_LTDL=no
+        - EXTENSIONS=-  # requests inclusion of no extensions (default?)
 # The install step occurs before the `script:` step runs.  The language that
 # was specified in the `matrix:` entry for each instance will guide certain
 # default tools that will be installed.  But you can add custom steps:

--- a/make/configs/emterpreter.r
+++ b/make/configs/emterpreter.r
@@ -1,0 +1,36 @@
+REBOL []
+
+os-id: 0.16.1 ; JS, web, emterpreter
+
+; Right now, either #web or #node
+;
+javascript-environment: #web
+
+
+; The inability to communicate synchronously between the worker and GUI in
+; JavaScript means that being deep in a C-based interpreter stack on the
+; worker cannot receive data from the GUI.  The "Emterpreter" works around
+; this limitation by running a JavaScript bytecode simulator...so even if
+; a JavaScript stack can't be paused, the bytecode interpreter can, long
+; enough to release the GUI thread it was running on to do let it do work.
+;
+; https://github.com/emscripten-core/emscripten/wiki/Emterpreter
+;
+; That's a slow and stopgap measure, which makes the build products twice as
+; large and much more than twice as slow.  It is supplanted entirely with a
+; superior approach based on WASM threads.  In this model, the GUI thread is
+; left free, while the code that's going to make demands runs on its own
+; thread...which can suspend and wait, using conventional atomics (mutexes,
+; wait conditions).
+;
+; There was some issue with WASM threading being disabled in 2018 due to
+; Spectre vulnerabilities in SharedArrayBuffer.  This seems to be mitigated,
+; and approaches are now focusing on assuming that the thread-based solution
+; will be available.  The emterpreter method is preserved as a fallback, but
+; should not be used without good reason--only basic features are implemented.
+;
+use-emterpreter: true
+
+use-wasm: false
+
+config: %emscripten.r

--- a/make/default-config.r
+++ b/make/default-config.r
@@ -96,3 +96,5 @@ ldflags: _
 main: _
 
 top: _
+
+config: _

--- a/make/make.r
+++ b/make/make.r
@@ -38,7 +38,16 @@ either commands: try find args '| [
 for-each [name value] options [
     switch name [
         'CONFIG 'LOAD 'DO [
-            user-config: make user-config load to-file value
+            config: to-file value
+            while [config] [
+                set [path: f:] split-path config
+                bak: system/options/current-path
+                cd :path
+                user-config/config: _
+                user-config: make user-config load f
+                config: try attempt [clean-path user-config/config]
+                cd :bak
+            ]
         ]
         'EXTENSIONS [
             ; [+|-|*] [NAME {+|-|*|[modules]}]... 
@@ -1599,7 +1608,7 @@ for-each ext dynamic-extensions [
 
 top: make rebmake/entry-class [
     target: 'top ; phony target
-    depends: flatten reduce ??
+    depends: flatten reduce
         either tmp: select user-config 'top
         [either block? tmp [tmp] [reduce [tmp]]]
         [[ app dynamic-libs ]]
@@ -1620,6 +1629,7 @@ clean: make rebmake/entry-class [
         make rebmake/cmd-delete-class [file: %objs/]
         make rebmake/cmd-delete-class [file: %prep/]
         make rebmake/cmd-delete-class [file: join %r3 opt rebmake/target-platform/exe-suffix]
+        make rebmake/cmd-delete-class [file:  %libr3.*]
     ]
 ]
 

--- a/make/tools/systems.r
+++ b/make/tools/systems.r
@@ -268,9 +268,11 @@ systems: [
 
     Emscripten: 16
     ;-------------------------------------------------------------------------
-    0.16.01 emscripten-asm/emscripten "asm.js"
-        #SG? #LEN /NOWASM
-    0.16.02 emscripten-wasm/emscripten "webassembly"
+    0.16.01 emterpreter/emscripten "emterpreter"
+        #SG? #LEN
+    0.16.02 pthread/emscripten "emscripten"
+        #SG? #LEN
+    0.16.03 node/emscripten "node.js"
         #SG? #LEN
 
     AIX: 17
@@ -396,7 +398,7 @@ linker-flags: make object! [
 
     CON: [<gnu:-mconsole> <msc:/subsystem:console>]
     S4M: [<gnu:-Wl,--stack=4194300> <msc:/stack:4194300>]
-    NOWASM: "-s WASM=0" ; emscripten webassembly
+    ;NOWASM: "-s WASM=0" ; emscripten webassembly
 ]
 
 system-libraries: make object! [


### PR DESCRIPTION
build emterpreted asm.js code and add to Travis

it sets some words, then chains* to configs/emscripten.r

* new mechanism to "chain" configs files:
  put in a `config: NEXT-CONFIG-FILE` line
  So you can build a tree of config files.