### PR TITLE
Unused refinements NULL, no error on NULL via WORD!/PATH!

### DIFF
--- a/extensions/console/ext-console-init.reb
+++ b/extensions/console/ext-console-init.reb
@@ -349,7 +349,7 @@ ext-console-impl: function [
     resumable "Is the RESUME function allowed to exit this console"
         [logic!]
     skin "Console skin to use if the console has to be launched"
-        [object! file! blank!]
+        [<opt> object! file!]
 ][
     === HOOK RETURN FUNCTION TO GIVE EMITTED INSTRUCTION ===
 
@@ -453,7 +453,7 @@ ext-console-impl: function [
         ;
         assert [blank? :result]
         if (unset? 'system/console) or [not system/console] [
-            emit [start-console/skin lit (<*> skin)]
+            emit [start-console/skin '(<*> skin)]
         ]
         return <prompt>
     ]
@@ -469,7 +469,7 @@ ext-console-impl: function [
     ]
 
     if find directives #start-console [
-        emit [start-console/skin lit (<*> skin)]
+        emit [start-console/skin '(<*> skin)]
         return <prompt>
     ]
 
@@ -506,7 +506,7 @@ ext-console-impl: function [
             return 128 + 2 ; standard cancellation exit status for bash
         ]
         if find directives #console-if-halt [
-            emit [start-console/skin lit (<*> skin)]
+            emit [start-console/skin '(<*> skin)]
             return <prompt>
         ]
         if find directives #unskin-if-halt [

--- a/extensions/console/mod-console.c
+++ b/extensions/console/mod-console.c
@@ -316,8 +316,8 @@ REBNATIVE(console)
                 "ext-console-impl",  // action! that takes 2 args, run it
                 code,  // group! or block! executed prior (or blank!)
                 result,  // prior result quoted, or error (or blank!)
-                rebL(REF(resumable)),
-                NULLIFY_NULLED(ARG(skin)),
+                rebL(did REF(resumable)),
+                REF(skin),
             "]", rebEND
         );
 

--- a/extensions/console/mod-console.c
+++ b/extensions/console/mod-console.c
@@ -317,7 +317,7 @@ REBNATIVE(console)
                 code,  // group! or block! executed prior (or blank!)
                 result,  // prior result quoted, or error (or blank!)
                 rebL(REF(resumable)),
-                ARG(skin),
+                NULLIFY_NULLED(ARG(skin)),
             "]", rebEND
         );
 

--- a/extensions/event/mod-event.c
+++ b/extensions/event/mod-event.c
@@ -402,7 +402,7 @@ REBNATIVE(wait)
         Init_Block(D_OUT, ports);
 
     // Process port events [stack-move]:
-    if (Wait_Ports_Throws(D_OUT, ports, timeout, REF(only)))
+    if (Wait_Ports_Throws(D_OUT, ports, timeout, did REF(only)))
         return R_THROWN;
 
     assert(IS_LOGIC(D_OUT));

--- a/extensions/filesystem/p-file.c
+++ b/extensions/filesystem/p-file.c
@@ -442,7 +442,7 @@ REB_R File_Actor(REBFRM *frame_, REBVAL *port, const REBVAL *verb)
                 len = n;
         }
 
-        Write_File_Port(file, data, len, REF(lines));
+        Write_File_Port(file, data, len, did REF(lines));
 
         if (opened) {
             REBVAL *result = OS_DO_DEVICE(file, RDC_CLOSE);

--- a/extensions/gob/t-gob.c
+++ b/extensions/gob/t-gob.c
@@ -1024,9 +1024,9 @@ REBTYPE(Gob)
         return rebValue(
             "applique :take* [",
                 "series: at", pane, rebI(index + 1),
-                "part:", rebQ1(NULLIFY_NULLED(ARG(part))),
-                "deep:", rebQ1(NULLIFY_NULLED(ARG(deep))),
-                "last:", rebQ1(NULLIFY_NULLED(ARG(last))),
+                "part:", rebQ1(REF(part)),
+                "deep:", rebQ1(REF(deep)),
+                "last:", rebQ1(REF(last)),
             "]",
         rebEND); }
 

--- a/extensions/gob/t-gob.c
+++ b/extensions/gob/t-gob.c
@@ -1024,9 +1024,9 @@ REBTYPE(Gob)
         return rebValue(
             "applique :take* [",
                 "series: at", pane, rebI(index + 1),
-                "part:", ARG(part),
-                "deep:", ARG(deep),
-                "last:", ARG(last),
+                "part:", rebQ1(NULLIFY_NULLED(ARG(part))),
+                "deep:", rebQ1(NULLIFY_NULLED(ARG(deep))),
+                "last:", rebQ1(NULLIFY_NULLED(ARG(last))),
             "]",
         rebEND); }
 

--- a/extensions/image/t-image.c
+++ b/extensions/image/t-image.c
@@ -609,7 +609,7 @@ REB_R Modify_Image(REBFRM *frame_, const REBVAL *verb)
     REBINT x = index % w;  // offset on the line
     REBINT y = index / w;  // offset line
 
-    bool only = REF(only);
+    bool only = did REF(only);
 
     // Validate that block arg is all tuple values:
     if (IS_BLOCK(arg) && Array_Has_Non_Tuple(&n, arg))

--- a/extensions/network/dev-net.c
+++ b/extensions/network/dev-net.c
@@ -373,6 +373,15 @@ DEVICE_CMD Connect_Socket(REBREQ *sock)
 
       default:
         req->state &= ~RSM_ATTEMPT;
+
+        // !!! If there is a connect error, we don't want to leave the request
+        // hanging around such that the Poll_Devices() call will have that
+        // lingering error to fail on future READs.  (Review this in light of
+        // a general policy for asynchronous error delivery).
+        // https://github.com/metaeducation/ren-c/issues/1048
+        //
+        Close_Socket(sock);
+        OS_Abort_Device(sock);
         rebFail_OS (result);
     }
 

