### PR TITLE
Switch to indefinite lifetime for function args/locals

### DIFF
--- a/src/include/datatypes/sys-context.h
+++ b/src/include/datatypes/sys-context.h
@@ -189,6 +189,11 @@ static inline void INIT_CTX_KEYLIST_UNIQUE(REBCTX *c, REBARR *keylist) {
 #define CTX_KEYS_HEAD(c) \
     SER_AT(REBVAL, SER(CTX_KEYLIST(c)), 1) // a CTX_KEY can't hold a RELVAL
 
+inline static bool Is_Frame_On_Stack(REBCTX *c) {
+    assert(IS_FRAME(CTX_ARCHETYPE(c)));
+    return (LINK_KEYSOURCE(c)->header.bits & NODE_FLAG_CELL);
+}
+
 inline static REBFRM *CTX_FRAME_IF_ON_STACK(REBCTX *c) {
     REBNOD *keysource = LINK_KEYSOURCE(c);
     if (not (keysource->header.bits & NODE_FLAG_CELL))

--- a/src/include/datatypes/sys-string.h
+++ b/src/include/datatypes/sys-string.h
@@ -560,7 +560,10 @@ inline static REBCHR(*) STR_AT(REBSTR *s, REBLEN at) {
     else {
         if (len < sizeof(REBVAL)) {
             if (not IS_STR_SYMBOL(s))
-                assert(not bookmark);  // mutations must ensure this
+                assert(
+                    not bookmark  // mutations must ensure this usually but...
+                    or GET_SERIES_FLAG(s, ALWAYS_DYNAMIC)  // !!! mold buffer?
+                );
             goto scan_from_tail;  // good locality, avoid bookmark logic
         }
         if (not bookmark and not IS_STR_SYMBOL(s)) {


### PR DESCRIPTION
Ren-C brought in a "reasonable cost" model for "specific binding",
which is the idea that WORD!s bound in the body of functions retain
a memory to which instantiation of that function they are for.  (This
replaced a technique of walking the stack to presume a word should
always be looked up in the most recent invocation of a function.)

However, when functions would finish the Drop_Action() call they'd mark
the frame of that specific instance as expired.  This was done due
to a belief that it would be expensive if an object instance (with
as many cells as a function had parameters and locals) would be kept
alive on every usermode function call after the call ended.  The
result would be an increased tax on the GC, creating one object per
(usermode) function call.

Desire to avoid that inefficiency ran up against the practical desire
of the semantics provided by what R3-Alpha called "CLOSURE".  A closure
would allow words to have a binding that survived the end of a
function call:

    r3-alpha>> foo: function [x] [return [x]]
    r3-alpha>> data: foo 10
    == [x]
    r3-alpha>> reduce data
    ** Script error: x word is not bound to a context

    r3-alpha>> foo: closure [x] [return [x]]
    r3-alpha>> data: foo 10
    == [x]
    r3-alpha>> reduce data
    == [10]

All things being equal, this behavior is usually the more desirable
one.  Especially when coding in an environment where functions must
frequently remove themselves from the stack and provide callbacks,
it helps if those callbacks can retain state from the environment
in which they were constructed.  As a canonical example:

    foo: function [x] [
        let y: 10
        return function [z] [x + y + z]
    ]

The generated function which is returned will be useless if x and y
are not still live after FOO has returned.

When considering the big picture--especially when trying to convince
JavaScript users that Rebol is a good language--it does not make sense
to make them need to learn a distinct word or concept to get this
feature.  Instead, the pressure should be on the system to optimize
and recycle frames that did not leak word references in this way.  Or
on those seeking optimization to use a special form of function that
does not permit this due to frame expiration.

This is a "future bet" on what the long tail of the language needs to
pick as its defaults.