### PR TITLE
Make PARSE COPY give just BLOCK!/GROUP!/TEXT!/BINARY!

### DIFF
--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -594,17 +594,17 @@ split: function [
         return map-each len dlm [
             if len <= 0 [
                 series: skip series negate len
-                continue ;-- don't add to output
+                continue  ; don't add to output
             ]
             copy/part series series: skip series len
         ]
     ]
 
-    if tag? dlm [dlm: form dlm] ;-- reserve other strings for future meanings
+    if tag? dlm [dlm: form dlm]  ; reserve other strings for future meanings
 
     result: collect [
         parse series if integer? dlm [
-            size: dlm ;-- alias for readability in integer case
+            size: dlm  ; alias for readability in integer case
             if size < 1 [fail "Bad SPLIT size given:" size]
 
             if into [

--- a/tests/parse-tests.r
+++ b/tests/parse-tests.r
@@ -289,9 +289,12 @@
 (did parse [... [a b]] [thru '[a b] end])
 (did parse [1 1 1] [some '1 end])
 
+; Quote level is currently retained by the return value, but not by the
+; captured content.
+;
 (did all [
     lit ''[] == parse lit ''[1 + 2] [copy x to end]
-    x == lit ''[1 + 2]
+    x == [1 + 2]
 ])
 
 


### PR DESCRIPTION
PARSE's COPY command was changed between Rebol2 and R3-Alpha to
preserve the BINARY!/string distinction.  Previously a parsed binary
would come back as a string:

    rebol2>> parse #{42434445} [copy x to end]
    == true

    rebol2>> x
    == "BCDE"

This was changed--but beyond changing just this case, it was assumed
that the returned type from COPY should match the type of the input.
This meant that copying a fragment out of a URL! would give a URL!
(for instance) even though it was not well-formed.

    r3-alpha>> parse http://example.com ["http://" thru "." copy x to end]
    == true

    r3-alpha>> x
    == com

    r3-alpha>> type? x
    == url!

Other awkward situations arose for copying pieces out of PATH!, which
are now considered illegal in Ren-C due to path immutability and
making them follow specific rules (they are not generic containers like
BLOCK! and GROUP! are):

    r3-alpha>> parse 'a/b/c [skip skip copy x to end]
    == true

    r3-alpha>> x
    == c

    r3-alpha>> type? x
    == path!

This commit keeps the choice to preserve BLOCK! and GROUP! distinction,
as well as the BINARY! distinction, but makes PARSE of a string always
COPY a TEXT!.  This helps even in cases like tags, where copying `<bc>`
out of `<abcd>` may not make an illegal tag, but makes a somewhat
unnatural suggestion that `<b` or `c>` were in the initial sequence.
The neturality of text in printing no delimiters avoids that.