### PR TITLE
Updated the JavaScript extension to use the built-in error handler from emmc

### DIFF
--- a/tools/libr3.js-workers-patch.reb
+++ b/tools/libr3.js-workers-patch.reb
@@ -32,7 +32,7 @@ patch1: {
      .then(function(response) {
        // https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
        if (!response.ok)
-           throw Error(response.statusText)
+           err(response.statusText)
        return response.blob()
      })
      .then(function(blob) ^{


### PR DESCRIPTION
There is no way to catch a JavaScript error thrown by a worker, and so I have updated the JavaScript extension to use the built-in error handler from Emscripten instead. This error handler allows the error to be logged to the console, otherwise it will cause the application to hang with no way to recover.

You can see an example of this in UI Builder ...

1) go to https://brianotto.github.io/ui-builder/web/
2) open your browser's console (CTRL-SHIFT-I)
3) click the Code Editor button
4) enter `test: js-native [] { alert(1); }` and Save
5) re-open the Code Editor and click Save again
6) go to the command line and enter `export`
7) wait for a few minutes and the browser will hang
8) the browser will ask if you want to stop the script
9) stop it and you will see a trace and an uncaught error

`Error: Can't delete 6050112 in JS_NATIVES table`

This PR allows the error to be logged to the console instead, and the browser will no longer hang. There does appear to be an underlying issue with deleting from the JS Natives table, when the same Rebol code is entered more than once, but that would need to be looked at separately.