### PR TITLE
Require BLOCK! to modify an ANY-ARRAY! unless /ONLY

### DIFF
--- a/extensions/console/ext-console-init.reb
+++ b/extensions/console/ext-console-init.reb
@@ -370,14 +370,14 @@ ext-console-impl: function [
     ][
         switch type of item [
             issue! [
-                if not empty? instruction [append/line instruction '|]
-                insert instruction item
+                if not empty? instruction [append/line instruction [|]]
+                insert instruction @item
             ]
             text! [
                 append/line instruction compose [comment (item)]
             ]
             block! [
-                if not empty? instruction [append/line instruction '|]
+                if not empty? instruction [append/line instruction [|]]
                 append/line instruction compose/deep <*> item
             ]
             fail
@@ -465,7 +465,7 @@ ext-console-impl: function [
     ;
     directives: collect [
         if block? prior [
-            parse prior [some [set i: issue! (keep i)] end]
+            parse prior [some [set i: issue! (keep @i)] end]
         ]
     ]
 

--- a/extensions/event/ext-event-init.reb
+++ b/extensions/event/ext-event-init.reb
@@ -69,7 +69,7 @@ sys/make-scheme [
                     ; Add port to wake list:
                     ;
                     ** -- /system-waked port/spec/ref
-                    if not find waked port [append waked port]
+                    if not find waked port [append waked @port]
                 ]
                 n-event: n-event + 1
             ]

--- a/extensions/ffi/make-spec.r
+++ b/extensions/ffi/make-spec.r
@@ -36,7 +36,7 @@ options: [
         ]
         either block? user-config/with-ffi [
             cfg-ffi: make cfg-ffi user-config/with-ffi
-            cfg-ffi/libraries: map-each lib cfg-ffi/libraries [
+            cfg-ffi/libraries: map-each/only lib cfg-ffi/libraries [
                 case [
                     file? lib [
                         make rebmake/ext-dynamic-class [
@@ -71,7 +71,7 @@ options: [
                         'libraries
                         %libffi
 
-                    cfg-ffi/libraries: map-each lib libs [
+                    cfg-ffi/libraries: map-each/only lib libs [
                         make rebmake/ext-dynamic-class [
                             output: lib
                             flags: either user-config/with-ffi = 'static [[static]][_]

--- a/extensions/gif/mod-gif.c
+++ b/extensions/gif/mod-gif.c
@@ -342,7 +342,7 @@ REBNATIVE(decode_gif)
         REBVAL *binary = rebRepossess(dp, (w * h) * 4);
 
         rebElide(
-            "append", frames, "make image! compose [",
+            "append/only", frames, "make image! compose [",
                 "(to pair! [", rebI(w), rebI(h), "])",
                 binary,
             "]",

--- a/extensions/javascript/prep-libr3-js.reb
+++ b/extensions/javascript/prep-libr3-js.reb
@@ -239,7 +239,7 @@ to-js-type: func [
 ; process them with the other APIs on matters like EMSCRIPTEN_KEEPALIVE and
 ; EMTERPRETER_BLACKLIST.
 
-append api-objects make object! [
+append/only api-objects make object! [
     spec: _  ; e.g. `name: RL_API [...this is the spec, if any...]`
     name: "rebPromise"
     returns: "intptr_t"
@@ -248,7 +248,7 @@ append api-objects make object! [
     is-variadic: true
 ]
 
-append api-objects make object! [
+append/only api-objects make object! [
     spec: _  ; e.g. `name: RL_API [...this is the spec, if any...]`
     name: "rebSignalResolveNative_internal"  ; !!! see %mod-javascript.c
     returns: "void"
@@ -259,7 +259,7 @@ append api-objects make object! [
     is-variadic: false
 ]
 
-append api-objects make object! [
+append/only api-objects make object! [
     spec: _  ; e.g. `name: RL_API [...this is the spec, if any...]`
     name: "rebSignalRejectNative_internal"  ; !!! see %mod-javascript.c
     returns: "void"
@@ -271,7 +271,7 @@ append api-objects make object! [
 ]
 
 if args/OS_ID = "0.16.2" [  ; APIs for only for pthreads build
-    append api-objects make object! [
+    append/only api-objects make object! [
         spec: _  ; e.g. `name: RL_API [...this is the spec, if any...]`
         name: "rebTakeAwaitLock_internal"  ; !!! see %mod-javascript.c
         returns: "void"
@@ -282,7 +282,7 @@ if args/OS_ID = "0.16.2" [  ; APIs for only for pthreads build
         is-variadic: false
     ]
 ] else [  ; APIs only for emterpreter build
-    append api-objects make object! [
+    append/only api-objects make object! [
         spec: _  ; e.g. `name: RL_API [...this is the spec, if any...]`
         name: "rebIdle_internal"  ; !!! see %mod-javascript.c
         returns: "void"
@@ -293,7 +293,7 @@ if args/OS_ID = "0.16.2" [  ; APIs for only for pthreads build
 ]
 
 if false [  ; Only used if DEBUG_JAVASCRIPT_SILENT_TRACE (how to know here?)
-    append api-objects make object! [
+    append/only api-objects make object! [
         spec: _  ; e.g. `name: RL_API [...this is the spec, if any...]`
         name: "rebGetSilentTrace_internal"  ; !!! see %mod-javascript.c
         returns: "intptr_t"
@@ -330,7 +330,7 @@ map-each-api [
 
     js-param-types: try collect* [
         for-each [type var] paramlist [
-            keep to-js-type type else [
+            keep/only to-js-type type else [
                 fail [
                     {No JavaScript argument mapping for type} type
                     {used by} name {with paramlist} mold paramlist
@@ -840,6 +840,7 @@ json-collect: function [body [block!]] [
     results: collect compose [
         keep: adapt 'keep [  ; Emscripten prefixes functions w/underscore
             value: unspaced [{"} {_} value {"}]
+            only: true
         ]
         ((body))
     ]

--- a/extensions/locale/iso3166.r
+++ b/extensions/locale/iso3166.r
@@ -15,7 +15,7 @@ capitalize: func [
     ret: copy ""
     words: split to text! n " "
     spaced [
-        map-each w words [
+        map-each/only w words [
             case [
                 w = "OF" [
                     "of"

--- a/extensions/network/dev-net.c
+++ b/extensions/network/dev-net.c
@@ -288,7 +288,7 @@ DEVICE_CMD Lookup_Socket(REBREQ *sock)
     req->flags &= ~RRF_DONE;
 
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'lookup",
             "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
         "]",
@@ -330,7 +330,7 @@ DEVICE_CMD Connect_Socket(REBREQ *sock)
         req->state |= RSM_CONNECT;
 
         rebElide(
-            "insert system/ports/system make event! [",
+            "insert/only system/ports/system make event! [",
                 "type: 'connect",
                 "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
             "]",
@@ -381,7 +381,7 @@ DEVICE_CMD Connect_Socket(REBREQ *sock)
     Get_Local_IP(sock);
 
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'connect",
             "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
         "]",
@@ -456,7 +456,7 @@ DEVICE_CMD Transfer_Socket(REBREQ *sock)
             req->actual += result;
             if (req->actual >= req->length) {
                 rebElide(
-                    "insert system/ports/system make event! [",
+                    "insert/only system/ports/system make event! [",
                         "type: 'wrote",
                         "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
                     "]",
@@ -492,7 +492,7 @@ DEVICE_CMD Transfer_Socket(REBREQ *sock)
             TERM_BIN_LEN(bin, old_len + result);
 
             rebElide(
-                "insert system/ports/system make event! [",
+                "insert/only system/ports/system make event! [",
                     "type: 'read",
                     "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
                 "]",
@@ -505,7 +505,7 @@ DEVICE_CMD Transfer_Socket(REBREQ *sock)
             req->state &= ~RSM_CONNECT; // But, keep RRF_OPEN true
 
             rebElide(
-                "insert system/ports/system make event! [",
+                "insert/only system/ports/system make event! [",
                     "type: 'close",
                     "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
                 "]",
@@ -682,7 +682,7 @@ DEVICE_CMD Accept_Socket(REBREQ *sock)
     // must be accepted, however, to recvfrom() data in the future.
     //
     if (req->modes & RST_UDP) {
-            rebElide("insert system/ports/system make event! [",
+            rebElide("insert/only system/ports/system make event! [",
                 "type: 'accept",
                 "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(sock))),
             "]",
@@ -749,7 +749,7 @@ DEVICE_CMD Accept_Socket(REBREQ *sock)
     // find out about it and get an `accept` event.  Signal that.
     //
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'accept",
             "port:", CTX_ARCHETYPE(listener),
         "]",

--- a/extensions/process/ext-process-init.reb
+++ b/extensions/process/ext-process-init.reb
@@ -32,7 +32,7 @@ call*: adapt 'call-internal* [
             if empty? command [  ; !!! should this be a no-op?
                 fail "Empty argv[] block passed to CALL"
             ]
-            map-each arg command [
+            map-each/only arg command [
                 switch type of arg [
                     text! [arg]  ; pass through as is
                     file! [file-to-local arg]
@@ -94,7 +94,7 @@ argv-block-to-command*: function [
     return: [text!]
     argv [block!]
 ][
-    return spaced map-each arg argv [
+    return spaced map-each/only arg argv [
         any [
             find arg space
             find arg {"}

--- a/extensions/serial/serial-posix.c
+++ b/extensions/serial/serial-posix.c
@@ -281,7 +281,7 @@ DEVICE_CMD Read_Serial(REBREQ *serial)
     req->actual = result;
 
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'read",
             "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(serial))),
         "]",
@@ -322,7 +322,7 @@ DEVICE_CMD Write_Serial(REBREQ *serial)
     req->common.data += result;
     if (req->actual >= req->length) {
         rebElide(
-            "insert system/ports/system make event! [",
+            "insert/only system/ports/system make event! [",
                 "type: 'wrote",
                 "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(serial))),
             "]",

--- a/extensions/serial/serial-windows.c
+++ b/extensions/serial/serial-windows.c
@@ -235,7 +235,7 @@ DEVICE_CMD Read_Serial(REBREQ *serial)
     req->actual = result;
 
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'read",
             "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(serial))),
         "]",
@@ -278,7 +278,7 @@ DEVICE_CMD Write_Serial(REBREQ *serial)
     req->common.data += result;
     if (req->actual >= req->length) {
         rebElide(
-            "insert system/ports/system make event! [",
+            "insert/only system/ports/system make event! [",
                 "type: 'wrote",
                 "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(serial))),
             "]",

--- a/extensions/signal/dev-signal.c
+++ b/extensions/signal/dev-signal.c
@@ -60,7 +60,7 @@ DEVICE_CMD Open_Signal(REBREQ *signal)
     req->flags |= RRF_OPEN;
 
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'open",
             "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(signal))),
         "]",
@@ -117,7 +117,7 @@ DEVICE_CMD Read_Signal(REBREQ *signal)
     //printf("read %d signals\n", req->actual);
 
     rebElide(
-        "insert system/ports/system make event! [",
+        "insert/only system/ports/system make event! [",
             "type: 'read",
             "port:", CTX_ARCHETYPE(CTX(ReqPortCtx(signal))),
         "]",

--- a/extensions/tcc/ext-tcc-init.reb
+++ b/extensions/tcc/ext-tcc-init.reb
@@ -206,7 +206,9 @@ compile: function [
         ; that TCC can find %libtcc1.a.  So adding the runtime path as a
         ; normal library directory.
         ;
-        insert config/library-path file-to-local/full config/runtime-path
+        insert config/library-path @(
+            file-to-local/full config/runtime-path
+        )
     ]
 
     ; Note: The few header files in %tcc/include/ must out-prioritize the ones
@@ -216,7 +218,9 @@ compile: function [
     ;
     ; https://stackoverflow.com/questions/53154898/
 
-    insert config/include-path file-to-local/full config/runtime-path/include
+    insert config/include-path @(
+        file-to-local/full config/runtime-path/include
+    )
 
     ; The other complicating factor is that once emitted code has these
     ; references to TCC-specific internal routines not in libc, the
@@ -299,7 +303,7 @@ compile: function [
 
     librebol: _
 
-    compilables: map-each item compilables [
+    compilables: map-each/only item compilables [
         item: maybe if match [word! path!] :item [get item]
 
         switch type of :item [
@@ -320,7 +324,7 @@ compile: function [
     ]
 
     if librebol [
-        insert compilables trim/auto mutable {
+        insert/only compilables trim/auto mutable {
             /* TCC's override of <stddef.h> defines int64_t in a way that
              * might not be compatible with glibc's <stdint.h> (which at time
              * of writing defines it as a `__int64_t`.)  You might get:
@@ -376,7 +380,7 @@ compile: function [
             ]
         ]
 
-        insert config/include-path file-to-local config/librebol-path
+        insert config/include-path @(file-to-local config/librebol-path)
     ]
 
     ; Having paths as Rebol FILE! is useful for doing work, but the TCC calls

--- a/extensions/uuid/ext-uuid-init.reb
+++ b/extensions/uuid/ext-uuid-init.reb
@@ -11,7 +11,7 @@ to-text: function [
     "Convert the UUID to the text string form ({8-4-4-4-12})"
     uuid [binary!]
 ][
-    delimit "-" map-each w reduce [
+    delimit "-" map-each/only w reduce [
         copy/part uuid 4
         copy/part (skip uuid 4) 2
         copy/part (skip uuid 6) 2

--- a/scripts/changes-file/changes-file.reb
+++ b/scripts/changes-file/changes-file.reb
@@ -265,7 +265,7 @@ make-changes-file: function [
 
             ; any related hash (cherry-pick collated)
             if related: select co 'related [
-                map-each n related [
+                map-each n related @[
                     md-link n join-all [url/ren-c n]
                 ]
             ]
@@ -279,7 +279,7 @@ make-changes-file: function [
 
             ; show CC issues (for now just list them)
             if cc: select co 'cc [
-                map-each n cc [
+                map-each n cc @[
                     md-link join-all [{#CC-} n] join-all [url/rebol-issues n]
                 ]
             ]

--- a/scripts/encap.reb
+++ b/scripts/encap.reb
@@ -598,7 +598,7 @@ pe-format: context [
             any [
                 find words to word! word
                 find def to set-word! word
-                append def to set-word! word
+                append def @(to set-word! word)
             ]
         ]
 
@@ -631,7 +631,7 @@ pe-format: context [
         parse rule [any block-rule end]
 
         ;dump def
-        set name make object! append def _
+        set name make object! append def [_]
         bind rule get name
     ]
 
@@ -756,7 +756,7 @@ pe-format: context [
     data-directory-rule: gen-rule [
         u32-le (RVA: u32)
         u32-le (size: u32)
-        (append data-directories copy data-directory)
+        (append data-directories @(copy data-directory))
     ] data-directory
 
     section: _
@@ -768,7 +768,7 @@ pe-format: context [
         u32-le (physical-offset: u32)
         copy reserved [12 byte]
         u32-le (flags: u32)
-        (append sections copy section)
+        (append sections @(copy section))
     ] section
 
     garbage: _

--- a/scripts/prot-tls.r
+++ b/scripts/prot-tls.r
@@ -431,7 +431,7 @@ client-hello: function [
     random/seed now/time/precise
     loop 28 [append ctx/client-random (random-secure 256) - 1]
 
-    cs-data: join-all map-each item cipher-suites [
+    cs-data: join-all map-each item cipher-suites @[
         if binary? item [item]
     ]
 
@@ -971,7 +971,7 @@ parse-messages: function [
                 )
 
                 len: to-integer/unsigned copy/part at data 2 3
-                append result switch msg-type [
+                append/only result switch msg-type [
                     <server-hello> [
                         ; https://tools.ietf.org/html/rfc5246#section-7.4.1.3
 
@@ -1044,7 +1044,7 @@ parse-messages: function [
                             certificate-list: make block! 4
                             while [not tail? msg-content] [
                                 if 0 < clen: to-integer/unsigned copy/part skip msg-content 3 3 [
-                                    append certificate-list copy/part at msg-content 7 clen
+                                    append certificate-list @(copy/part at msg-content 7 clen)
                                 ]
                                 msg-content: skip msg-content 3 + clen
                             ]
@@ -1188,13 +1188,13 @@ parse-messages: function [
 
         <change-cipher-spec> [
             ctx/encrypted?: true
-            append result context [
+            append/only result context [
                 type: 'ccs-message-type
             ]
         ]
 
         #application [
-            append result msg-obj: context [
+            append/only result msg-obj: context [
                 type: 'app-data
                 content: copy/part data (length of data) - ctx/hash-size
             ]
@@ -1438,7 +1438,7 @@ tls-read-data: function [
 
         debug ["received bytes:" length of fragment | "parsing response..."]
 
-        append ctx/resp parse-response ctx fragment
+        append ctx/resp @(parse-response ctx fragment)
 
         data: skip data len
 
@@ -1481,7 +1481,7 @@ tls-awake: function [
         'lookup [
             open port
             tls-init tls-port/state
-            insert system/ports/system make event! [
+            insert/only system/ports/system make event! [
                 type: 'lookup
                 port: tls-port
             ]
@@ -1498,7 +1498,7 @@ tls-awake: function [
                     <finished>
                 ]
             ]
-            insert system/ports/system make event! [
+            insert/only system/ports/system make event! [
                 type: 'connect
                 port: tls-port
             ]
@@ -1511,7 +1511,7 @@ tls-awake: function [
                     return true
                 ]
                 #application [
-                    insert system/ports/system make event! [
+                    insert/only system/ports/system make event! [
                         type: 'wrote
                         port: tls-port
                     ]
@@ -1549,7 +1549,7 @@ tls-awake: function [
                         for-each msg proto/messages [
                             if msg/description = "Close notify" [
                                 do-commands tls-port/state [<close-notify>]
-                                insert system/ports/system make event! [
+                                insert/only system/ports/system make event! [
                                     type: 'read
                                     port: tls-port
                                 ]
@@ -1563,7 +1563,7 @@ tls-awake: function [
             debug ["data complete?:" complete? "application?:" application?]
 
             if application? [
-                insert system/ports/system make event! [
+                insert/only system/ports/system make event! [
                     type: 'read
                     port: tls-port
                 ]
@@ -1574,7 +1574,7 @@ tls-awake: function [
         ]
 
         'close [
-            insert system/ports/system make event! [
+            insert/only system/ports/system make event! [
                 type: 'close
                 port: tls-port
             ]

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -791,7 +791,7 @@ redbol-form: form: emulate [
             ]
             block? value [
                 delimit: either unspaced [:lib/unspaced] [:lib/spaced]
-                delimit map-each item value [
+                delimit map-each item value @[
                     redbol-form :item
                 ]
             ]

--- a/scripts/unzip.reb
+++ b/scripts/unzip.reb
@@ -480,8 +480,8 @@ ctx-zip: context [
                     ]
 
                     either any-array? where [
-                        where: insert where name
-                        where: insert where either all [
+                        where: insert/only where name
+                        where: insert/only where either all [
                             #"/" = last name
                             empty? uncompressed-data
                         ][blank][uncompressed-data]

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -103,6 +103,8 @@ Script: [
     ambiguous-infix:    {Ambiguous infix expression--use GROUP! to clarify}
     literal-left-path:  {Use -> to pass literal left PATH! parameters right}
 
+    only-if-non-block:  {Must use /ONLY if not splicing BLOCK! into ANY-ARRAY!}
+
     bad-get-group:      {GET-GROUP! gets WORD!/PATH!/BLOCK!, arity-0 ACTION!}
     bad-set-group:      {SET-GROUP! sets WORD!/PATH!/BLOCK!, arity-1 ACTION!}
 

--- a/src/boot/generics.r
+++ b/src/boot/generics.r
@@ -313,10 +313,10 @@ insert: generic [
         [<requote> any-series! port! map! object! bitset! port!]
     series "At position (modified)"
         [<dequote> any-series! port! map! object! bitset! port!]
-    value [<opt> any-value!] {The value to insert}
+    value [<opt> <modal> any-value!] {The value to insert}
+    /only "Add value atomically to an array (not the contents of the block)"
     /part "Limits to a given length or position"
         [any-number! any-series! pair!]
-    /only "Insert a block as a single value (not the contents of the block)"
     /dup "Duplicates the insert a specified number of times"
         [any-number! pair!]
     /line "Data should be its own line (use as formatting cue if ANY-ARRAY!)"
@@ -331,10 +331,10 @@ append: generic [
     return: [<requote> any-series! port! map! object! module! bitset!]
     series "Any position (modified)"
         [<dequote> any-series! port! map! object! module! bitset!]
-    value [<opt> any-value!]
+    value [<opt> <modal> any-value!]
+    /only "Add value atomically to an array (not the contents of the block)"
     /part "Limits to a given length or position"
         [any-number! any-series! pair!]
-    /only "Insert a block as a single value (not the contents of the block)"
     /dup "Duplicates the insert a specified number of times"
         [any-number! pair!]
     /line "Data should be its own line (use as formatting cue if ANY-ARRAY!)"
@@ -349,10 +349,10 @@ change: generic [
     return: [<requote> any-series! port!]
     series "At position (modified)"
         [<dequote> any-series! port!]
-    value [<opt> any-value!] {The new value}
+    value [<opt> <modal> any-value!] {The new value}
+    /only "Add value atomically to an array (not the contents of the block)"
     /part "Limits the amount to change to a given length or position"
         [any-number! any-series! pair!]
-    /only "Change a block as a single value (not the contents of the block)"
     /dup "Duplicates the change a specified number of times"
         [any-number! pair!]
     /line "Data should be its own line (use as formatting cue if ANY-ARRAY!)"

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -945,6 +945,9 @@ REBTYPE(Array)
         UNUSED(PAR(series));
         UNUSED(PAR(value));
 
+        if (not ANY_ARRAY(arg) and not IS_NULLED(arg) and not REF(only))
+            fail (Error_Only_If_Non_Block_Raw());
+
         REBLEN len; // length of target
         if (VAL_WORD_SYM(verb) == SYM_CHANGE)
             len = Part_Len_May_Modify_Index(array, ARG(part));

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1041,7 +1041,8 @@ REBTYPE(String)
         UNUSED(PAR(series));
         UNUSED(PAR(value));
 
-        UNUSED(REF(only)); // all strings appends are /ONLY...currently unused
+        if (REF(only))
+            fail ("/ONLY modifications are only relevant to ANY-ARRAY! args");
 
         REBLEN len; // length of target
         if (VAL_WORD_SYM(verb) == SYM_CHANGE)

--- a/src/main/main-startup.reb
+++ b/src/main/main-startup.reb
@@ -246,14 +246,14 @@ main-startup: function [
     ][
         switch type of item [
             issue! [
-                if not empty? instruction [append/line instruction '|]
-                insert instruction item
+                if not empty? instruction [append/line instruction [|]]
+                insert instruction @item
             ]
             text! [
                 append/line instruction compose [comment (item)]
             ]
             block! [
-                if not empty? instruction [append/line instruction '|]
+                if not empty? instruction [append/line instruction [|]]
                 append/line instruction compose/deep <*> item
             ]
             unreachable

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -217,7 +217,7 @@ int main(int argc, char *argv_ansi[])
         // needing more than two bytes to be represented will cause a failure.
         //
         rebElide(
-            "append", argv_block, rebR(rebTextWide(argv_ucs2[i])),
+            "append/only", argv_block, rebR(rebTextWide(argv_ucs2[i])),
         rebEND);
     }
   #else
@@ -228,7 +228,7 @@ int main(int argc, char *argv_ansi[])
         if (argv_ansi[i] == nullptr)
             continue;  // !!! R3-Alpha commented here saying "shell bug" (?)
 
-        rebElide("append", argv_block, rebT(argv_ansi[i]), rebEND);
+        rebElide("append/only", argv_block, rebT(argv_ansi[i]), rebEND);
     }
   #endif
 

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -135,7 +135,7 @@ make-dir: func [
         ; work, but seems to cause a problem.  Review why when time permits.
         ;
         end: find-last/tail path slash else [path]
-        insert dirs copy end
+        insert dirs @(copy end)
         clear end
     ]
 
@@ -148,7 +148,7 @@ make-dir: func [
             for-each dir created [attempt [delete dir]]
             fail e
         ])
-        insert created path
+        insert created @path
     ]
     path
 ]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -114,17 +114,17 @@ function: func [
     ; !!! REVIEW: ignore self too if binding object?
     ;
     parse spec [any [
-        <void> (append new-spec <void>)
+        <void> (append new-spec [<void>])
     |
         :(either var '[
             set var: [
                 match [any-word! 'word!]
                 | ahead any-path! into [blank! word!]
             ](
-                append new-spec var
+                append new-spec @var
 
                 ; exclude args/refines
-                append exclusions either any-path? var [var/2] [var]
+                append exclusions @(either any-path? var [var/2] [var])
             )
             |
             set other: block! (
@@ -136,8 +136,8 @@ function: func [
             )
         ] '[
             set var: set-word! (  ; locals legal anywhere
-                append exclusions var
-                append new-spec var
+                append exclusions @var
+                append new-spec @var
                 var: _
             )
         ])
@@ -162,8 +162,8 @@ function: func [
     |
         <local>
         any [set var: word! (other: _) opt set other: group! (
-            append new-spec as set-word! var
-            append exclusions var
+            append new-spec @(as set-word! var)
+            append exclusions @var
             if other [
                 defaulters: default [copy []]
                 append defaulters compose [  ; always sets
@@ -175,7 +175,7 @@ function: func [
     |
         <in> (
             new-body: default [
-                append exclusions 'self
+                append exclusions [self]
                 copy/deep body
             ]
         )
@@ -184,13 +184,13 @@ function: func [
                 if not object? other [other: ensure any-context! get other]
                 bind new-body other
                 for-each [key val] other [
-                    append exclusions key
+                    append exclusions @key
                 ]
             )
         ]
     |
         <with> any [
-            set other: [word! | path!] (append exclusions other)
+            set other: [word! | path!] (append exclusions @other)
         |
             text!  ; skip over as commentary
         ]
@@ -198,15 +198,15 @@ function: func [
         <static> (
             statics: default [copy []]
             new-body: default [
-                append exclusions 'self
+                append exclusions [self]
                 copy/deep body
             ]
         )
         any [
             set var: word! (other: _) opt set other: group! (
-                append exclusions var
+                append exclusions @var
                 append statics compose [
-                    (as set-word! var) ((other))
+                    (var): (other)
                 ]
             )
         ]
@@ -237,7 +237,7 @@ function: func [
     ; a possible COLLECT-WORDS/INTO
     ;
     for-each loc locals [
-        append new-spec to set-word! loc
+        append new-spec @(to set-word! loc)
     ]
 
     func new-spec either defaulters [

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -93,7 +93,11 @@ join: function [
             fail @value "Can't JOIN an ACTION! onto a series (use APPEND)."
         ]
         default [
-            append/only head :value
+            if any-array? head [
+                append/only head :value
+            ] else [
+                append head :value
+            ]
         ]
     ]
 

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -28,7 +28,7 @@ spec-of: function [
     ]
 
     return collect [
-        keep/line ensure [<opt> text!] any [
+        keep/line/only ensure [<opt> text!] any [
             select meta 'description
             select original-meta 'description
         ]
@@ -296,17 +296,17 @@ help: function [
         print collect [
             keep [(uppercase mold topic) "is" an (mold type of :value)]
             if free? :value [
-                keep "that has been FREEd"
+                keep ["that has been FREEd"]
             ] else [
-                keep "of value:"
+                keep ["of value:"]
                 if match [object! port!] value [
-                    keep newline
+                    keep @newline
                     for-each line summarize-obj value [
-                        keep line
-                        keep newline
+                        keep @line
+                        keep @newline
                     ]
                 ] else [
-                    keep mold value
+                    keep @(mold value)
                 ]
             ]
         ]

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -110,7 +110,7 @@ save: function [
     case/all [
         tmp: find header 'checksum [
             ; Checksum uncompressed data, if requested
-            change next tmp (checksum-core data 'crc32)
+            change next tmp @(checksum-core data 'crc32)
         ]
 
         compress [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -297,9 +297,9 @@ reword: function [
                 compose lit (keyword-match: lit (keyword))
             ]
 
-            keep/line '|
+            keep/line [|]
         ]
-        keep 'false  ; add failure if no match, instead of removing last |
+        keep [false]  ; add failure if no match, instead of removing last |
     ]
 
     rule: [
@@ -444,9 +444,9 @@ collect*-with: func [
         [<opt> block!]
     'name [word! lit-word!]
         "Name to which keep function will be assigned (<local> if word!)"
-    body [<blank> block!]
-        "Block to evaluate"
-
+    @body "Block to evaluate"
+        [<blank> block!]
+    /only "Always keep values atomically (e.g. KEEP has no /ONLY)"
     <local> out keeper
 ][
     ; Derive from APPEND to inherit /ONLY, /LINE, /DUP automatically
@@ -465,6 +465,7 @@ collect*-with: func [
         ]
     )[
         series: <replaced>
+        only: if only [/only]
     ]
 
     either word? name [
@@ -506,7 +507,7 @@ collect-lines: redescribe [
 ] adapt 'collect [  ; https://forum.rebol.info/t/945/1
     body: compose [
         keep: adapt specialize 'keep [
-            line: true | only: false | part: _
+            line: true | only: true | part: _
         ] [value: spaced try :value]
         (as group! body)
     ]
@@ -519,7 +520,7 @@ collect-text: redescribe [
     adapt 'collect [
         body: compose [
             keep: adapt specialize 'keep [
-                line: false | only: false | part: _
+                line: false | only: true | part: _
             ][
                 value: unspaced try :value
             ]
@@ -607,7 +608,7 @@ split: function [
     /into "If dlm is integer, split in n pieces (vs. pieces of length n)"
 ][
     parse (try match block! dlm) [some integer! end] then [
-        return map-each len dlm [
+        return map-each len dlm @[
             if len <= 0 [
                 series: skip series negate len
                 continue  ; don't add to output

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -53,7 +53,9 @@ register-codec*: func [
     ; Media-types block format: [.abc .def type ...]
     ; !!! Should be a map, with blocks of codecs on collisions
     ;
-    append append system/options/file-types suffixes (bind name system/codecs)
+    append/only append system/options/file-types suffixes (
+        bind name system/codecs
+    )
 
     return codec
 ]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -285,7 +285,7 @@ load: function [
         ; A BLOCK! means multiple sources, calls LOAD recursively for each
 
         a: self/all  ; !!! Some bad interaction requires this, review
-        return map-each s source [
+        return map-each/only s source [
             applique 'load [
                 source: s
                 header: header
@@ -374,7 +374,7 @@ load: function [
     ]
 
     if header [
-        insert data hdr
+        insert/only data hdr
     ]
 
     ; Bind code to user context
@@ -482,7 +482,7 @@ do-needs: function [
 
     ; Import the modules:
     ;
-    mods: map-each [name vers hash] mods [
+    mods: map-each/only [name vers hash] mods [
         mod: applique 'import [
             module: name
 
@@ -644,7 +644,7 @@ load-module: function [
                 cause-error 'script 'invalid-arg tmp
             ]
 
-            return map-each [mod ver name] source [
+            return map-each/only [mod ver name] source [
                 applique 'load-module [
                     source: mod
                     version: version
@@ -695,7 +695,7 @@ load-module: function [
         line: 1
     ]
     if no-share [
-        hdr/options: append any [hdr/options make block! 1] 'isolate
+        hdr/options: append any [hdr/options make block! 1] [isolate]
     ]
 
     ; Unify hdr/name and /AS name
@@ -715,7 +715,7 @@ load-module: function [
         ; But make it a mixin and it will be imported directly later
 
         if not find hdr/options 'private [
-            hdr/options: append any [hdr/options make block! 1] 'private
+            hdr/options: append any [hdr/options make block! 1] [private]
         ]
     ]
     if not tuple? set 'modver :hdr/version [
@@ -796,7 +796,7 @@ load-module: function [
             set [hdr: code:] load-ext-module code
             hdr/name: name ; in case of delayed rename
             if all [no-share not find hdr/options 'isolate] [
-                hdr/options: append any [hdr/options make block! 1] 'isolate
+                hdr/options: append any [hdr/options make block! 1] [isolate]
             ]
         ]
 

--- a/tests/control/compose.test.reb
+++ b/tests/control/compose.test.reb
@@ -47,13 +47,12 @@
     error? trap blk
 )
 
-; #1906
-(
-    b: copy [] insert/dup b 1 32768 compose b
+[#1906 (
+    b: copy [] insert/dup b [1] 32768 compose b
     sum: 0
     for-each i b [sum: me + i]
     sum = 32768
-)
+)]
 
 ; COMPOSE with implicit /ONLY-ing
 

--- a/tests/control/continue.test.reb
+++ b/tests/control/continue.test.reb
@@ -22,7 +22,7 @@
 
 (<result> = loop 1 [continue <result> <not-result>])
 (
-    [2 <big> <big>] = map-each x [1 2000 3000] [
+    [2 <big> <big>] = map-each x [1 2000 3000] @[
         if x > 1000 [continue <big>]
         x + 1
     ]

--- a/tests/control/for-each.test.reb
+++ b/tests/control/for-each.test.reb
@@ -148,7 +148,7 @@
         if count = 5 [return null]
         return count: count + 1
     ]
-    [10 20 30 40 50] = map-each i :make-one-thru-five [
+    [10 20 30 40 50] = map-each i :make-one-thru-five @[
         i * 10
     ]
 )(
@@ -156,7 +156,7 @@
         if count = 5 [return null]
         return count: count + 1
     ]
-    [[1 2] [3 4] [5]]  = map-each [a b] :make-one-thru-five [
+    [[1 2] [3 4] [5]]  = map-each/only [a b] :make-one-thru-five [
         compose [(:a) (:b)]
     ]
 )
@@ -173,25 +173,25 @@
                 throw <thrown>
             ]
         ]
-        [a b c 10] = append block 10
+        [a b c 10] = append block [10]
     ]
 )(
     block: copy [a b c]
     all [
         e: trap [
             for-each item block [
-                append block <failure>
+                append block [<failure>]
             ]
         ]
         e/id = 'series-held
-        [a b c 10] = append block 10
+        [a b c 10] = append block [10]
     ]
 )
 
 ; paths are immutable, but for-each is legal on them
 
 (
-    [a b c] = collect [for-each x 'a/b/c [keep x]]
+    [a b c] = collect [for-each x 'a/b/c [keep @x]]
 )(
-    [_ _] = collect [for-each x '/ [keep x]]
+    [_ _] = collect [for-each x '/ [keep @x]]
 )

--- a/tests/control/forskip.test.reb
+++ b/tests/control/forskip.test.reb
@@ -1,8 +1,8 @@
 ; functions/control/for-skip.r
 (
     blk: copy out: copy []
-    for i 1 25 1 [append blk i]
-    iterate-skip blk 3 [append out blk/1]
+    for i 1 25 1 [append blk @i]
+    iterate-skip blk 3 [append out @blk/1]
     out = [1 4 7 10 13 16 19 22 25]
 )
 ; cycle return value

--- a/tests/control/map-each.test.reb
+++ b/tests/control/map-each.test.reb
@@ -7,13 +7,17 @@
 ; PATH! is immutable, but MAP-EACH should work on it
 
 (
-     [[a 1] [b 1] [c 1]] = map-each x 'a/b/c [reduce [x 1]]
+     [a 1 b 1 c 1] = map-each x 'a/b/c [reduce [x 1]]
+)
+
+(
+     [[a 1] [b 1] [c 1]] = map-each x 'a/b/c @[reduce [x 1]]
 )
 
 ; BLANK! is legal for slots you don't want to name variables for:
 
 (
-    [5 11] = map-each [dummy a b] [1 2 3 4 5 6] [a + b]
+    [5 11] = map-each [dummy a b] [1 2 3 4 5 6] @[a + b]
 )(
     sum: 0
     for-each _ [a b c] [sum: sum + 1]
@@ -23,9 +27,9 @@
 [
     "Modal splicing control"
 
-    ([[1 1] [2 2] [3 3]] = map-each x [1 2 3] [reduce [x x]])
+    ([1 1 2 2 3 3] = map-each x [1 2 3] [reduce [x x]])
 
-    ([1 1 2 2 3 3] = map-each/splice x [1 2 3] [reduce [x x]])
+    ([[1 1] [2 2] [3 3]] = map-each/only x [1 2 3] [reduce [x x]])
 
-    ([1 1 2 2 3 3] = map-each x [1 2 3] @[reduce [x x]])
+    ([[1 1] [2 2] [3 3]] = map-each x [1 2 3] @[reduce [x x]])
 ]

--- a/tests/control/quit.test.reb
+++ b/tests/control/quit.test.reb
@@ -13,7 +13,7 @@
         save/header script compose [quit (value)] []
         do script
     ]
-    all map-each value reduce [
+    all map-each/only value reduce [
         42
         {foo}
         #{CAFE}

--- a/tests/control/repeat.test.reb
+++ b/tests/control/repeat.test.reb
@@ -35,10 +35,10 @@
     success
 )
 ; decimal! test
-([1 2 3] == collect [repeat i 3.0 [keep i]])
-([1 2 3] == collect [repeat i 3.1 [keep i]])
-([1 2 3] == collect [repeat i 3.5 [keep i]])
-([1 2 3] == collect [repeat i 3.9 [keep i]])
+([1 2 3] == collect [repeat i 3.0 [keep @i]])
+([1 2 3] == collect [repeat i 3.1 [keep @i]])
+([1 2 3] == collect [repeat i 3.5 [keep @i]])
+([1 2 3] == collect [repeat i 3.9 [keep @i]])
 ; text! test
 (
     out: copy ""
@@ -115,6 +115,6 @@
 )
 (
     out: copy []
-    repeat i [1 2 3] [append out first i]
+    repeat i [1 2 3] [append out @(first i)]
     out = [1 2 3]
 )

--- a/tests/control/switch.test.reb
+++ b/tests/control/switch.test.reb
@@ -16,7 +16,7 @@
 (void? switch 1 [1 []])
 
 (
-    cases: reduce [1 head of insert copy [] trap [1 / 0]]
+    cases: reduce [1 head of insert/only copy [] trap [1 / 0]]
     error? switch 1 cases
 )
 

--- a/tests/datatypes/error.test.reb
+++ b/tests/datatypes/error.test.reb
@@ -4,7 +4,7 @@
 (error! = type of trap [1 / 0])
 
 ; error evaluation
-(error? do head of insert copy [] trap [1 / 0])
+('zero-divide = (do head of insert copy [] @(trap [1 / 0]))/id)
 
 ; error that does not exist in the SCRIPT category--all of whose ids are
 ; reserved by the system and must be formed from mezzanine/user code in

--- a/tests/datatypes/map.test.reb
+++ b/tests/datatypes/map.test.reb
@@ -27,8 +27,8 @@
     m: make map! reduce [1 thing]
     m2: copy/deep m
     thing2: select m2 1
-    append thing/2 'c
-    append thing2 'd
+    append thing/2 [c]
+    append thing2 [d]
     did all [
         thing = [a [b c]]
         thing2 = [a [b] d]
@@ -117,6 +117,6 @@
     ('II = m/[x y])
     ('IIII = m/[m n o p])
 
-    ((trap [append b2 'z])/id = 'series-auto-locked)
-    ((trap [append b4 'q])/id = 'series-auto-locked)
+    ((trap [append/only b2 'z])/id = 'series-auto-locked)
+    ((trap [append/only b4 'q])/id = 'series-auto-locked)
 ]

--- a/tests/datatypes/quoted.test.reb
+++ b/tests/datatypes/quoted.test.reb
@@ -136,7 +136,7 @@
 
 ((lit '''[a b c]) == copy lit '''[a b c])
 
-((lit '(1 2 3 <four>)) == append ''(1 2 3) <four>)
+((lit '(1 2 3 <four>)) == append ''(1 2 3) [<four>])
 
 
 ; All escaped values are truthy, regardless of what it is they are escaping

--- a/tests/datatypes/set-group.test.reb
+++ b/tests/datatypes/set-group.test.reb
@@ -30,6 +30,6 @@
 (
     count: 0
     [1] = collect [
-        (if count != 1 [fail] :keep): (count: count + 1)
+        (if count != 1 [fail] :keep/only): count: count + 1
     ]
 )

--- a/tests/datatypes/vector.test.reb
+++ b/tests/datatypes/vector.test.reb
@@ -20,7 +20,7 @@
 (
     comment [
         {enumeration temporarily not supported}
-        all map-each x make vector! [integer! 32 16] [zero? x]
+        all map-each x make vector! [integer! 32 16] @[zero? x]
     ]
     true
 )

--- a/tests/functions/adapt.test.reb
+++ b/tests/functions/adapt.test.reb
@@ -21,6 +21,7 @@
     ]
     adapted-append-v: adapt 'append-v [
         value: to integer! value
+        only: true
     ]
     adapted-append-v "10"
     adapted-append-v "20"

--- a/tests/functions/read-lines.test.reb
+++ b/tests/functions/read-lines.test.reb
@@ -17,7 +17,7 @@
         lines: collect [
             for-each l read-lines/binary test-file [keep l]
         ]
-        lines = map-each l [{a^Mb} {c} {} {d} {} {e} {} {f}] [to-binary l]
+        lines = map-each l [{a^Mb} {c} {} {d} {} {e} {} {f}] @[to-binary l]
     )
     ( { READ-LINES/DELIMITER }
         eol: "^M^/"

--- a/tests/functions/redescribe.test.reb
+++ b/tests/functions/redescribe.test.reb
@@ -70,7 +70,7 @@
 )
 
 (
-    append-lit: reskinned [@change :value] :append
+    append-lit: reskinned [@change :value] :append/only
     [a b c d] = append-lit [a b c] d
 )
 

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -41,7 +41,7 @@
     [a b c [1 2 3] [1 2 3]] = append-123-twice copy [a b c]
 )
 (
-    append-10: specialize 'append [value: 10]
+    append-10: specialize 'append [value: [10]]
     f: make frame! :append-10
     f/series: copy [a b c]
 
@@ -138,7 +138,7 @@
 
 
 (
-    ap10d: specialize 'append/dup [value: 10]
+    ap10d: specialize 'append/dup [value: [10]]
     f: make frame! :ap10d
     f/series: copy [a b c]
     did all [

--- a/tests/redbol/redbol-apply.test.reb
+++ b/tests/redbol/redbol-apply.test.reb
@@ -71,9 +71,8 @@
 (use [a] [a: false /a = redbol-apply func [/a] [a] [/a]])
 (use [a] [a: false /a = redbol-apply/only func [/a] [/a] [/a]])
 (group! == redbol-apply/only (specialize 'of [property: 'type]) [()])
-([1] == head of redbol-apply :insert [copy [] [1] blank blank])
-([1] == head of redbol-apply :insert [copy [] [1] blank false])
-([[1]] == head of redbol-apply :insert [copy [] [1] blank true])
+([1] == head of redbol-apply :insert [copy [] [1] blank blank blank])
+([[1]] == head of redbol-apply :insert [copy [] [1] true blank blank])
 (action! == redbol-apply (specialize 'of [property: 'type]) [:print])
 (get-word! == redbol-apply/only (specialize 'of [property: 'type]) [:print])
 
@@ -139,12 +138,12 @@
 (
     error? redbol-apply/only func [x [<opt> any-value!]] [
         return get 'x
-    ] head of insert copy [] make error! ""
+    ] head of insert/only copy [] make error! ""
 )
 (
     error? redbol-apply/only func ['x [<opt> any-value!]] [
         return get 'x
-    ] head of insert copy [] make error! ""
+    ] head of insert/only copy [] make error! ""
 )
 (use [x] [x: 1 strict-equal? 1 redbol-apply func ['x] [:x] [:x]])
 (use [x] [x: 1 strict-equal? 1 redbol-apply func ['x] [:x] [:x]])

--- a/tests/secure/const.test.reb
+++ b/tests/secure/const.test.reb
@@ -6,8 +6,8 @@
     data: mutable [a b c]
     data-readonly: const data
     did all [
-        (e: trap [append data-readonly <readonly>] e/id = 'const-value)
-        append data <readwrite>
+        (e: trap [append data-readonly [<readonly>]] e/id = 'const-value)
+        append data [<readwrite>]
         data = [a b c <readwrite>]
         data-readonly = [a b c <readwrite>]
     ]
@@ -15,7 +15,7 @@
     sum: 0
     loop 5 code: [
         ()
-        append code/1 sum: sum + 1
+        append code/1 @(sum: sum + 1)
     ]
     did all [
         sum = 5
@@ -26,7 +26,7 @@
     e: trap [
         loop 5 code: const [
             ()
-            append code/1 sum: sum + 1
+            append code/1 @(sum: sum + 1)
         ]
     ]
     e/id = 'const-value
@@ -34,7 +34,7 @@
     sum: 0
     loop 5 code: const [
         ()
-        append mutable code/1 sum: sum + 1
+        append mutable code/1 @(sum: sum + 1)
     ]
     did all [
         sum = 5
@@ -46,13 +46,13 @@
 ; DO should be neutral...if the value it gets in is const, it should run that
 ; as const...it shouldn't be inheriting a "wave of constness" otherwise.
 (
-    e: trap [loop 2 [do [append d: [] <item>]]]
+    e: trap [loop 2 [do [append d: [] [<item>]]]]
     e/id = 'const-value
 )(
-    block: [append d: [] <item>]
+    block: [append d: [] [<item>]]
     [<item> <item>] = loop 2 [do block]
 )(
-    block: [append d: [] <item>]
+    block: [append d: [] [<item>]]
     e: trap [loop 2 [do const block]]
     e/id = 'const-value
 )
@@ -63,16 +63,16 @@
 ; do a COMPOSE then it looks the same from the evaluator's point of view.
 ; Hence, if you want to modify composed-in blocks, use explicit mutability.
 (
-    [<legal> <legal>] = do compose [loop 2 [append mutable [] <legal>]]
+    [<legal> <legal>] = do compose [loop 2 [append mutable [] [<legal>]]]
 )(
     block: []
     e: trap [
-        do compose/deep [loop 2 [append (block) <fail>]]
+        do compose/deep [loop 2 [append (block) [<fail>]]]
     ]
     e/id = 'const-value
 )(
     block: mutable []
-    do compose/deep [loop 2 [append (block) <legal>]]
+    do compose/deep [loop 2 [append (block) [<legal>]]]
     block = [<legal> <legal>]
 )
 
@@ -82,9 +82,9 @@
 ; if they weren't copied (and weren't mutable explicitly)
 (
     loop 1 [data: copy [a [b [c]]]]
-    append data <success>
-    e2: trap [append data/2 <fail>]
-    e22: trap [append data/2/2 <fail>]
+    append data [<success>]
+    e2: trap [append data/2 [<fail>]]
+    e22: trap [append data/2/2 [<fail>]]
     did all [
         data = [a [b [c]] <success>]
         e2/id = 'const-value
@@ -92,21 +92,21 @@
     ]
 )(
     loop 1 [data: copy/deep [a [b [c]]]]
-    append data <success>
-    append data/2 <success>
-    append data/2/2 <success>
+    append data [<success>]
+    append data/2 [<success>]
+    append data/2/2 [<success>]
     data = [a [b [c <success>] <success>] <success>]
 )(
     loop 1 [sub: copy/deep [b [c]]]
     data: copy compose [a (sub)]
-    append data <success>
-    append data/2 <success>
-    append data/2/2 <success>
+    append data [<success>]
+    append data/2 [<success>]
+    append data/2/2 [<success>]
     data = [a [b [c <success>] <success>] <success>]
 )
 
 [https://github.com/metaeducation/ren-c/issues/633 (
-    e: trap [repeat x 1 [append foo: [] x]]
+    e: trap [repeat x 1 [append foo: [] @x]]
     e/id = 'const-value
 )]
 
@@ -138,7 +138,7 @@
 ; Reskinning capabilities can remove the <const> default
 (
     func-r2: reskinned [body [block!]] adapt :func []
-    aggregator: func-r2 [x] [data: [] append data x]
+    aggregator: func-r2 [x] [data: [] append data @x]
     did all [
         [10] = aggregator 10
         [10 20] = aggregator 20
@@ -148,10 +148,10 @@
 
 ; COMPOSE should splice with awareness of const/mutability
 (
-    e: trap [loop 2 compose [append ([1 2 3]) <bad>]]
+    e: trap [loop 2 compose [append ([1 2 3]) [<bad>]]]
     e/id = 'const-value
 )(
-    block: loop 2 compose [append (mutable [1 2 3]) <legal>]
+    block: loop 2 compose [append (mutable [1 2 3]) [<legal>]]
     block = [1 2 3 <legal> <legal>]
 )
 

--- a/tests/secure/unprotect.test.reb
+++ b/tests/secure/unprotect.test.reb
@@ -4,19 +4,19 @@
     value: copy original: [1 + 2 + 3]
     protect value
     unprotect value
-    not error? trap [insert value 4]
+    not error? trap [insert value [4]]
 )]
 (
     value: copy original: [1 + 2 + 3]
     protect value
     unprotect value
-    not error? trap [append value 4]
+    not error? trap [append value [4]]
 )
 (
     value: copy original: [1 + 2 + 3]
     protect value
     unprotect value
-    not error? trap [change value 4]
+    not error? trap [change value [4]]
 )
 (
     value: copy original: [1 + 2 + 3]

--- a/tests/series/append.test.reb
+++ b/tests/series/append.test.reb
@@ -32,9 +32,9 @@
 
 ; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
 ;
-([a b c d/e/f] = append copy [a b c] 'd/e/f)
+([a b c d/e/f] = append copy [a b c] [d/e/f])
 ('a/b/c/d/e/f = join 'a/b/c ['d 'e 'f])
-('(a b c d/e/f) = append copy '(a b c) 'd/e/f)
+('(a b c d/e/f) = append copy '(a b c) [d/e/f])
 (did trap ['a/b/c/d/e/f = join 'a/b/c '('d 'e 'f)])
 ('a/b/c/d/e/f = join 'a/b/c 'd/e/f)
 

--- a/tests/series/as.test.reb
+++ b/tests/series/as.test.reb
@@ -1,13 +1,13 @@
 (
     block: copy [a b c]
     path: to path! block
-    append block 'd
+    append block [d]
     path = 'a/b/c  ; AS was not legal
 )
 (
     block: copy [a b c]
     group: as group! block
-    append block 'd
+    append block [d]
     group = lit (a b c d)
 )
 

--- a/tests/series/change.test.reb
+++ b/tests/series/change.test.reb
@@ -2,8 +2,8 @@
 (
     blk1: at copy [1 2 3 4 5] 3
     blk2: at copy [1 2 3 4 5] 3
-    change/part blk1 6 -2147483647
-    change/part blk2 6 -2147483648
+    change/part blk1 [6] -2147483647
+    change/part blk2 [6] -2147483648
     equal? head of blk1 head of blk2
 )
 [#9

--- a/tests/series/insert.test.reb
+++ b/tests/series/insert.test.reb
@@ -1,13 +1,13 @@
 ; functions/series/insert.r
 (
     a: make block! 0
-    insert a 0
+    insert a [0]
     a == [0]
 )
 (
     a: [0]
     b: make block! 0
-    insert b first a
+    insert/only b first a
     a == b
 )
 (
@@ -19,13 +19,13 @@
 ; paren
 (
     a: make group! 0
-    insert a 0
+    insert a [0]
     a == first [(0)]
 )
 (
     a: first [(0)]
     b: make group! 0
-    insert b first a
+    insert/only b first a
     a == b
 )
 (
@@ -201,26 +201,26 @@
 ; insert/dup
 (
     a: make block! 0
-    insert/dup a 0 2
+    insert/dup a [0] 2
     a == [0 0]
 )
 (
     a: make block! 0
-    insert/dup a 0 0
+    insert/dup a [0] 0
     a == []
 )
 (
     a: make block! 0
-    insert/dup a 0 -1
+    insert/dup a [0] -1
     a == []
 )
 (
     a: make block! 0
-    insert/dup a 0 -2147483648
+    insert/dup a [0] -2147483648
     a == []
 )
 (
     a: make block! 0
-    insert/dup a 0 -2147483648
+    insert/dup a [0] -2147483648
     empty? a
 )

--- a/tests/series/replace.test.reb
+++ b/tests/series/replace.test.reb
@@ -9,12 +9,12 @@
 
 ; REPLACE
 
-([1 2 8 4 5] = replace [1 2 3 4 5] 3 8)
+([1 2 8 4 5] = replace [1 2 3 4 5] 3 [8])
 ([1 2 8 9 4 5] = replace [1 2 3 4 5] 3 [8 9])
 ([1 2 8 9 5] = replace [1 2 3 4 5] [3 4] [8 9])
-([1 2 8 5] = replace [1 2 3 4 5] [3 4] 8)
-([1 2 a 5] = replace [1 2 3 4 5] [3 4] 'a)
-([a g c d] = replace [a b c d] 'b 'g)
+([1 2 8 5] = replace [1 2 3 4 5] [3 4] [8])
+([1 2 a 5] = replace [1 2 3 4 5] [3 4] [a])
+([a g c d] = replace [a b c d] 'b [g])
 (#{006400} = replace #{000100} #{01} 100)
 (%file.ext = replace %file.sub.ext ".sub." #".")
 ("abra-abra" = replace "abracadabra" "cad" #"-")
@@ -32,10 +32,10 @@
 
 ; REPLACE/ALL
 
-([1 4 3 4 5] = replace/all [1 2 3 2 5] 2 4)
+([1 4 3 4 5] = replace/all [1 2 3 2 5] 2 [4])
 ([1 4 5 3 4 5] = replace/all [1 2 3 2] 2 [4 5])
 ([1 8 9 8 9] = replace/all [1 2 3 2 3] [2 3] [8 9])
-([1 8 8] = replace/all [1 2 3 2 3] [2 3] 8)
+([1 8 8] = replace/all [1 2 3 2 3] [2 3] [8])
 (#{640164} = replace/all #{000100} #{00} #{64})
 (%file.sub.ext = replace/all %file!sub!ext #"!" #".")
 (<tag body end> = replace/all <tag_body_end> "_" " ")
@@ -50,8 +50,8 @@
 (%file.txt = replace/case/all %file.TXT.txt.TXT %.TXT "")
 (<tag xyXx> = replace/case <tag xXXx> "X" "y")
 (<tag xyyx> = replace/case/all <tag xXXx> "X" "y")
-(["a" "B" "x"] = replace/case/all ["a" "B" "a" "b"] ["a" "b"] "x")
-((lit (x A x)) = replace/case/all lit (a A a) 'a 'x)
+(["a" "B" "x"] = replace/case/all ["a" "B" "a" "b"] ["a" "b"] ["x"])
+((lit (x A x)) = replace/case/all lit (a A a) 'a [x])
 
 ;((make hash! [x a b [a B]]) = replace/case make hash! [a B a b [a B]] [a B] 'x)
 

--- a/tests/source-tools.reb
+++ b/tests/source-tools.reb
@@ -120,7 +120,7 @@ rebsource: context [
         body [block!]
     ][
         body: new-line/all compose/only body false
-        append/line log (head insert body label)
+        append/line log (head insert body @label)
     ]
 
     analyse: context [
@@ -172,7 +172,7 @@ rebsource: context [
 
                 malloc-check: [
                     and identifier "malloc" (
-                        append malloc-found try text-line-of position
+                        append/only malloc-found try text-line-of position
                     )
                 ]
 
@@ -213,7 +213,7 @@ rebsource: context [
                                 )
                                 append
                                     non-std-func-space: default [copy []]
-                                    line  ; should it be appending BLANK! ?
+                                    @line  ; should it be appending BLANK! ?
                             ]
                         ]
                     ]
@@ -322,9 +322,9 @@ rebsource: context [
                 (
                     line-len: subtract index of position index of bol
                     if line-len > standard/std-line-length [
-                        append over-std-len line
+                        append over-std-len @line
                         if line-len > standard/max-line-length [
-                            append over-max-len line
+                            append over-max-len @line
                         ]
                     ]
                     line: 1 + line
@@ -420,7 +420,7 @@ rebsource: context [
 
             if equal? #"/" last item [
                 contents: read join src-folder item
-                insert queue map-each x contents [join item x]
+                insert queue map-each/only x contents [join item x]
                 item: _
             ] else [
                 any [

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -102,7 +102,7 @@ make object! [
             return
         ]) else [
             change-dir current-dir
-            append collected-tests test-file
+            append collected-tests @test-file
         ]
 
         types: context [
@@ -134,7 +134,7 @@ make object! [
             copy vector ["(" test-source-rule ")"] (
                 type: in types 'tst
                 append/only collected-tests flags
-                append collected-tests vector
+                append collected-tests @vector
             )
         ]
 
@@ -150,7 +150,7 @@ make object! [
                 [
                     :(tag? value) (
                         type: in types 'flag
-                        append flags value
+                        append flags @value
                     )
                         |
                     :(issue? value) (type: in types 'isu)
@@ -180,14 +180,14 @@ make object! [
             [
                 :(tag? get 'value) (
                     type: in types 'flg
-                    append flags value
+                    append flags @value
                 )
                 |
                 :(file? get 'value) (
                     type: in types 'fil
                     collect-tests collected-tests value
                     print ["file:" mold test-file]
-                    append collected-tests test-file
+                    append collected-tests @test-file
                 )
             ]
         ]

--- a/tools/bootstrap-shim.r
+++ b/tools/bootstrap-shim.r
@@ -320,3 +320,20 @@ eval: func [] [
         https://forum.rebol.info/t/eval-evaluate-and-reeval-reevaluate/1173
     ]
 ]
+
+map-each: function [
+    {https://forum.rebol.info/t/1155}
+    return: [block!]
+    'vars [blank! word! block!]
+    data [any-series! any-path! action!]
+    body [block!]
+    /only
+][
+    collect [
+        for-each (vars) :data compose [
+            set* lit item: (as group! body)
+            if void? :item [continue]  ; assume it was a CONTINUE :-/
+            keep/(try if only ['only]) :item
+        ]
+    ]
+]

--- a/tools/common-emitter.r
+++ b/tools/common-emitter.r
@@ -103,7 +103,7 @@ cscape: function [
 
             any-upper: did find/case expr charset [#"A" - #"Z"]
             any-lower: did find/case expr charset [#"a" - #"z"]
-            keep pattern
+            keep/only pattern
 
             code: load/all expr
             if with [
@@ -139,10 +139,10 @@ cscape: function [
             ; If the substitution started at a certain column, make any line
             ; breaks continue at the same column.
             ;
-            indent: unspaced collect [keep newline | keep prefix]
+            indent: unspaced collect [keep/only newline | keep/only prefix]
             replace/all sub newline indent
 
-            keep sub
+            keep/only sub
         ]
     ]
 

--- a/tools/common.r
+++ b/tools/common.r
@@ -195,7 +195,7 @@ for-each-record: function [
         fail {Table of records does not start with a header block}
     ]
 
-    headings: map-each word first table [
+    headings: map-each/only word first table [
         if not word? word [
             fail [{Heading} word {is not a word}]
         ]
@@ -211,7 +211,7 @@ for-each-record: function [
 
         spec: collect [
             for-each column-name headings [
-                keep column-name
+                keep/only column-name
                 keep compose/only [lit (table/1)]
                 table: next table
             ]
@@ -418,14 +418,14 @@ stripload: function [
             |
             "^^}"  ; (actually `^}`) escaped brace, never count
             |
-            "{" (if <Q> != last pushed [append pushed <B>])
+            "{" (if <Q> != last pushed [append pushed [<B>]])
             |
             "}" (if <B> = last pushed [take/last pushed])
             |
             {"} (
                 case [
                     <Q> = last pushed [take/last pushed]
-                    empty? pushed [append pushed <Q>]
+                    empty? pushed [append pushed [<Q>]]
                 ]
             )
             |

--- a/tools/make-boot-ext-header.r
+++ b/tools/make-boot-ext-header.r
@@ -46,7 +46,7 @@ args: parse-args system/options/args
 output-dir: system/options/path/prep
 mkdir/deep output-dir/include
 
-extensions: map-each e (split args/EXTENSIONS #":") [
+extensions: map-each/only e (split args/EXTENSIONS #":") [
     to-c-name e  ; so SOME-EXTENSION becomes SOME_EXTENSION for C macros
 ]
 

--- a/tools/make-headers.r
+++ b/tools/make-headers.r
@@ -89,7 +89,7 @@ emit-proto: func [
         fail ["Duplicate prototype:" the-file ":" proto]
     ]
 
-    append prototypes proto
+    append/only prototypes proto
 
     e-funcs/emit [proto the-file] {
         RL_API $<Proto>; /* $<The-File> */

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -94,7 +94,9 @@ emit-include-params-macro: function [
                 seen-refinement: true
                 param-name: as text! to word! item
 
-                keep cscape/with {REFINE($<n>, ${param-name})} [n param-name]
+                keep/only cscape/with {REFINE($<n>, ${param-name})} [
+                    n param-name
+                ]
             ][
                 ; !!! As a transition to refinements-being-the-arg, we don't
                 ; generate macros for things that look like refinement args.
@@ -102,12 +104,14 @@ emit-include-params-macro: function [
                 ; it will be legal to order normal parameters after refines.
                 ;
                 if seen-refinement [
-                    keep cscape/with {#error "${param-name}"} [param-name]
+                    keep/only cscape/with {#error "${param-name}"} [param-name]
                 ]
                 else [
                     param-name: as text! item
 
-                    keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
+                    keep/only cscape/with {PARAM($<n>, ${param-name})} [
+                        n param-name
+                    ]
                 ]
             ]
             n: n + 1

--- a/tools/prep-extension.r
+++ b/tools/prep-extension.r
@@ -133,7 +133,7 @@ native-defs: collect [
         ]
         opt [quote platforms: set n-platforms block!]
         (
-            keep make natdef compose/only [
+            keep/only make natdef compose/only [
                 export: (n-export)
                 name: lit (to word! n-name)
                 spec: (n-spec)  ; includes NATIVE or NATIVE/BODY
@@ -187,7 +187,7 @@ for-each native native-defs [
     num-natives: num-natives + 1
 
     if native/export [
-        append native-list 'export
+        append native-list [export]
 
         ; !!! This used to add to an "export-list" in the header of a module
         ; whose source was entirely generated.  The idea was that there could
@@ -210,7 +210,7 @@ for-each native native-defs [
         ; http://www.rebol.net/r3blogs/0300.html
         ;
         comment [
-            append export-list to word! native/name
+            append/only export-list to word! native/name
             ...
             compose/only [
                 Module [
@@ -233,7 +233,7 @@ names: collect [
     for-each item native-list [
         if set-word? item [
             item: to word! item
-            keep cscape/with {N_${MOD}_${Item}} 'item
+            keep/only cscape/with {N_${MOD}_${Item}} 'item
         ]
     ]
 ]
@@ -242,7 +242,7 @@ native-forward-decls: collect [
     for-each item native-list [
         if set-word? item [
             item: to word! item
-            keep cscape/with {REBNATIVE(${Item})} 'item
+            keep/only cscape/with {REBNATIVE(${Item})} 'item
         ]
     ]
 ]

--- a/tools/read-deep.reb
+++ b/tools/read-deep.reb
@@ -27,7 +27,7 @@ read-deep-seq: function [
     item: take queue
 
     if equal? #"/" last item [
-        insert queue map-each x read item [join item x]
+        insert queue map-each/only x read item [join item x]
     ]
 
     item
@@ -51,7 +51,7 @@ read-deep: function [
     queue: blockify root
 
     while [not tail? queue] [
-        append result taker queue  ; Possible null
+        append result @(taker queue)  ; Possible null
     ]
 
     if not full [

--- a/tools/rebmake.r
+++ b/tools/rebmake.r
@@ -49,7 +49,7 @@ map-files-to-local: function [
     files [file! block!]
 ][
     if not block? files [files: reduce [files]]
-    map-each f files [
+    map-each/only f files [
         file-to-local f
     ]
 ]
@@ -132,7 +132,7 @@ pkg-config: function [
                 thru dlm
                 copy item: to [dlm | end] (
                     ;dump item
-                    append ret to file! item
+                    append/only ret to file! item
                 )
             ]
             end
@@ -714,7 +714,7 @@ ld: make linker-class [
                 file-to-local dep/output
             ]
             #object-library [
-                spaced map-each ddep dep/depends [
+                spaced map-each/only ddep dep/depends [
                     file-to-local ddep/output
                 ]
             ]
@@ -809,7 +809,7 @@ llvm-link: make linker-class [
                 _
             ]
             #object-library [
-                spaced map-each ddep dep/depends [
+                spaced map-each/only ddep dep/depends [
                     file-to-local ddep/output
                 ]
             ]
@@ -903,7 +903,7 @@ link: make linker-class [
                 file-to-local dep/output
             ]
             #object-library [
-                spaced map-each ddep dep/depends [
+                spaced map-each/only ddep dep/depends [
                     file-to-local to-file ddep/output
                 ]
             ]
@@ -1026,7 +1026,7 @@ object-file-class: make object! [
 
         make entry-class [
             target: output
-            depends: append copy either depends [depends][[]] source
+            depends: append/only copy either depends [depends][[]] source
             commands: reduce [command/I/D/F/O/g/(
                 try if (PIC or [parent/class = #dynamic-library]) ['PIC]
             )
@@ -1399,7 +1399,7 @@ makefile: make generator-class [
                     ]
                     append buf gen-rule make entry-class [
                         target: dep/output
-                        depends: join objs map-each ddep dep/depends [
+                        depends: join objs map-each/only ddep dep/depends [
                             if ddep/class <> #object-library [ddep]
                         ]
                         commands: append reduce [dep/command] opt dep/post-build-commands
@@ -1981,7 +1981,7 @@ visual-studio: make generator-class [
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <AdditionalOptions>}
       if project/cflags [
-          spaced map-each i project/cflags [
+          spaced map-each/only i project/cflags [
               filter-flag i "msc"
           ]
       ] {</AdditionalOptions>}
@@ -2022,7 +2022,7 @@ visual-studio: make generator-class [
         ][
             unspaced [ {
     <PreBuildEvent>
-      <Command>} delimit newline map-each cmd project/commands [reify cmd] {
+      <Command>} delimit newline map-each/only cmd project/commands [reify cmd] {
       </Command>
     </PreBuildEvent>}
             ]
@@ -2034,7 +2034,7 @@ visual-studio: make generator-class [
     ][
         unspaced [ {
     <PostBuildEvent>
-      <Command>} delimit newline map-each cmd project/post-build-commands [reify cmd] {
+      <Command>} delimit newline map-each/only cmd project/post-build-commands [reify cmd] {
       </Command>
     </PostBuildEvent>}
         ]
@@ -2100,7 +2100,7 @@ visual-studio: make generator-class [
                     ]
 
                     if o/cflags [
-                        collected: map-each i o/cflags [
+                        collected: map-each/only i o/cflags [
                             filter-flag i "msc"
                         ]
                         if not empty? collected [

--- a/tools/systems.r
+++ b/tools/systems.r
@@ -466,16 +466,16 @@ for-each-system: function [
                 )
             ]
             copy definitions [any issue!] (
-                definitions: map-each x definitions [to-word x]
+                definitions: map-each/only x definitions [to-word x]
             )
             copy cflags [any tag!] (
-                cflags: map-each x cflags [to-word to-text x]
+                cflags: map-each/only x cflags [to-word to-text x]
             )
             copy ldflags [any refinement!] (
-                ldflags: map-each x ldflags [to-word x]
+                ldflags: map-each/only x ldflags [to-word x]
             )
             copy libraries [any file!] (
-                libraries: map-each x libraries [to-word to-text x]
+                libraries: map-each/only x libraries [to-word to-text x]
             )
 
             (

--- a/tools/text-lines.reb
+++ b/tools/text-lines.reb
@@ -101,7 +101,7 @@ lines-exceeding: function [  ; !!! Doesn't appear used, except in tests (?)
         (
             line: 1 + any [line 0]
             if line-length < subtract index-of eol index of bol [
-                append line-list: any [line-list copy []] line
+                append/only line-list: any [line-list copy []] line
             ]
         )
     ]


### PR DESCRIPTION
For aggregate values, there has always been an ambiguous situation in
Rebol as to whether an operation (e.g. APPEND, INSERT, CHANGE) means
to treat another aggregate value as a collection of things to splice
or a single item:

    ; Option (1)
    >> append [a b c] [d e]
    == [a b c d e]

    ; Option (2)
    >> append [a b c] [d e]
    == [a b c [d e]]

From a technical point of view, the more fundamental operation is (2)
That is because with iteration you could implement (1) by adding the
items one at a time.  But if blocks always spliced in these operations
and (1) was the only mechanic, you'd have no way to append a block to
a block (well, without changing the thing you append to *be* a block,
as pointed out by @Mark-hi; e.g. your APPEND would have to take a
constructed value vs. one that already exists in memory.)

Despite adding items atomically seeming more "fundamental", Rebol chose
to make most operations interpret aggregates as being spliced by
default.  To get the behavior in (2), an /ONLY refinement would have
to be used.

The benefits of this choice aren't obvious at first glance, when
thinking purely in mechanical terms.  But usage of the language in
practice reveals that there's leverage in this assumption.  It also
aligns well with string operations, which have no choice but to splice
and have no parallel to appending another string atomically, e.g.:

    >> append "abc" "de"
    == "abcde"  ; you don't want ["abc" "de"]

HOWEVER, accepting splice-by-default led to some poor invariants; as
non-aggregates would fall back to just adding a single item.  Code
that was meant to be generic could appear to work.  So imagine a
generic function like:

    block: []
    add-item: function [x] [append block x]

The intent to use /ONLY here could be very easily overlooked...
especially since code can appear to work for a time and then suddenly
not work when a BLOCK! is used (or historically also PATH!, GROUP!).
Calling it a newbie mistake is not true: it is a chronic problem in
the system due to the duality that aggregates are also values
themselves.

The suggestion has often been made to reverse the bias and require an
explicit /SPLICE.  However this carries its own set of tradeoffs,
making formerly elegant code inelegant, and does not allow one
to write code in a way that is compatible with historical Rebol.

THIS EXPERIMENTAL COMMIT EMBRACES THE HISTORICAL CONVENTION OF SPLICE IF
THE TARGET IS AN ANY-ARRAY!, BUT ONLY IF THE SOURCE MATERIAL IS BLOCK!,
AND WILL ERROR ON OTHER SOURCE DATA.  The idea is to train users and
ingrain it in their mind to think of using /ONLY whenever they intend
to work with single items within a block.  This elevates blocks to a
greater common currency in the system.

For those looking at callsites where the intent seems obvious, this may
appear to add a bit of hassle.  e.g. instead of `append block <tag>`
one must say `append block [<tag>]` or `append/only block <tag>`.
But the benefits are for `append block (black-box-expression)`, where
the poor invariants have been rearing their ugly head since the
beginning of the language...where the convenience that drove APPEND
to splice by default runs up against the intuition that those writing
generic code have about what the more fundamental operation is.  By
forcing the black box expression to resolve to a block when /ONLY is
not used, the callsite becomes more sensible.

To mitigate any perceived pain, "modal" parameters are used to allow
the /ONLY flag to be conveyed by a single character in many of the most
common cases:

    b1: [a b c]
    b2: [d e]

    >> append b1 @b2
    == [a b c [d e]]

    >> append b1 @(reverse copy b2)
    == [a b c [d e] [e d]]

    >> append b1 @[f g h]
    == [a b c [d e] [e d] [f g h]]

This commit also rethinks MAP-EACH to splice by default, adding an
/ONLY option to avoid that (which can be conveyed via a modal parameter
on the code block itself).  COLLECT is also given an /ONLY option, so
that /ONLY is removed from KEEP and it always means keep one item.