### PR TITLE
Change Refinements to being their own Arguments

### DIFF
--- a/extensions/clipboard/mod-clipboard.c
+++ b/extensions/clipboard/mod-clipboard.c
@@ -52,8 +52,8 @@ static REB_R Clipboard_Actor(
 
     case SYM_REFLECT: {
         INCLUDE_PARAMS_OF_REFLECT;
+        UNUSED(ARG(value));  // implied by `port`
 
-        UNUSED(ARG(value)); // implied by `port`
         REBSYM property = VAL_WORD_SYM(ARG(property));
         assert(property != 0);
 
@@ -69,18 +69,13 @@ static REB_R Clipboard_Actor(
 
     case SYM_READ: {
         INCLUDE_PARAMS_OF_READ;
+        UNUSED(ARG(source));  // implied by `port`
 
-        UNUSED(PAR(source)); // already accounted for
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+        if (REF(part) or REF(seek))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
-        UNUSED(PAR(string)); // handled in dispatcher
-        UNUSED(PAR(lines)); // handled in dispatcher
+
+        UNUSED(REF(string));  // handled in dispatcher
+        UNUSED(REF(lines));  // handled in dispatcher
 
         SetLastError(NO_ERROR);
         if (not IsClipboardFormatAvailable(CF_UNICODETEXT)) {
@@ -128,21 +123,10 @@ static REB_R Clipboard_Actor(
 
     case SYM_WRITE: {
         INCLUDE_PARAMS_OF_WRITE;
+        UNUSED(ARG(destination));  // implied by `port`
+        UNUSED(ARG(data)); // implied by `arg`
 
-        UNUSED(PAR(destination));
-        UNUSED(PAR(data)); // used as arg
-
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(append))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(lines))
+        if (REF(seek) or REF(append) or REF(allow) or REF(lines))
             fail (Error_Bad_Refines_Raw());
 
         // !!! Traditionally the currency of READ and WRITE is binary data.
@@ -155,8 +139,8 @@ static REB_R Clipboard_Actor(
         // Handle /part refinement:
         //
         REBINT len = VAL_LEN_AT(arg);
-        if (REF(part) and VAL_INT32(ARG(limit)) < len)
-            len = VAL_INT32(ARG(limit));
+        if (REF(part) and VAL_INT32(ARG(part)) < len)
+            len = VAL_INT32(ARG(part));
 
         if (not OpenClipboard(NULL))
             rebJumps(
@@ -204,20 +188,10 @@ static REB_R Clipboard_Actor(
 
     case SYM_OPEN: {
         INCLUDE_PARAMS_OF_OPEN;
-
         UNUSED(PAR(spec));
-        if (REF(new))
+
+        if (REF(new) or REF(read) or REF(write) or REF(seek) or REF(allow))
             fail (Error_Bad_Refines_Raw());
-        if (REF(read))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(write))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(seek))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         // !!! Currently just ignore (it didn't do anything)
 

--- a/extensions/console/mod-console.c
+++ b/extensions/console/mod-console.c
@@ -297,8 +297,7 @@ REBNATIVE(console)
 
     REBVAL *code;
     if (REF(provoke)) {
-        code = rebArg("provocation", rebEND);  // fetch as an API handle
-        UNUSED(ARG(provocation));
+        code = rebArg("provoke", rebEND);  // fetch as an API handle
         goto provoked;
     }
     else {
@@ -494,11 +493,11 @@ REBNATIVE(resume)
 
     if (REF(with)) {
         Init_False(ARR_AT(instruction, RESUME_INST_MODE)); // don't DO
-        Move_Value(ARR_AT(instruction, RESUME_INST_PAYLOAD), ARG(value));
+        Move_Value(ARR_AT(instruction, RESUME_INST_PAYLOAD), ARG(with));
     }
     else if (REF(do)) {
         Init_True(ARR_AT(instruction, RESUME_INST_MODE)); // DO value
-        Move_Value(ARR_AT(instruction, RESUME_INST_PAYLOAD), ARG(code));
+        Move_Value(ARR_AT(instruction, RESUME_INST_PAYLOAD), ARG(do));
     }
     else {
         Init_Blank(ARR_AT(instruction, RESUME_INST_MODE)); // use default

--- a/extensions/console/mod-console.c
+++ b/extensions/console/mod-console.c
@@ -241,12 +241,11 @@ static REBVAL *Run_Sandboxed_Group(REBVAL *group) {
 //
 //  export console: native [
 //
-//  {Runs an instance of a customizable Read-Eval-Print Loop}
+//  {Runs customizable Read-Eval-Print Loop, may "provoke" code before input}
 //
 //      return: "Integer if QUIT result, path if RESUME instruction"
 //          [integer! path!]
-//      /provoke "Give the console some code to run before taking user input"
-//      provocation "Block must return a console state, group is cancellable"
+//      /provoke "Block must return a console state, group is cancellable"
 //          [block! group!]
 //      /resumable "Allow RESUME instruction (will return a PATH!)"
 //  ]
@@ -440,14 +439,10 @@ enum {
 //
 //  {Resume after a breakpoint, can evaluate code in the breaking context.}
 //
-//      /with
-//          "Return the given value as return value from BREAKPOINT"
-//      value [any-value!]
-//          "Value to use"
-//      /do
-//          "Evaluate given code as return value from BREAKPOINT"
-//      code [block!]
-//          "Code to evaluate"
+//      /with "Return the given value as return value from BREAKPOINT"
+//          [any-value!]
+//      /do "Evaluate given code as return value from BREAKPOINT"
+//          [block!]
 //  ]
 //
 REBNATIVE(resume)

--- a/extensions/console/p-console.c
+++ b/extensions/console/p-console.c
@@ -58,14 +58,12 @@ REB_R Console_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
 
         UNUSED(PAR(source));
 
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+        if (REF(part))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(seek)) {
-            UNUSED(ARG(index));
+
+        if (REF(seek))
             fail (Error_Bad_Refines_Raw());
-        }
+
         UNUSED(PAR(string)); // handled in dispatcher
         UNUSED(PAR(lines)); // handled in dispatcher
 

--- a/extensions/debugger/ext-debugger-init.reb
+++ b/extensions/debugger/ext-debugger-init.reb
@@ -26,12 +26,9 @@ backtrace*: function [
         "Where to consider the trace point as starting from"
     level [blank! integer! action!]
         "Stack level to return frame for (blank to list)"
-    /limit
-        "Limit the length of the backtrace"
-    frames [blank! integer!]
-        "Max number of frames (pending and active), blank for no limit"
-    /brief
-        "Do not list depths, just function labels on one line"
+    /limit "Max number of frames (pending and active), false for no limit"
+        [logic! integer!]
+    /brief "Do not list depths, just function labels on one line"
 ][
     get-frame: not blank? :level
 
@@ -47,23 +44,25 @@ backtrace*: function [
         ]
     ]
 
-    ; The "frames" from /LIMIT, plus one (for ellipsis)
-    ; Default 20, as on an 80x25 terminal leaves room to type afterward
-    ;
-    max-rows: 20 unless (limit and [
-        if blank? frames [
-            99999 ; as many frames as possible
-        ] else [
-            if frames < 0 [
+    max-rows: case [
+        blank? limit [
+            20  ; Default 20, leaves room to type on 80x25 terminal
+        ]
+        limit = false [
+            99999  ; as many frames as possible
+        ]
+        integer? limit [
+            if limit < 0 [
                 fail ["Invalid limit of frames" frames]
             ]
-            frames + 1 ; add one for ellipsis
+            limit + 1  ; add one for ellipsis
         ]
-    ])
+        fail
+    ]
 
-    row: 0 ; row we're on (incl. pending frames and maybe ellipsis)
-    number: 0 ; level label number in the loop (no pending frames)
-    first-frame: true ; special check of first frame for "breakpoint 0"
+    row: 0  ; row we're on (incl. pending frames and maybe ellipsis)
+    number: 0  ; level label number in the loop (no pending frames)
+    first-frame: true  ; special check of first frame for "breakpoint 0"
 
     f: start
 

--- a/extensions/event/p-event.c
+++ b/extensions/event/p-event.c
@@ -208,18 +208,9 @@ REB_R Event_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_OPEN;
 
         UNUSED(PAR(spec));
-        if (REF(new))
+
+        if (REF(new) or REF(read) or REF(write) or REF(seek) or REF(allow))
             fail (Error_Bad_Refines_Raw());
-        if (REF(read))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(write))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(seek))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         REBREQ *req = OS_MAKE_DEVREQ(RDI_EVENT);
 

--- a/extensions/gob/t-gob.c
+++ b/extensions/gob/t-gob.c
@@ -950,8 +950,6 @@ REBTYPE(Gob)
             VAL_WORD_SYM(verb) == SYM_CHANGE
             && (REF(part) || REF(only) || REF(dup))
         ){
-            UNUSED(PAR(limit));
-            UNUSED(PAR(count));
             fail (Error_Not_Done_Raw());
         }
 
@@ -978,11 +976,8 @@ REBTYPE(Gob)
         if (REF(line))
             fail (Error_Bad_Refines_Raw());
 
-        if (REF(part) || REF(only) || REF(dup)) {
-            UNUSED(PAR(limit));
-            UNUSED(PAR(count));
+        if (REF(part) || REF(only) || REF(dup))
             fail (Error_Not_Done_Raw());
-        }
 
         REBCNT len;
         if (IS_GOB(arg)) {
@@ -1010,7 +1005,7 @@ REBTYPE(Gob)
         INCLUDE_PARAMS_OF_REMOVE;
         UNUSED(PAR(series));
 
-        REBCNT len = REF(part) ? Get_Num_From_Arg(ARG(limit)) : 1;
+        REBCNT len = REF(part) ? Get_Num_From_Arg(ARG(part)) : 1;
         if (index + len > tail)
             len = tail - index;
         if (index < tail && len != 0)
@@ -1036,7 +1031,6 @@ REBTYPE(Gob)
             "applique :take* [",
                 "series: at", pane, rebI(index + 1),
                 "part:", ARG(part),
-                "limit:", ARG(limit),
                 "deep:", ARG(deep),
                 "last:", ARG(last),
             "]",

--- a/extensions/odbc/ext-odbc-init.reb
+++ b/extensions/odbc/ext-odbc-init.reb
@@ -126,11 +126,8 @@ sys/make-scheme [
             insert-odbc port/locals reduce compose [(sql)]
         ]
 
-        copy: function [port [port!] /part length [integer!]] [
-            if not part [
-                length: blank
-            ]
-            copy-odbc port/locals length
+        copy: function [port [port!] /part [integer!]] [
+            copy-odbc port/locals part
         ]
     ]
 ]

--- a/extensions/process/mod-process.c
+++ b/extensions/process/mod-process.c
@@ -82,12 +82,12 @@
 //      /console "Runs command with I/O redirected to console"
 //      /shell "Forces command to be run from shell"
 //      /info "Returns process information object"
-//      /input "Redirects stdin to in (if blank, /dev/null)"
-//      in [text! binary! file! blank!]
-//      /output "Redirects stdout to out (if blank, /dev/null)"
-//      out [text! binary! file! blank!]
-//      /error "Redirects stderr to err (if blank, /dev/null)"
-//      err [text! binary! file! blank!]
+//      /input "Redirects stdin (false=/dev/null, true=inherit)"
+//          [text! binary! file! logic!]
+//      /output "Redirects stdout (false=/dev/null, true=inherit)"
+//          [text! binary! file! logic!]
+//      /error "Redirects stderr (false=/dev/null, true=inherit)"
+//          [text! binary! file! logic!]
 //  ]
 //
 REBNATIVE(call_internal_p)

--- a/extensions/tcc/ext-tcc-init.reb
+++ b/extensions/tcc/ext-tcc-init.reb
@@ -45,15 +45,14 @@ compile: function [
 
     return: <void>
     compilables "Functions from MAKE-NATIVE, TEXT! strings of code, ..."
-    /with
-    settings [block!] {
+    /settings [block!] {
         The block supports the following dialect:
             options [text!]
             include-path [block! file! text!]
             library-path [block! file! text!]
             library [block! file! text!]
             runtime-path [file! text!]
-            debug [word! logic!] ;; currently unimplemented
+            debug [word! logic!]  ; !!! currently unimplemented
     }
     /inspect "Return the C source code as text, but don't compile it"
 ][
@@ -67,9 +66,10 @@ compile: function [
         fail ["COMPILABLES must have at least one element"]
     ]
 
-    ; !!! BLOCK! is preprocessed into an OBJECT! for COMPILE*.  It would be
-    ; difficult to check a passed-in object for validity as well as add to
-    ; it when needed: https://github.com/rebol/rebol-issues/issues/2334
+    ; !!! `settings` BLOCK! is preprocessed into a `config` OBJECT! for
+    ; COMPILE*.  It's difficult to check a passed-in object for validity as
+    ; well as add to it when needed:
+    ; https://github.com/rebol/rebol-issues/issues/2334
 
     settings: default [[]]
     config: make object! [

--- a/extensions/tcc/mod-tcc.c
+++ b/extensions/tcc/mod-tcc.c
@@ -298,16 +298,14 @@ REB_R Pending_Native_Dispatcher(REBFRM *f) {
 //
 //  {Create an ACTION! which is compiled from a C source STRING!}
 //
-//      return: [action!]
-//          "Function value, will be compiled on demand or by COMPILE"
-//      spec [block!]
-//          "The spec of the native"
-//      source [text!]
-//          "C source of the native implementation"
-//      /linkname
-//          "Provide a specific linker name"
-//      name [text!]
-//          "Legal C identifier (default will be auto-generated)"
+//      return: "Function value, will be compiled on demand or by COMPILE"
+//          [action!]
+//      spec "Rebol parameter definitions (similar to FUNCTION's spec)"
+//          [block!]
+//      source "C source of the native implementation"
+//          [text!]
+//      /linkname "Provide a specific linker name (default is auto-generated)"
+//          [text!]
 //  ]
 //
 REBNATIVE(make_native)
@@ -345,14 +343,14 @@ REBNATIVE(make_native)
     );
 
     if (REF(linkname)) {
-        REBVAL *name = ARG(name);
+        REBVAL *linkname = ARG(linkname);
 
-        if (Is_Series_Frozen(VAL_SERIES(name)))
-            Move_Value(ARR_AT(details, IDX_TCC_NATIVE_LINKNAME), name);
+        if (Is_Series_Frozen(VAL_SERIES(linkname)))
+            Move_Value(ARR_AT(details, IDX_TCC_NATIVE_LINKNAME), linkname);
         else {
             Init_Text(
                 ARR_AT(details, IDX_TCC_NATIVE_LINKNAME),
-                Copy_String_At(name)
+                Copy_String_At(linkname)
             );
         }
     }

--- a/extensions/vector/t-vector.c
+++ b/extensions/vector/t-vector.c
@@ -641,16 +641,8 @@ REBTYPE(Vector)
         INCLUDE_PARAMS_OF_COPY;
         UNUSED(PAR(value));  // same as `v`
 
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+        if (REF(part) or REF(deep) or REF(types))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(deep))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(types)) {
-            UNUSED(ARG(kinds));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         REBBIN *bin = Copy_Sequence_Core(
             VAL_BINARY(VAL_VECTOR_BINARY(v)),

--- a/extensions/view/ext-view-init.reb
+++ b/extensions/view/ext-view-init.reb
@@ -10,18 +10,15 @@ REBOL [
 ; Move the default filters to usermode code, instead of a hardcoded C literal
 ;
 request-file: adapt :request-file* [
-    if not filter [
-        ;
-        ; !!! What notation should be used to indicate the default filter?
-        ; Perhaps put in a GROUP!?
-        ;
-        filter: true
-        list: [
-            "All files"         %*.*
-            "Rebol scripts"     %*.r
-            ; ("Default idea"   %*.xxx)
-            "Text files"        %*.txt
-        ]
+    ;
+    ; !!! What notation should be used to indicate the default filter?
+    ; Perhaps put in a GROUP!?
+    ;
+    filter: default [
+        "All files"         %*.*
+        "Rebol scripts"     %*.r
+        ; ("Default idea"   %*.xxx)
+        "Text files"        %*.txt
     ]
 ]
 

--- a/extensions/view/mod-view.c
+++ b/extensions/view/mod-view.c
@@ -104,11 +104,11 @@ bool osDialogOpen = false;
 //      /save "File save mode"
 //      /multi "Allows multiple file selection, returned as a block"
 //      /file "Default file name or directory"
-//      name [file!]
+//          [file!]
 //      /title "Window title"
-//      text [text!]
+//          [text!]
 //      /filter "Block of filters (filter-name filter)"
-//      list [block!]
+//          [block!]
 //  ]
 //
 REBNATIVE(request_file_p)
@@ -539,12 +539,10 @@ int CALLBACK ReqDirCallbackProc(
 //
 //  "Asks user to select a directory and returns it as file path"
 //
-//      /title
-//          "Custom dialog title text"
-//      text [text!]
-//      /path
-//          "Default directory path"
-//      dir [file!]
+//      /title "Custom dialog title text"
+//          [text!]
+//      /path "Default directory path"
+//          [file!]
 //  ]
 //
 REBNATIVE(request_dir_p)

--- a/extensions/zeromq/mod-zeromq.c
+++ b/extensions/zeromq/mod-zeromq.c
@@ -8,7 +8,7 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // Copyright 2011 Andreas Bolka <a AT bolka DOT at>
-// Copyright 2018 Rebol Open Source Contributors
+// Copyright 2018-2019 Rebol Open Source Contributors
 // REBOL is a trademark of REBOL Technologies
 //
 // See README.md and CREDITS.md for more information.
@@ -71,7 +71,7 @@ ATTRIBUTE_NO_RETURN static void fail_ZeroMQ(void) {
 
 
 //
-//  export zmq-init: native [ ;; >= 0MQ 2.0.7
+//  export zmq-init: native [  ; >= 0MQ 2.0.7
 //
 //  {Initialise 0MQ context}
 //
@@ -585,7 +585,7 @@ REBNATIVE(zmq_setsockopt) {
 //      name "see http://api.zeromq.org/4-1:zmq-getsockopt"
 //          [word! integer!]
 //      /type "If name is an INTEGER!, specify the return type"
-//      datatype [datatype!]
+//          [datatype!]
 //  ]
 //
 REBNATIVE(zmq_getsockopt) {
@@ -599,7 +599,7 @@ REBNATIVE(zmq_getsockopt) {
         name = rebUnboxInteger(ARG(name)); // take their word for it :-/
         if (not REF(type))
             rebJumps("FAIL {INTEGER! name use requires /TYPE specification}");
-        datatype = ARG(datatype);
+        datatype = ARG(type);
     }
     else {
         if (REF(type))
@@ -875,7 +875,7 @@ REBNATIVE(zmq_poll)
 //      frontend [handle!] {Socket handle}
 //      backend [handle!] {Socket handle}
 //      /capture
-//      capturer [handle!] {Socket handle}
+//          [handle!] {Socket handle}
 //  ]
 //
 REBNATIVE(zmq_proxy) {
@@ -886,7 +886,7 @@ REBNATIVE(zmq_proxy) {
 
     void *capture_socket;
     if (REF(capture))
-        capture_socket = VAL_HANDLE_VOID_POINTER(ARG(capturer));
+        capture_socket = VAL_HANDLE_VOID_POINTER(ARG(capture));
     else
         capture_socket = nullptr;
 

--- a/make.r
+++ b/make.r
@@ -144,11 +144,11 @@ to-obj-path: func [
 
 gen-obj: func [
     s
-    /dir directory [any-string!]
-    /D definitions [block!]
-    /I includes [block!]
-    /F cflags [block!]
-    /main ; for main object
+    /dir "directory" [any-string!]
+    /D "definitions" [block!]
+    /I "includes" [block!]
+    /F "cflags" [block!]
+    /main "for main object"
     <local>
     flags
 ][
@@ -223,11 +223,11 @@ gen-obj: func [
         s: s/1
     ]
 
-    if F [append flags :cflags]
+    append flags opt F  ; cflags
 
     make rebmake/object-file-class compose/only [
         source: to-file case [
-            dir [join directory s]
+            dir [join dir s]
             main [s]
             default [join src-dir s]
         ]
@@ -236,8 +236,8 @@ gen-obj: func [
                 join %main/ (last ensure path! s)
             ] [s]
         cflags: either empty? flags [_] [flags]
-        definitions: (try get 'definitions)
-        includes: (try get 'includes)
+        definitions: D
+        includes: I
     ]
 ]
 
@@ -1232,11 +1232,11 @@ all-extensions: join builtin-extensions dynamic-extensions
 add-project-flags: func [
     return: <void>
     project [object!]
-    /I includes
-    /D definitions
-    /c cflags
-    /O optimization
-    /g debug
+    /I "includes" [block!]
+    /D "definitions" [block!]
+    /c "cflags" [block!]
+    /O "optimization" [any-value!] ; !!! types?
+    /g "debug" [any-value!]  ; !!! types?
 ][
     assert [
         find [
@@ -1249,31 +1249,31 @@ add-project-flags: func [
 
     if D [
         if block? project/definitions [
-            append project/definitions definitions
+            append project/definitions D
         ] else [
             ensure blank! project/definitions
-            project/definitions: definitions
+            project/definitions: D
         ]
     ]
 
     if I [
         if block? project/includes [
-            append project/includes includes
+            append project/includes I
         ] else [
             ensure blank! project/includes
-            project/includes: includes
+            project/includes: I
         ]
     ]
     if c [
         if block? project/cflags [
-            append project/cflags cflags
+            append project/cflags c
         ] else [
             ensure blank! project/cflags
-            project/cflags: cflags
+            project/cflags: c
         ]
     ]
-    if g [project/debug: debug]
-    if O [project/optimization: optimization]
+    if g [project/debug: g]
+    if O [project/optimization: O]
 ]
 
 process-module: func [

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -151,11 +151,11 @@ Script: [
     no-refine:          [:arg1 {has no refinement called} :arg2]
     bad-refines:        {incompatible or invalid refinements}
     bad-refine:         [{incompatible or duplicate refinement:} :arg1]
-    argument-revoked:   [:arg1 {refinement revoked, cannot supply} :arg2]
-    bad-refine-revoke:  [:arg1 {refinement in use, can't be revoked by} :arg2]
     non-logic-refine:   [:arg1 {refinement must be LOGIC!, not} :arg2]
-    refinement-arg-opt: [{refinement arguments cannot be <opt>}]
-    ambiguous-partial:  {Ambiguous partial (try SPECIALIZE-ing a PATH!)}
+    legacy-refinement:  [
+                            {Refinements now act as their own args.  See}
+                            {https://trello.com/c/DaVz9GG3 - spec was} :arg1
+                        ]
 
     bad-field-set:      [{cannot set} :arg1 {field to} :arg2 {datatype}]
     bad-path-pick:      [{cannot pick} :arg1 {in path}]

--- a/src/boot/generics.r
+++ b/src/boot/generics.r
@@ -91,62 +91,59 @@ power: generic [
 
 
 intersect: generic [
-    {Returns the intersection (AND) of two values.}
+    {Returns the intersection (AND) of two values}
+
     value1 [
-        logic! integer! char! tuple! ;-- math
-        any-array! any-string! bitset! typeset! ;-- sets
+        logic! integer! char! tuple!  ; math
+        any-array! any-string! bitset! typeset!  ; sets
         binary! ;-- ???
     ]
     value2 [
-        logic! integer! char! tuple! ;-- math
-        any-array! any-string! bitset! typeset! ;-- sets
-        binary! ;-- ???
+        logic! integer! char! tuple!  ; math
+        any-array! any-string! bitset! typeset!  ; sets
+        binary!  ; ???
     ]
-    /case
-        "Uses case-sensitive comparison"
-    /skip
-        "Treat the series as records of fixed size"
-    size [integer!]
+    /case "Uses case-sensitive comparison"
+    /skip "Treat the series as records of fixed size"
+        [integer!]
 ]
 
 union: generic [
-    {Returns the union (OR) of two values.}
+    {Returns the union (OR) of two values}
+
     value1 [
-        logic! integer! char! tuple! ;-- math
-        any-array! any-string! bitset! typeset! ;-- sets
-        binary! ;-- ???
+        logic! integer! char! tuple!  ; math
+        any-array! any-string! bitset! typeset!  ; sets
+        binary!  ; ???
     ]
     value2 [
-        logic! integer! char! tuple! ;-- math
-        any-array! any-string! bitset! typeset! ;-- sets
-        binary! ;-- ???
+        logic! integer! char! tuple!  ; math
+        any-array! any-string! bitset! typeset!  ; sets
+        binary!  ; ???
     ]
-    /case
-        "Use case-sensitive comparison"
-    /skip
-        "Treat the series as records of fixed size"
-    size [integer!]
+    /case "Use case-sensitive comparison"
+    /skip "Treat the series as records of fixed size"
+        [integer!]
 ]
 
 difference: generic [
-    {Returns the special difference (XOR) of two values.}
+    {Returns the special difference (XOR) of two values}
+
     value1 [
-        logic! integer! char! tuple! ;-- math
-        any-array! any-string! bitset! typeset! ;-- sets
-        binary! ;-- ???
-        date! ;-- !!! Under review, this really doesn't fit
+        logic! integer! char! tuple!  ; math
+        any-array! any-string! bitset! typeset!  ; sets
+        binary!  ; ???
+        date!  ; !!! Under review, this really doesn't fit
     ]
     value2 [
-        logic! integer! char! tuple! ;-- math
-        any-array! any-string! bitset! typeset! ;-- sets
-        binary! ;-- ???
-        date! ;-- !!! Under review, this really doesn't fit
+        logic! integer! char! tuple!  ; math
+        any-array! any-string! bitset! typeset!  ; sets
+        binary!  ; ???
+        date!  ; !!! Under review, this really doesn't fit
     ]
-    /case
-        "Uses case-sensitive comparison"
-    /skip
-        "Treat the series as records of fixed size"
-    size [integer!]
+    /case "Uses case-sensitive comparison"
+    /skip "Treat the series as records of fixed size"
+        [integer!]
 ]
 
 
@@ -168,15 +165,17 @@ absolute: generic [
 ]
 
 round: generic [
-    {Rounds a numeric value; halves round up (away from zero) by default.}
-    value [any-number! pair! money! time!] "The value to round"
-    /to "Return the nearest multiple of the scale parameter"
-    scale [any-number! money! time!] "Must be a non-zero value"
-    /even      "Halves round toward even results"
-    /down      "Round toward zero, ignoring discarded digits. (truncate)"
+    {Rounds a numeric value; halves round up (away from zero) by default}
+
+    value "The value to round"
+        [any-number! pair! money! time!] 
+    /to "Return the nearest multiple of the parameter (must be non-zero)"
+        [any-number! money! time!]
+    /even "Halves round toward even results"
+    /down "Round toward zero, ignoring discarded digits. (truncate)"
     /half-down "Halves round toward zero"
-    /floor     "Round in negative direction"
-    /ceiling   "Round in positive direction"
+    /floor "Round in negative direction"
+    /ceiling "Round in positive direction"
     /half-ceiling "Halves round in positive direction"
 ]
 
@@ -226,37 +225,39 @@ at: generic [
 
 find: generic [
     {Searches for the position where a matching value is found}
-    return: {position found, else null - logic true if non-positional find}
+
+    return: "position found, else null - logic true if non-positional find"
         [<opt> <requote> any-series! logic!]
     series [
         <blank> <dequote> any-series! any-context! map! gob! bitset! typeset!
     ]
     pattern [any-value!]
-    /part {Limits the search to a given length or position}
-    limit [any-number! any-series! pair!]
-    /only {Treats a series value as only a single value}
-    /case {Characters are case-sensitive}
-    /skip {Treat the series as records of fixed size}
-    size [integer!]
-    /tail {Returns the end of the series}
-    /match {Performs comparison and returns the tail of the match}
+    /part "Limits the search to a given length or position"
+        [any-number! any-series! pair!]
+    /only "Treats a series value as only a single value"
+    /case "Characters are case-sensitive"
+    /skip "Treat the series as records of fixed size"
+        [integer!]
+    /tail "Returns the end of the series"
+    /match "Performs comparison and returns the tail of the match"
     /reverse "Deprecated: https://forum.rebol.info/t/1126"
     /last "Deprecated: https://forum.rebol.info/t/1126"
 ]
 
 select: generic [
-    {Searches for a value; returns the value that follows, else void.}
+    {Searches for a value; returns the value that follows, else null}
+
     return: [<opt> any-value!]
     series [<blank> any-series! any-context! map!]
     value [any-value!]
-    /part {Limits the search to a given length or position}
-    limit [any-number! any-series! pair!]
-    /only {Treats a series value as only a single value}
-    /case {Characters are case-sensitive}
-    /skip {Treat the series as records of fixed size}
-    size [integer!]
-    /tail ;-- for frame compatibility with FIND
-    /match ;-- for frame compatibility with FIND
+    /part "Limits the search to a given length or position"
+        [any-number! any-series! pair!]
+    /only "Treats a series value as only a single value"
+    /case "Characters are case-sensitive"
+    /skip "Treat the series as records of fixed size"
+        [integer!]
+    /tail  ; for frame compatibility with FIND
+    /match  ; for frame compatibility with FIND
     /reverse "Deprecated: https://forum.rebol.info/t/1126"
     /last "Deprecated: https://forum.rebol.info/t/1126"
 ]
@@ -280,25 +281,27 @@ put: generic [
 copy: generic [
     {Copies a series, object, or other value.}
 
-    return: {Return type will match the input type, or void if blank}
+    return: "Return type will match the input type, or void if blank"
         [<opt> <requote> any-value!]
-    value {If an ANY-SERIES!, it is only copied from its current position}
+    value "If an ANY-SERIES!, it is only copied from its current position"
         [<dequote> any-value!]
-    /part {Limits to a given length or position}
-    limit [any-number! any-series! pair!]
-    /deep {Also copies series values within the block}
-    /types {What datatypes to copy}
-    kinds [typeset! datatype!]
+    /part "Limits to a given length or position"
+        [any-number! any-series! pair!]
+    /deep "Also copies series values within the block"
+    /types "What datatypes to copy"
+        [typeset! datatype!]
 ]
 
 take*: generic [
-    {Removes and returns one or more elements.}
+    {Removes and returns one or more elements}
+
     return: [<opt> any-value!]
-    series [any-series! port! gob! varargs!] {At position (modified)}
-    /part {Specifies a length or end position}
-    limit [any-number! any-series! pair!]
-    /deep {Also copies series values within the block}
-    /last {Take it from the tail end}
+    series "At position (modified)"
+        [any-series! port! gob! varargs!]
+    /part "Specifies a length or end position"
+        [any-number! any-series! pair!]
+    /deep "Also copies series values within the block"
+    /last "Take it from the tail end"
 ]
 
 ; !!! INSERT, APPEND, CHANGE expect to have compatible frames...same params
@@ -306,17 +309,18 @@ take*: generic [
 ;
 insert: generic [
     {Inserts element(s); for series, returns just past the insert.}
+
     return: "Just past the insert"
         [<requote> any-series! port! map! gob! object! bitset! port!]
     series "At position (modified)"
         [<dequote> any-series! port! map! gob! object! bitset! port!]
     value [<opt> any-value!] {The value to insert}
-    /part {Limits to a given length or position}
-    limit [any-number! any-series! pair!]
-    /only {Only insert a block as a single value (not the contents of the block)}
-    /dup {Duplicates the insert a specified number of times}
-    count [any-number! pair!]
-    /line {Data should be its own line (use as formatting cue if ANY-ARRAY!)}
+    /part "Limits to a given length or position"
+        [any-number! any-series! pair!]
+    /only "Insert a block as a single value (not the contents of the block)"
+    /dup "Duplicates the insert a specified number of times"
+        [any-number! pair!]
+    /line "Data should be its own line (use as formatting cue if ANY-ARRAY!)"
 ]
 
 ; !!! INSERT, APPEND, CHANGE expect to have compatible frames...same params
@@ -324,74 +328,84 @@ insert: generic [
 ;
 append: generic [
     {Inserts element(s) at tail; for series, returns head.}
+
     return: [<requote> any-series! port! map! gob! object! module! bitset!]
     series "Any position (modified)"
         [<dequote> any-series! port! map! gob! object! module! bitset!]
-    value [<opt> any-value!] {The value to insert}
-    /part {Limits to a given length or position}
-    limit [any-number! any-series! pair!]
-    /only {Only insert a block as a single value (not the contents of the block)}
-    /dup {Duplicates the insert a specified number of times}
-    count [any-number! pair!]
-    /line {Data should be its own line (use as formatting cue if ANY-ARRAY!)}
+    value [<opt> any-value!]
+    /part "Limits to a given length or position"
+        [any-number! any-series! pair!]
+    /only "Insert a block as a single value (not the contents of the block)"
+    /dup "Duplicates the insert a specified number of times"
+        [any-number! pair!]
+    /line "Data should be its own line (use as formatting cue if ANY-ARRAY!)"
 ]
 
 ; !!! INSERT, APPEND, CHANGE expect to have compatible frames...same params
 ; at the same position, with same types!
 ;
 change: generic [
-    {Replaces element(s); returns just past the change.}
+    {Replaces element(s); returns just past the change}
+
     return: [<requote> any-series! gob! port! struct!]
     series "At position (modified)"
         [<dequote> any-series! gob! port! struct!]
     value [<opt> any-value!] {The new value}
-    /part {Limits the amount to change to a given length or position}
-    limit [any-number! any-series! pair!]
-    /only {Only change a block as a single value (not the contents of the block)}
-    /dup {Duplicates the change a specified number of times}
-    count [any-number! pair!]
-    /line {Data should be its own line (use as formatting cue if ANY-ARRAY!)}
+    /part "Limits the amount to change to a given length or position"
+        [any-number! any-series! pair!]
+    /only "Change a block as a single value (not the contents of the block)"
+    /dup "Duplicates the change a specified number of times"
+        [any-number! pair!]
+    /line "Data should be its own line (use as formatting cue if ANY-ARRAY!)"
 ]
 
 remove: generic [
-    {Removes element(s); returns same position.}
+    {Removes element(s); returns same position}
+
     return: [<requote> any-series! map! gob! port! bitset!]
     series "At position (modified)"
         [<dequote> any-series! map! gob! port! bitset!]
-    /part {Removes multiple elements or to a given position}
-    limit [any-number! any-series! pair! char!]
+    /part "Removes multiple elements or to a given position"
+        [any-number! any-series! pair! char!]
 ]
 
 clear: generic [
-    {Removes elements from current position to tail; returns at new tail.}
-    series [any-series! port! map! gob! bitset!] {At position (modified)}
+    {Removes elements from current position to tail; returns at new tail}
+
+    series "At position (modified)"
+        [any-series! port! map! gob! bitset!] 
 ]
 
 swap: generic [
-    {Swaps elements between two series or the same series.}
+    {Swaps elements between two series or the same series}
+
     series1 [any-series! gob!] {At position (modified)}
     series2 [any-series! gob!] {At position (modified)}
 ]
 
 reverse: generic [
-    {Reverses the order of elements; returns at same position.}
-    series [any-series! gob! tuple! pair!] {At position (modified)}
-    /part {Limits to a given length or position}
-    limit [any-number! any-series!]
+    {Reverses the order of elements; returns at same position}
+
+    series "At position (modified)"
+        [any-series! gob! tuple! pair!]
+    /part "Limits to a given length or position"
+        [any-number! any-series!]
 ]
 
 sort: generic [
-    {Sorts a series; default sort order is ascending.}
-    series [any-series!] {At position (modified)}
-    /case {Case sensitive sort}
-    /skip {Treat the series as records of fixed size}
-    size [integer!] {Size of each record}
-    /compare  {Comparator offset, block or action}
-    comparator [integer! block! action!]
-    /part {Sort only part of a series}
-    limit [any-number! any-series!] {Length of series to sort}
-    /all {Compare all fields}
-    /reverse {Reverse sort order}
+    {Sorts a series; default sort order is ascending}
+
+    series "At position (modified)"
+        [any-series!] 
+    /case "Case sensitive sort"
+    /skip "Treat the series as records of fixed size"
+        [integer!]
+    /compare "Comparator offset, block or action"
+        [integer! block! action!]
+    /part "Sort only part of a series (by length or position)"
+        [any-number! any-series!]
+    /all "Compare all fields"
+    /reverse "Reverse sort order"
 ]
 
 ;-- Port actions:
@@ -407,14 +421,15 @@ delete: generic [
 ]
 
 open: generic [
-    {Opens a port; makes a new port from a specification if necessary.}
+    {Opens a port; makes a new port from a specification if necessary}
+
     spec [port! file! url! block!]
-    /new   {Create new file - if it exists, reset it (truncate)}
-    /read  {Open for read access}
-    /write {Open for write access}
-    /seek  {Optimize for random access}
-    /allow {Specifies protection attributes}
-        access [block!]
+    /new "Create new file - if it exists, reset it (truncate)"
+    /read "Open for read access"
+    /write "Open for write access"
+    /seek "Optimize for random access"
+    /allow "Specifies protection attributes"
+        [block!]
 ]
 
 close: generic [
@@ -433,37 +448,37 @@ read: generic [
         tuple!  ; READ/DNS returned tuple!
     ]
     source [port! file! url! block!]
-    /part {Partial read a given number of units (source relative)}
-        limit [any-number!]
-    /seek {Read from a specific position (source relative)}
-        index [any-number!]
-    /string {Convert UTF and line terminators to standard text string}
-    /lines {Convert to block of strings (implies /string)}
+    /part "Partial read a given number of units (source relative)"
+        [any-number!]
+    /seek "Read from a specific position (source relative)"
+        [any-number!]
+    /string "Convert UTF and line terminators to standard text string"
+    /lines "Convert to block of strings (implies /string)"
 ]
 
 write: generic [
-    {Writes to a file, URL, or port - auto-converts text strings.}
+    {Writes to a file, URL, or port - auto-converts text strings}
+
     destination [port! file! url! block!]
-    data [binary! text! block! object!] ; !!! CHAR! support?
-        {Data to write (non-binary converts to UTF-8)}
-    /part {Partial write a given number of units}
-        limit [any-number!]
-    /seek {Write at a specific position}
-        index [any-number!]
-    /append {Write data at end of file}
-    /allow {Specifies protection attributes}
-        access [block!]
-    /lines {Write each value in a block as a separate line}
-;   /as {Convert string to a specified encoding}
-;       encoding [blank! any-number!] {UTF number (0 8 16 -16)}
+    data "Data to write (non-binary converts to UTF-8)"
+        [binary! text! block! object!]  ; !!! should this support CHAR!?
+    /part "Partial write a given number of units"
+        [any-number!]
+    /seek "Write at a specific position"
+        [any-number!]
+    /append "Write data at end of file"
+    /allow "Specifies protection attributes"
+        [block!]
+    /lines "Write each value in a block as a separate line"
 ]
 
 query: generic [
-    {Returns information about a port, file, or URL.}
+    {Returns information about a port, file, or URL}
+
     return: [<opt> object!]
     target [port! file! url! block!]
-    /mode "Get mode information"
-    field [word! blank!] "blank will return valid modes for port type"
+    /mode "Get mode information (blank will return valid modes for port type)"
+        [word! blank!]
 ]
 
 modify: generic [

--- a/src/core/a-lib.c
+++ b/src/core/a-lib.c
@@ -1273,7 +1273,6 @@ REBVAL *RL_rebRescue(
     Begin_Action(f, opt_label);
     assert(IS_END(f->arg));
     f->param = END_NODE; // signal all arguments gathered
-    assert(f->refine == ORDINARY_ARG); // Begin_Action() sets
     f->arg = m_cast(REBVAL*, END_NODE);
     f->special = END_NODE;
 

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -645,8 +645,8 @@ REBARR *Collect_Keylist_Managed(
 //
 REBARR *Collect_Unique_Words_Managed(
     const RELVAL *head,
-    REBFLGS flags, // See COLLECT_XXX
-    const REBVAL *ignore // BLOCK!, ANY-CONTEXT!, or void for none
+    REBFLGS flags,  // See COLLECT_XXX
+    const REBVAL *ignore  // BLOCK!, ANY-CONTEXT!, or BLANK! for none
 ){
     // We do not want to fail() during the bind at this point in time (the
     // system doesn't know how to clean up, and the only cleanup it does
@@ -654,7 +654,7 @@ REBARR *Collect_Unique_Words_Managed(
     // the "ignore" bindings.)  Do a pre-pass to fail first, if there are
     // any non-words in a block the user passed in.
     //
-    if (not IS_NULLED(ignore)) {
+    if (not IS_BLANK(ignore)) {
         RELVAL *check = VAL_ARRAY_AT(ignore);
         for (; NOT_END(check); ++check) {
             if (not ANY_WORD_KIND(CELL_KIND(VAL_UNESCAPED(check))))
@@ -707,7 +707,7 @@ REBARR *Collect_Unique_Words_Managed(
         }
     }
     else
-        assert(IS_NULLED(ignore));
+        assert(IS_BLANK(ignore));
 
     Collect_Inner_Loop(cl, head);
 
@@ -734,12 +734,11 @@ REBARR *Collect_Unique_Words_Managed(
     }
     else if (ANY_CONTEXT(ignore)) {
         REBVAL *key = CTX_KEYS_HEAD(VAL_CONTEXT(ignore));
-        for (; NOT_END(key); ++key) {
+        for (; NOT_END(key); ++key)
             Remove_Binder_Index(&cl->binder, VAL_KEY_CANON(key));
-        }
     }
     else
-        assert(IS_NULLED(ignore));
+        assert(IS_BLANK(ignore));
 
     Collect_End(cl);
     return array;
@@ -1214,7 +1213,7 @@ void Resolve_Context(
     key = CTX_KEYS_HEAD(source);
     for (n = 1; NOT_END(key); n++, key++) {
         REBSTR *canon = VAL_KEY_CANON(key);
-        if (IS_NULLED(only_words))
+        if (IS_BLANK(only_words))
             Add_Binder_Index(&binder, canon, n);
         else {
             if (Get_Binder_Index_Else_0(&binder, canon) != 0) {

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -970,10 +970,15 @@ REBCTX *Error_Need_Non_Null_Core(const RELVAL *target, REBSPC *specifier) {
 //
 //  Error_Non_Logic_Refinement: C
 //
-// Ren-C allows functions to be specialized, such that a function's frame can
-// be filled (or partially filled) by an example frame.  The variables
-// corresponding to refinements must be canonized to either TRUE or FALSE
-// by these specializations, because that's what the called function expects.
+// !!! This error is a placeholder for addressing the issue of using a value
+// to set a refinement that's not a good fit for the refinement type, e.g.
+//
+//     specialize 'append [only: 10]
+//
+// It seems that LOGIC! should be usable, and for purposes of chaining a
+// refinement-style PATH! should be usable too (for using one refinement to
+// trigger another--whether the name is the same or not).  BLANK! has to be
+// legal as well.  But arbitrary values probably should not be.
 //
 REBCTX *Error_Non_Logic_Refinement(const RELVAL *param, const REBVAL *arg) {
     DECLARE_LOCAL (word);
@@ -1145,34 +1150,6 @@ REBCTX *Error_Bad_Func_Def_Core(const RELVAL *item, REBSPC *specifier)
     DECLARE_LOCAL (specific);
     Derelativize(specific, item, specifier);
     return Error_Bad_Func_Def_Raw(specific);
-}
-
-
-//
-//  Error_Bad_Refine_Revoke: C
-//
-// We may have to search for the refinement, so we always do (speed of error
-// creation not considered that relevant to the evaluator, being overshadowed
-// by the error handling).  See the remarks about the state of f->refine in
-// the Reb_Frame definition.
-//
-REBCTX *Error_Bad_Refine_Revoke(const RELVAL *param, const REBVAL *arg)
-{
-    DECLARE_LOCAL (param_name);
-    Init_Word(param_name, VAL_PARAM_SPELLING(param));
-
-    while (not TYPE_CHECK(param, REB_TS_REFINEMENT))
-        --param;
-
-    DECLARE_LOCAL (refine_name);
-    Refinify(Init_Word(refine_name, VAL_PARAM_SPELLING(param)));
-
-    if (IS_NULLED(arg)) // was void and shouldn't have been
-        return Error_Bad_Refine_Revoke_Raw(refine_name, param_name);
-
-    // wasn't void and should have been
-    //
-    return Error_Argument_Revoked_Raw(refine_name, param_name);
 }
 
 

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -1462,7 +1462,11 @@ bool Eval_Internal_Maybe_Stale_Throws(REBFRM * const f)
         // need to take a "hold" on the cell to prevent a rebFree() while the
         // evaluation was in progress.
         //
-        /*assert(f->out->header.bits & (CELL_FLAG_STACK_LIFETIME | NODE_FLAG_ROOT)); */
+        assert(f->out->header.bits & (
+            CELL_FLAG_STACK_LIFETIME
+            | NODE_FLAG_TRANSIENT
+            | NODE_FLAG_ROOT
+        ));
 
         *next_gotten = nullptr; // arbitrary code changes fetched variables
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -363,19 +363,6 @@ REBARR *Make_Paramlist_Managed_May_Fail(
                 derived
             );
 
-            // Refinements and refinement arguments cannot be specified as
-            // <opt>.  Although refinement arguments may be void, they are
-            // not "passed in" that way...the refinement is inactive.
-            //
-            if (refinement_seen) {
-                if (
-                    TYPE_CHECK(param, REB_NULLED)
-                    and not TYPE_CHECK(param, REB_TS_SKIPPABLE)  // !!! allow?
-                ){
-                    fail (Error_Refinement_Arg_Opt_Raw());
-                }
-            }
-
             has_types = true;
             continue;
         }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -381,7 +381,7 @@ REBARR *Make_Paramlist_Managed_May_Fail(
             spelling = VAL_WORD_SPELLING(item);
 
             if (refinement_seen and mode == SPEC_MODE_NORMAL)
-                PROBE(spec);
+                fail (Error_Legacy_Refinement_Raw(spec));
 
             pclass = (mode == SPEC_MODE_LOCAL)
                 ? REB_P_LOCAL

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -447,15 +447,14 @@ REB_R Do_Port_Action(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
     //
     // !!! Note this code is incorrect for files read in chunks!!!
 
-post_process_output:
+  post_process_output:
+
     if (VAL_WORD_SYM(verb) == SYM_READ) {
         INCLUDE_PARAMS_OF_READ;
 
         UNUSED(PAR(source));
         UNUSED(PAR(part));
-        UNUSED(PAR(limit));
         UNUSED(PAR(seek));
-        UNUSED(PAR(index));
 
         if (not r)
             return nullptr;  // !!! `read dns://` returns nullptr on failure

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -35,18 +35,16 @@
 // specifying a refinement without all its arguments is made complicated
 // because ordering matters:
 //
-//     foo: func [/ref1 arg1 /ref2 arg2 /ref3 arg3] [...]
+//     foo: func [/ref1 [integer!] /ref2 [integer!] /ref3 [integer!]] [...]
 //
 //     foo23: :foo/ref2/ref3
 //     foo32: :foo/ref3/ref2
 //
-//     foo23 A B ;-- should give A to arg2 and B to arg3
-//     foo32 A B ;-- should give B to arg2 and A to arg3
+//     foo23 A B  ; should give A to arg2 and B to arg3
+//     foo32 A B  ; should give B to arg2 and A to arg3
 //
-// Merely filling in the slots for the refinements specified with TRUE will
-// not provide enough information for a call to be able to tell the difference
-// between the intents.  Also, a call to `foo23/ref1 A B C` does not want to
-// make arg1 A, because it should act like `foo/ref2/ref3/ref1 A B C`.
+// Also, a call to `foo23/ref1 A B C` does not want to make arg1 A, because it
+// should act like `foo/ref2/ref3/ref1 A B C`.
 //
 // The current trick for solving this efficiently involves exploiting the
 // fact that refinements in exemplar frames are nominally only unspecialized

--- a/src/core/d-eval.c
+++ b/src/core/d-eval.c
@@ -217,7 +217,6 @@ void Eval_Core_Expression_Checks_Debug(REBFRM *f)
     TRASH_POINTER_IF_DEBUG(f->param);
     TRASH_POINTER_IF_DEBUG(f->arg);
     TRASH_POINTER_IF_DEBUG(f->special);
-    TRASH_POINTER_IF_DEBUG(f->refine);
 
     assert(not f->varlist or NOT_SERIES_INFO(f->varlist, INACCESSIBLE));
 
@@ -245,7 +244,6 @@ void Do_Process_Action_Checks_Debug(REBFRM *f) {
 
     assert(GET_ARRAY_FLAG(ACT_PARAMLIST(phase), IS_PARAMLIST));
 
-    assert(f->refine == ORDINARY_ARG);
     if (NOT_EVAL_FLAG(f, NEXT_ARG_FROM_OUT)) {
         if (NOT_CELL_FLAG(f->out, OUT_MARKED_STALE))
             assert(GET_ACTION_FLAG(phase, IS_INVISIBLE));

--- a/src/core/d-stats.c
+++ b/src/core/d-stats.c
@@ -43,7 +43,7 @@
 //          "High resolution time difference from start"
 //      /evals
 //          "Number of values evaluated by interpreter"
-//      /dump-series
+//      /pool
 //          "Dump all series in pool"
 //      pool-id [integer!]
 //          "-1 for all pools"
@@ -106,8 +106,8 @@ REBNATIVE(stats)
         return D_OUT;
     }
 
-    if (REF(dump_series)) {
-        REBVAL *pool_id = ARG(pool_id);
+    if (REF(pool)) {
+        REBVAL *pool_id = ARG(pool);
         Dump_Series_In_Pool(VAL_INT32(pool_id));
         return nullptr;
     }

--- a/src/core/d-stats.c
+++ b/src/core/d-stats.c
@@ -35,18 +35,12 @@
 //  {Provides status and statistics information about the interpreter.}
 //
 //      return: [<opt> time! integer!]
-//      /show
-//          "Print formatted results to console"
-//      /profile
-//          "Returns profiler object"
-//      /timer
-//          "High resolution time difference from start"
-//      /evals
-//          "Number of values evaluated by interpreter"
-//      /pool
-//          "Dump all series in pool"
-//      pool-id [integer!]
-//          "-1 for all pools"
+//      /show "Print formatted results to console"
+//      /profile "Returns profiler object"
+//      /timer "High resolution time difference from start"
+//      /evals "Number of values evaluated by interpreter"
+//      /pool "Dump all series in pool"
+//          [integer!]
 //  ]
 //
 REBNATIVE(stats)
@@ -67,8 +61,7 @@ REBNATIVE(stats)
 #ifdef NDEBUG
     UNUSED(REF(show));
     UNUSED(REF(profile));
-    UNUSED(REF(dump_series));
-    UNUSED(ARG(pool_id));
+    UNUSED(ARG(pool));
 
     fail (Error_Debug_Only_Raw());
 #else

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -359,11 +359,10 @@ static const REBVAL *Unloaded_Dispatcher(REBFRM *f)
 //  "Unload an extension"
 //
 //      return: [void!]
-//      ext [object!]
-//          "The extension to be unloaded"
-//      /cleanup
-//      cleaner [handle!]
-//          "The RX_Quit pointer for the builtin extension"
+//      ext "The extension to be unloaded"
+//          [object!]
+//      /cleanup "The RX_Quit pointer for the builtin extension"
+//          [handle!]
 //  ]
 //
 REBNATIVE(unload_extension)

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -165,7 +165,7 @@ REB_R Series_Common_Action_Maybe_Unhandled(
 
         REBINT len;
         if (REF(part))
-            len = Part_Len_May_Modify_Index(value, ARG(limit));
+            len = Part_Len_May_Modify_Index(value, ARG(part));
         else
             len = 1;
 
@@ -204,7 +204,7 @@ REB_R Series_Common_Action_Maybe_Unhandled(
                 ARG(value2),
                 sop_flags,
                 REF(case),
-                REF(skip) ? Int32s(ARG(size), 1) : 1
+                REF(skip) ? Int32s(ARG(skip), 1) : 1
             )
         ); }
 

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -443,25 +443,24 @@ void Extra_Init_Action_Checks_Debug(REBACT *a) {
 // position, so that a positive length for the partial region is returned.
 //
 static REBCNT Part_Len_Core(
-    REBVAL *series, // this is the series whose index may be modified
-    const REBVAL *limit // /PART (number, position in value, or NULLED cell)
+    REBVAL *series,  // ANY-SERIES! value whose index may be modified
+    const REBVAL *part  // /PART (number, position in value, or BLANK! cell)
 ){
-    if (IS_NULLED(limit)) // limit is nulled when /PART refinement unused
-        return VAL_LEN_AT(series); // leave index alone, use plain length
+    if (IS_BLANK(part))  // indicates /PART refinement unused
+        return VAL_LEN_AT(series);  // leave index alone, use plain length
 
     REBI64 len;
-    if (IS_INTEGER(limit) or IS_DECIMAL(limit))
-        len = Int32(limit); // may be positive or negative
-    else {
-        assert(ANY_SERIES(limit)); // must be same series (same series, even)
+    if (IS_INTEGER(part) or IS_DECIMAL(part))
+        len = Int32(part);  // may be positive or negative
+    else {  // must be same series
         if (
-            VAL_TYPE(series) != VAL_TYPE(limit) // !!! should AS be tolerated?
-            or VAL_SERIES(series) != VAL_SERIES(limit)
+            VAL_TYPE(series) != VAL_TYPE(part)  // !!! allow AS aliases?
+            or VAL_SERIES(series) != VAL_SERIES(part)
         ){
-            fail (Error_Invalid_Part_Raw(limit));
+            fail (Error_Invalid_Part_Raw(part));
         }
 
-        len = cast(REBINT, VAL_INDEX(limit)) - cast(REBINT, VAL_INDEX(series));
+        len = cast(REBINT, VAL_INDEX(part)) - cast(REBINT, VAL_INDEX(series));
     }
 
     // Restrict length to the size available
@@ -537,16 +536,16 @@ REBCNT Part_Tail_May_Modify_Index(REBVAL *series, const REBVAL *limit)
 //
 REBCNT Part_Len_Append_Insert_May_Modify_Index(
     REBVAL *value,
-    const REBVAL *limit
+    const REBVAL *part
 ){
     if (ANY_SERIES(value))
-        return Part_Len_Core(value, limit);
+        return Part_Len_Core(value, part);
 
-    if (IS_NULLED(limit))
+    if (IS_BLANK(part))
         return 1;
 
-    if (IS_INTEGER(limit) or IS_DECIMAL(limit))
-        return Part_Len_Core(value, limit);
+    if (IS_INTEGER(part) or IS_DECIMAL(part))
+        return Part_Len_Core(value, part);
 
     fail ("Invalid /PART specified for non-series APPEND/INSERT argument");
 }

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -2540,10 +2540,10 @@ void Shutdown_Scanner(void)
 //      /next "Translate next complete value (blocks as single value)"
 //      /only "Translate only a single value (blocks dissected)"
 //      /relax "Do not cause errors - return error object as value in place"
-//      /file
-//      file-name [file! url!]
-//      /line
-//      line-number [integer! any-word!]
+//      /file "File to be associated with BLOCK!s and GROUP!s in source"
+//          [file! url!]
+//      /line "Line number for start of scan, word variable will be updated"
+//          [integer! any-word!]
 //  ]
 //
 REBNATIVE(transcode)

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -2561,23 +2561,22 @@ REBNATIVE(transcode)
     // !!! Should the base name and extension be stored, or whole path?
     //
     REBSTR *filename = REF(file)
-        ? Intern(ARG(file_name))
+        ? Intern(ARG(file))
         : Canon(SYM___ANONYMOUS__);
 
     const REBVAL *line_number;
-    if (ANY_WORD(ARG(line_number)))
-        line_number = Get_Opt_Var_May_Fail(ARG(line_number), SPECIFIED);
+    if (ANY_WORD(ARG(line)))
+        line_number = Get_Opt_Var_May_Fail(ARG(line), SPECIFIED);
     else
-        line_number = ARG(line_number);
-    UNUSED(ARG(line));
+        line_number = ARG(line);
 
     REBLIN start_line;
     if (IS_INTEGER(line_number)) {
         start_line = VAL_INT32(line_number);
         if (start_line <= 0)
-            fail (PAR(line_number));
+            fail (PAR(line));
     }
-    else if (IS_NULLED_OR_BLANK(line_number)) {
+    else if (IS_BLANK(line_number)) {
         start_line = 1;
     }
     else
@@ -2630,8 +2629,8 @@ REBNATIVE(transcode)
         Init_Block(Sink_Var_May_Fail(ARG(var), SPECIFIED), a);
     }
 
-    if (ANY_WORD(ARG(line_number)))  // they wanted the line number updated
-        Init_Integer(Sink_Var_May_Fail(ARG(line_number), SPECIFIED), ss.line);
+    if (ANY_WORD(ARG(line)))  // they wanted the line number updated
+        Init_Integer(Sink_Var_May_Fail(ARG(line), SPECIFIED), ss.line);
 
     // Return the input BINARY! or TEXT! advanced by how much the transcode
     // operation consumed.

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -768,13 +768,10 @@ static void Mark_Frame_Stack_Deep(void)
         if (f->opt_label)
             Queue_Mark_Node_Deep(f->opt_label);  // nullptr if anonymous
 
-        // refine and special can be used to GC protect an arbitrary value
-        // while a function is running, currently.  nullptr is permitted as
-        // well for flexibility (e.g. path frames use nullptr to indicate no
-        // set value on a path)
+        // special can be used to GC protect an arbitrary value while a
+        // function is running, currently.  nullptr is permitted as well
+        // (e.g. path frames use nullptr to indicate no set value on a path)
         //
-        if (f->refine)
-            Queue_Mark_Opt_End_Cell_Deep(f->refine);
         if (f->special)
             Queue_Mark_Opt_End_Cell_Deep(f->special);
 

--- a/src/core/m-stacks.c
+++ b/src/core/m-stacks.c
@@ -130,7 +130,6 @@ void Startup_Frame_Stack(void)
     Begin_Action(f, opt_label);
     assert(IS_END(f->arg));
     f->param = END_NODE; // signal all arguments gathered
-    assert(f->refine == ORDINARY_ARG); // Begin_Action() sets
     f->arg = m_cast(REBVAL*, END_NODE);
     f->special = END_NODE;
 

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1323,8 +1323,7 @@ REBNATIVE(default)
 //          [<opt> any-value!]
 //      block "Block to evaluate"
 //          [block!]
-//      /name "Catches a named throw" ;-- should it be called /named ?
-//      names "Names to catch (single name if not block)"
+//      /name "Catches a named throw (single name if not block)"
 //          [block! word! action! object!]
 //      /quit "Special catch for QUIT native"
 //      /any "Catch all throws except QUIT (can be used with /QUIT)"
@@ -1439,7 +1438,7 @@ REBNATIVE(catch)
 //      value "Value returned from catch"
 //          [<opt> any-value!]
 //      /name "Throws to a named catch"
-//      name-value [word! action! object!]
+//          [word! action! object!]
 //  ]
 //
 REBNATIVE(throw)

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1370,19 +1370,19 @@ REBNATIVE(catch)
         REBVAL *temp1 = ARG(quit);
         REBVAL *temp2 = ARG(any);
 
-        if (IS_BLOCK(ARG(names))) {
+        if (IS_BLOCK(ARG(name))) {
             //
             // Test all the words in the block for a match to catch
 
-            RELVAL *candidate = VAL_ARRAY_AT(ARG(names));
+            RELVAL *candidate = VAL_ARRAY_AT(ARG(name));
             for (; NOT_END(candidate); candidate++) {
                 //
                 // !!! Should we test a typeset for illegal name types?
                 //
                 if (IS_BLOCK(candidate))
-                    fail (PAR(names));
+                    fail (PAR(name));
 
-                Derelativize(temp1, candidate, VAL_SPECIFIER(ARG(names)));
+                Derelativize(temp1, candidate, VAL_SPECIFIER(ARG(name)));
                 Move_Value(temp2, label);
 
                 // Return the THROW/NAME's arg if the names match
@@ -1393,7 +1393,7 @@ REBNATIVE(catch)
             }
         }
         else {
-            Move_Value(temp1, ARG(names));
+            Move_Value(temp1, ARG(name));
             Move_Value(temp2, label);
 
             // Return the THROW/NAME's arg if the names match
@@ -1447,13 +1447,13 @@ REBNATIVE(throw)
 // Choices are currently limited for what one can use as a "name" of a THROW.
 // Note blocks as names would conflict with the `name_list` feature in CATCH.
 //
-// !!! Should parameters be /NAMED and NAME ?
+// !!! Should it be /NAMED instead of /NAME?
 {
     INCLUDE_PARAMS_OF_THROW;
 
     return Init_Thrown_With_Label(
         D_OUT,
         ARG(value),
-        REF(name) ? ARG(name_value) : BLANK_VALUE // uses blank, not null
+        ARG(name)  // will be BLANK! if unused (vs. null)
     );
 }

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -476,17 +476,13 @@ REBNATIVE(unbind)
 //
 //  collect-words: native [
 //
-//  {Collect unique words used in a block (used for context construction).}
+//  {Collect unique words used in a block (used for context construction)}
 //
 //      block [block!]
-//      /deep
-//          "Include nested blocks"
-//      /set
-//          "Only include set-words"
-//      /ignore
-//          "Ignore prior words"
-//      hidden [any-context! block!]
-//          "Words to ignore"
+//      /deep "Include nested blocks"
+//      /set "Only include set-words"
+//      /ignore "Ignore prior words"
+//          [any-context! block!]
 //  ]
 //
 REBNATIVE(collect_words)
@@ -820,7 +816,7 @@ REBNATIVE(opt)
 //      target [any-context!] "(modified)"
 //      source [any-context!]
 //      /only "Only specific words (exports) or new words in target"
-//      from [block! integer!]
+//          [block! integer!]
 //      /all "Set all words, even those in the target that already have a value"
 //      /extend "Add source words to the target if necessary"
 //  ]

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -102,21 +102,17 @@ REBNATIVE(as_pair)
 //
 //  bind: native [
 //
-//  "Binds words or words in arrays to the specified context."
+//  {Binds words or words in arrays to the specified context}
 //
 //      return: [<requote> action! any-array! any-path! any-word!]
-//      value [<dequote> action! any-array! any-path! any-word!]
-//          "Value whose binding is to be set (modified) (returned)"
-//      target [any-word! any-context!]
-//          "The target context or a word whose binding should be the target"
-//      /copy
-//          "Bind and return a deep copy of a block, don't modify original"
-//      /only
-//          "Bind only first block (not deep)"
-//      /new
-//          "Add to context any new words found"
-//      /set
-//          "Add to context any new set-words found"
+//      value "Value whose binding is to be set (modified) (returned)"
+//          [<dequote> action! any-array! any-path! any-word!]
+//      target "Target context or a word whose binding should be the target"
+//          [any-word! any-context!]
+//      /copy "Bind and return a deep copy of a block, don't modify original"
+//      /only "Bind only first block (not deep)"
+//      /new "Add to context any new words found"
+//      /set "Add to context any new set-words found"
 //  ]
 //
 REBNATIVE(bind)
@@ -506,12 +502,10 @@ REBNATIVE(collect_words)
     if (REF(deep))
         flags |= COLLECT_DEEP;
 
-    UNUSED(REF(ignore)); // implied used or unused by ARG(hidden)'s voidness
-
     RELVAL *head = VAL_ARRAY_AT(ARG(block));
     return Init_Block(
         D_OUT,
-        Collect_Unique_Words_Managed(head, flags, ARG(hidden))
+        Collect_Unique_Words_Managed(head, flags, ARG(ignore))
     );
 }
 
@@ -825,30 +819,23 @@ REBNATIVE(opt)
 //
 //      target [any-context!] "(modified)"
 //      source [any-context!]
-//      /only
-//          "Only specific words (exports) or new words in target"
+//      /only "Only specific words (exports) or new words in target"
 //      from [block! integer!]
-//          "(index to tail)"
-//      /all
-//          "Set all words, even those in the target that already have a value"
-//      /extend
-//          "Add source words to the target if necessary"
+//      /all "Set all words, even those in the target that already have a value"
+//      /extend "Add source words to the target if necessary"
 //  ]
 //
 REBNATIVE(resolve)
 {
     INCLUDE_PARAMS_OF_RESOLVE;
 
-    if (IS_INTEGER(ARG(from))) {
-        // check range and sign
-        Int32s(ARG(from), 1);
-    }
+    if (IS_INTEGER(ARG(only)))
+        Int32s(ARG(only), 1);  // check range and sign
 
-    UNUSED(REF(only)); // handled by noticing if ARG(from) is void
     Resolve_Context(
         VAL_CONTEXT(ARG(target)),
         VAL_CONTEXT(ARG(source)),
-        ARG(from),
+        ARG(only),
         REF(all),
         REF(extend)
     );

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -744,7 +744,7 @@ REBNATIVE(applique)
     //
     struct Reb_Binder binder;
     INIT_BINDER(&binder);
-    REBCTX *exemplar = Make_Context_For_Action_Int_Partials(
+    REBCTX *exemplar = Make_Context_For_Action_Push_Partials(
         applicand,
         f->dsp_orig, // lowest_ordered_dsp of refinements to weave in
         &binder,

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -254,23 +254,21 @@ REBNATIVE(shove)
 //
 //      return: [<opt> any-value!]
 //      source [
-//          <blank> ;-- opts out of the DO, returns null
-//          block! ;-- source code in block form
-//          group! ;-- same as block (or should it have some other nuance?)
-//          text! ;-- source code in text form
-//          binary! ;-- treated as UTF-8
-//          url! ;-- load code from URL via protocol
-//          file! ;-- load code from file on local disk
-//          tag! ;-- module name (URL! looked up from table)
-//          error! ;-- should use FAIL instead
-//          action! ;-- will only run arity 0 actions (avoids DO variadic)
-//          frame! ;-- acts like APPLY (voids are optionals, not unspecialized)
-//          varargs! ;-- simulates as if frame! or block! is being executed
+//          <blank>  ; opts out of the DO, returns null
+//          block!  ; source code in block form
+//          group!  ; same as block (or should it have some other nuance?)
+//          text!  ; source code in text form
+//          binary!  ; treated as UTF-8
+//          url!  ; load code from URL via protocol
+//          file!  ; load code from file on local disk
+//          tag!  ; module name (URL! looked up from table)
+//          error!  ; should use FAIL instead
+//          action!  ; will only run arity 0 actions (avoids DO variadic)
+//          frame!  ; acts like APPLY (voids are optionals, not unspecialized)
+//          varargs!  ; simulates as if frame! or block! is being executed
 //      ]
-//      /args
-//          {If value is a script, this will set its system/script/args}
-//      arg
-//          "Args passed to a script (normally a string)"
+//      /args "Sets system/script/args if doing a script (usually a TEXT!)"
+//          [any-value!]
 //      /only "Don't catch QUIT (default behavior for BLOCK!)"
 //  ]
 //
@@ -486,8 +484,7 @@ REBNATIVE(do)
 //          varargs!  ; simulates as if frame! or block! is being executed
 //      ]
 //      /set "Store result in a variable (assuming something was evaluated)"
-//      var [any-word!]
-//          "If not blank, then a variable updated with new position"
+//          [any-word!]
 //  ]
 //
 REBNATIVE(evaluate)
@@ -630,7 +627,6 @@ REBNATIVE(sync_invisibles)
 //      restartee "Frame to restart, or bound word (e.g. REDO 'RETURN)"
 //          [frame! any-word!]
 //      /other "Restart in a frame-compatible function (sibling tail-call)"
-//      sibling "Action derived from the same underlying frame as restartee"
 //          [action!]
 //  ]
 //

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -374,7 +374,7 @@ REBNATIVE(do)
             true,  // fully = true, error if not all arguments consumed
             rebU1(sys_do_helper),
             source,
-            NULLIFY_NULLED(ARG(arg)), // nulled cells => nullptr for API
+            ARG(args),
             REF(only) ? TRUE_VALUE : FALSE_VALUE,
             rebEND
         )){
@@ -518,7 +518,7 @@ REBNATIVE(evaluate)
             return nullptr;  // leave the result variable with old value
 
         if (REF(set))
-            Move_Value(Sink_Var_May_Fail(ARG(var), SPECIFIED), D_SPARE);
+            Move_Value(Sink_Var_May_Fail(ARG(set), SPECIFIED), D_SPARE);
 
         Move_Value(D_OUT, source);
         VAL_INDEX(D_OUT) = index;
@@ -559,7 +559,7 @@ REBNATIVE(evaluate)
             }
 
             if (REF(set))
-                Move_Value(Sink_Var_May_Fail(ARG(var), SPECIFIED), D_SPARE);
+                Move_Value(Sink_Var_May_Fail(ARG(set), SPECIFIED), D_SPARE);
 
             VAL_INDEX(position) = index;
             RETURN (source);  // original VARARGS! will have updated position
@@ -586,7 +586,7 @@ REBNATIVE(evaluate)
             return nullptr;
 
         if (REF(set))
-            Move_Value(Sink_Var_May_Fail(ARG(var), SPECIFIED), D_SPARE);
+            Move_Value(Sink_Var_May_Fail(ARG(set), SPECIFIED), D_SPARE);
 
         RETURN (source); }  // original VARARGS! will have an updated position
 
@@ -672,7 +672,7 @@ REBNATIVE(redo)
     // than the established check for a common "ancestor".
     //
     if (REF(other)) {
-        REBVAL *sibling = ARG(sibling);
+        REBVAL *sibling = ARG(other);
         if (FRM_UNDERLYING(f) != ACT_UNDERLYING(VAL_ACTION(sibling)))
             fail ("/OTHER function passed to REDO has incompatible FRAME!");
 

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -94,7 +94,7 @@ REB_R Init_Thrown_Unwind_Value(
 
             --count;
             if (count == 0) {
-                INIT_BINDING(out, f->varlist);
+                INIT_BINDING_MAY_MANAGE(out, SPC(f->varlist));
                 break;
             }
         }
@@ -114,7 +114,7 @@ REB_R Init_Thrown_Unwind_Value(
                 continue; // not ready to exit
 
             if (VAL_ACTION(level) == f->original) {
-                INIT_BINDING(out, f->varlist);
+                INIT_BINDING_MAY_MANAGE(out, SPC(f->varlist));
                 break;
             }
         }
@@ -131,8 +131,8 @@ REB_R Init_Thrown_Unwind_Value(
 //
 //      level "Frame, action, or index to exit from"
 //          [frame! action! integer!]
-//      /with "Result for enclosing state"
-//          [<opt> any-value!]
+//      result "Result for enclosing state"
+//          [<opt> <end> any-value!]
 //  ]
 //
 REBNATIVE(unwind)
@@ -147,7 +147,12 @@ REBNATIVE(unwind)
 {
     INCLUDE_PARAMS_OF_UNWIND;
 
-    return Init_Thrown_Unwind_Value(D_OUT, ARG(level), ARG(with), frame_);
+    return Init_Thrown_Unwind_Value(
+        D_OUT,
+        ARG(level),
+        IS_ENDISH_NULLED(ARG(result)) ? VOID_VALUE : ARG(result),
+        frame_
+    );
 }
 
 

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -131,8 +131,8 @@ REB_R Init_Thrown_Unwind_Value(
 //
 //      level "Frame, action, or index to exit from"
 //          [frame! action! integer!]
-//      /with "Result for enclosing state (default is void)"
-//      value [any-value!]
+//      /with "Result for enclosing state"
+//      value [<opt> any-value!]
 //  ]
 //
 REBNATIVE(unwind)
@@ -147,9 +147,7 @@ REBNATIVE(unwind)
 {
     INCLUDE_PARAMS_OF_UNWIND;
 
-    UNUSED(REF(with)); // implied by non-null value
-
-    return Init_Thrown_Unwind_Value(D_OUT, ARG(level), ARG(value), frame_);
+    return Init_Thrown_Unwind_Value(D_OUT, ARG(level), ARG(with), frame_);
 }
 
 

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -132,7 +132,7 @@ REB_R Init_Thrown_Unwind_Value(
 //      level "Frame, action, or index to exit from"
 //          [frame! action! integer!]
 //      /with "Result for enclosing state"
-//      value [<opt> any-value!]
+//          [<opt> any-value!]
 //  ]
 //
 REBNATIVE(unwind)

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -50,16 +50,12 @@ REBNATIVE(form)
 //
 //  "Converts a value to a REBOL-readable string."
 //
-//      value [any-value!]
-//          "The value to mold"
-//      /only
-//          {For a block value, mold only its contents, no outer []}
-//      /all
-//          "Use construction syntax"
-//      /flat
-//          "No indentation"
-//      /limit
-//          "Limit to a certain length"
+//      value "The value to mold"
+//          [any-value!]
+//      /only "For a block value, mold only its contents, no outer []"
+//      /all "Use construction syntax"
+//      /flat "No indentation"
+//      /limit "Limit to a certain length"
 //      amount [integer!]
 //  ]
 //
@@ -74,7 +70,7 @@ REBNATIVE(mold)
         SET_MOLD_FLAG(mo, MOLD_FLAG_INDENT);
     if (REF(limit)) {
         SET_MOLD_FLAG(mo, MOLD_FLAG_LIMIT);
-        mo->limit = Int32(ARG(amount));
+        mo->limit = Int32(ARG(limit));
     }
 
     Push_Mold(mo);
@@ -180,7 +176,7 @@ REBNATIVE(new_line)
     if (REF(all))
         skip = 1;
     else if (REF(skip)) {
-        skip = Int32s(ARG(count), 1);
+        skip = Int32s(ARG(skip), 1);
         if (skip < 1)
             skip = 1;
     }

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -56,7 +56,7 @@ REBNATIVE(form)
 //      /all "Use construction syntax"
 //      /flat "No indentation"
 //      /limit "Limit to a certain length"
-//      amount [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(mold)
@@ -142,15 +142,13 @@ REBNATIVE(write_stdout)
 //
 //  {Sets or clears the new-line marker within a block or group.}
 //
-//      position [block! group!]
-//          "Position to change marker (modified)"
-//      mark [logic!]
-//          "Set TRUE for newline"
-//      /all
-//          "Set/clear marker to end of series"
-//      /skip
-//          {Set/clear marker periodically to the end of the series}
-//      count [integer!]
+//      position "Position to change marker (modified)"
+//          [block! group!]
+//      mark "Set TRUE for newline"
+//          [logic!]
+//      /all "Set/clear marker to end of series"
+//      /skip "Set/clear marker periodically to the end of the series"
+//          [integer!]
 //  ]
 //
 REBNATIVE(new_line)

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -324,14 +324,12 @@ REBSER *Make_Set_Operation_Series(
 //
 //  {Returns the first data set less the second data set.}
 //
-//      series [any-array! any-string! binary! bitset! typeset!]
-//          "original data"
-//      exclusions [any-array! any-string! binary! bitset! typeset!]
-//          "data to exclude from series"
-//      /case
-//          "Uses case-sensitive comparison"
-//      /skip
-//          "Treat the series as records of fixed size"
+//      series "original data"
+//          [any-array! any-string! binary! bitset! typeset!]
+//      exclusions "data to exclude from series"
+//          [any-array! any-string! binary! bitset! typeset!]
+//      /case "Uses case-sensitive comparison"
+//      /skip "Treat the series as records of fixed size"
 //      size [integer!]
 //  ]
 //
@@ -378,7 +376,7 @@ REBNATIVE(exclude)
             val2,
             SOP_FLAG_CHECK | SOP_FLAG_INVERT,
             REF(case),
-            REF(skip) ? Int32s(ARG(size), 1) : 1
+            REF(skip) ? Int32s(ARG(skip), 1) : 1
         )
     );
 }
@@ -390,10 +388,8 @@ REBNATIVE(exclude)
 //  "Returns the data set with duplicates removed."
 //
 //      series [any-array! any-string! binary! bitset! typeset!]
-//      /case
-//          "Use case-sensitive comparison (except bitsets)"
-//      /skip
-//          "Treat the series as records of fixed size"
+//      /case "Use case-sensitive comparison (except bitsets)"
+//      /skip "Treat the series as records of fixed size"
 //      size [integer!]
 //  ]
 //
@@ -414,7 +410,7 @@ REBNATIVE(unique)
             NULL,
             SOP_NONE,
             REF(case),
-            REF(skip) ? Int32s(ARG(size), 1) : 1
+            REF(skip) ? Int32s(ARG(skip), 1) : 1
         )
     );
 }

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -330,7 +330,7 @@ REBSER *Make_Set_Operation_Series(
 //          [any-array! any-string! binary! bitset! typeset!]
 //      /case "Uses case-sensitive comparison"
 //      /skip "Treat the series as records of fixed size"
-//      size [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(exclude)
@@ -390,7 +390,7 @@ REBNATIVE(exclude)
 //      series [any-array! any-string! binary! bitset! typeset!]
 //      /case "Use case-sensitive comparison (except bitsets)"
 //      /skip "Treat the series as records of fixed size"
-//      size [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(unique)

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -134,15 +134,15 @@ REBNATIVE(delimit)
 //
 //      data [binary!]
 //      /part "Length of data"
-//      limit
+//          [any-value!]
 //      /tcp "Returns an Internet TCP 16-bit checksum"
 //      /secure "Returns a cryptographically secure checksum"
 //      /hash "Returns a hash value with given size"
-//      size [integer!]
+//          [integer!]
 //      /method "Method to use (SHA1, MD5, CRC32)"
-//      word [word!]
+//          [word!]
 //      /key "Returns keyed HMAC value"
-//      key-value [binary! text!]
+//          [binary! text!]
 //  ]
 //
 REBNATIVE(checksum)
@@ -272,9 +272,9 @@ REBNATIVE(checksum)
 //      data "If text, it will be UTF-8 encoded"
 //          [binary! text!]
 //      /part "Length of data (elements)"
-//      limit
+//          [any-value!]
 //      /envelope "ZLIB (adler32, no size) or GZIP (crc32, uncompressed size)"
-//      format [word!]
+//          [word!]
 //  ]
 //
 REBNATIVE(deflate)
@@ -321,11 +321,11 @@ REBNATIVE(deflate)
 //      return: [binary!]
 //      data [binary!]
 //      /part "Length of compressed data (must match end marker)"
-//      limit
+//          [any-value!]
 //      /max "Error out if result is larger than this"
-//      bound
+//          [integer!]
 //      /envelope "ZLIB, GZIP, or DETECT (http://stackoverflow.com/a/9213826)"
-//      format [word!]
+//          [word!]
 //  ]
 //
 REBNATIVE(inflate)
@@ -383,7 +383,7 @@ REBNATIVE(inflate)
 //          ;-- Comment said "we don't know the encoding" of the return binary
 //      value [binary! text!]
 //      /base "The base to convert from: 64, 16, or 2 (defaults to 64)"
-//      base-value [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(debase)
@@ -415,7 +415,7 @@ REBNATIVE(debase)
 //      value "If text, will be UTF-8 encoded"
 //          [binary! text!]
 //      /base "Binary base to use: 64, 16, or 2 (BASE-64 default)"
-//      base-value [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(enbase)
@@ -736,10 +736,9 @@ REBNATIVE(dehex)
 //  {Converts string terminators to standard format, e.g. CR LF to LF.}
 //
 //      return: [any-string! block!]
-//      string [any-string!]
-//          "Will be modified (unless /LINES used)"
-//      /lines
-//          {Return block of lines (works for LF, CR, CR-LF endings)}
+//      string "Will be modified (unless /LINES used)"
+//          [any-string!]
+//      /lines "Return block of lines (works for LF, CR, CR-LF endings)"
 //  ]
 //
 REBNATIVE(deline)
@@ -869,7 +868,7 @@ REBNATIVE(enline)
 //      string "(modified)"
 //          [any-string!]
 //      /size "Specifies the number of spaces per tab"
-//      number [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(entab)
@@ -941,11 +940,10 @@ REBNATIVE(entab)
 //
 //  "Converts tabs to spaces (default tab size is 4)."
 //
-//      string [any-string!]
-//          "(modified)"
-//      /size
-//          "Specifies the number of spaces per tab"
-//      number [integer!]
+//      string "(modified)"
+//          [any-string!]
+//      /size "Specifies the number of spaces per tab"
+//          [integer!]
 //  ]
 //
 REBNATIVE(detab)
@@ -1003,7 +1001,7 @@ REBNATIVE(detab)
 //      string "(modified if series)"
 //          [any-string! char!]
 //      /part "Limits to a given length or position"
-//      limit [any-number! any-string!]
+//          [any-number! any-string!]
 //  ]
 //
 REBNATIVE(lowercase)
@@ -1023,7 +1021,7 @@ REBNATIVE(lowercase)
 //      string "(modified if series)"
 //          [any-string! char!]
 //      /part "Limits to a given length or position"
-//      limit [any-number! any-string!]
+//          [any-number! any-string!]
 //  ]
 //
 REBNATIVE(uppercase)
@@ -1042,7 +1040,7 @@ REBNATIVE(uppercase)
 //
 //      value [integer! tuple!]
 //      /size "Specify number of hex digits in result"
-//      len [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(to_hex)

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -98,21 +98,15 @@ REBNATIVE(exit_rebol)
 //
 //  "Recycles unused memory."
 //
-//      return: [<opt> integer!]
-//          {Number of series nodes recycled (if applicable)}
-//      /off
-//          "Disable auto-recycling"
-//      /on
-//          "Enable auto-recycling"
-//      /ballast
-//          "Trigger for auto-recycle (memory used)"
+//      return: "Number of series nodes recycled (if applicable)"
+//          [<opt> integer!]
+//      /off "Disable auto-recycling"
+//      /on "Enable auto-recycling"
+//      /ballast "Trigger for auto-recycle (memory used)"
 //      size [integer!]
-//      /torture
-//          "Constant recycle (for internal debugging)"
-//      /watch
-//          "Monitor recycling (debug only)"
-//      /verbose
-//          "Dump out information about series being recycled (debug only)"
+//      /torture "Constant recycle (for internal debugging)"
+//      /watch "Monitor recycling (debug only)"
+//      /verbose "Dump information about series being recycled (debug only)"
 //  ]
 //
 REBNATIVE(recycle)
@@ -130,7 +124,7 @@ REBNATIVE(recycle)
     }
 
     if (REF(ballast)) {
-        TG_Max_Ballast = VAL_INT32(ARG(size));
+        TG_Max_Ballast = VAL_INT32(ARG(ballast));
         TG_Ballast = TG_Max_Ballast;
     }
 

--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -103,7 +103,7 @@ REBNATIVE(exit_rebol)
 //      /off "Disable auto-recycling"
 //      /on "Enable auto-recycling"
 //      /ballast "Trigger for auto-recycle (memory used)"
-//      size [integer!]
+//          [integer!]
 //      /torture "Constant recycle (for internal debugging)"
 //      /watch "Monitor recycling (debug only)"
 //      /verbose "Dump information about series being recycled (debug only)"

--- a/src/core/p-dir.c
+++ b/src/core/p-dir.c
@@ -173,14 +173,10 @@ static REB_R Dir_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_READ;
 
         UNUSED(PAR(source));
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+
+        if (REF(part) or REF(seek))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
+
         UNUSED(PAR(string)); // handled in dispatcher
         UNUSED(PAR(lines)); // handled in dispatcher
 
@@ -293,16 +289,9 @@ static REB_R Dir_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_OPEN;
 
         UNUSED(PAR(spec));
-        if (REF(read))
+
+        if (REF(read) or REF(write) or REF(seek) or REF(allow))
             fail (Error_Bad_Refines_Raw());
-        if (REF(write))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(seek))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         // !! If open fails, what if user does a READ w/o checking for error?
         if (IS_BLOCK(state))

--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -66,15 +66,9 @@ static REB_R DNS_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_READ;
 
         UNUSED(PAR(source));
-        if (REF(part)) {
-            UNUSED(ARG(limit));
-            fail (Error_Bad_Refines_Raw());
-        }
 
-        if (REF(seek)) {
-            UNUSED(ARG(index));
+        if (REF(part) or REF(seek))
             fail (Error_Bad_Refines_Raw());
-        }
 
         UNUSED(PAR(string)); // handled in dispatcher
         UNUSED(PAR(lines)); // handled in dispatcher
@@ -140,19 +134,10 @@ static REB_R DNS_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_OPEN;
 
         UNUSED(PAR(spec));
-        if (REF(new))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(read))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(write))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(seek))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
 
+        if (REF(new) or REF(read) or REF(write) or REF(seek) or REF(allow))
+            fail (Error_Bad_Refines_Raw());
+ 
         OS_DO_DEVICE_SYNC(req, RDC_OPEN);
         RETURN (port); }
 

--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -365,9 +365,9 @@ static REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         }
 
         if (REF(seek))
-            Set_Seek(file, ARG(index));
+            Set_Seek(file, ARG(seek));
 
-        REBCNT len = Set_Length(file, REF(part) ? VAL_INT64(ARG(limit)) : -1);
+        REBCNT len = Set_Length(file, REF(part) ? VAL_INT64(ARG(part)) : -1);
         Read_File_Port(D_OUT, port, file, path, flags, len);
 
         if (opened) {
@@ -397,10 +397,8 @@ static REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
 
         UNUSED(PAR(destination));
 
-        if (REF(allow)) {
-            UNUSED(ARG(access));
+        if (REF(allow))
             fail (Error_Bad_Refines_Raw());
-        }
 
         REBVAL *data = ARG(data); // binary, string, or block
 
@@ -430,13 +428,14 @@ static REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
             req->modes |= RFM_RESEEK;
         }
         if (REF(seek))
-            Set_Seek(file, ARG(index));
+            Set_Seek(file, ARG(seek));
 
         // Determine length. Clip /PART to size of string if needed.
         REBCNT len = VAL_LEN_AT(data);
         if (REF(part)) {
-            REBCNT n = Int32s(ARG(limit), 0);
-            if (n <= len) len = n;
+            REBCNT n = Int32s(ARG(part), 0);
+            if (n <= len)
+                len = n;
         }
 
         Write_File_Port(file, data, len, REF(lines));
@@ -459,10 +458,9 @@ static REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_OPEN;
 
         UNUSED(PAR(spec));
-        if (REF(allow)) {
-            UNUSED(ARG(access));
+
+        if (REF(allow))
             fail (Error_Bad_Refines_Raw());
-        }
 
         REBFLGS flags = (
             (REF(new) ? AM_OPEN_NEW : 0)
@@ -483,17 +481,14 @@ static REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_COPY;
 
         UNUSED(PAR(value));
-        if (REF(deep))
+
+        if (REF(deep) or REF(types))
             fail (Error_Bad_Refines_Raw());
-        if (REF(types)) {
-            UNUSED(ARG(kinds));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         if (not (req->flags & RRF_OPEN))
             fail (Error_Not_Open_Raw(path)); // !!! wrong msg
 
-        REBCNT len = Set_Length(file, REF(part) ? VAL_INT64(ARG(limit)) : -1);
+        REBCNT len = Set_Length(file, REF(part) ? VAL_INT64(ARG(part)) : -1);
         REBFLGS flags = 0;
         Read_File_Port(D_OUT, port, file, path, flags, len);
         return D_OUT; }
@@ -575,10 +570,9 @@ static REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_QUERY;
 
         UNUSED(PAR(target));
-        if (REF(mode)) {
-            UNUSED(ARG(field));
+
+        if (REF(mode))
             fail (Error_Bad_Refines_Raw());
-        }
 
         if (not (req->flags & RRF_OPEN)) {
             Setup_File(file, 0, path);

--- a/src/core/p-net.c
+++ b/src/core/p-net.c
@@ -295,14 +295,9 @@ static REB_R Transport_Actor(
 
         UNUSED(PAR(source));
 
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+        if (REF(part) or REF(seek))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
+
         UNUSED(PAR(string)); // handled in dispatcher
         UNUSED(PAR(lines)); // handled in dispatcher
 
@@ -371,17 +366,7 @@ static REB_R Transport_Actor(
 
         UNUSED(PAR(destination));
 
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(append))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(lines))
+        if (REF(seek) or REF(append) or REF(allow) or REF(lines))
             fail (Error_Bad_Refines_Raw());
 
         // Write the entire argument string to the network.
@@ -399,7 +384,7 @@ static REB_R Transport_Actor(
 
         REBCNT len = VAL_LEN_AT(data);
         if (REF(part)) {
-            REBCNT n = Int32s(ARG(limit), 0);
+            REBCNT n = Int32s(ARG(part), 0);
             if (n <= len)
                 len = n;
         }
@@ -450,12 +435,10 @@ static REB_R Transport_Actor(
         if (not (req->modes & RST_LISTEN) or (req->modes & RST_UDP))
             fail ("TAKE is only available on TCP LISTEN ports");
 
-        UNUSED(REF(part)); // non-null limit accounts for
-
         return rebRunQ(
             "take*/part/(", ARG(deep), ")/(", ARG(last), ")",
                 CTX_VAR(ctx, STD_PORT_CONNECTIONS),
-                NULLIFY_NULLED(ARG(limit)),
+                ARG(part),
                 rebEND
         ); }
 

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -177,14 +177,10 @@ static REB_R Serial_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         INCLUDE_PARAMS_OF_READ;
 
         UNUSED(PAR(source));
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+
+        if (REF(part) or REF(seek))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
+
         UNUSED(PAR(string)); // handled in dispatcher
         UNUSED(PAR(lines)); // handled in dispatcher
 
@@ -225,17 +221,7 @@ static REB_R Serial_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
 
         UNUSED(PAR(destination));
 
-        if (REF(seek)) {
-            UNUSED(ARG(index));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(append))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(allow)) {
-            UNUSED(ARG(access));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(lines))
+        if (REF(seek) or REF(append) or REF(allow) or REF(lines))
             fail (Error_Bad_Refines_Raw());
 
         // Determine length. Clip /PART to size of binary if needed.
@@ -243,7 +229,7 @@ static REB_R Serial_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
         REBVAL *data = ARG(data);
         REBCNT len = VAL_LEN_AT(data);
         if (REF(part)) {
-            REBCNT n = Int32s(ARG(limit), 0);
+            REBCNT n = Int32s(ARG(part), 0);
             if (n <= len)
                 len = n;
         }

--- a/src/core/t-binary.c
+++ b/src/core/t-binary.c
@@ -880,6 +880,7 @@ REBTYPE(Binary)
 
     case SYM_REVERSE: {
         INCLUDE_PARAMS_OF_REVERSE;
+        UNUSED(ARG(series));
 
         FAIL_IF_READ_ONLY(v);
 

--- a/src/core/t-binary.c
+++ b/src/core/t-binary.c
@@ -400,17 +400,17 @@ static void Sort_Binary(
 ){
     assert(IS_BINARY(binary));
 
-    if (!IS_VOID(compv))
-        fail (Error_Bad_Refine_Raw(compv)); // !!! R3-Alpha didn't support :-/
+    if (not IS_BLANK(compv))
+        fail (Error_Bad_Refine_Raw(compv));  // !!! R3-Alpha didn't support
 
     REBFLGS thunk = 0;
 
-    REBCNT len = Part_Len_May_Modify_Index(binary, part); // length of sort
+    REBCNT len = Part_Len_May_Modify_Index(binary, part);  // length of sort
     if (len <= 1)
         return;
 
     REBCNT skip;
-    if (IS_VOID(skipv))
+    if (IS_BLANK(skipv))
         skip = 1;
     else {
         skip = Get_Num_From_Arg(skipv);
@@ -602,9 +602,9 @@ REBTYPE(Binary)
 
         REBCNT len; // length of target
         if (VAL_WORD_SYM(verb) == SYM_CHANGE)
-            len = Part_Len_May_Modify_Index(v, ARG(limit));
+            len = Part_Len_May_Modify_Index(v, ARG(part));
         else
-            len = Part_Len_Append_Insert_May_Modify_Index(arg, ARG(limit));
+            len = Part_Len_Append_Insert_May_Modify_Index(arg, ARG(part));
 
         REBFLGS flags = 0;
         if (REF(part))
@@ -618,7 +618,7 @@ REBTYPE(Binary)
             arg,
             flags,
             len,
-            REF(dup) ? Int32(ARG(count)) : 1
+            REF(dup) ? Int32(ARG(dup)) : 1
         );
         RETURN (v); }
 
@@ -644,11 +644,11 @@ REBTYPE(Binary)
         flags |= AM_FIND_CASE;
 
         if (REF(part))
-            tail = Part_Tail_May_Modify_Index(v, ARG(limit));
+            tail = Part_Tail_May_Modify_Index(v, ARG(part));
 
         REBCNT skip;
         if (REF(skip))
-            skip = Part_Len_May_Modify_Index(v, ARG(size));
+            skip = Part_Len_May_Modify_Index(v, ARG(part));
         else
             skip = 1;
 
@@ -682,10 +682,9 @@ REBTYPE(Binary)
         if (REF(deep))
             fail (Error_Bad_Refines_Raw());
 
-
         REBINT len;
         if (REF(part)) {
-            len = Part_Len_May_Modify_Index(v, ARG(limit));
+            len = Part_Len_May_Modify_Index(v, ARG(part));
             if (len == 0)
                 return Init_Any_Series(D_OUT, VAL_TYPE(v), Make_Binary(0));
         } else
@@ -750,15 +749,10 @@ REBTYPE(Binary)
 
         UNUSED(PAR(value));
 
-        if (REF(deep))
+        if (REF(deep) or REF(types))
             fail (Error_Bad_Refines_Raw());
-        if (REF(types)) {
-            UNUSED(ARG(kinds));
-            fail (Error_Bad_Refines_Raw());
-        }
-
-        UNUSED(REF(part));
-        REBINT len = Part_Len_May_Modify_Index(v, ARG(limit));
+ 
+        REBINT len = Part_Len_May_Modify_Index(v, ARG(part));
 
         return Init_Any_Series(
             D_OUT,
@@ -885,9 +879,11 @@ REBTYPE(Binary)
         RETURN (v); }
 
     case SYM_REVERSE: {
+        INCLUDE_PARAMS_OF_REVERSE;
+
         FAIL_IF_READ_ONLY(v);
 
-        REBINT len = Part_Len_May_Modify_Index(v, D_ARG(3));
+        REBINT len = Part_Len_May_Modify_Index(v, ARG(part));
         if (len > 0)
             reverse_binary(v, len);
         RETURN (v); }
@@ -898,11 +894,8 @@ REBTYPE(Binary)
         FAIL_IF_READ_ONLY(v);
 
         UNUSED(PAR(series));
-        UNUSED(REF(skip));
-        UNUSED(REF(compare));
-        UNUSED(REF(part));
 
-        if (REF(all)) // Not Supported
+        if (REF(all))
             fail (Error_Bad_Refine_Raw(ARG(all)));
 
         if (REF(case)) {
@@ -911,9 +904,9 @@ REBTYPE(Binary)
 
         Sort_Binary(
             v,
-            ARG(size), // skip size (void if not /SKIP)
-            ARG(comparator), // (void if not /COMPARE)
-            ARG(limit),   // (void if not /PART)
+            ARG(skip),  // blank! if not /SKIP
+            ARG(compare),  // (blank! if not /COMPARE)
+            ARG(part),   // (blank! if not /PART)
             REF(reverse)
         );
         RETURN (v); }

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -605,19 +605,8 @@ REBTYPE(Bitset)
 
         UNUSED(PAR(series));
         UNUSED(PAR(pattern));
-        if (REF(part)) {
-            UNUSED(ARG(limit));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(only))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(skip)) {
-            UNUSED(ARG(size));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(tail))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(match))
+
+        if (REF(part) or REF(only) or REF(skip) or REF(tail) or REF(match))
             fail (Error_Bad_Refines_Raw());
 
         if (not Check_Bits(VAL_BITSET(v), arg, REF(case)))
@@ -654,8 +643,8 @@ REBTYPE(Bitset)
         if (not REF(part))
             fail (Error_Missing_Arg_Raw());
 
-        if (not Set_Bits(VAL_BITSET(v), ARG(limit), false))
-            fail (ARG(limit));
+        if (not Set_Bits(VAL_BITSET(v), ARG(part), false))
+            fail (PAR(part));
 
         RETURN (v); }
 
@@ -663,16 +652,8 @@ REBTYPE(Bitset)
         INCLUDE_PARAMS_OF_COPY;
         UNUSED(PAR(value));
 
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+        if (REF(part) or REF(deep) or REF(types))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(deep))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(types)) {
-            UNUSED(ARG(kinds));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         REBBIN *copy = Copy_Sequence_Core(VAL_BITSET(v), NODE_FLAG_MANAGED);
         INIT_BITS_NOT(copy, BITS_NOT(VAL_BITSET(v)));

--- a/src/core/t-blank.c
+++ b/src/core/t-blank.c
@@ -159,13 +159,13 @@ REBTYPE(Unit)
       case SYM_COPY: { // since `copy/deep [1 _ 2]` is legal, allow `copy _`
         INCLUDE_PARAMS_OF_COPY;
         UNUSED(ARG(value)); // already referenced as `unit`
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+
+        if (REF(part))
             fail (Error_Bad_Refines_Raw());
-        }
+
         UNUSED(REF(deep));
         UNUSED(REF(types));
-        UNUSED(ARG(kinds));
+
         return Init_Blank(D_OUT); }
 
       default: break;

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1068,6 +1068,7 @@ REBTYPE(Array)
 
     case SYM_REVERSE: {
         INCLUDE_PARAMS_OF_REVERSE;
+        UNUSED(ARG(series));
 
         FAIL_IF_READ_ONLY(array);
 

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -1008,7 +1008,6 @@ REBTYPE(Date)
 
             if (REF(skip))
                 fail (Error_Bad_Refines_Raw());
-            UNUSED(PAR(size));
 
             // !!! Plain SUBTRACT on dates has historically given INTEGER! of
             // days, while DIFFERENCE has given back a TIME!.  This is not

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -502,21 +502,20 @@ REBTYPE(Decimal)
             | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
         );
 
-        arg = ARG(scale);
         if (REF(to)) {
-            if (IS_MONEY(arg))
+            if (IS_MONEY(ARG(to)))
                 return Init_Money(D_OUT, Round_Deci(
-                    decimal_to_deci(d1), flags, VAL_MONEY_AMOUNT(arg)
+                    decimal_to_deci(d1), flags, VAL_MONEY_AMOUNT(ARG(to))
                 ));
 
-            if (IS_TIME(arg))
-                fail (arg);
+            if (IS_TIME(ARG(to)))
+                fail (PAR(to));
 
-            d1 = Round_Dec(d1, flags, Dec64(arg));
-            if (IS_INTEGER(arg))
+            d1 = Round_Dec(d1, flags, Dec64(ARG(to)));
+            if (IS_INTEGER(ARG(to)))
                 return Init_Integer(D_OUT, cast(REBI64, d1));
 
-            if (IS_PERCENT(arg))
+            if (IS_PERCENT(ARG(to)))
                 type = REB_PERCENT;
         }
         else

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -171,14 +171,10 @@ REBTYPE(Action)
         INCLUDE_PARAMS_OF_COPY;
 
         UNUSED(PAR(value));
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+
+        if (REF(part) or REF(types))
             fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(types)) {
-            UNUSED(ARG(kinds));
-            fail (Error_Bad_Refines_Raw());
-        }
+
         if (REF(deep)) {
             // !!! always "deep", allow it?
         }

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -537,31 +537,32 @@ REBTYPE(Integer)
             | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
         );
 
-        REBVAL *val2 = ARG(scale);
-        if (REF(to)) {
-            if (IS_MONEY(val2))
-                return Init_Money(
-                    D_OUT,
-                    Round_Deci(
-                        int_to_deci(num), flags, VAL_MONEY_AMOUNT(val2)
-                    )
-                );
-            if (IS_DECIMAL(val2) || IS_PERCENT(val2)) {
-                REBDEC dec = Round_Dec(
-                    cast(REBDEC, num), flags, VAL_DECIMAL(val2)
-                );
-                RESET_CELL(D_OUT, VAL_TYPE(val2), CELL_MASK_NONE);
-                VAL_DECIMAL(D_OUT) = dec;
-                return D_OUT;
-            }
-            if (IS_TIME(val2))
-                fail (val2);
-            arg = VAL_INT64(val2);
-        }
-        else
-            arg = 0L;
+        if (not REF(to))
+            return Init_Integer(D_OUT, Round_Int(num, flags, 0L));
 
-        return Init_Integer(D_OUT, Round_Int(num, flags, arg)); }
+        REBVAL *to = ARG(to);
+
+        if (IS_MONEY(to))
+            return Init_Money(
+                D_OUT,
+                Round_Deci(
+                    int_to_deci(num), flags, VAL_MONEY_AMOUNT(to)
+                )
+            );
+
+        if (IS_DECIMAL(to) || IS_PERCENT(to)) {
+            REBDEC dec = Round_Dec(
+                cast(REBDEC, num), flags, VAL_DECIMAL(to)
+            );
+            RESET_CELL(D_OUT, VAL_TYPE(to), CELL_MASK_NONE);
+            VAL_DECIMAL(D_OUT) = dec;
+            return D_OUT;
+        }
+
+        if (IS_TIME(ARG(to)))
+            fail (PAR(to));
+
+        return Init_Integer(D_OUT, Round_Int(num, flags, VAL_INT64(to))); }
 
     case SYM_RANDOM: {
         INCLUDE_PARAMS_OF_RANDOM;

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -684,20 +684,7 @@ REBTYPE(Map)
         UNUSED(PAR(series));
         UNUSED(PAR(pattern)); // handled as `arg`
 
-        if (REF(part)) {
-            UNUSED(ARG(limit));
-            fail (Error_Bad_Refines_Raw());
-        }
-        if (REF(only))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(skip)) {
-            UNUSED(ARG(size));
-            fail (Error_Bad_Refines_Raw());
-        }
-
-        if (REF(tail))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(match))
+        if (REF(part) or REF(only) or REF(skip) or REF(tail) or REF(match))
             fail (Error_Bad_Refines_Raw());
 
         REBINT n = Find_Map_Entry(
@@ -749,20 +736,13 @@ REBTYPE(Map)
 
         UNUSED(PAR(series));
 
-        if (REF(only))
+        if (REF(only) or REF(line) or REF(dup))
             fail (Error_Bad_Refines_Raw());
-        if (REF(line))
-            fail (Error_Bad_Refines_Raw());
-        if (REF(dup)) {
-            UNUSED(ARG(count));
-            fail (Error_Bad_Refines_Raw());
-        }
 
         if (not IS_BLOCK(arg))
             fail (PAR(value));
 
-        REBCNT len = Part_Len_May_Modify_Index(arg, ARG(limit));
-        UNUSED(REF(part)); // detected by if limit is nulled
+        REBCNT len = Part_Len_May_Modify_Index(arg, ARG(part));
 
         Append_Map(
             map,
@@ -776,12 +756,10 @@ REBTYPE(Map)
 
     case SYM_COPY: {
         INCLUDE_PARAMS_OF_COPY;
-
         UNUSED(PAR(value));
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+
+        if (REF(part))
             fail (Error_Bad_Refines_Raw());
-        }
 
         REBU64 types = 0; // which types to copy non-"shallowly"
 
@@ -789,11 +767,11 @@ REBTYPE(Map)
             types |= REF(types) ? 0 : TS_CLONE;
 
         if (REF(types)) {
-            if (IS_DATATYPE(ARG(kinds)))
-                types |= FLAGIT_KIND(VAL_TYPE(ARG(kinds)));
+            if (IS_DATATYPE(ARG(types)))
+                types |= FLAGIT_KIND(VAL_TYPE(ARG(types)));
             else {
-                types |= VAL_TYPESET_LOW_BITS(ARG(kinds));
-                types |= cast(REBU64, VAL_TYPESET_HIGH_BITS(ARG(kinds))) << 32;
+                types |= VAL_TYPESET_LOW_BITS(ARG(types));
+                types |= cast(REBU64, VAL_TYPESET_HIGH_BITS(ARG(types))) << 32;
             }
         }
 

--- a/src/core/t-money.c
+++ b/src/core/t-money.c
@@ -261,18 +261,18 @@ REBTYPE(Money)
             | (REF(half_ceiling) ? RF_HALF_CEILING : 0)
         );
 
-        REBVAL *scale = ARG(scale);
+        REBVAL *to = ARG(to);
 
         DECLARE_LOCAL (temp);
         if (REF(to)) {
-            if (IS_INTEGER(scale))
-                Init_Money(temp, int_to_deci(VAL_INT64(scale)));
-            else if (IS_DECIMAL(scale) or IS_PERCENT(scale))
-                Init_Money(temp, decimal_to_deci(VAL_DECIMAL(scale)));
-            else if (IS_MONEY(scale))
-                Move_Value(temp, scale);
+            if (IS_INTEGER(to))
+                Init_Money(temp, int_to_deci(VAL_INT64(to)));
+            else if (IS_DECIMAL(to) or IS_PERCENT(to))
+                Init_Money(temp, decimal_to_deci(VAL_DECIMAL(to)));
+            else if (IS_MONEY(to))
+                Move_Value(temp, to);
             else
-                fail (PAR(scale));
+                fail (PAR(to));
         }
         else
             Init_Money(temp, int_to_deci(0));
@@ -284,13 +284,13 @@ REBTYPE(Money)
         ));
 
         if (REF(to)) {
-            if (IS_DECIMAL(scale) or IS_PERCENT(scale)) {
+            if (IS_DECIMAL(to) or IS_PERCENT(to)) {
                 REBDEC dec = deci_to_decimal(VAL_MONEY_AMOUNT(D_OUT));
-                RESET_CELL(D_OUT, VAL_TYPE(scale), CELL_MASK_NONE);
+                RESET_CELL(D_OUT, VAL_TYPE(to), CELL_MASK_NONE);
                 VAL_DECIMAL(D_OUT) = dec;
                 return D_OUT;
             }
-            if (IS_INTEGER(scale)) {
+            if (IS_INTEGER(to)) {
                 REBI64 i64 = deci_to_int(VAL_MONEY_AMOUNT(D_OUT));
                 return Init_Integer(D_OUT, i64);
             }

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -814,18 +814,16 @@ REBTYPE(Context)
 
         UNUSED(PAR(value));
 
-        if (REF(part)) {
-            UNUSED(ARG(limit));
+        if (REF(part))
             fail (Error_Bad_Refines_Raw());
-        }
 
         REBU64 types = 0;
         if (REF(types)) {
-            if (IS_DATATYPE(ARG(kinds)))
-                types = FLAGIT_KIND(VAL_TYPE_KIND(ARG(kinds)));
+            if (IS_DATATYPE(ARG(types)))
+                types = FLAGIT_KIND(VAL_TYPE_KIND(ARG(types)));
             else {
-                types |= VAL_TYPESET_LOW_BITS(ARG(kinds));
-                types |= cast(REBU64, VAL_TYPESET_HIGH_BITS(ARG(kinds))) << 32;
+                types |= VAL_TYPESET_LOW_BITS(ARG(types));
+                types |= cast(REBU64, VAL_TYPESET_HIGH_BITS(ARG(types))) << 32;
             }
         }
         else if (REF(deep))
@@ -887,7 +885,7 @@ REBNATIVE(construct)
     INCLUDE_PARAMS_OF_CONSTRUCT;
 
     REBVAL *spec = ARG(spec);
-    REBCTX *parent = REF(with) ? VAL_CONTEXT(ARG(prototype)) : nullptr;
+    REBCTX *parent = REF(with) ? VAL_CONTEXT(ARG(with)) : nullptr;
 
     // This parallels the code originally in CONSTRUCT.  Run it if the /ONLY
     // refinement was passed in.

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -866,8 +866,7 @@ REBTYPE(Context)
 //      spec [<blank> block!]
 //          "Object specification block (bindings modified)"
 //      /only "Values are kept as-is"
-//      /with "Use a prototype object"
-//      prototype "parent/prototype context"
+//      /with "Use a parent/prototype context"
 //          [any-context!]
 //  ]
 //

--- a/src/core/t-port.c
+++ b/src/core/t-port.c
@@ -127,17 +127,7 @@ REB_R Retrigger_Append_As_Write(REBFRM *frame_) {
         fail (PAR(value));
     }
 
-    if (REF(part)) {
-        UNUSED(ARG(limit));
-        fail (Error_Bad_Refines_Raw());
-    }
-    if (REF(only))
-        fail (Error_Bad_Refines_Raw());
-    if (REF(dup)) {
-        UNUSED(ARG(count));
-        fail (Error_Bad_Refines_Raw());
-    }
-    if (REF(line))
+    if (REF(part) or REF(only) or REF(dup) or REF(line))
         fail (Error_Bad_Refines_Raw());
 
     return rebRunQ("write/append", D_ARG(1), D_ARG(2), rebEND);

--- a/src/core/t-quoted.c
+++ b/src/core/t-quoted.c
@@ -192,7 +192,7 @@ REBNATIVE(literal) // aliased in %base-defs.r as LIT
 //      return: [quoted!]
 //      optional [<opt> any-value!]
 //      /depth "Number of quoting levels to apply (default 1)"
-//      count [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(uneval) // !!! This will be renamed QUOTE in the future
@@ -215,7 +215,7 @@ REBNATIVE(uneval) // !!! This will be renamed QUOTE in the future
 //      return: [<opt> any-value!]
 //      optional [<opt> any-value!]
 //      /depth "Number of quoting levels to remove (default 1)"
-//      count [integer!]
+//          [integer!]
 //  ]
 //
 REBNATIVE(unquote)

--- a/src/core/t-quoted.c
+++ b/src/core/t-quoted.c
@@ -199,9 +199,9 @@ REBNATIVE(uneval) // !!! This will be renamed QUOTE in the future
 {
     INCLUDE_PARAMS_OF_UNEVAL;
 
-    REBINT depth = REF(depth) ? VAL_INT32(ARG(count)) : 1;
+    REBINT depth = REF(depth) ? VAL_INT32(ARG(depth)) : 1;
     if (depth < 0)
-        fail (PAR(count));
+        fail (PAR(depth));
 
     return Quotify(Move_Value(D_OUT, ARG(optional)), depth);
 }
@@ -222,11 +222,11 @@ REBNATIVE(unquote)
 {
     INCLUDE_PARAMS_OF_UNQUOTE;
 
-    REBINT depth = REF(depth) ? VAL_INT32(ARG(count)) : 1;
+    REBINT depth = REF(depth) ? VAL_INT32(ARG(depth)) : 1;
     if (depth < 0)
-        fail (PAR(count));
+        fail (PAR(depth));
     if (cast(REBCNT, depth) > VAL_NUM_QUOTES(ARG(optional)))
-        fail (PAR(count));
+        fail (PAR(depth));
 
     return Unquotify(Move_Value(D_OUT, ARG(optional)), depth);
 }

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1252,6 +1252,7 @@ REBTYPE(String)
 
     case SYM_REVERSE: {
         INCLUDE_PARAMS_OF_REVERSE;
+        UNUSED(ARG(series));
 
         FAIL_IF_READ_ONLY(v);
 

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -479,7 +479,7 @@ REBTYPE(Tuple)
         UNUSED(PAR(series));
 
         if (REF(part)) {
-            len = Get_Num_From_Arg(ARG(limit));
+            len = Get_Num_From_Arg(ARG(part));
             len = MIN(len, VAL_TUPLE_LEN(value));
         }
         if (len > 0) {

--- a/src/core/t-varargs.c
+++ b/src/core/t-varargs.c
@@ -493,10 +493,10 @@ REBTYPE(Varargs)
 
         REBDSP dsp_orig = DSP;
 
-        if (not IS_INTEGER(ARG(limit)))
-            fail (PAR(limit));
+        if (not IS_INTEGER(ARG(part)))
+            fail (PAR(part));
 
-        REBINT limit = VAL_INT32(ARG(limit));
+        REBINT limit = VAL_INT32(ARG(part));
         if (limit < 0)
             limit = 0;
 

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -230,7 +230,6 @@ static bool Subparse_Throws(
 
     f->param = END_NODE; // informs infix lookahead
     f->arg = m_cast(REBVAL*, END_NODE);
-    assert(f->refine == ORDINARY_ARG); // Begin_Action() sets
     f->special = END_NODE;
 
     Derelativize(Prep_Stack_Cell(P_INPUT_VALUE), input, input_specifier);

--- a/src/include/datatypes/sys-frame.h
+++ b/src/include/datatypes/sys-frame.h
@@ -491,8 +491,6 @@ inline static void Begin_Action(REBFRM *f, REBSTR *opt_label)
     f->label_utf8 = cast(const char*, Frame_Label_Or_Anonymous_UTF8(f));
   #endif
 
-    f->refine = ORDINARY_ARG;
-
     assert(NOT_EVAL_FLAG(f, REQUOTE_NULL));
     f->requotes = 0;
 }

--- a/src/include/datatypes/sys-typeset.h
+++ b/src/include/datatypes/sys-typeset.h
@@ -383,3 +383,10 @@ inline static bool Typecheck_Including_Quoteds(
 
     return false;
 }
+
+
+inline static bool Is_Typeset_Invisible(const RELVAL *param) {
+    REBU64 bits = VAL_TYPESET_LOW_BITS(param);
+    bits |= cast(REBU64, VAL_TYPESET_HIGH_BITS(param)) << 32;
+    return (bits & TS_OPT_VALUE) == 0;  // e.g. `return: []` or `[/refine]`
+}

--- a/src/include/datatypes/sys-value.h
+++ b/src/include/datatypes/sys-value.h
@@ -830,7 +830,7 @@ inline static void INIT_BINDING(RELVAL *v, void *p) {
         if (v->header.bits & NODE_FLAG_TRANSIENT) {
             // let anything go... for now.
             // SERIES_FLAG_STACK_LIFETIME might not be set yet due to construction
-            // constraints, see Make_Context_For_Action_Int_Partials()
+            // constraints, see Make_Context_For_Action_Push_Partials()
         }
         else {
             assert(v->header.bits & CELL_FLAG_STACK_LIFETIME);

--- a/src/include/sys-rebval.h
+++ b/src/include/sys-rebval.h
@@ -178,6 +178,8 @@
 //
 #define CELL_FLAG_ENFIXED \
     FLAG_LEFT_BIT(20)
+#define CELL_FLAG_PUSH_PARTIAL \
+    FLAG_LEFT_BIT(20)
 
 
 //=//// CELL_FLAG_NEWLINE_BEFORE //////////////////////////////////////////=//
@@ -348,11 +350,6 @@ struct Reb_Typeset_Extra  // see %sys-typeset.h
     uint_fast32_t high_bits;  // 64 typeflags, can't all fit in payload second
 };
 
-struct Reb_Partial_Extra  // see %c-specialize.c (used with REB_X_PARTIAL)
-{
-    REBVAL *next;  // links to next potential partial refinement arg
-};
-
 union Reb_Any {  // needed to beat strict aliasing, used in payload
     bool flag;  // "wasteful" to just use for one flag, but fast to read/write
 
@@ -395,7 +392,6 @@ union Reb_Value_Extra { //=/////////////////// ACTUAL EXTRA DEFINITION ////=//
     struct Reb_Datatype_Extra Datatype;
     struct Reb_Date_Extra Date;
     struct Reb_Typeset_Extra Typeset;
-    struct Reb_Partial_Extra Partial;
 
     union Reb_Any Any;
     union Reb_Bytes_Extra Bytes;
@@ -460,12 +456,6 @@ struct Reb_Any_Payload  // generic, for adding payloads after-the-fact
     union Reb_Any second;
 };
 
-struct Reb_Partial_Payload  // see %c-specialize.c (used w/REB_X_PARTIAL)
-{
-    REBDSP dsp;  // the DSP of this partial slot (if ordered on the stack)
-    REBINT signed_index;  // index in the paramlist, negative if not "in use"
-};
-
 struct Reb_Bookmark_Payload {   // see %sys-string.h (used w/REB_X_BOOKMARK)
     REBCNT index;
     REBSIZ offset;
@@ -527,7 +517,6 @@ union Reb_Value_Payload { //=/////////////// ACTUAL PAYLOAD DEFINITION ////=//
     struct Reb_Decimal_Payload Decimal;
     struct Reb_Time_Payload Time;
 
-    struct Reb_Partial_Payload Partial;  // internal (see REB_X_PARTIAL)
     struct Reb_Bookmark_Payload Bookmark;  // internal (see REB_X_BOOKMARK)
 
     union Reb_Bytes_Payload Bytes;

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -130,12 +130,12 @@ function: func [
         ((either var [[
             set var: [
                 match [any-word! 'word!]
-                | ahead path! into [blank! word!]
+                | ahead any-path! into [blank! word!]
             ](
                 append new-spec var
 
                 ;-- exclude args/refines
-                append exclusions either path? var [var/2] [var]
+                append exclusions either any-path? var [var/2] [var]
             )
             |
             set other: block! (

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -889,7 +889,7 @@ module: func [
     ; In Ren-C, MAKE MODULE! acts just like MAKE OBJECT! due to the generic
     ; facility for SET-META.
 
-    mod: default [
+    mod: into: default [
         make module! 7 ; arbitrary starting size
     ]
 

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -206,10 +206,10 @@ trim: function [
                 fail "Invalid refinements for TRIM of STRING!"
             ]
 
-            rule: either with [
-                either bitset? str [str] [charset str]
-            ][
-                charset reduce [space tab]
+            rule: case [
+                blank? with [charset reduce [space tab]]
+                bitset? with [with]
+                default [charset with]
             ]
 
             if any [all_TRIM lines head_TRIM tail_TRIM] [append rule newline]
@@ -221,7 +221,7 @@ trim: function [
             ]
 
             rule: either with [
-                either bitset? str [str] [charset str]
+                either bitset? with [with] [charset with]
             ][
                 #{00}
             ]

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -113,18 +113,10 @@ charset: function [
     {Makes a bitset of chars for the parse function.}
 
     chars [text! block! binary! char! integer!]
-    /length "Preallocate this many bits"
-    len [integer!] "Must be > 0"
+    /length "Preallocate this many bits (must be > 0)"
+        [integer!]
 ][
-    ;-- CHARSET function historically has a refinement called /LENGTH, that
-    ;-- is used to preallocate bits.  Yet the LENGTH? function has been
-    ;-- changed to use just the word LENGTH.  We could change this to
-    ;-- /CAPACITY SIZE or something similar, but keep it working for now.
-    ;--
-    length_CHARSET: length      ; refinement passed in
-    unset 'length               ; helps avoid overlooking the ambiguity
-
-    init: either length_CHARSET [len][[]]
+    init: either length [length] [[]]
     append make bitset! init chars
 ]
 
@@ -142,8 +134,8 @@ trim: function [
     /auto "Auto indents lines relative to first line"
     /lines "Removes all line breaks and extra spaces"
     /all "Removes all whitespace"
-    /with "Same as /all, but removes characters in 'str'"
-    str [char! text! binary! integer! block! bitset!]
+    /with "Same as /all, but removes specific characters"
+        [char! text! binary! integer! block! bitset!]
 ][
     tail_TRIM: :tail
     tail: :lib/tail

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -11,17 +11,19 @@ REBOL [
     }
 ]
 
-launch: func [
+launch: function [
     {Runs a script as a separate process; return immediately.}
 
-    script [<blank> file! text!] "The name of the script"
-    /args arg [text! block!] "Arguments to the script"
+    script "The name of the script"
+        [<blank> file! text!]
+    /args "Arguments to the script"
+        [text! block!]
     /wait "Wait for the process to terminate"
 ][
     if file? script [script: file-to-local clean-path script]
-    args: reduce [file-to-local system/options/boot script]
-    if set? 'arg [append args arg]
-    call*/(wait) args
+    command: reduce [file-to-local system/options/boot script]
+    append command opt arg
+    call*/(wait) command
 ]
 
 wrap: func [

--- a/src/mezz/mezz-dump.r
+++ b/src/mezz/mezz-dump.r
@@ -21,14 +21,14 @@ dump: function [
     :extra "Optional variadic data for SET-WORD!, e.g. `dump x: 1 + 2`"
         [any-value! <...>]
     /prefix "Put a custom marker at the beginning of each output line"
-    sigil [text!]
+        [text!]
 
     <static> enablements (make map! [])
 ][
     print: adapt 'lib/print [
-        if set? 'sigil [
-            if select enablements sigil <> #on [return]
-            write-stdout sigil
+        if prefix [
+            if select enablements prefix <> #on [return]
+            write-stdout prefix
             write-stdout space
         ]
     ]
@@ -43,8 +43,8 @@ dump: function [
 
     dump-one: function [return: <void> item] [
         switch type of item [
-            refinement! ;-- treat as label, /a no shift and shorter than "a"
-            text! [ ;-- good for longer labeling when you need spaces/etc.
+            refinement!  ; treat as label, /a no shift and shorter than "a"
+            text! [  ; good for longer labeling when you need spaces/etc.
                 print [mold/limit item system/options/dump-size]
             ]
 
@@ -61,7 +61,7 @@ dump: function [
             ]
 
             issue! [
-                enablements/(sigil): item
+                enablements/(prefix): item
             ]
 
             fail 'value [
@@ -135,8 +135,8 @@ dumps: enfix function [
         [<opt> any-value! <...>]
 ][
     if issue? value [
-        d: specialize 'dump-to-newline [sigil: as text! name]
-        if value <> #off [d #on] ;-- note: d hard quotes its argument
+        d: specialize 'dump-to-newline [prefix: as text! name]
+        if value <> #off [d #on]  ; note: d hard quotes its argument
     ] else [
         ; Make it easy to declare and dump a variable at the same time.
         ;
@@ -155,7 +155,7 @@ dumps: enfix function [
         ;
         d: function [return: [] /on /off <static> d'] compose/deep [
             d': default [
-                d'': specialize 'dump [sigil: (as text! name)]
+                d'': specialize 'dump [prefix: (as text! name)]
                 d'' #on
             ]
             case [
@@ -190,9 +190,9 @@ summarize-obj: function [
         [<opt> block!]
     obj [object! port!]
     /match "Include only fields that match a string or datatype"
-    pattern [text! datatype!]
+        [text! datatype!]
 ][
-    match_DUMP-OBJ: match
+    pattern: match
     match: :lib/match
 
     form-pad: func [
@@ -219,8 +219,8 @@ summarize-obj: function [
                 form word
             ]
 
-            switch type of :pattern [  ; filter out any non-matching items
-                null []
+            switch type of pattern [  ; filter out any non-matching items
+                blank! []
 
                 datatype! [
                     if type != pattern [continue]

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -137,34 +137,33 @@ ask: function [
 
 
 confirm: function [
-    {Confirms a user choice.}
+    {Confirms a user choice}
 
     return: [logic!]
-    question [any-series!]
-        "Prompt to user"
-    /with
-    choices [text! block!]
+    question "Prompt to user"
+        [any-series!]
+    /with [text! block!]
 ][
-    choices: default [["y" "yes"] ["n" "no"]]
+    with: default [["y" "yes"] ["n" "no"]]
 
     all [
-        block? choices
-        length of choices > 2
+        block? with
+        length of with > 2
 
-        fail 'choices [
-            "maximum 2 arguments allowed for choices [true false]"
-            "got:" mold choices
+        fail 'with [
+            "maximum 2 arguments allowed for with [true false]"
+            "got:" mold with
         ]
     ]
 
     response: ask question
 
     return case [
-        empty? choices [true]
-        text? choices [did find/match response choices]
-        length of choices < 2 [did find/match response first choices]
-        find first choices response [true]
-        find second choices response [false]
+        empty? with [true]
+        text? with [did find/match response with]
+        length of with < 2 [did find/match response first with]
+        find first with response [true]
+        find second with response [false]
     ]
 ]
 
@@ -181,9 +180,9 @@ list-dir: function [
 ;   /t "Time order"
     /r "Recursive"
     /i "Indent"
-        indent
+        [any-value!]
 ][
-    indent: default [""]
+    i: default [""]
 
     save-dir: what-dir
 
@@ -192,7 +191,7 @@ list-dir: function [
     ]
 
     switch type of :path [
-        null [] ; Stay here
+        null []  ; Stay here
         file! [change-dir path]
         text! [change-dir local-to-file path]
         word! path! [change-dir to-file path]
@@ -222,9 +221,9 @@ list-dir: function [
         ] else [
             info: get (words of query file)
             change info second split-path info/1
-            printf [indent 16 -8 #" " 24 #" " 6] info
+            printf [i 16 -8 #" " 24 #" " 6] info
             if all [r | dir? file] [
-                list-dir/l/r/i :file join indent "    "
+                list-dir/l/r/i :file join i "    "
             ]
         ]
     ]

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -64,20 +64,21 @@ sign-of: func [
     ]
 ]
 
-extreme-of: func [
+extreme-of: function [
     {Finds the value with a property in a series that is the most "extreme"}
 
-    return: [any-series!] {Position where the extreme value was found}
-    series [any-series!] {Series to search}
-    comparator [action!] {Comparator to use, e.g. LESSER? for MINIMUM-OF}
-    /skip {Treat the series as records of fixed size}
-    size [integer!]
-    <local> spot
+    return: "Position where the extreme value was found"
+        [any-series!]
+    series [any-series!]
+    comparator "Comparator to use, e.g. LESSER? for MINIMUM-OF"
+        [action!]
+    /skip "Treat the series as records of fixed size"
+        [integer!]
 ][
-    size: default [1]
-    if 1 > size [cause-error 'script 'out-of-range size]
+    skip: default [1]
+    if 1 > skip [cause-error 'script 'out-of-range skip]
     spot: series
-    iterate-skip series size [
+    iterate-skip series skip [
         if (comparator first series first spot) [spot: series]
     ]
     spot

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -767,9 +767,9 @@ encrypt-data: function [
     switch ctx/crypt-method [
         aes@ [
             ctx/encrypt-stream: default [
-                aes/key ctx/client-crypt-key ctx/client-iv
+                aes-key ctx/client-crypt-key ctx/client-iv
             ]
-            data: aes/stream ctx/encrypt-stream data
+            data: aes-stream ctx/encrypt-stream data
 
             if ctx/version > 1.0 [
                 ; encrypt-stream must be reinitialized each time with the
@@ -801,9 +801,9 @@ decrypt-data: function [
     switch ctx/crypt-method [
         aes@ [
             ctx/decrypt-stream: default [
-                aes/key/decrypt ctx/server-crypt-key ctx/server-iv
+                aes-key/decrypt ctx/server-crypt-key ctx/server-iv
             ]
-            data: aes/stream ctx/decrypt-stream data
+            data: aes-stream ctx/decrypt-stream data
 
             ; TLS 1.1 and above must use a new initialization vector each time
             ; so the decrypt stream has to get GC'd.

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -369,18 +369,18 @@ update-write-state: specialize 'update-state [
 client-hello: function [
     return: <void>
     ctx [object!]
-    /version "TLS version to request (default is minimum 1.0, maximum 1.2)"
-    ver "If block, lowest and highest version to allow"
+    /version "TLS version to request (block is [lowest highest] allowed)"
         [decimal! block!]
 ][
+    version: default [[1.0 1.2]]
+
     set [ctx/min-version: ctx/max-version:] case [
-        not set? 'ver [[1.0 1.2]]
-        decimal? ver [reduce [ver ver]]
-        block? ver [
-            parse ver [decimal! decimal! end] else [
+        decimal? version [reduce [version version]]
+        block? version [
+            parse version [decimal! decimal! end] else [
                 fail "BLOCK! /VERSION must be two DECIMAL! (min ver, max ver)"
             ]
-            ver
+            version
         ]
     ]
     min-ver-bytes: select version-to-bytes ctx/min-version else [
@@ -722,9 +722,9 @@ encrypt-data: function [
     ctx [object!]
     content [binary!]
     /type
-    msg-type [binary!] "application data is default"
+        [binary!] "application data is default"
 ][
-    msg-type: default [#{17}] ;-- #application
+    type: default [#{17}] ;-- #application
 
     ; GenericBlockCipher: https://tools.ietf.org/html/rfc5246#section-6.2.3.2
 
@@ -747,7 +747,7 @@ encrypt-data: function [
     ;
     MAC: checksum/method/key join-all [
         to-bin ctx/seq-num-w 8              ; sequence number (64-bit int)
-        msg-type                            ; msg type
+        type                                ; msg type
         ctx/ver-bytes                       ; version
         to-bin length of content 2          ; msg content length
         content                             ; msg content

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -44,14 +44,12 @@ do*: function [
     return: [<opt> any-value!]
     source [file! url! text! binary! tag!]
         {Files, urls and modules evaluate as scripts, other strings don't.}
-    arg [<opt> any-value!]
+    args [any-value!]
         "Args passed as system/script/args to a script (normally a string)"
     only [logic!]
         "Do not catch quits...propagate them."
 ][
     ; Refinements on the original DO, re-derive for helper
-
-    args: value? :arg
 
     next: :lib/next
 
@@ -158,12 +156,12 @@ do*: function [
 
         ; Make the new script object
         original-script: system/script  ; and save old one
-        system/script: make system/standard/script [
+        system/script: make system/standard/script compose [
             title: try select hdr 'title
             header: hdr
             parent: :original-script
             path: what-dir
-            args: try :arg
+            args: (:args)
         ]
 
         if set? 'script-pre-load-hook [

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -99,13 +99,11 @@ encode: function [
     {Encodes a datatype (e.g. image!) into a series of bytes.}
 
     return: [binary!]
-    type [word!]
-        {Media type (jpeg, png, etc.)}
-    data
-        {The data to encode}
-    /options
-        {Special encoding options}
-    opts [block!]
+    type "Media type (jpeg, png, etc.)"
+        [word!]
+    data [any-value!]
+    /options "Encoding options"
+        [block!]  ; !!! Not currently used
 ][
     all [
         cod: select system/codecs type

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -258,9 +258,8 @@ load: function [
         [file! url! text! binary! block!]
     /header "Result includes REBOL header object "
     /all "Load all values (cannot be used with /HEADER)"
-    /type "Override default file-type"
-    ftype "E.g. rebol, text, markup, jpeg... (by default, auto-detected)"
-        [word!]
+    /type "E.g. rebol, text, markup, jpeg... (by default, auto-detected)"
+    ftype [word!]
     <in> no-all  ; !!! temporary fake of <unbind> option
 ][
     self: binding of 'return  ; so you can say SELF/ALL
@@ -291,7 +290,7 @@ load: function [
                 source: s
                 header: header
                 all: a
-                set* lit ftype: :ftype
+                type: :type
             ]
         ]
     ]
@@ -301,9 +300,9 @@ load: function [
     if match [file! url!] source [
         file: source
         line: 1
-        ftype: default [file-type? source else ['rebol]]  ; !!! rebol default?
+        type: default [file-type? source else ['rebol]]  ; !!! rebol default?
 
-        if ftype = 'extension [
+        if type = 'extension [
             if not file? source [
                 fail ["Can only load extensions from FILE!, not" source]
             ]
@@ -329,19 +328,19 @@ load: function [
     else [
         file: line: _
         data: source
-        ftype: default ['rebol]
+        type: default ['rebol]
 
-        if ftype = 'extension [
+        if type = 'extension [
             fail "Extensions can only be loaded from a FILE! (.DLL, .so)"
         ]
     ]
 
-    if not find [unbound rebol] ftype [
-        if find system/options/file-types ftype [
-            return decode ftype :data
+    if not find [unbound rebol] type [
+        if find system/options/file-types type [
+            return decode type :data
         ]
 
-        fail ["No" ftype "LOADer found for" type of source]
+        fail ["No" type "LOADer found for" type of source]
     ]
 
     ensure [text! binary!] data
@@ -381,7 +380,7 @@ load: function [
     ; Bind code to user context
 
     none [
-        'unbound = ftype
+        'unbound = type
         'module = select hdr 'type
         find try get 'hdr/options 'unbound
     ] then [
@@ -808,17 +807,17 @@ load-module: function [
 
         if exports [
             if null? select hdr 'exports [
-                append hdr compose [exports: (export-list)]
+                append hdr compose [exports: (exports)]
             ] else [
                 append exports hdr/exports
-                hdr/exports: export-list
+                hdr/exports: exports
             ]
         ]
 
         catch/quit [
             mod: module/mixin/into hdr code (
                 opt do-needs/no-user hdr
-            ) :existing
+            ) :into
         ]
     ]
 

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -259,7 +259,7 @@ load: function [
     /header "Result includes REBOL header object "
     /all "Load all values (cannot be used with /HEADER)"
     /type "E.g. rebol, text, markup, jpeg... (by default, auto-detected)"
-    ftype [word!]
+        [word!]
     <in> no-all  ; !!! temporary fake of <unbind> option
 ][
     self: binding of 'return  ; so you can say SELF/ALL
@@ -514,19 +514,19 @@ load-module: function [
     source {Source (file, URL, binary, etc.) or block of sources}
         [word! file! url! text! binary! module! block!]
     /version "Module must be this version or greater"
-    ver [tuple!]
+        [tuple!]
     /no-share "Force module to use its own non-shared global namespace"
     /no-lib "Don't export to the runtime library (lib)"
     /import "Do module import now, overriding /delay and 'delay option"
     /as "New name for the module (not valid for reloads)"
-    name [word!]
+        [word!]
     /delay "Delay module init until later (ignored if source is module!)"
     /into "Load into an existing module (e.g. populated with some natives)"
-    existing [module!]
+        [module!]
     /exports "Add exports on top of those in the EXPORTS: section"
-    export-list [block!]
+        [block!]
 ][
-    as_LOAD_MODULE: :as
+    name: as
     as: :lib/as
 
     ; NOTES:
@@ -550,7 +550,7 @@ load-module: function [
 
     switch type of source [
         word! [ ; loading the preloaded
-            if as_LOAD_MODULE [
+            if name [
                 cause-error 'script 'bad-refine /as  ; no renaming
             ]
 
@@ -602,7 +602,7 @@ load-module: function [
         module! [
             ; see if the same module is already in the list
             if tmp: find/skip next system/modules mod: source 2 [
-                if as_LOAD_MODULE [
+                if name [
                     ; already imported
                     cause-error 'script 'bad-refine /as
                 ]
@@ -620,7 +620,7 @@ load-module: function [
         ]
 
         block! [
-            if any [version as] [
+            if any [version name] [
                 cause-error 'script 'bad-refines blank
             ]
 
@@ -633,8 +633,10 @@ load-module: function [
                     set mod [
                         word! | module! | file! | url! | text! | binary!
                     ]
-                    set ver opt tuple! (
-                        append data reduce [mod ver if name [to word! name]]
+                    set version opt tuple! (
+                        append data reduce [
+                            mod version if name [to word! name]
+                        ]
                     )
                 ]
                 end
@@ -646,9 +648,7 @@ load-module: function [
                 applique 'load-module [
                     source: mod
                     version: version
-                    ver: :ver
-                    as: true
-                    name: opt name
+                    as: name
                     no-share: no-share
                     no-lib: no-lib
                     import: import
@@ -699,7 +699,7 @@ load-module: function [
     ]
 
     ; Unify hdr/name and /AS name
-    if set? 'name [
+    if name [
         hdr/name: name  ; rename /AS name
     ] else [
         name: :hdr/name
@@ -852,7 +852,7 @@ import: function [
 
     module [word! file! url! text! binary! module! block! tag!]
     /version "Module must be this version or greater"
-    ver [tuple!]
+        [tuple!]
     /no-share "Force module to use its own non-shared global namespace"
     /no-lib "Don't export to the runtime library (lib)"
     /no-user "Don't export to the user context"
@@ -893,7 +893,6 @@ import: function [
     set [name: mod:] applique 'load-module [
         source: module
         version: version
-        ver: :ver
         no-share: no-share
         no-lib: no-lib
         import: true  ; !!! original code always passed /IMPORT, should it?
@@ -915,7 +914,6 @@ import: function [
                     applique 'load-module [
                         source: path/:file
                         version: version
-                        ver: :ver
                         no-share: :no-share
                         no-lib: :no-lib
                         import: true

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -187,8 +187,8 @@ make-scheme: function [
     base-name [word!]
         "Scheme name to use as base"
 ][
-    with: either with [get in system/schemes base-name][system/standard/scheme]
-    if not with [cause-error 'access 'no-scheme base-name]
+    with: either with [get in system/schemes with][system/standard/scheme]
+    if not with [cause-error 'access 'no-scheme with]
 
     scheme: make with def
     if not scheme/name [cause-error 'access 'no-scheme-name scheme]

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -180,12 +180,13 @@ decode-url: _ ; used by sys funcs, defined above, set below
 ;-- Native Schemes -----------------------------------------------------------
 
 make-scheme: function [
-    "Make a scheme from a specification and add it to the system."
-    def [block!]
-        "Scheme specification"
-    /with
-    base-name [word!]
-        "Scheme name to use as base"
+    {Make a scheme from a specification and add it to the system}
+
+    def "Scheme specification"
+        [block!]
+    /with "Scheme name to use as base"
+        [word!]
+        
 ][
     with: either with [get in system/schemes with][system/standard/scheme]
     if not with [cause-error 'access 'no-scheme with]

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -588,6 +588,9 @@ pe-format: context [
         def
         find-a-word
     ][
+        words: skip
+        skip: :lib/skip
+
         find-a-word: func [
             return: <void>
             word [any-word!]
@@ -599,7 +602,7 @@ pe-format: context [
             ]
         ]
 
-        either skip [
+        either words [
             if word? words [
                 words: reduce [words]
             ]

--- a/src/os/encap.reb
+++ b/src/os/encap.reb
@@ -580,8 +580,8 @@ pe-format: context [
         "Collect all set-words in @rule and make an object out of them and save it in @name"
         rule [block!]
         'name [word!]
-        /skip
-            words [word! block!] "Do not collect these words"
+        /skip "Do not collect these words"
+            [word! block!]
         <local>
         word
         skips
@@ -1239,28 +1239,27 @@ generic-format: context [
 
 
 encap: function [
-    return: [file!]
-        {Path location of the resulting output}
-    spec [file! block!]
-        {Single script to embed, directory to zip with main.reb, or dialect}
-    /rebol
-        {Specify a path to a Rebol to encap instead of using the current one}
-    in-rebol-path
+    return: "Path location of the resulting output"
+        [file!]
+    spec "Single script to embed, directory to zip with main.reb, or dialect"
+        [file! block!]
+    /rebol "Path to a Rebol to encap instead of using the current one"
+        [any-value!]
 ][
     if block? spec [
         fail "The spec dialect for encapping has not been defined yet"
     ]
 
-    in-rebol-path: default [system/options/boot]
-    either ".exe" = base-name: skip tail of in-rebol-path -4 [
+    rebol: default [system/options/boot]
+    either ".exe" = base-name: skip tail of rebol -4 [
         out-rebol-path: join
-            copy/part in-rebol-path (index of base-name) - 1
+            copy/part rebol (index of base-name) - 1
             "-encap.exe"
     ][
-        out-rebol-path: join in-rebol-path "-encap"
+        out-rebol-path: join rebol "-encap"
     ]
 
-    print ["Encapping from original executable:" in-rebol-path]
+    print ["Encapping from original executable:" rebol]
 
     executable: read in-rebol-path
 
@@ -1285,9 +1284,9 @@ encap: function [
     ; actual names of disk files at this moment.  Just signal which it is.
     ;
     either single-script [
-        insert compressed 0 ;-- signal a single file encap
+        insert compressed 0  ; signal a single file encap
     ][
-        insert compressed 1 ;-- signal a zipped encap
+        insert compressed 1  ; signal a zipped encap
     ]
 
     print ["Extending compressed resource by one byte for zipped/not signal"]

--- a/src/os/host-start.r
+++ b/src/os/host-start.r
@@ -343,20 +343,25 @@ host-start: function [
         load-extension collation
     ]
 
-    ; helper functions
-    ;
+    === HELPER FUNCTIONS ===
+
     die: func [
         {A graceful way to "FAIL" during startup}
-        reason [text! block!]
-            {Error message}
-        /error e [error!]
-            {Error object, shown if --verbose option used}
+
+        reason "Error message"
+            [text! block!]
+        /error "Error object, shown if --verbose option used"
+            [error!]
         <with> return
     ][
         print "Startup encountered an error!"
         print ["**" if block? reason [spaced reason] else [reason]]
         if error [
-            print either o/verbose [[e]] ["!! use --verbose for more detail"]
+            print either o/verbose [
+                [error]
+            ][
+                "!! use --verbose for more detail"
+            ]
         ]
         return <die>
     ]

--- a/tests/call/call.test.reb
+++ b/tests/call/call.test.reb
@@ -66,7 +66,7 @@
             {--do} {"write-stdout read system/ports/input"}
         ]
     ] function [frame [frame!]] [
-        out: frame/out
+        out: frame/output
         do frame
         return out
     ])

--- a/tests/context/bind.test.reb
+++ b/tests/context/bind.test.reb
@@ -20,7 +20,7 @@
 ; BIND works 'as expected' in function body
 [#1549 (
     b1: [self]
-    f: func [/local b2] [
+    f: func [<local> b2] [
         b2: [self]
         same? first b2 first bind/copy b1 'b2
     ]

--- a/tests/control/reduce.test.reb
+++ b/tests/control/reduce.test.reb
@@ -16,7 +16,6 @@
 (1 = catch [reduce [throw 1]])
 ([a 1] = catch/name [reduce [throw/name 1 'a]] 'a)
 (1 = eval func [] [reduce [return 1 2] 2])
-(null? if 1 < 2 [eval does [reduce [unwind :if 1] 2]])
 ; recursive behaviour
 (1 = first reduce [first reduce [1]])
 ; infinite recursion

--- a/tests/control/while.test.reb
+++ b/tests/control/while.test.reb
@@ -67,23 +67,6 @@
     f1: func [] [while [if cycle? [return 1] cycle?] [cycle?: false 2]]
     1 = f1
 )
-; UNWIND the IF should stop the loop
-(
-    cycle?: true
-    f1: does [if 1 < 2 [while [cycle?] [cycle?: false unwind :if] 2]]
-    null? f1
-)
-
-(  ; bug#1519
-    cycle?: true
-    if-not: adapt 'if [condition: not :condition]
-    f1: does [
-        if-not 1 > 2 [
-            while [if cycle? [unwind :if-not] cycle?] [cycle?: false 2]
-        ]
-    ]
-    null? f1
-)
 
 ; CONTINUE out of a condition continues any enclosing loop (it does not mean
 ; continue the WHILE whose condition it appears in)

--- a/tests/convert/mold.test.reb
+++ b/tests/convert/mold.test.reb
@@ -117,7 +117,7 @@
 [#145 (
     test-block: [a b c d e f]
     set 'f func [
-        /local buff
+        <local> buff
     ][
         buff: copy ""
         for-each val test-block [

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -158,6 +158,7 @@
 %functions/redescribe.test.reb
 %functions/redo.test.reb
 %functions/specialize.test.reb
+%functions/unwind.test.reb
 
 %math/absolute.test.reb
 %math/add.test.reb

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -319,7 +319,7 @@
 )
 [#19 ; but duplicate specializations currently not legal in Ren-C
     (
-    f: func [/r x] [x]
+    f: func [/r [integer!]] [x]
     error? trap [2 == f/r/r 1 2]
     )
 ]
@@ -371,17 +371,17 @@
     n: 20
 
     f: function [
-        /count
-        n (2)
+        /count [integer!]
         <in> o1 o1/o2
         <with> outer
         <static> static (10 + n)
     ][
-        data: reduce [n x y outer static]
+        count: default [2]
+        data: reduce [count x y outer static]
         return case [
-            n = 0 [reduce [data]]
+            count = 0 [reduce [data]]
             true [
-               append/only (f/count n - 1) data
+               append/only (f/count count - 1) data
             ]
         ]
     ]
@@ -409,7 +409,7 @@
 
 ; /LOCAL is an ordinary refinement in Ren-C
 (
-    a-value: func [/local a] [a]
+    a-value: func [/local [integer!]] [local]
     1 == a-value/local 1
 )
 

--- a/tests/datatypes/get-word.test.reb
+++ b/tests/datatypes/get-word.test.reb
@@ -12,15 +12,10 @@
     null? :a
 )
 
-[#1477 (
-    e: trap [load ":/"]
-    (error? e) and [e/id = 'scan-invalid]
-)]
-(
-    e: trap [load "://"]
-    (error? e) and [e/id = 'scan-invalid]
-)
-(
-    e: trap [load ":///"]
-    (error? e) and [e/id = 'scan-invalid]
-)
+[#1477
+    ((match get-path! lit :/) = (load ":/"))
+
+    ((match get-path! lit ://) = (load "://"))
+
+    ((match get-path! lit :///) = (load ":///"))
+]

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -120,7 +120,7 @@
     1 == obj/fun
 )
 (
-    obj: make object! [fun: func [/ref val] [val]]
+    obj: make object! [fun: func [/ref [integer!]] [ref]]
     1 == obj/fun/ref 1
 )
 ; calling functions through paths: function in block, positional

--- a/tests/functions/apply.test.reb
+++ b/tests/functions/apply.test.reb
@@ -4,8 +4,7 @@
     s: applique :append [
         series: [a b c]
         value: [d e]
-        dup: true
-        count: 2
+        dup: 2
     ]
     s = [a b c d e d e]
 )

--- a/tests/functions/hijack.test.reb
+++ b/tests/functions/hijack.test.reb
@@ -18,57 +18,60 @@
 
 ; Hijacking and un-hijacking out from under specializations, as well as
 ; specializing hijacked functions afterward.
-(
-    three: func [x y z /available add-me] [
-        x + y + z + either available [add-me] [0]
-    ]
-    step1: (three 10 20 30) ; 60
+[
+    (
+        three: func [x y z /available "add me" [integer!]] [
+            x + y + z + either available [available] [0]
+        ]
+        60 = (three 10 20 30)
+    )
 
-    old-three: copy :three
+    (
+        old-three: copy :three
 
-    two-30: specialize 'three [z: 30]
-    step2: (two-30 10 20) ; 60
+        two-30: specialize 'three [z: 30]
+        60 = (two-30 10 20)
+    )
 
-    hijack 'three func [a b c /unavailable /available mul-me] [
-       a * b * c * either available [mul-me] [1]
-    ]
+    (
+        hijack 'three func [
+            a b c /unavailable /available "mul me" [integer!]
+        ][
+            a * b * c * either available [available] [1]
+        ]
+        true
+    )
 
-    step3: (three 10 20 30) ; 6000
-    step4: (two-30 10 20) ; 6000
+    (6000 = (three 10 20 30))
+    (6000 = (two-30 10 20))
 
-    step5: trap [three/unavailable 10 20 30] ; error
+    (error? trap [three/unavailable 10 20 30])
 
-    step6: (three/available 10 20 30 40) ; 240000
+    (240000 = (three/available 10 20 30 40))
 
-    step7: (two-30/available 10 20 40) ; 240000
+    (240000 = (two-30/available 10 20 40))
 
-    one-20: specialize 'two-30 [y: 20]
+    (
+        one-20: specialize 'two-30 [y: 20]
 
-    hijack 'three func [q r s] [
-        q - r - s
-    ]
+        hijack 'three func [q r s] [
+            q - r - s
+        ]
 
-    step8: (one-20 10) ; -40
+        true
+    )
 
-    hijack 'three 'old-three
+    (-40 = (one-20 10))
 
-    step9: (three 10 20 30) ; 60
+    (
+        hijack 'three 'old-three
+        true
+    )
 
-    step10: (two-30 10 20) ; 60
+    (60 = (three 10 20 30))
 
-    did all [
-        step1 = 60
-        step2 = 60
-        step3 = 6000
-        step4 = 6000
-        error? step5
-        step6 = 240000
-        step7 = 240000
-        step8 = -40
-        step9 = 60
-        step10 = 60
-    ]
-)
+    (60 = (two-30 10 20))
+]
 
 ; HIJACK of a specialization (needs to notice paramlist has "hidden" params)
 (

--- a/tests/functions/redo.test.reb
+++ b/tests/functions/redo.test.reb
@@ -69,25 +69,25 @@
             return <success>
         ]
         n: 0
-        redo 'n ;-- should redo INNER, not outer
+        redo 'n  comment {should redo INNER, not outer}
     ]
 
     outer: adapt 'inner [
         if n = 0 [
             return "outer phase run by redo"
         ]
-        ;-- fall through to inner, using same frame
+        comment {fall through to inner, using same frame}
     ]
 
     <success> = outer 1
 )
 (
-    inner: func [n /captured-frame f] [
+    inner: func [n /captured-frame [frame!]] [
         if n = 0 [
            return "inner phase run by redo"
         ]
         n: 0
-        redo f ;-- should redo OUTER, not INNER
+        redo captured-frame  comment {should redo OUTER, not INNER}
     ]
 
     outer: adapt 'inner [
@@ -95,12 +95,13 @@
             return <success>
         ]
 
-        f: binding of 'n
-        captured-frame: true
+        captured-frame: binding of 'n
 
-        ;-- fall through to inner
-        ;-- it is running in the same frame's memory, but...
-        ;-- F is a FRAME! value that stowed outer's "phase"
+        comment {
+            Fall through to inner
+            It is running in the same frame's memory, but...
+            CAPURED-FRAME is a FRAME! value that stowed outer's "phase"
+        }
     ]
 
     <success> = outer 1
@@ -162,17 +163,17 @@
 ; a tag and signals success.
 (
     log: (
-        func ['x] [] ;-- no-op
-        elide (:dump) ;-- un-elide to get output
+        func ['x] []  comment {no-op}
+        elide (:dump)  comment {un-elide to get output}
     )
 
-    base: func [n delta /captured-frame f [frame!]] [
+    base: func [n delta /captured-frame [frame!]] [
         log [{BASE} n delta]
 
         n: n - delta
         if n < 0 [return "base less than zero"]
         if n = 0 [return "base done"]
-        if captured-frame [redo f]
+        if captured-frame [redo captured-frame]
         return "base got no frame"
     ]
 
@@ -180,11 +181,10 @@
         adapt 'base [
            log [{C} n delta]
 
-           f: binding of 'n
-           captured-frame: true
+           captured-frame: binding of 'n
            redo/other 'n :s
 
-           ;-- fall through to base
+           comment {fall through to base}
         ]
             |
         func [x] [

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -6,29 +6,30 @@
 ;     specialize 'append/dup/part []
 ;     :append/dup/part
 
-(
-    foo: func [/A aa /B bb /C cc] [
-        return compose [
-            (opt A) (:aa) (opt B) (:bb) (opt C) (:cc)
+[
+    (
+        foo: func [/A [integer!] /B [integer!] /C [integer!]] [
+            return compose [
+                /A (A) /B (B) /C (C)
+            ]
         ]
-    ]
 
-    fooBC: :foo/B/C
-    fooCB: :foo/C/B
+        fooBC: :foo/B/C
+        fooCB: :foo/C/B
+        true
+    )
 
-    did all [
-        [/B 10 /C 20] = fooBC 10 20
-        [/A 30 /B 10 /C 20] = fooBC/A 10 20 30
+    ([/A _ /B 10 /C 20] = fooBC 10 20)
+    ([/A 30 /B 10 /C 20] = fooBC/A 10 20 30)
 
-        [/B 20 /C 10] = fooCB 10 20
-        [/A 30 /B 20 /C 10] = fooCB/A 10 20 30
+    ([/A _ /B 20 /C 10] = fooCB 10 20)
+    ([/A 30 /B 20 /C 10] = fooCB/A 10 20 30)
 
-        error? trap [fooBC/B 1 2 3 4 5 6]
-        error? trap [fooBC/C 1 2 3 4 5 6]
-        error? trap [fooCB/B 1 2 3 4 5 6]
-        error? trap [fooCB/C 1 2 3 4 5 6]
-    ]
-)
+    (error? trap [fooBC/B 1 2 3 4 5 6])
+    (error? trap [fooBC/C 1 2 3 4 5 6])
+    (error? trap [fooCB/B 1 2 3 4 5 6])
+    (error? trap [fooCB/C 1 2 3 4 5 6])
+]
 
 (
     append-123: specialize :append [value: [1 2 3] only: true]
@@ -36,14 +37,16 @@
 )
 (
     append-123: specialize :append [value: [1 2 3] only: true]
-    append-123-twice: specialize :append-123 [dup: true count: 2]
+    append-123-twice: specialize :append-123 [dup: 2]
     [a b c [1 2 3] [1 2 3]] = append-123-twice copy [a b c]
 )
 (
     append-10: specialize 'append [value: 10]
     f: make frame! :append-10
     f/series: copy [a b c]
-    do copy f ;-- COPY before DO allows reuse of F, only the copy is "stolen"
+
+    comment {COPY before DO allows reuse of F, only the copy is "stolen"}
+    do copy f
     [a b c 10 10] = do f
 )
 (
@@ -61,50 +64,54 @@
     foo = 5
 )
 
-(
-    apd: specialize 'append/part [dup: true]
-    apd3: specialize 'apd [count: 3]
-    ap2d: specialize 'apd [limit: 2]
+[
+    (
+        apd: :append/part/dup
+        apd3: specialize 'apd [dup: 3]
+        ap2d: specialize 'apd [part: 2]
 
-    xy: [<X> #Y]
-    abc: [A B C]
-    r: [<X> #Y A B A B A B]
+        xy: [<X> #Y]
+        abc: [A B C]
+        r: [<X> #Y A B A B A B]
+        true
+    )
 
-    did all [
-        | r = apd copy xy abc 2 3
-        | r = applique 'apd [series: copy xy | value: abc | limit: 2 | count: 3]
-        |
-        | r = apd3 copy xy abc 2
-        | r = applique 'apd3 [series: copy xy | value: abc | limit: 2]
-        |
-        | r = ap2d copy xy abc 3
-        | r = applique 'ap2d [series: copy xy | value: abc | count: 3]
-    ]
-)(
-    adp: specialize 'append/dup [part: true]
-    adp2: specialize 'adp [limit: 2]
-    ad3p: specialize 'adp [count: 3]
+    (r = apd copy xy abc 2 3)
+    (r = applique 'apd [series: copy xy | value: abc | part: 2 | dup: 3])
 
-    xy: [<X> #Y]
-    abc: [A B C]
-    r: [<X> #Y A B A B A B]
+    (r = apd3 copy xy abc 2)
+    (r = applique 'apd3 [series: copy xy | value: abc | part: 2])
 
-    did all [
-        | r = adp copy xy abc 3 2
-        | r = applique 'adp [series: copy xy | value: abc | count: 3 | limit: 2]
-        |
-        | r = adp2 copy xy abc 3
-        | r = applique 'adp2 [series: copy xy | value: abc | count: 3]
-        |
-        | r = ad3p copy xy abc 2
-        | r = applique 'ad3p [series: copy xy | value: abc | limit: 2]
-    ]
-)
+    (r = ap2d copy xy abc 3)
+    (r = applique 'ap2d [series: copy xy | value: abc | dup: 3])
+]
+
+[
+    (
+        adp: :append/dup/part
+        adp2: specialize 'adp [part: 2]
+        ad3p: specialize 'adp [dup: 3]
+
+        xy: [<X> #Y]
+        abc: [A B C]
+        r: [<X> #Y A B A B A B]
+        true
+    )
+
+    (r = adp copy xy abc 3 2)
+    (r = applique 'adp [series: copy xy | value: abc | dup: 3 | part: 2])
+
+    (r = adp2 copy xy abc 3)
+    (r = applique 'adp2 [series: copy xy | value: abc | dup: 3])
+
+    (r = ad3p copy xy abc 2)
+    (r = applique 'ad3p [series: copy xy | value: abc | part: 2])
+]
 
 (
     aopd3: specialize lit (specialize 'append/only [])/part [
-        count: 3
-        limit: 1
+        dup: 3
+        part: 1
     ]
 
     r: [a b c [d e] [d e] [d e]]
@@ -136,7 +143,7 @@
     f/series: copy [a b c]
     did all [
         [a b c 10] = do copy f
-        f/count: 2
+        f/dup: 2
         [a b c 10 10 10] = do f
     ]
 )
@@ -144,19 +151,22 @@
 ; Partial specialization can do some complex reordering of argument gathering,
 ; which the evaluator needs to accomodate with backwards quoting skippables
 ; and other enfix situations.
-(
-    foo: function [/a aa /b :bb [<skip> word!]] [
-        reduce [a (:aa else '<null>) b (:bb else '<null>)]
-    ]
-    foob: enfix :foo/b
-    did all [
-        [_ <null> /b word] = (word foob |)
-        [_ <null> _ <null>] = (<not a word> foob |)
-        [/a 20 /b word] = (word <- foob/a 20)
-        comment [
-            {Currently SHOVE and <skip> don't work together, maybe shouldn't}
-            https://github.com/metaeducation/ren-c/issues/909
-            [/a 20 _ <null>] = (<not a word> <- foob/a 20)
+[
+    (
+        foo: function [/A [integer!] :/B [<skip> word!]] [
+            reduce [/A (A) /B (B)]
         ]
-    ]
-)
+        foob: enfix :foo/b
+        true
+    )
+
+    ([/A _ /B word] = (word foob |))
+    ([/A _ /B _] = (<not a word> foob |))
+    ([/A 20 /B word] = (word <- foob/a 20))
+
+    (comment [
+        {Currently SHOVE and <skip> don't work together, maybe shouldn't}
+        https://github.com/metaeducation/ren-c/issues/909
+        [/A 20 /B _] = (<not a word> <- foob/a 20)
+    ] true)
+]

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -154,7 +154,7 @@
 [
     (
         foo: function [/A [integer!] :/B [<skip> word!]] [
-            reduce [/A (A) /B (B)]
+            reduce [/A (A) /B (try :B)]
         ]
         foob: enfix :foo/b
         true

--- a/tests/functions/unwind.test.reb
+++ b/tests/functions/unwind.test.reb
@@ -1,0 +1,29 @@
+; UNWIND allows one to name specific stack levels to jump up to
+; and return a value from.  It uses the same mechanism as RETURN
+
+(<good> = if 1 < 2 [eval does [reduce [unwind :if <good> | <bad1>] <bad2>]])
+
+; UNWIND the IF should stop the loop
+(
+    cycle?: true
+    f1: does [
+        if 1 < 2 [
+            while [cycle?] [cycle?: false | unwind :if]
+            <bad>
+        ]
+        <good>
+    ]
+    <good> = f1
+)
+
+; Related to #1519
+(
+    cycle?: true
+    if-not: adapt 'if [condition: not :condition]
+    f1: does [
+        if-not 1 > 2 [
+            while [if cycle? [unwind :if-not <ret>] cycle?] [cycle?: false 2]
+        ]
+    ]
+    f1 = <ret>
+)

--- a/tests/redbol/redbol-apply.test.reb
+++ b/tests/redbol/redbol-apply.test.reb
@@ -30,17 +30,16 @@
     ]
 
     comment [
-        ;
-        ; Too many arguments was not a problem for R3-alpha's APPLY, it
-        ; would evaluate them all even if not used by the function.  It
-        ; may or may not be better to have it be an error.
-        ;
+        {Too many arguments was not a problem for R3-alpha's APPLY, it
+        would evaluate them all even if not used by the function.  It
+        may or may not be better to have it be an error.}
+
         if not tail? block [
             fail "Too many arguments passed in R3-ALPHA-APPLY block."
         ]
     ]
 
-    do frame  ; nulls are optionals
+    do frame  comment {nulls are optionals}
 ])
 
 [#44 (
@@ -57,22 +56,24 @@
 
 (error? redbol-apply :make [error! ""])
 
-(/a = redbol-apply func [/a] [a] [true])
-(_ = redbol-apply func [/a] [a] [false])
+(/a = redbol-apply func [/a] [a] [#[true]])
+(_ = redbol-apply func [/a] [a] [#[false]])
 (_ = redbol-apply func [/a] [a] [])
-(/a = redbol-apply/only func [/a] [a] [true])
+(/a = redbol-apply/only func [/a] [a] [#[true]])
 ; the word 'false
-(/a = redbol-apply/only func [/a] [a] [false])
+(
+    e: trap [/a = redbol-apply/only func [/a] [a] [false]]
+    e/id = 'invalid-type
+)
 (_ == redbol-apply/only func [/a] [a] [])
 (use [a] [a: true /a = redbol-apply func [/a] [a] [a]])
 (use [a] [a: false _ == redbol-apply func [/a] [a] [a]])
-(use [a] [a: false /a = redbol-apply func [/a] [a] ['a]])
 (use [a] [a: false /a = redbol-apply func [/a] [a] [/a]])
-(use [a] [a: false /a = redbol-apply/only func [/a] [a] [a]])
+(use [a] [a: false /a = redbol-apply/only func [/a] [/a] [/a]])
 (group! == redbol-apply/only (specialize 'of [property: 'type]) [()])
-([1] == head of redbol-apply :insert [copy [] [1] blank blank blank])
-([1] == head of redbol-apply :insert [copy [] [1] blank blank false])
-([[1]] == head of redbol-apply :insert [copy [] [1] blank blank true])
+([1] == head of redbol-apply :insert [copy [] [1] blank blank])
+([1] == head of redbol-apply :insert [copy [] [1] blank false])
+([[1]] == head of redbol-apply :insert [copy [] [1] blank true])
 (action! == redbol-apply (specialize 'of [property: 'type]) [:print])
 (get-word! == redbol-apply/only (specialize 'of [property: 'type]) [:print])
 

--- a/tests/series/reword.test.reb
+++ b/tests/series/reword.test.reb
@@ -9,7 +9,7 @@
     "BrianH is answering Adrian." = reword/escape "I am answering you." [
         "I am" "BrianH is"
         you "Adrian"
-    ] blank
+    ] ""
 )(
     "Hello is Goodbye" = reword/escape "$$$a$$$ is $$$b$$$" [
        a Hello

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -114,7 +114,7 @@ make object! compose [
         flags [block!] {which flags to accept}
         code-checksum [binary! blank!]
         log-file-prefix [file!]
-        /local interpreter last-vector value position next-position
+        <local> interpreter last-vector value position next-position
         test-sources test-checksum guard
     ] [
         allowed-flags: flags

--- a/tools/common-emitter.r
+++ b/tools/common-emitter.r
@@ -40,7 +40,7 @@ cscape: function [
     template "${Expr} case as-is, ${expr} lowercased, ${EXPR} is uppercased"
         [text!]
     /with "Lookup var words in additional context (besides user context)"
-    context [any-word! lit-word! any-context! block!]
+        [any-word! lit-word! any-context! block!]
 ][
     string: trim/auto copy template
 
@@ -107,10 +107,10 @@ cscape: function [
 
             code: load/all expr
             if with [
-                if lit-word? context [context: to word! context]
+                if lit-word? with [with: to word! with]
 
-                context: compose [((context))]  ; convert to block
-                for-each item context [
+                with: compose [((with))]  ; convert to block
+                for-each item with [
                     bind code item
                 ]
             ]

--- a/tools/common.r
+++ b/tools/common.r
@@ -37,8 +37,7 @@ to-c-name: function [
     return: [text!]
     value "Will be converted to text (via UNSPACED if BLOCK!)"
         [text! block! word!]
-    /scope "See C's rules: http://stackoverflow.com/questions/228783/"
-    where "Either #global or #local (defaults global)"
+    /scope "#global or #local, see http://stackoverflow.com/questions/228783/"
         [issue!]
 ][
     all [
@@ -120,16 +119,16 @@ to-c-name: function [
         ]
     ]
 
-    where: default [#global]
+    scope: default [#global]
 
     case [
         string/1 != "_" [<ok>]
 
-        where = 'global [
+        scope = 'global [
             fail "global C ids starting with _ are reserved"
         ]
 
-        where = 'local [
+        scope = 'local [
             find charset [#"A" - #"Z"] string/2 then [
                 fail "local C ids starting with _ and uppercase are reserved"
             ]

--- a/tools/make-boot.r
+++ b/tools/make-boot.r
@@ -236,13 +236,11 @@ e-types/emit {
         REB_R_THROWN = PSEUDOTYPE_ONE,
         REB_P_NORMAL = PSEUDOTYPE_ONE,
         REB_TS_VARIADIC = PSEUDOTYPE_ONE,
-        REB_X_PARTIAL = PSEUDOTYPE_ONE,
 
         PSEUDOTYPE_TWO,
         REB_R_INVISIBLE = PSEUDOTYPE_TWO,
         REB_P_HARD_QUOTE = PSEUDOTYPE_TWO,
         REB_TS_SKIPPABLE = PSEUDOTYPE_TWO,
-        REB_X_PARTIAL_SAW_NULL_ARG = PSEUDOTYPE_TWO,
       #if defined(DEBUG_TRASH_MEMORY)
         REB_T_TRASH = PSEUDOTYPE_TWO,  /* identify trash in debug build */
       #endif

--- a/tools/make-os-ext.r
+++ b/tools/make-os-ext.r
@@ -75,7 +75,7 @@ host-lib-macros: make text! 1000
 ;
 checksum-source: make text! 1000
 
-count: func [s c /local n] [
+count: func [s c <local> n] [
     if find ["()" "(void)"] s [return "()"]
     output-buffer: copy "(a"
     n: 1

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -76,7 +76,7 @@ emit-include-params-macro: function [
     e [object!] "where to emit (see %common-emitters.r)"
     word [word!] "name of the native"
     paramlist [block!] "paramlist of the native"
-    /ext ext-name
+    /ext [text!] "extension name"
 ][
     seen-refinement: false
 
@@ -114,7 +114,7 @@ emit-include-params-macro: function [
         ]
     ]
 
-    prefix: either ext [unspaced [ext-name "_"]] [""]
+    prefix: either ext [unspaced [ext "_"]] [""]
     e/emit [prefix word items] {
         #define $<PREFIX>INCLUDE_PARAMS_OF_${WORD} \
             $[Items]; \

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -78,6 +78,8 @@ emit-include-params-macro: function [
     paramlist [block!] "paramlist of the native"
     /ext ext-name
 ][
+    seen-refinement: false
+
     n: 1
     items: try collect* [
         for-each item paramlist [
@@ -89,13 +91,21 @@ emit-include-params-macro: function [
             ]
 
             either refinement? item [
+                seen-refinement: true
                 param-name: as text! to word! item
 
                 keep cscape/with {REFINE($<n>, ${param-name})} [n param-name]
             ][
-                param-name: as text! item
+                ; !!! As a transition to refinements-being-the-arg, we don't
+                ; generate macros for things that look like refinement args.
+                ; This forces usages to change to ARG(refinename).  In time,
+                ; it will be legal to order normal parameters after refines.
+                ;
+                if not seen-refinement [
+                    param-name: as text! item
 
-                keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
+                    keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
+                ]
             ]
             n: n + 1
         ]

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -101,7 +101,10 @@ emit-include-params-macro: function [
                 ; This forces usages to change to ARG(refinename).  In time,
                 ; it will be legal to order normal parameters after refines.
                 ;
-                if not seen-refinement [
+                if seen-refinement [
+                    keep cscape/with {#error "${param-name}"} [param-name]
+                ]
+                else [
                     param-name: as text! item
 
                     keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]

--- a/tools/read-deep.reb
+++ b/tools/read-deep.reb
@@ -40,14 +40,11 @@ read-deep: function [
     {Return files and folders using recursive read strategy.}
 
     root [file! url! block!]
-    /full
-        {Include root path, retains full paths vs. returning relative paths.}
-    /strategy
-        {Allows Queue building to be overridden.}
-    taker [action!]
-        {TAKE next item from queue, building the queue as necessary.}
+    /full "Include root path, retains full paths vs. returning relative paths"
+    /strategy "TAKEs next item from queue, building the queue as necessary"
+        [action!]
 ][
-    taker: default [:read-deep-seq]
+    taker: strategy: default [:read-deep-seq]
 
     result: copy []
 


### PR DESCRIPTION
Change summary: https://trello.com/c/DaVz9GG3/
Forum post: https://forum.rebol.info/t/1120

While this is a major change, it's a pretty easy one to adapt to.  It gives a 100% reliable error for when you are using the old style, so it doesn't in-and-of-itself give subtle errors.

...and I'm pretty convinced that in the process of adapting to it, you're going to like it...a lot.  The specs are tighter and cleaner.  Looking through the diffs should make that obvious.

And it should be a hint that the change is "2,301 additions and 3,022 deletions."  A lot of what went missing was just *outright complexity*.  The entirety of the [refinement mode "gear-shift" the evaluator had to be in](https://github.com/metaeducation/ren-c/blob/094d731299e461e03b5831ea17d0a3ddeb7e3eef/src/include/sys-rebfrm.h#L783) **is gone**.  A lot of work went into trying to figure out how to do that as cheaply as possible...but pandering to complexity is nothing compared to just getting rid of it entirely.

For anyone who was skeptical of having to check refinement arguments for the null state, this gives the best of both worlds.  You can't ambiguously specify an argument when there's no refinement or vice versa, because they are one and the same.  And they are (ordinarily) blank if unused.  You can revoke arguments as before...but now you can do so with blanks as well.

I'm willing to do the update to any files anyone wants to point me at if they don't feel like doing it themselves... *but I think you actually will enjoy it*.  What I've been doing for spec format is:

     name: function [
         {Use a braced-string for the description, no period, newline after}

         foo "Put a description on the same line in plain quoted string"
             [type-one! type-two!]
         bar "Most every line should have a description so this fits best"
         /baz "Refinements taking no args just have the string"
         /mumble "Refinements with arg need a type block now"
             [any-value!]
      ] [...]

Not only do you not have the awkwardness of thinking of what to name those arguments but the bodies tidy up too.  Don't forget that LOGIC! false is falsey, so if you take a LOGIC! then check for blank explicitly if it means something different from false.