### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -304,7 +304,7 @@ matrix:
     # https://forum.rebol.info/t/ffi-updates-and-notes/1201
     #
     - os: linux
-      dist: trusty  # Note: released in 2013
+      dist: xenial # trusty being decommissioned by Travis, Note: it was released in 2013
       sudo: false  # force new container-based infrastructure.
       language: cpp
       env:


### PR DESCRIPTION
travis reports

```
This job ran on our Precise environment, which is in the process of being decommissioned. Please update to a newer Ubuntu version by specifying dist: xenial in your .travis.yml.
```