--- a/extensions/network/mod-network.c
+++ b/extensions/network/mod-network.c
@@ -410,7 +410,7 @@ static REB_R Transport_Actor(
         //
         TRASH_POINTER_IF_DEBUG(req->common.data);
         req->common.binary = rebValue(
-            "as binary! copy/part", data, rebQ1(NULLIFY_NULLED(ARG(part))),
+            "as binary! copy/part", data, rebQ1(REF(part)),
         rebEND);
 
         // Because requests can be handled asynchronously, we won't

--- a/extensions/network/mod-network.c
+++ b/extensions/network/mod-network.c
@@ -410,7 +410,7 @@ static REB_R Transport_Actor(
         //
         TRASH_POINTER_IF_DEBUG(req->common.data);
         req->common.binary = rebValue(
-            "as binary! copy/part", data, ARG(part),
+            "as binary! copy/part", data, rebQ1(NULLIFY_NULLED(ARG(part))),
         rebEND);
 
         // Because requests can be handled asynchronously, we won't

--- a/extensions/vector/t-vector.c
+++ b/extensions/vector/t-vector.c
@@ -666,7 +666,7 @@ REBTYPE(Vector)
         if (REF(seed) or REF(only))
             fail (Error_Bad_Refines_Raw());
 
-        Shuffle_Vector(v, REF(secure));
+        Shuffle_Vector(v, did REF(secure));
         RETURN (v); }
 
     default:

--- a/make.r
+++ b/make.r
@@ -309,7 +309,7 @@ parse-ext-build-spec: function [
             fail ["Could not parse extension build spec" mold spec]
         ]
 
-        if set? 'config [
+        if defined? 'config [
             do as block! config  ; Note: old Ren-Cs disallowed DO of GROUP!
         ]
     ]

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -596,7 +596,7 @@ parse: emulate [
             blank! [split input charset reduce [tab space CR LF]]
             text! [split input to-bitset rules]
         ] else [
-            if not pos: parse/(try if case_PARSE [/case]) input rules [
+            if not pos: parse/(case_PARSE) input rules [
                 return false
             ]
             return tail? pos

--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -297,7 +297,7 @@ static void Add_Lib_Keys_For_Unscannable_Set_Words(void)
     for (i = 0; names[i] != NULL; ++i) {
         REBSTR *str = Intern_UTF8_Managed(cb_cast(names[i]), strlen(names[i]));
         REBVAL *val = Append_Context(Lib_Context, NULL, str);
-        assert(IS_NULLED(val));
+        assert(IS_VOID(val));
         UNUSED(val);
     }
 }

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -720,7 +720,7 @@ void Virtual_Bind_Deep_To_New_Context(
             // unreadable blank.  But since this code is also shared with USE,
             // it doesn't do any initialization...so go ahead and put void.
             //
-            Init_Nulled(var);
+            Init_Void(var);
 
             assert(rebinding); // shouldn't get here unless we're rebinding
 

--- a/src/core/c-context.c
+++ b/src/core/c-context.c
@@ -231,7 +231,7 @@ REBVAL *Append_Context(
     //
     EXPAND_SERIES_TAIL(SER(CTX_VARLIST(context)), 1);
 
-    REBVAL *value = Init_Nulled(ARR_LAST(CTX_VARLIST(context)));
+    REBVAL *value = Init_Void(ARR_LAST(CTX_VARLIST(context)));
     TERM_ARRAY_LEN(CTX_VARLIST(context), ARR_LEN(CTX_VARLIST(context)));
 
     if (not opt_any_word)
@@ -247,7 +247,7 @@ REBVAL *Append_Context(
         INIT_WORD_INDEX(opt_any_word, len);
     }
 
-    return value; // location we just added (nulled cell)
+    return value;  // location we just added (void cell)
 }
 
 
@@ -652,7 +652,7 @@ REBARR *Collect_Unique_Words_Managed(
     // the "ignore" bindings.)  Do a pre-pass to fail first, if there are
     // any non-words in a block the user passed in.
     //
-    if (not IS_BLANK(ignore)) {
+    if (not IS_NULLED(ignore)) {
         RELVAL *check = VAL_ARRAY_AT(ignore);
         for (; NOT_END(check); ++check) {
             if (not ANY_WORD_KIND(CELL_KIND(VAL_UNESCAPED(check))))
@@ -705,7 +705,7 @@ REBARR *Collect_Unique_Words_Managed(
         }
     }
     else
-        assert(IS_BLANK(ignore));
+        assert(IS_NULLED(ignore));
 
     Collect_Inner_Loop(cl, head);
 
@@ -736,7 +736,7 @@ REBARR *Collect_Unique_Words_Managed(
             Remove_Binder_Index(&cl->binder, VAL_KEY_CANON(key));
     }
     else
-        assert(IS_BLANK(ignore));
+        assert(IS_NULLED(ignore));
 
     Collect_End(cl);
     return array;
@@ -1215,7 +1215,7 @@ void Resolve_Context(
     REBINT n = 1;
     for (; NOT_END(key); n++, key++) {
         REBSTR *canon = VAL_KEY_CANON(key);
-        if (IS_BLANK(only_words))
+        if (IS_NULLED(only_words))
             Add_Binder_Index(&binder, canon, n);
         else {
             if (Get_Binder_Index_Else_0(&binder, canon) != 0) {
@@ -1236,9 +1236,9 @@ void Resolve_Context(
         if (m != 0) {
             // "the remove succeeded, so it's marked as set now" (old comment)
 
-            if (NOT_CELL_FLAG(var, PROTECTED) and (all or IS_NULLED(var))) {
+            if (NOT_CELL_FLAG(var, PROTECTED) and (all or IS_VOID(var))) {
                 if (m < 0)
-                    Init_Nulled(var); // no value in source context
+                    Init_Void(var);  // no value in source context
                 else
                     Move_Var(var, CTX_VAR(source, m));  // preserves flags
             }

--- a/src/core/c-eval.c
+++ b/src/core/c-eval.c
@@ -924,10 +924,7 @@ bool Eval_Internal_Maybe_Stale_Throws(REBFRM * const f)
 
               unused_refinement:  // Note: might get pushed by a later slot
 
-                if (TYPE_CHECK(f->param, REB_NULLED))
-                    Init_Nulled(f->arg);  // <opt> refinements null if unused
-                else
-                    Init_Blank(f->arg);
+                Init_Nulled(f->arg);
                 SET_CELL_FLAG(f->arg, ARG_MARKED_CHECKED);
                 goto continue_arg_loop;
 
@@ -964,7 +961,7 @@ bool Eval_Internal_Maybe_Stale_Throws(REBFRM * const f)
                 if (SPECIAL_IS_ARBITRARY_SO_SPECIALIZED)
                     assert(IS_NULLED(f->special));
 
-                Init_Nulled(f->arg);
+                Init_Void(f->arg);
                 SET_CELL_FLAG(f->arg, ARG_MARKED_CHECKED);
                 goto continue_arg_loop;
 
@@ -1495,7 +1492,7 @@ bool Eval_Internal_Maybe_Stale_Throws(REBFRM * const f)
                 goto arg_loop_and_any_pickups_done;
             }
 
-            assert(IS_UNREADABLE_DEBUG(f->arg) or IS_BLANK(f->arg));
+            assert(IS_UNREADABLE_DEBUG(f->arg) or IS_NULLED(f->arg));
             SET_EVAL_FLAG(f, DOING_PICKUPS);
             goto fulfill_arg;
         }
@@ -1837,11 +1834,8 @@ bool Eval_Internal_Maybe_Stale_Throws(REBFRM * const f)
             goto process_action;
         }
 
-        if (IS_NULLED_OR_VOID(gotten)) { // need `:x` if it's unset or void
-            if (IS_NULLED(gotten))
-                fail (Error_No_Value_Core(v, *specifier));
+        if (IS_VOID(gotten))  // need `:x` if it's void ("unset")
             fail (Error_Need_Non_Void_Core(v, *specifier));
-        }
 
         Move_Value(f->out, gotten); // no copy CELL_FLAG_UNEVALUATED
         break;
@@ -1983,11 +1977,8 @@ bool Eval_Internal_Maybe_Stale_Throws(REBFRM * const f)
             goto process_action;
         }
 
-        if (IS_NULLED_OR_VOID(where)) {  // need `:x/y` if it's unset or void
-            if (IS_NULLED(where))
-                fail (Error_No_Value_Core(v, *specifier));
+        if (IS_VOID(where))  // need `:x/y` if it's void (unset)
             fail (Error_Need_Non_Void_Core(v, *specifier));
-        }
 
         if (where != f->out)
             Move_Value(f->out, where);  // won't move CELL_FLAG_UNEVALUATED

--- a/src/core/c-path.c
+++ b/src/core/c-path.c
@@ -132,13 +132,6 @@ bool Next_Path_Throws(REBPVS *pvs)
         Derelativize(PVS_PICKER(pvs), *v, *specifier);
     }
 
-    // Disallow voids from being used in path dispatch.  This rule seems like
-    // common sense for safety, and also corresponds to voids being illegal
-    // to use in SELECT.
-    //
-    if (IS_NULLED(PVS_PICKER(pvs)))
-        fail (Error_No_Value_Core(*v, *specifier));
-
     Fetch_Next_Forget_Lookback(pvs);  // may be at end
 
   redo:;
@@ -217,6 +210,8 @@ bool Next_Path_Throws(REBPVS *pvs)
             Init_Nulled(pvs->out);
         }
         else if (r == R_UNHANDLED) {
+            if (IS_NULLED(PVS_PICKER(pvs)))
+                fail ("NULL used in path picking but was not handled");
             fail (Error_Bad_Path_Pick_Raw(PVS_PICKER(pvs)));
         }
         else if (GET_CELL_FLAG(r, ROOT)) { // API, from Alloc_Value()

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -248,7 +248,7 @@ bool Redo_Action_Throws(REBVAL *out, REBFRM *f, REBACT *run)
             continue;  // don't throw in skippable args that are nulled out
 
         if (TYPE_CHECK(f->param, REB_TS_REFINEMENT)) {
-            if (IS_BLANK(f->arg))  // don't add to PATH!
+            if (IS_NULLED(f->arg))  // don't add to PATH!
                 continue;
 
             Init_Word(DS_PUSH(), VAL_PARAM_SPELLING(f->param));

--- a/src/core/c-specialize.c
+++ b/src/core/c-specialize.c
@@ -27,7 +27,7 @@
 //
 // The method used is to store a FRAME! in the specialization's ACT_BODY.
 // Any of those items that have ARG_MARKED_CHECKED are copied from
-// that frame instead of gathered from the callsite.  Eval_Core() heeds theis
+// that frame instead of gathered from the callsite.  Eval_Core() heeds this
 // when walking parameters (see `f->special`).
 //
 // Code is shared between the SPECIALIZE native and specialization of a
@@ -356,6 +356,17 @@ bool Specialize_Action_Throws(
 
     for (; NOT_END(param); ++param, ++arg) {
         if (TYPE_CHECK(param, REB_TS_REFINEMENT)) {
+            if (IS_BLANK(arg)) {
+                //
+                // !!! Temporary compatibility solution... blank refinements
+                // are considered to be unusable ones that have been
+                // specialized out.
+                //
+                Init_Nulled(arg);
+                SET_CELL_FLAG(arg, ARG_MARKED_CHECKED);
+                goto specialized_arg_no_typecheck;
+            }
+
             if (IS_NULLED(arg)) {
                 //
                 // A refinement that is nulled is a candidate for usage at the
@@ -396,7 +407,7 @@ bool Specialize_Action_Throws(
 
             if (GET_CELL_FLAG(arg, ARG_MARKED_CHECKED)) {
                 assert(
-                    IS_BLANK(arg)
+                    IS_NULLED(arg)
                     or (
                         IS_REFINEMENT(arg)
                         and (

--- a/src/core/d-stats.c
+++ b/src/core/d-stats.c
@@ -115,7 +115,7 @@ REBNATIVE(stats)
     if (REF(show))
         Dump_Pools();
 
-    return Init_Integer(D_OUT, Inspect_Series(REF(show)));
+    return Init_Integer(D_OUT, Inspect_Series(did REF(show)));
 #endif
 }
 

--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -203,7 +203,7 @@ REB_R Series_Common_Action_Maybe_Unhandled(
                 value,
                 ARG(value2),
                 sop_flags,
-                REF(case),
+                did REF(case),
                 REF(skip) ? Int32s(ARG(skip), 1) : 1
             )
         ); }

--- a/src/core/f-stubs.c
+++ b/src/core/f-stubs.c
@@ -435,7 +435,7 @@ static REBLEN Part_Len_Core(
     REBVAL *series,  // ANY-SERIES! value whose index may be modified
     const REBVAL *part  // /PART (number, position in value, or BLANK! cell)
 ){
-    if (IS_BLANK(part))  // indicates /PART refinement unused
+    if (IS_NULLED(part))  // indicates /PART refinement unused
         return VAL_LEN_AT(series);  // leave index alone, use plain length
 
     REBI64 len;
@@ -523,7 +523,7 @@ REBLEN Part_Tail_May_Modify_Index(REBVAL *series, const REBVAL *limit)
 // https://github.com/rebol/rebol-issues/issues/1570
 //
 REBLEN Part_Limit_Append_Insert(const REBVAL *part) {
-    if (IS_BLANK(part))
+    if (IS_NULLED(part))
         return UINT32_MAX;  // treat as no limit
 
     if (IS_INTEGER(part)) {

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -2661,13 +2661,13 @@ REBNATIVE(transcode)
         line_number = ARG(line);
 
     REBLIN start_line;
-    if (IS_INTEGER(line_number)) {
+    if (IS_NULLED(line_number)) {
+        start_line = 1;
+    }
+    else if (IS_INTEGER(line_number)) {
         start_line = VAL_INT32(line_number);
         if (start_line <= 0)
             fail (PAR(line));
-    }
-    else if (IS_BLANK(line_number)) {
-        start_line = 1;
     }
     else
         fail ("/LINE must be an INTEGER! or an ANY-WORD! integer variable");

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1286,8 +1286,13 @@ REBNATIVE(default)
         }
     }
 
-    if (not IS_NULLED(D_OUT) and (not IS_BLANK(D_OUT) or REF(only)))
-        return D_OUT; // count it as "already set" !!! what about VOID! ?
+    if (
+        not IS_VOID(D_OUT)
+        and not IS_NULLED(D_OUT)
+        and (not IS_BLANK(D_OUT) or REF(only))
+    ){
+        return D_OUT;  // count it as "already set" !!! is this right?
+    }
 
     if (Do_Branch_Throws(D_OUT, D_SPARE, ARG(branch)))
         return R_THROWN;
@@ -1404,7 +1409,7 @@ REBNATIVE(catch)
     else {
         // Return THROW's arg only if it did not have a /NAME supplied
         //
-        if (IS_BLANK(label))
+        if (IS_NULLED(label))
             goto was_caught;
     }
 
@@ -1452,6 +1457,6 @@ REBNATIVE(throw)
     return Init_Thrown_With_Label(
         D_OUT,
         ARG(value),
-        ARG(name)  // will be BLANK! if unused (vs. null)
+        ARG(name)  // NULLED if unused
     );
 }

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -467,7 +467,7 @@ REBNATIVE(unbind)
     if (ANY_WORD(word))
         Unbind_Any_Word(word);
     else
-        Unbind_Values_Core(VAL_ARRAY_AT(word), NULL, REF(deep));
+        Unbind_Values_Core(VAL_ARRAY_AT(word), NULL, did REF(deep));
 
     RETURN (word);
 }
@@ -568,8 +568,8 @@ REBNATIVE(get)
             D_OUT,
             source,
             SPECIFIED,
-            REF(any),
-            REF(hard)
+            did REF(any),
+            did REF(hard)
         );
         return D_OUT;  // IS_NULLED() is okay
     }
@@ -583,8 +583,8 @@ REBNATIVE(get)
             dest,
             item,
             VAL_SPECIFIER(source),
-            REF(any),
-            REF(hard)
+            did REF(any),
+            did REF(hard)
         );
         Voidify_If_Nulled(dest);  // blocks can't contain nulls
     }
@@ -702,8 +702,8 @@ REBNATIVE(set)
             SPECIFIED,
             IS_BLANK(value) and REF(some) ? NULLED_CELL : value,
             SPECIFIED,
-            REF(any),
-            REF(hard)
+            did REF(any),
+            did REF(hard)
         );
 
         RETURN (value);
@@ -738,8 +738,8 @@ REBNATIVE(set)
             (IS_BLOCK(value) and not REF(single))
                 ? VAL_SPECIFIER(value)
                 : SPECIFIED,
-            REF(any),
-            REF(hard)
+            did REF(any),
+            did REF(hard)
         );
     }
 
@@ -820,8 +820,8 @@ REBNATIVE(resolve)
         VAL_CONTEXT(ARG(target)),
         VAL_CONTEXT(ARG(source)),
         ARG(only),
-        REF(all),
-        REF(extend)
+        did REF(all),
+        did REF(extend)
     );
 
     RETURN (ARG(target));

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -387,7 +387,7 @@ REBNATIVE(do)
             true,  // fully = true, error if not all arguments consumed
             rebU1(sys_do_helper),
             source,
-            ARG(args),
+            NULLIFY_NULLED(ARG(args)),
             REF(only) ? TRUE_VALUE : FALSE_VALUE,
             rebEND
         )){

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -231,7 +231,7 @@ REBNATIVE(shove)
         frame_,
         shovee,
         flags,
-        REF(enfix)
+        did REF(enfix)
     )){
         rebRelease(composed_set_path);  // ok if nullptr
         return R_THROWN;
@@ -387,7 +387,7 @@ REBNATIVE(do)
             true,  // fully = true, error if not all arguments consumed
             rebU1(sys_do_helper),
             source,
-            NULLIFY_NULLED(ARG(args)),
+            REF(args),
             REF(only) ? TRUE_VALUE : FALSE_VALUE,
             rebEND
         )){

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -112,7 +112,7 @@ REBNATIVE(cosine)
 {
     INCLUDE_PARAMS_OF_COSINE;
 
-    REBDEC dval = cos(Trig_Value(ARG(angle), REF(radians), COSINE));
+    REBDEC dval = cos(Trig_Value(ARG(angle), did REF(radians), COSINE));
     if (fabs(dval) < DBL_EPSILON)
         dval = 0.0;
 
@@ -135,7 +135,7 @@ REBNATIVE(sine)
 {
     INCLUDE_PARAMS_OF_SINE;
 
-    REBDEC dval = sin(Trig_Value(ARG(angle), REF(radians), SINE));
+    REBDEC dval = sin(Trig_Value(ARG(angle), did REF(radians), SINE));
     if (fabs(dval) < DBL_EPSILON)
         dval = 0.0;
 
@@ -158,7 +158,7 @@ REBNATIVE(tangent)
 {
     INCLUDE_PARAMS_OF_TANGENT;
 
-    REBDEC dval = Trig_Value(ARG(angle), REF(radians), TANGENT);
+    REBDEC dval = Trig_Value(ARG(angle), did REF(radians), TANGENT);
     if (Eq_Decimal(fabs(dval), PI / 2.0))
         fail (Error_Overflow_Raw());
 
@@ -181,7 +181,7 @@ REBNATIVE(arccosine)
 {
     INCLUDE_PARAMS_OF_ARCCOSINE;
 
-    Arc_Trans(D_OUT, ARG(cosine), REF(radians), COSINE);
+    Arc_Trans(D_OUT, ARG(cosine), did REF(radians), COSINE);
     return D_OUT;
 }
 
@@ -201,7 +201,7 @@ REBNATIVE(arcsine)
 {
     INCLUDE_PARAMS_OF_ARCSINE;
 
-    Arc_Trans(D_OUT, ARG(sine), REF(radians), SINE);
+    Arc_Trans(D_OUT, ARG(sine), did REF(radians), SINE);
     return D_OUT;
 }
 
@@ -221,7 +221,7 @@ REBNATIVE(arctangent)
 {
     INCLUDE_PARAMS_OF_ARCTANGENT;
 
-    Arc_Trans(D_OUT, ARG(tangent), REF(radians), TANGENT);
+    Arc_Trans(D_OUT, ARG(tangent), did REF(radians), TANGENT);
     return D_OUT;
 }
 

--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -445,9 +445,9 @@ REBNATIVE(compose)
         ARG(value),
         VAL_SPECIFIER(ARG(value)),
         ARG(label),
-        REF(deep),
-        IS_NULLED(predicate) ? nullptr : predicate,
-        REF(only)
+        did REF(deep),
+        NULLIFY_NULLED(predicate),
+        did REF(only)
     );
 
     if (r == R_THROWN)

--- a/src/core/n-sets.c
+++ b/src/core/n-sets.c
@@ -376,7 +376,7 @@ REBNATIVE(exclude)
             val1,
             val2,
             SOP_FLAG_CHECK | SOP_FLAG_INVERT,
-            REF(case),
+            did REF(case),
             REF(skip) ? Int32s(ARG(skip), 1) : 1
         )
     );
@@ -410,7 +410,7 @@ REBNATIVE(unique)
             val,
             NULL,
             SOP_NONE,
-            REF(case),
+            did REF(case),
             REF(skip) ? Int32s(ARG(skip), 1) : 1
         )
     );

--- a/src/core/t-binary.c
+++ b/src/core/t-binary.c
@@ -915,7 +915,7 @@ REBTYPE(Binary)
             ARG(skip),  // blank! if not /SKIP
             ARG(compare),  // (blank! if not /COMPARE)
             ARG(part),   // (blank! if not /PART)
-            REF(reverse)
+            did REF(reverse)
         );
         RETURN (v); }
 
