### PR TITLE
Clunky first implementation of LET in FUNC/FUNCTION

### DIFF
--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -239,6 +239,16 @@ dummy7
 dummy8
 dummy9
 
+; !!! The best implementation concept for LET would be a runtime concept
+; where only those instances of LET in an evaluation stream could somehow add
+; dynamically to a running context, while inert ones would not.  e.g.
+; code like `data: [let x:]` would not create memory for an x variable unless
+; you actually `do data`.  But as an interim step before the "virtual binding"
+; needed for that exists, LET is searched for as a keyword by FUNC at
+; function creation time, much like SET-WORD!s were looked for before.
+;
+let
+
 ; !!! Legacy: Used to report an error on usage of /LOCAL when <local> was
 ; intended.  Should be removed from code when the majority of such uses have
 ; been found, as the responsibility for that comes from %r2-warn.reb

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -862,7 +862,8 @@ REB_R Block_Dispatcher(REBFRM *f)
         REBARR *body_array = Copy_And_Bind_Relative_Deep_Managed(
             KNOWN(block),
             ACT_PARAMLIST(FRM_PHASE(f)),
-            TS_WORD
+            TS_WORD,
+            false  // do not gather LETs
         );
 
         // Preserve file and line information from the original, if present.

--- a/src/core/n-function.c
+++ b/src/core/n-function.c
@@ -461,7 +461,8 @@ REBNATIVE(adapt)
     REBARR *prelude = Copy_And_Bind_Relative_Deep_Managed(
         ARG(prelude),
         ACT_PARAMLIST(underlying), // relative bindings ALWAYS use underlying
-        TS_WORD
+        TS_WORD,
+        false  // do not gather LETs
     );
 
     REBARR *details = ACT_DETAILS(adaptation);

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -157,6 +157,7 @@
 %functions/frame.test.reb
 %functions/hijack.test.reb
 %functions/invisible.test.reb
+%functions/let.test.reb
 %functions/modal.test.reb
 %functions/oneshot.test.reb
 %functions/redescribe.test.reb

--- a/tests/functions/let.test.reb
+++ b/tests/functions/let.test.reb
@@ -1,0 +1,13 @@
+; LET is Ren-C's initiative to try and make FUNC and FUNCTION synonyms
+;
+; https://forum.rebol.info/t/rethinking-auto-gathered-set-word-locals/1150
+
+(
+    y: <global>
+    plus1000: func [j] [let b: 1000 | b + j]
+    did all [
+        1020 = plus1000 20
+        [j] = parameters of :plus1000 
+        [return j b] = words of make frame! :plus1000
+    ] 
+)


### PR DESCRIPTION
R3-Alpha introduced the idea of a "FUNCT", which would notice when a
SET-WORD! was used in a function body that was not one of the arguments
or locals in the spec.  It would then automatically "gather" these and
add them as locals in the spec.

This was much more convenient than having to maintain by hand a list
of the locals in the spec, which might get out of date as the body was
edited.  The convenience was such that this concept took the name
FUNCTION away from it former use (as a slight variant of FUNC which
let you separate the locals into their own parameter block).

However, the idea of auto-gathered locals based on SET-WORD! runs into
several problems in Rebol--as SET-WORD!s are used for many purposes
besides local variables.  Function frames became inflated with stray
variables that were really just keys in objects being used, and there
were many mechanical consequences.  It also led to FUNC having a
meaning that was distinct from an abbreviation for FUNCTION...with
the two developing different feature sets, leading to a greater
mental tax on users to understand these differences.

This implements a first step moving away from the idea that SET-WORD!
with no annotation will provoke locals in functions.  It is not ideal,
as it treats LET as something of a keyword to signal the same kind of
gathering that SET-WORD!s did.  Ideally it would be more of a runtime
concept, so that a LET would actually have to be *running* in order
to create a runtime addition to a "wave" of context:

    data: [let x: 10]
    code: [let y: 10 print y]
    do code  ; this invocation would incarnate y
    ; but since data never runs, x doesn't get allocated

The methodology needed to do that hasn't been fully figured out yet,
but there are several pieces of what would be needed in place.