### PR TITLE
Fix: Console halt bug due to missing WAIT

### DIFF
--- a/extensions/console/make-spec.r
+++ b/extensions/console/make-spec.r
@@ -6,3 +6,4 @@ source: %console/mod-console.c
 includes: [
     %prep/extensions/console  ; for %tmp-mod-console.h
 ]
+requires: 'Event


### PR DESCRIPTION
Console extension now requires Event extension so that WAIT native
is available to Console code.