@@ -935,11 +935,12 @@ REBTYPE(Binary)
             if (index >= tail)
                 return Init_Blank(D_OUT);
 
-            index += cast(REBLEN, Random_Int(REF(secure))) % (tail - index);
+            index += cast(REBLEN, Random_Int(did REF(secure)))
+                % (tail - index);
             return Init_Integer(D_OUT, *VAL_BIN_AT_HEAD(v, index)); // PICK
         }
 
-        Shuffle_String(v, REF(secure));
+        Shuffle_String(v, did REF(secure));
         RETURN (v); }
 
       default:

--- a/src/core/t-binary.c
+++ b/src/core/t-binary.c
@@ -406,7 +406,7 @@ static void Sort_Binary(
 ){
     assert(IS_BINARY(binary));
 
-    if (not IS_BLANK(compv))
+    if (not IS_NULLED(compv))
         fail (Error_Bad_Refine_Raw(compv));  // !!! R3-Alpha didn't support
 
     REBFLGS thunk = 0;
@@ -416,7 +416,7 @@ static void Sort_Binary(
         return;
 
     REBLEN skip;
-    if (IS_BLANK(skipv))
+    if (IS_NULLED(skipv))
         skip = 1;
     else {
         skip = Get_Num_From_Arg(skipv);

--- a/src/core/t-bitset.c
+++ b/src/core/t-bitset.c
@@ -606,7 +606,7 @@ REBTYPE(Bitset)
         if (REF(part) or REF(only) or REF(skip) or REF(tail) or REF(match))
             fail (Error_Bad_Refines_Raw());
 
-        if (not Check_Bits(VAL_BITSET(v), ARG(pattern), REF(case)))
+        if (not Check_Bits(VAL_BITSET(v), ARG(pattern), did REF(case)))
             return nullptr;
         return Init_True(D_OUT); }
 

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -1130,12 +1130,12 @@ REBTYPE(Array)
 
         Sort_Block(
             array,
-            REF(case),
+            did REF(case),
             ARG(skip),   // blank! if no /SKIP
             ARG(compare),  // blank! if no /COMPARE
             ARG(part),  // blank! if no /PART
-            REF(all),
-            REF(reverse)
+            did REF(all),
+            did REF(reverse)
         );
         RETURN (array); }
 
@@ -1154,7 +1154,8 @@ REBTYPE(Array)
 
             Init_Integer(
                 ARG(seed),
-                1 + (Random_Int(REF(secure)) % (VAL_LEN_HEAD(array) - index))
+                1 + (Random_Int(did REF(secure))
+                    % (VAL_LEN_HEAD(array) - index))
             );
 
             RELVAL *slot = Pick_Block(D_OUT, array, ARG(seed));
@@ -1167,7 +1168,7 @@ REBTYPE(Array)
         }
 
         FAIL_IF_READ_ONLY(array);
