### PR TITLE
Make it possible to AWAIT in JS-AWAITER

### DIFF
--- a/make/tools/make-reb-lib.r
+++ b/make/tools/make-reb-lib.r
@@ -1075,9 +1075,16 @@ e-cwrap/emit {
             resolve_or_reject(arg, 1)
         }
 
-        var dummy = RL_JS_NATIVES[id](resolve, reject)
-        if (dummy !== undefined)
-            throw Error("JS-AWAITER cannot return a value, use resolve()")
+        /* Is an `async` function and hence returns a Promise.  We aren't
+         * expecting it to return a value, so the only time it should return
+         * anything but undefined (same as no return or no argument to return)
+         * is if it AWAITs.
+         */
+        RL_JS_NATIVES[id](resolve, reject)
+          .then(function(dummy) {
+            if (dummy !== undefined)
+                throw Error("JS-AWAITER can't return a value, use resolve()")
+          }).catch(reject)
     }
 
     reb.GetNativeResult_internal = function(frame_id) {


### PR DESCRIPTION
This adds the ability to use the JavaScript AWAIT statement in a
JS-AWAITER.  It does so by labeling those functions `async`.

These functions were previously not expected to return a value, rather
to (eventually) call one of the resolve() or reject() functions passed
to them as implicit parameters.  With this change, they will return
an ES6 Promise.  If AWAIT is called then that promise will not be
in a fulfilled state when the promise is returned, and it must be
waited on.