-        Shuffle_Block(array, REF(secure));
+        Shuffle_Block(array, did REF(secure));
         RETURN (array); }
 
       default:

--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -549,7 +549,7 @@ static void Sort_Block(
         flags.offset = Int32(compv) - 1;
     }
     else {
-        assert(IS_BLANK(compv));
+        assert(IS_NULLED(compv));
         flags.comparator = NULL;
         flags.offset = 0;
     }
@@ -560,7 +560,7 @@ static void Sort_Block(
 
     // Skip factor:
     REBLEN skip;
-    if (not IS_BLANK(skipv)) {
+    if (not IS_NULLED(skipv)) {
         skip = Get_Num_From_Arg(skipv);
         if (skip <= 0 or len % skip != 0 or skip > len)
             fail (Error_Out_Of_Range(skipv));

--- a/src/core/t-char.c
+++ b/src/core/t-char.c
@@ -286,8 +286,11 @@ REBTYPE(Char)
             Set_Random(chr);
             return nullptr;
         }
-        if (chr == 0) break;
-        chr = cast(REBUNI, 1 + cast(REBLEN, Random_Int(REF(secure)) % chr));
+        if (chr == 0)
+            break;
+        chr = cast(REBUNI,
+            1 + cast(REBLEN, Random_Int(did REF(secure)) % chr)
+        );
         break; }
 
     default:

--- a/src/core/t-date.c
+++ b/src/core/t-date.c
@@ -967,7 +967,7 @@ REBTYPE(Date)
             if (REF(only))
                 fail (Error_Bad_Refines_Raw());
 
-            const bool secure = REF(secure);
+            const bool secure = did REF(secure);
 
             if (REF(seed)) {
                 //

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -538,7 +538,7 @@ REBTYPE(Decimal)
             Set_Random(i); // use IEEE bits
             return nullptr;
         }
-        d1 = Random_Dec(d1, REF(secure));
+        d1 = Random_Dec(d1, did REF(secure));
         goto setDec; }
 
     case SYM_COMPLEMENT:

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -349,19 +349,16 @@ REB_R PD_Action(
 
     assert(IS_ACTION(pvs->out));
 
-    if (IS_BLANK(picker)) {
+    if (IS_NULLED_OR_BLANK(picker)) {  // !!! BLANK! used in bootstrap scripts
         //
         // Leave the function value as-is, and continue processing.  This
-        // enables things like `append/(either only [/only] [_])/dup`...
+        // enables things like `append/(if only [/only])/dup`...
         //
         // Note this feature doesn't have obvious applications to refinements
-        // that take arguments...only ones that don't.  Use "revoking" to
-        // pass void as arguments to a refinement that is always present
-        // in that case.
-        //
-        // Null might seem more convenient, for `append/(if only [/only])/dup`
-        // however it is disallowed to use nulls at the higher level path
-        // protocol.  This is probably for the best.
+        // that take arguments...only ones that don't.  If a refinement takes
+        // an argument then you should supply it normally and then use NULL
+        // in that argument slot to "revoke" it (the call will appear as if
+        // the refinement was never used at the callsite).
         //
         return pvs->out;
     }

--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -352,7 +352,7 @@ REBNATIVE(to_integer)
 {
     INCLUDE_PARAMS_OF_TO_INTEGER;
 
-    Value_To_Int64(D_OUT, ARG(value), REF(unsigned));
+    Value_To_Int64(D_OUT, ARG(value), did REF(unsigned));
 
     return D_OUT;
 }
@@ -577,7 +577,7 @@ REBTYPE(Integer)
         }
         if (num == 0)
             break;
-        return Init_Integer(D_OUT, Random_Range(num, REF(secure))); }
+        return Init_Integer(D_OUT, Random_Range(num, did REF(secure))); }
 
     default:
         break;

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -476,7 +476,7 @@ REBTYPE(Logic)
             fail ("LOGIC! random seed currently not implemented");
         }
 
-        if (Random_Int(REF(secure)) & 1)
+        if (Random_Int(did REF(secure)) & 1)
             return Init_True(D_OUT);
         return Init_False(D_OUT); }
 

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -682,7 +682,7 @@ REBTYPE(Map)
             SPECIFIED,
             NULL,
             SPECIFIED,
-            REF(case)
+            did REF(case)
         );
 
         if (n == 0)
@@ -708,7 +708,7 @@ REBTYPE(Map)
             SPECIFIED,
             ARG(value),
             SPECIFIED,
-            REF(case)
+            did REF(case)
         );
         UNUSED(n);
 

--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -325,6 +325,9 @@ REB_R PD_Map(
 ){
     assert(IS_MAP(pvs->out));
 
+    if (IS_NULLED(picker))  // best to error on a null picker
+        return R_UNHANDLED;
+
     if (opt_setval)
         FAIL_IF_READ_ONLY(pvs->out);
 

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1242,7 +1242,7 @@ REBTYPE(String)
                 v,
                 ARG(value2),
                 sop_flags,
-                REF(case),
+                did REF(case),
                 REF(skip) ? Int32s(ARG(skip), 1) : 1
             )
         ); }
@@ -1289,11 +1289,11 @@ REBTYPE(String)
 
         Sort_String(
             v,
-            REF(case),
+            did REF(case),
             ARG(skip),  // blank! if not /SKIP
             ARG(compare),  // blank! if not /COMPARE
             ARG(part),  // blank! if not /PART
-            REF(reverse)
+            did REF(reverse)
         );
         RETURN (v); }
 
@@ -1316,7 +1316,8 @@ REBTYPE(String)
         if (REF(only)) {
             if (index >= tail)
                 return nullptr;
-            index += cast(REBLEN, Random_Int(REF(secure))) % (tail - index);
+            index += cast(REBLEN, Random_Int(did REF(secure)))
+                % (tail - index);
 
             return Init_Char_Unchecked(
                 D_OUT,
@@ -1329,7 +1330,7 @@ REBTYPE(String)
 
         FAIL_IF_READ_ONLY(v);
 
-        Shuffle_String(v, REF(secure));
+        Shuffle_String(v, did REF(secure));
         RETURN (v); }
 
       default:

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -470,7 +470,7 @@ static void Sort_String(
     // sized codepoints.  However, it could work if all the codepoints were
     // known to be ASCII range in the memory of interest, maybe common case.
 
-    if (not IS_BLANK(compv))
+    if (not IS_NULLED(compv))
         fail (Error_Bad_Refine_Raw(compv)); // !!! didn't seem to be supported (?)
 
     REBLEN skip = 1;
@@ -481,7 +481,7 @@ static void Sort_String(
     if (len <= 1)
         return;
 
-    if (not IS_BLANK(skipv)) {
+    if (not IS_NULLED(skipv)) {
         skip = Get_Num_From_Arg(skipv);
         if (skip <= 0 or len % skip != 0 or skip > len)
             fail (skipv);

--- a/src/core/t-time.c
+++ b/src/core/t-time.c
@@ -710,7 +710,7 @@ REBTYPE(Time)
                 Set_Random(secs);
                 return nullptr;
             }
-            secs = Random_Range(secs / SEC_SEC, REF(secure)) * SEC_SEC;
+            secs = Random_Range(secs / SEC_SEC, did REF(secure)) * SEC_SEC;
             return Init_Time_Nanoseconds(D_OUT, secs); }
 
           default:

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -448,7 +448,7 @@ REBTYPE(Tuple)
             fail (Error_Bad_Refines_Raw());
         for (; len > 0; len--, vp++) {
             if (*vp)
-                *vp = cast(REBYTE, Random_Int(REF(secure)) % (1 + *vp));
+                *vp = cast(REBYTE, Random_Int(did REF(secure)) % (1 + *vp));
         }
         RETURN (value);
     }

--- a/src/include/datatypes/sys-frame.h
+++ b/src/include/datatypes/sys-frame.h
@@ -833,7 +833,7 @@ inline static void Drop_Action(REBFRM *f) {
         ACT_PARAM(FRM_PHASE(frame_), (p_##name))  // a REB_P_XXX pseudovalue
 
     #define REF(name) \
-        (not IS_BLANK(ARG(name)))  // should be faster than IS_FALSEY()
+        (not IS_NULLED(ARG(name)))
 #else
     struct Native_Param {
         int num;
@@ -870,8 +870,8 @@ inline static void Drop_Action(REBFRM *f) {
 
     #define REF(name) \
         ((p_##name).used_cache /* used_cache use stops REF() on PARAM()s */ \
-            ? not IS_BLANK(ARG(name)) \
-            : not IS_BLANK(ARG(name)))
+            ? not IS_NULLED(ARG(name)) \
+            : not IS_NULLED(ARG(name)))
 #endif
 
 // Quick access functions from natives (or compatible functions that name a

--- a/src/include/datatypes/sys-typeset.h
+++ b/src/include/datatypes/sys-typeset.h
@@ -430,37 +430,15 @@ inline static void Typecheck_Refinement_And_Canonize(
     assert(NOT_CELL_FLAG(arg, ARG_MARKED_CHECKED));
     assert(TYPE_CHECK(param, REB_TS_REFINEMENT));
 
-    if (IS_BLANK(arg) and not TYPE_CHECK(param, REB_NULLED)) {
+    if (IS_NULLED(arg)) {
         //
-        // Nearly all refinements accept BLANK! (e.g. [/foo [integer!]]` does
-        // not need to explicitly say `[/foo [blank! integer!]]`...it is
-        // understood that blank means the refinement is not used).  However,
-        // an <opt> refinement will be null when it is not used (or used
-        // and explicitly passed null).  It must typecheck specifically for
-        // blanks if it is to accept them.
-    }
-    else if (IS_NULLED(arg)) {
-        //
-        // MAKE FRAME! creates a frame with all nulls.  It would be very
-        // inconvenient if one had to manually turn them into blanks to meet
-        // the expectations of the function body.  So unless the refinement
-        // explicitly requested nulls as ok, auto-convert to blank.
-        //
-        // (This suggests people might get in the habit of using nulls from
-        // an IF or other conditional to opt out of refinements, without
-        // regard to whether that function--today or someday--might give the
-        // null a special meaning.  However, even if it does, it will still
-        // be unable to discern unused from null...as an <opt> refinement is
-        // null if it is unused!)
-        //
-        if (not TYPE_CHECK(param, REB_NULLED))
-            Init_Blank(arg);  // coerces to blank if not expected verbatim
+        // Not in use
     }
     else if (Is_Typeset_Invisible(param)) {
         //
         // Refinements that don't have a corresponding argument are in a
         // sense LOGIC!-based.  But for convenience, Ren-C canonizes them as
-        // either a BLANK! or a refinement-style PATH!--providing logical
+        // either a NULL or a refinement-style PATH!--providing logical
         // false/true behavior while making it easier to chain them, e.g.
         //
         //    keep: func [value /only] [... append/(only) ...]
@@ -478,8 +456,10 @@ inline static void Typecheck_Refinement_And_Canonize(
         }
         else if (IS_LOGIC(arg)) {
             assert(not VAL_LOGIC(arg));
-            Init_Blank(arg);
+            Init_Nulled(arg);
         }
+        else if (IS_BLANK(arg))  // give an error to show where this is
+            fail ("Use NULL/FALSE for unused refinements, not BLANK!");
         else
             fail (Error_Invalid_Type(VAL_TYPE(arg)));
     }

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -214,11 +214,8 @@ inline static bool Do_Branch_Core_Throws(
             return true;
         }
 
-        if (IS_NULLED_OR_VOID(out)) {  // need `[:x]` if it's unset or void
-            if (IS_NULLED(out))
-                fail (Error_No_Value_Core(branch, SPECIFIED));
+        if (IS_VOID(out))  // need `[:x]` if it's void (unset)
             fail (Error_Need_Non_Void_Core(branch, SPECIFIED));
-        }
 
         return false; }
 

--- a/src/main/main-startup.reb
+++ b/src/main/main-startup.reb
@@ -204,7 +204,7 @@ host-script-pre-load: function [
 ; document the issue.  So we make them SET-WORD!s added to lib up front, so
 ; the lib modification gets picked up.
 ;
-get-current-exec: file-to-local: local-to-file: what-dir: change-dir: null
+get-current-exec: file-to-local: local-to-file: what-dir: change-dir: void
 
 
 main-startup: function [

--- a/src/main/main-startup.reb
+++ b/src/main/main-startup.reb
@@ -363,10 +363,14 @@ main-startup: function [
     ; https://stackoverflow.com/q/1023306/
     ; http://stackoverflow.com/a/933996/211160
     ;
-    ; It's not foolproof, so it might come back blank.  The console code can
+    ; It's not foolproof, so it might come back null.  The console code can
     ; then decide if it wants to fall back on argv[0]
     ;
-    system/options/boot: lib/ensure [blank! file!] get-current-exec
+    switch type of system/options/boot: get-current-exec [
+        file! []  ; found it
+        null []  ; also okay (not foolproof!)
+        fail
+    ]
 
     === HELPER FUNCTIONS ===
 

--- a/src/mezz/base-constants.r
+++ b/src/mezz/base-constants.r
@@ -59,10 +59,7 @@ abs: :absolute
 rebol.com: http://www.rebol.com
 
 blank: _   ; e.g. sometimes `return blank` reads better than `return _`
-
-; A single apostrophe with nothing after it is a quoted null, and evaluates
-; to null.  But there can't be a literal type that *is* null, by definition.
-; See the NULL native.
+null: '  ; a single apostrophe with nothing after it is a quoted null
 
 void: func* [
     "Function returning void result (alternative for `#[void]`)"

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -340,7 +340,7 @@ newlined: chain [
     ]
         |
     func* [t [<opt> text!]] [
-        if unset? 't [return null]
+        if null? t [return null]
         append t newline  ; Terminal newline is POSIX standard, more useful
     ]
 ]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -56,7 +56,7 @@ maybe: enfixed func* [
     ;
     ; https://github.com/rebol/rebol-issues/issues/2275
     ;
-    if unset? 'optional [return get/hard/any compose target]
+    if null? :optional [return get/hard/any compose target]
     set/hard/any compose target :optional
 ]
 
@@ -76,7 +76,7 @@ steal: func* [
 ]
 
 assert [null = binding of :return]  ; it's archetypal, nowhere to return to
-unset 'return  ; so don't let the archetype be visible
+return: void  ; so don't let the archetype be visible
 
 func: func* [
     {Make action with set-words as locals, <static>, <in>, <with>, <local>}
@@ -429,7 +429,7 @@ redescribe: func [
     ; If you kill all the notes then they will be cleaned up.  The meta
     ; object will be left behind, however.
     ;
-    if notes and [every [param note] notes [unset? 'note]] [
+    if notes and [every [param note] notes [null? :note]] [
         meta/parameter-notes: _
     ]
 
@@ -441,6 +441,18 @@ redescribe [
     {Create an ACTION, implicity gathering SET-WORD!s as <local> by default}
 ] :function
 
+
+undefine: redescribe [
+    {Sets the value of a word to VOID! (in its current context.)}
+](
+    specialize 'set [any: true | value: void]
+)
+
+unset: redescribe [
+    {Clear the value of a word to null (in its current context.)}
+](
+    adapt specialize 'set [value: <overwrite>] [value: null]  ; !!! fix
+)
 
 so: enfixed func [
     {Postfix assertion which won't keep running if left expression is false}
@@ -827,7 +839,7 @@ module: func [
     for-each [var types] [
         spec object!
         body block!
-        mixin [object! blank!]
+        mixin [<opt> object!]
         spec/name [word! blank!]
         spec/type [word! blank!]
         spec/version [tuple! blank!]
@@ -1007,21 +1019,21 @@ fail: func [
             ])
         ]
     ] else [
-        not set? 'reason so make error! compose [
+        null? reason so make error! compose [
             Type: 'Script
             ((case [
-                frame and [set? blame] '[
+                frame and [blame] '[
                     id: 'invalid-arg
                     arg1: label of frame
                     arg2: blame
                     arg3: get blame
                 ]
-                frame and [unset? blame] '[
+                frame and [not blame] '[
                     id: 'no-arg
                     arg1: label of frame
                     arg2: blame
                 ]
-                :blame and [set? blame] '[
+                blame and [get blame] '[
                     id: 'bad-value
                     arg1: get blame
                 ]

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -199,7 +199,7 @@ trim: function [
             ]
 
             rule: case [
-                blank? with [charset reduce [space tab]]
+                null? with [charset reduce [space tab]]
                 bitset? with [with]
                 default [charset with]
             ]

--- a/src/mezz/mezz-dump.r
+++ b/src/mezz/mezz-dump.r
@@ -35,7 +35,7 @@ dump: function [
 
     val-to-text: function [return: [text!] val [<opt> any-value!]] [
         case [
-            not set? 'val ["\null\"]
+            null? :val ["\null\"]
             object? :val [unspaced ["make object! [" (summarize-obj val) "]"]]
             default [mold/limit :val system/options/dump-size]
         ]
@@ -220,7 +220,7 @@ summarize-obj: function [
             ]
 
             switch type of pattern [  ; filter out any non-matching items
-                blank! []
+                null []
 
                 datatype! [
                     if type != pattern [continue]
@@ -236,13 +236,13 @@ summarize-obj: function [
                 fail @pattern
             ]
 
-            if desc: description-of :val [
+            if desc: description-of try :val [
                 if 48 < length of desc [
                     desc: append copy/part desc 45 "..."
                 ]
             ]
 
-            keep ["  " (form-pad word 15) (form-pad type 10) :desc]
+            keep ["  " (form-pad word 15) (form-pad try type 10) :desc]
         ]
     ]
 ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -69,7 +69,7 @@ description-of: function [
     {One-line summary of a value's purpose}
 
     return: [<opt> text!]
-    v [any-value!]
+    v [<blank> any-value!]
 ][
     opt switch type of :v [
         any-array! [spaced ["array of length:" length of v]]
@@ -109,7 +109,7 @@ help: function [
     /doc
         "Open web browser to related documentation."
 ][
-    if unset? 'topic [
+    if null? :topic [
         ;
         ; Was just `>> help` or `do [help]` or similar.
         ; Print out generic help message.
@@ -221,8 +221,14 @@ help: function [
                 return
             ]
 
-            value: get topic else [
-                print ["No information on" topic "(has no value)"]
+            switch type of value: get/any topic [
+                null [
+                    print ["No information on" topic "(is null)"]
+                ]
+                void! [
+                    print [topic "is unset (e.g. a VOID! value)"]
+                ]
+            ] then [
                 return
             ]
             enfixed: did all [action? :value | enfixed? :value]

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -76,7 +76,7 @@ save: function [
         ; Sync the header option with the /COMPRESS setting
         ;
         case [
-            blank? compress [
+            null? compress [
                 compress: did find try (select header 'options) 'compress
             ]
             compress = false [
@@ -108,7 +108,7 @@ save: function [
     append data newline  ; MOLD does not append a newline
 
     case/all [
-        tmp: find header 'checksum [
+        tmp: find try header 'checksum [
             ; Checksum uncompressed data, if requested
             change next tmp (checksum-core data 'crc32)
         ]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -77,8 +77,9 @@ array: function [
     size "Size or block of sizes for each dimension"
         [integer! block!]
     /initial "Initial value (will be called each time if a function)"
-        [any-value!]  ; refinement, so will default to BLANK!
+        [any-value!]
 ][
+    initial: :initial else '_  ; default to BLANK!
     if block? size [
         if tail? rest: next size [rest: _]
         if not integer? size: first size [
@@ -223,7 +224,7 @@ reword: function [
     prefix: _
     suffix: _
     case [
-        blank? escape [prefix: "$"]  ; refinement not used, so use default
+        null? escape [prefix: "$"]  ; refinement not used, so use default
 
         any [
             escape = ""
@@ -313,7 +314,7 @@ reword: function [
                     any-keyword-rule suffix (
                         append/part out a offset? a b  ; output before prefix
 
-                        v: select/(case_REWORD) values keyword-match
+                        v: select/(try case_REWORD) values keyword-match
                         append out switch type of :v [
                             action! [
                                 ; Give v the option of taking an argument, but
@@ -336,7 +337,7 @@ reword: function [
         (append out a)  ; finalize output - transfer any remainder verbatim
     ]
 
-    parse/(case_REWORD) source rule else [fail]  ; should succeed
+    parse/(try case_REWORD) source rule else [fail]  ; should succeed
     return out
 ]
 
@@ -445,7 +446,7 @@ collect*: func [
     body "Block to evaluate"
         [<blank> block!]
 ][
-    let out
+    let out: null
     let keeper: specialize* (  ; SPECIALIZE to hide series argument
         enclose* 'append func* [  ; Derive from APPEND for /ONLY /LINE /DUP
             f [frame!]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -164,7 +164,7 @@ replace: function [
         any-array? :pattern [length of :pattern]
     ]
 
-    while [pos: find/(try if case_REPLACE [/case]) target :pattern] [
+    while [pos: find/(case_REPLACE) target :pattern] [
         either action? :replacement [
             ;
             ; If arity-0 action, value gets replacement and pos discarded
@@ -314,7 +314,7 @@ reword: function [
                     any-keyword-rule suffix (
                         append/part out a offset? a b  ; output before prefix
 
-                        v: select/(try case_REWORD) values keyword-match
+                        v: select/(case_REWORD) values keyword-match
                         append out switch type of :v [
                             action! [
                                 ; Give v the option of taking an argument, but
@@ -337,7 +337,7 @@ reword: function [
         (append out a)  ; finalize output - transfer any remainder verbatim
     ]
 
-    parse/(try case_REWORD) source rule else [fail]  ; should succeed
+    parse/(case_REWORD) source rule else [fail]  ; should succeed
     return out
 ]
 
@@ -430,7 +430,7 @@ alter: func [
         append series :value
         return true
     ]
-    if remove (find/(try if case_ALTER [/case]) series :value) [
+    if remove (find/(case_ALTER) series :value) [
         append series :value
         return true
     ]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -45,7 +45,7 @@ do*: func [
     source "Files, urls and modules evaluate as scripts, other strings don't"
         [file! url! text! binary! tag!]
     args "Args passed as system/script/args to a script (normally a string)"
-        [any-value!]
+        [<opt> any-value!]
     only "Do not catch quits...propagate them"
         [logic!]
 ][
@@ -166,7 +166,7 @@ do*: func [
             header: hdr
             parent: :original-script
             path: what-dir
-            args: (:args)
+            args: (try :args)
         ]
 
         if set? 'script-pre-load-hook [

--- a/tests/context/use.test.reb
+++ b/tests/context/use.test.reb
@@ -13,8 +13,8 @@
 )
 
 ; initialization (lack of)
-(a: 10 all [use [a] [null? :a] a = 10])
-(use [a] [not set? 'a])
+(a: 10 all [use [a] [void? :a] a = 10])
+(use [a] [undefined? 'a])
 
 ; BREAK out of USE
 (

--- a/tests/context/valueq.test.reb
+++ b/tests/context/valueq.test.reb
@@ -1,6 +1,6 @@
 ; functions/context/valueq.r
-(false == set? 'nonsense)
-(true == set? 'set?)
+(false == defined? 'nonsense)
+(true == defined? 'set?)
 
 [#1914 (
     set? reeval func [x] ['x] blank

--- a/tests/datatypes/map.test.reb
+++ b/tests/datatypes/map.test.reb
@@ -8,7 +8,7 @@
 (m: make map! [a 1 b 2] 2 == m/b)
 (
     m: make map! [a 1 b 2]
-    error? trap [m/c]
+    null? m/c
 )
 (m: make map! [a 1 b 2] m/c: 3 3 == m/c)
 ; Maps contain key/value pairs and must be created from blocks of even length.

--- a/tests/datatypes/unset.test.reb
+++ b/tests/datatypes/unset.test.reb
@@ -4,7 +4,7 @@
 (not null? 1)
 
 (
-    is-barrier?: func [x [<end> integer!]] [unset? 'x]
+    is-barrier?: func [x [<end> integer!]] [null? x]
     is-barrier? ()
 )
 (void! = type of (do []))
@@ -14,7 +14,7 @@
     ('need-non-end = (trap [a: ()])/id)
 ]
 
-(error? trap [a: null a])
+(null? trap [a: null a])
 (not error? trap [set* 'a null])
 
 (error? trap [a: void a])
@@ -22,7 +22,7 @@
 
 (
     a-value: 10
-    unset 'a-value
+    undefine 'a-value
     e: trap [a-value]
-    e/id = 'no-value
+    e/id = 'need-non-void
 )

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -85,8 +85,8 @@
 
     ([] = do [soft])
     (
-        a: null
-        (trap [a soft])/id = 'no-value
+        a: void
+        (trap [a soft])/id = 'need-non-void
     )
     ([7] = do [(1 + 2) (3 + 4) soft])
 ][
@@ -103,8 +103,8 @@
 
     ([] = do [hard])
     (
-        a: null
-        (trap [a hard])/id = 'no-value
+        a: void
+        (trap [a hard])/id = 'need-non-void
     )
     ([(3 + 4)] = do [(1 + 2) (3 + 4) hard])
 ]
@@ -132,7 +132,7 @@
 )
 
 (
-    is-barrier?: func [x [<end> integer!]] [unset? 'x]
+    is-barrier?: func [x [<end> integer!]] [null? x]
     is-barrier? (<| 10)
 )
 (

--- a/tests/datatypes/word.test.reb
+++ b/tests/datatypes/word.test.reb
@@ -149,9 +149,9 @@
     same? :a-value a-value
 )
 (
-    unset 'a-value
+    undefine 'a-value
     e: trap [a-value]
-    e/id = 'no-value
+    e/id = 'need-non-void
 )
 (
     a-value: 'a

--- a/tests/functions/augment.test.reb
+++ b/tests/functions/augment.test.reb
@@ -40,7 +40,7 @@
             [block!]
     ]) func [f [frame!]] [
         let def: f/default
-        do f else (def)
+        do f else (try def)
     ]
     true)
 

--- a/tests/functions/redo.test.reb
+++ b/tests/functions/redo.test.reb
@@ -32,7 +32,7 @@
 ; (locals should be cleared on each redo)
 (
     foo: func [n <local> unset-me] [
-        if set? 'unset-me [
+        if defined? 'unset-me [
             return "local not cleared"
         ]
         if n = 0 [

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -10,7 +10,7 @@
     (
         foo: func [/A [integer!] /B [integer!] /C [integer!]] [
             return compose [
-                /A (A) /B (B) /C (C)
+                /A (A else '<null>) /B (B else '<null>) /C (C else '<null>)
             ]
         ]
 
@@ -19,10 +19,10 @@
         true
     )
 
-    ([/A _ /B 10 /C 20] = fooBC 10 20)
+    ([/A <null> /B 10 /C 20] = fooBC 10 20)
     ([/A 30 /B 10 /C 20] = fooBC/A 10 20 30)
 
-    ([/A _ /B 20 /C 10] = fooCB 10 20)
+    ([/A <null> /B 20 /C 10] = fooCB 10 20)
     ([/A 30 /B 20 /C 10] = fooCB/A 10 20 30)
 
     (error? trap [fooBC/B 1 2 3 4 5 6])

--- a/tests/misc/help.test.reb
+++ b/tests/misc/help.test.reb
@@ -26,7 +26,8 @@
 (not error? trap [
     for-each w words of lib [
         dump w
-        if not set? w [continue]
+        if unset? w [continue]
+        if undefined? w [continue]
         if action? get w
             (compose [help (w)])
         else [
@@ -39,7 +40,7 @@
 (not error? trap [
     for-each w words of lib [
         dump w
-        if action? get w
+        if action? get/any w
             (compose [source (w)])
     ]
 ])

--- a/tools/bootstrap-shim.r
+++ b/tools/bootstrap-shim.r
@@ -43,6 +43,15 @@ REBOL [
 trap [
     func [i [<blank> integer!]] [...]
 ] else [
+    ; OPT has behavior of turning NULLs into VOID! to keep you from optioning
+    ; something you don't need to, but with refinement changes bootstrap code
+    ; would get ugly if it had to turn every OPT of a refinement into OPT TRY.
+    ; Bypass the voidification for the refinement sake.
+    ;
+    opt: func [v [<opt> any-value!]] [
+        either blank? :v [null] [:v]
+    ]
+
     QUIT
 ]
 
@@ -60,6 +69,15 @@ trap [
 ; mutating directly.
 ;
 enfixed: enfix :enfix
+
+; NULL was used for cases that were non-set variables that were unmentioned,
+; which could be also thought of as typos.  This was okay because NULL access
+; would cause errors through word or path access.  As NULL became more
+; normalized, the idea of an "unset" variable (no value) was complemented with
+; "undefined" variables (set to a VOID! value).  Older Ren-C conflated these.
+;
+defined?: :set?
+undefined?: :unset?
 
 ; COLLECT was changed back to default to returning an empty block on no
 ; collect, but it is built on a null collect lower-level primitive COLLECT*

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -105,26 +105,8 @@ emit-include-params-macro: function [
                 continue
             ]
 
-            either refinement? item [
-                seen-refinement: true
-                param-name: as text! to word! item
-
-                keep cscape/with {REFINE($<n>, ${param-name})} [n param-name]
-            ][
-                ; !!! As a transition to refinements-being-the-arg, we don't
-                ; generate macros for things that look like refinement args.
-                ; This forces usages to change to ARG(refinename).  In time,
-                ; it will be legal to order normal parameters after refines.
-                ;
-                if seen-refinement [
-                    keep cscape/with {#error "${param-name}"} [param-name]
-                ]
-                else [
-                    param-name: as text! item
-
-                    keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
-                ]
-            ]
+            param-name: as text! item
+            keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
             n: n + 1
         ]
     ]

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -105,7 +105,7 @@ emit-include-params-macro: function [
                 continue
             ]
 
-            param-name: as text! item
+            param-name: as text! to word! item
             keep cscape/with {PARAM($<n>, ${param-name})} [n param-name]
             n: n + 1
         ]


### PR DESCRIPTION
[This has been pondered for many months, long-winded discussion here.](https://forum.rebol.info/t/are-nulls-the-best-representation-for-unused-refinements/1140)  This commit is not a done deal--there's pros and cons--but there's certainly things to like about the implementation.  I'd like to review it in a broader context and understand if it's really what we want to finalize on, or if there is a better answer in here somewhere.

The PR title says the most important bit.  Where unused refinements used to be BLANK!, this makes them NULL...and then gets rid of the idea that the evaluator requires a GET-WORD! or GET-PATH! to fetch nulls without error.  This tightens things up, for instance in places like ARRAY/INITIAL where you might literally want to ask for BLANK!, and where not saying `/INITIAL` might have a different subtlety to it.

Most code should work the same, though anything which detected a type and expected BLANK! will get in trouble.  OPT on a NULL gives you a VOID!, so there may be some superfluous OPT to take out.  You'll probably find you have a lot of GET-WORD!s in places they're not really needed now, and feel the code is cleaner by dropping the colons.

To keep this from getting too permissive, it means that words that are bound to things that have never been assigned (e.g. not function arguments) must be set to VOID! to trigger errors when they are accessed.  So the system does this in a way that's very similar to historical UNSET!...but I still prefer to say that NULL variables are "unset" because *they have no value*.  This PR tries to inject the terminology that VOID! variables are instead **undefined?** (but "voided?" might be better, I just thought we'd try it).

I like VOID because it's the return value of functions that aren't supposed to have any usable result.  But more accurately, think of a paper check that has VOID written on it.  You can still hand it to people, and you can get in trouble if you try to cash it.  But you can't cause a problem by trying to cash a NULL check because there's no paper and nothing written on it--it is the literal absence of a check.

Note that also in this commit is the ability to use NULL in evaluated refinements.  You can write **append/(if false [/only]) [a b c] [d e]** and it works.  Please note that it might be `@only` and not `/only` in the future, but I'm reasonably confident that some chaining concept will be used...and the [unused no-argument refinement state will stay NULL as well](https://forum.rebol.info/t/should-refinement-arguments-be-refinement-if-used/735/3?u=hostilefork).