### PR TITLE
Revise Ren-C's rules for CR and 0 bytes in strings

### DIFF
--- a/scripts/prot-http.r
+++ b/scripts/prot-http.r
@@ -231,9 +231,10 @@ do-request: function [
     info/headers: info/response-line: info/response-parsed: port/data:
     info/size: info/date: info/name: blank
     write port/state/connection
-    req: make-http-request spec/method any [spec/path %/]
-    spec/headers spec/content
-    net-log/C to text! req
+    req: (make-http-request spec/method any [spec/path %/]
+        spec/headers spec/content)
+
+    net-log/C as text! req  ; Note: may contain CR (can't use TO TEXT!)
 ]
 
 ; if a no-redirect keyword is found in the write dialect after 'headers then
@@ -489,7 +490,7 @@ check-response: function [port] [
 ]
 crlfbin: #{0D0A}
 crlf2bin: #{0D0A0D0A}
-crlf2: to text! crlf2bin
+crlf2: as text! crlf2bin
 http-response-headers: context [
     Content-Length: _
     Transfer-Encoding: _

--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -58,6 +58,9 @@ Internal: [
 
     bad-utf8:           {invalid UTF-8 byte sequence found during decoding}
     codepoint-too-high: [{codepoint} :arg1 {too large (or data is not UTF-8)}]
+    illegal-zero-byte:  {#{00} bytes illegal in ANY-STRING!, use BINARY!}
+    illegal-cr:         {Illegal CR: See ENLINE, DELINE, and TO-TEXT/RELAX}
+    mixed-cr-lf-found:  {DELINE requires files to be CR LF or LF consistently}
 
     debug-only:         {Feature available only in DEBUG builds}
 

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -1106,7 +1106,7 @@ const REBYTE *Scan_URL(
     const REBYTE *cp,
     REBLEN len
 ){
-    return Scan_Any(out, cp, len, REB_URL);
+    return Scan_Any(out, cp, len, REB_URL, STRMODE_NO_CR);
 }
 
 
@@ -1266,7 +1266,8 @@ const REBYTE *Scan_Any(
     RELVAL *out, // may live in data stack (do not call DS_PUSH(), GC, eval)
     const REBYTE *cp,
     REBLEN num_bytes,
-    enum Reb_Kind type
+    enum Reb_Kind type,
+    enum Reb_Strmode strmode
 ) {
     TRASH_CELL_IF_DEBUG(out);
 
@@ -1281,9 +1282,16 @@ const REBYTE *Scan_Any(
     //
     // http://blog.hostilefork.com/death-to-carriage-return/
     //
-    bool crlf_to_lf = true;
-
-    REBSTR *s = Append_UTF8_May_Fail(NULL, cs_cast(cp), num_bytes, crlf_to_lf);
+    // So at time of writing it is always STRMODE_NO_CR, but the option is
+    // being left open to make the scanner flexible in this respect...to
+    // either convert CR LF sequences to just LF, or to preserve the CR.
+    //
+    REBSTR *s = Append_UTF8_May_Fail(
+        nullptr,
+        cs_cast(cp),
+        num_bytes,
+        strmode
+    );
     Init_Any_String(out, type, s);
 
     return cp + num_bytes;

--- a/src/include/datatypes/sys-char.h
+++ b/src/include/datatypes/sys-char.h
@@ -282,6 +282,43 @@ inline static bool isLegalUTF8(const REBYTE *source, int length) {
 }
 
 
+// This routine is formulated in a way to try and share it in order to not
+// repeat code for implementing Reb_Strmode many places.  See notes there.
+//
+inline static bool Should_Skip_Ascii_Byte_May_Fail(
+    const REBYTE *bp,
+    enum Reb_Strmode strmode
+){
+    if (*bp == '\0')
+        fail (Error_Illegal_Zero_Byte_Raw());  // never allow #{00} in strings
+
+    if (*bp == '\r') {
+        switch (strmode) {
+          case STRMODE_ALL_CODEPOINTS:
+            break;  // let the CR slide
+
+          case STRMODE_CRLF_TO_LF: {
+            if (bp[1] == LF)
+                return true;  // skip the CR and get the LF as next character
+            goto strmode_no_cr; }  // don't allow e.g. CR CR
+
+          case STRMODE_NO_CR:
+          strmode_no_cr:
+            fail (Error_Illegal_Cr_Raw());
+
+          case STRMODE_LF_TO_CRLF:
+            assert(!"STRMODE_LF_TO_CRLF handled by exporting routines only");
+            break;
+        }
+    }
+
+    return false;  // character is okay for string, don't skip
+}
+
+#define Validate_Ascii_Byte(c,strmode) \
+    cast(void, Should_Skip_Ascii_Byte_May_Fail(&(c), (strmode)))
+
+
 // Converts a single UTF8 code-point and returns the position *at the
 // the last byte of the character's data*.  (This differs from the usual
 // `Scan_XXX` interface of returning the position after the scanned

--- a/src/include/datatypes/sys-string.h
+++ b/src/include/datatypes/sys-string.h
@@ -867,13 +867,11 @@ inline static REBLEN Num_Codepoints_For_Bytes(
     Make_String_Core((encoded_capacity), SERIES_FLAGS_NONE)
 
 inline static REBSTR *Make_String_UTF8(const char *utf8) {
-    const bool crlf_to_lf = false;
-    return Append_UTF8_May_Fail(NULL, utf8, strsize(utf8), crlf_to_lf);
+    return Append_UTF8_May_Fail(NULL, utf8, strsize(utf8), STRMODE_NO_CR);
 }
 
 inline static REBSTR *Make_Sized_String_UTF8(const char *utf8, size_t size) {
-    const bool crlf_to_lf = false;
-    return Append_UTF8_May_Fail(NULL, utf8, size, crlf_to_lf);
+    return Append_UTF8_May_Fail(NULL, utf8, size, STRMODE_NO_CR);
 }
 
 

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -259,6 +259,35 @@ typedef REB_R (MAKE_HOOK)(
 typedef REB_R (TO_HOOK)(REBVAL*, enum Reb_Kind, const REBVAL*);
 
 
+//=//// STRING MODES //////////////////////////////////////////////////////=//
+//
+// Ren-C is prescriptive about disallowing 0 bytes in strings to more safely
+// use the rebSpell() API, which only returns a pointer and must interoperate
+// with C.  It enforces the use of BINARY! if you want to embed 0 bytes (and
+// using the rebBytes() API, which always returns a size.)
+//
+// Additionally, it tries to build on Rebol's historical concept of unifying
+// strings within the system to use LF-only.  But rather than try "magic" to
+// filter out CR LF sequences (and "magically" put them back later), it adds
+// in speedbumps to try and stop CR from casually getting into strings.  Then
+// it encourages active involvement at the source level with functions like
+// ENLINE and DELINE when a circumstance can't be solved by standardizing the
+// data sources themselves:
+//
+// https://forum.rebol.info/t/1264
+//
+// Note: These policies may over time extend to adding more speedbumps for
+// other invisibles, e.g. choosing prescriptivisim about tab vs. space also.
+//
+
+enum Reb_Strmode {
+    STRMODE_ALL_CODEPOINTS,  // all codepoints allowed but 0
+    STRMODE_NO_CR,  // carriage returns not legal
+    STRMODE_CRLF_TO_LF,  // convert CR LF to LF (error on isolated CR or LF)
+    STRMODE_LF_TO_CRLF  // convert plain LF to CR LF (error on stray CR)
+};
+
+
 //=//// MOLDING ///////////////////////////////////////////////////////////=//
 //
 struct rebol_mold;

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -15,6 +15,22 @@ REBOL [
     }
 ]
 
+
+; Help try to avoid introducing CR into strings, and subvert the default
+; checking on output that text does not contain CR bytes.
+;
+write-enlined: redescribe [
+    {Write out a TEXT! with its LF sequences translated to CR LF}
+](
+    adapt 'write [
+        if not text? data [
+            fail ["WRITE-ENLINED only works on TEXT! data"]
+        ]
+        data: as binary! enline copy data
+    ]
+)
+
+
 mold64: function [
     "Temporary function to mold binary base 64." ; fix the need for this! -CS
     data

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -21,17 +21,17 @@ REBOL [
 ; These must be listed explicitly in order for the words to be collected
 ; as legal "globals" for the mezzanine context (otherwise SET would fail)
 
-; Note that TO-LOGIC, TO-INTEGER are currently their own natives (even with
-; additional refinements), and thus should not be overwritten here
+; Note that TO-LOGIC, TO-INTEGER, and TO-TEXT are currently their own natives
+; (even with additional refinements), and thus should not be overwritten here.
 
 to-decimal: to-percent: to-money: to-char: to-pair:
 to-tuple: to-time: to-date: to-binary: to-file: to-email: to-url: to-tag:
-to-text: to-bitset: to-image: to-vector: to-block: to-group:
+to-bitset: to-image: to-vector: to-block: to-group:
 to-path: to-set-path: to-get-path: to-map: to-datatype: to-typeset:
 to-word: to-set-word: to-get-word: to-issue:
 to-function: to-object: to-module: to-error: to-port:
 to-gob: to-event:
-    blank
+    void
 
 ; Auto-build the functions for the above TO-* words.
 use [word] [
@@ -42,7 +42,7 @@ use [word] [
         ; overwrite any NATIVE! implementations.  (e.g. TO-INTEGER is a
         ; native with a refinement for interpreting as unsigned.)
 
-        if (word: in lib word) and [blank? get word] [
+        if (word: in lib word) and [undefined? word] [
             set word redescribe compose [
                 (spaced ["Converts to" form type "value."])
             ](

--- a/tests/series/copy.test.reb
+++ b/tests/series/copy.test.reb
@@ -33,23 +33,3 @@
     error? trap [copy :f]
     true
 )]
-[#648
-    (["a"] = deline/lines "a")
-]
-[#1794
-    (1 = length of deline/lines "Slovenščina")
-]
-
-[https://github.com/metaeducation/ren-c/issues/923
-    (
-        a: copy #{60}
-        repeat i 16 [
-            append a a
-            deline to-text a
-        ]
-        did all [
-            (length of a) = 65536
-            every b a [b = 96]
-        ]
-    )
-]

--- a/tests/series/emptyq.test.reb
+++ b/tests/series/emptyq.test.reb
@@ -7,5 +7,5 @@
 )
 (empty? blank)
 [#190
-    (x: copy "xx^/" loop 20 [enline x: join x x] true)
+    (x: copy "xx^/" loop 20 [enline y: join x x] true)
 ]

--- a/tests/string/deline.test.reb
+++ b/tests/string/deline.test.reb
@@ -1,0 +1,145 @@
+; Ren-C tries to bring more method to the madness of Rebol2/R3-Alpha's
+; attempt to standardize the internal string format for the language to a
+; single codepoint (line feed) to represent newlines.
+;
+; The basis of this method is to allow carriage returns in strings at
+; a mechanical level, but to put in various speed bumps on the edges
+; that increasingly prohibit them from entering the system.  Rather than
+; try and do "magic", it coaxes users into the world of LF-only files
+; (even on Windows)... and for cases where that is not possible it uses
+; errors that guide the user to become involved on any needed filtering
+; or mutation explicitly at the source level:
+;
+; https://forum.rebol.info/t/1264/2
+
+
+; CR codepoints (^M) are ILLEGAL in TO-conversion unless /RELAX is used.
+; CR codepoints (^M) are LEGAL in AS-conversion unless /STRICT is used.
+[
+    (
+        str: "a^M^/b"
+        a-bin: as binary! str  comment {remembers it was utf-8, optimizes!}
+        t-bin: to binary! str  comment {makes dissociated/unconstrained copy}
+        true
+    )
+
+    ('illegal-cr = pick trap [to text! t-bin] 'id)
+    ('illegal-cr = pick trap [to-text t-bin] 'id)
+    (str = to-text/relax t-bin)
+
+    ('illegal-cr = pick trap [to text! a-bin] 'id)
+    ('illegal-cr = pick trap [to-text a-bin] 'id)
+    (str = to-text/relax a-bin)
+
+    (str = as text! t-bin)
+    (str = as-text t-bin)
+    ('illegal-cr = pick trap [as-text/strict t-bin] 'id)
+
+    (str = as text! a-bin)
+    (str = as-text a-bin)
+    ('illegal-cr = pick trap [as-text/strict a-bin] 'id)
+]
+
+; #{00} bytes are illegal in strings regardless of /RELAX or /STRICT
+[
+    ('illegal-zero-byte = pick trap [to text! #{00}] 'id)
+    ('illegal-zero-byte = pick trap [to-text #{00}] 'id)
+    ('illegal-zero-byte = pick trap [to-text/relax #{00}] 'id)
+
+    ('illegal-zero-byte = pick trap [as text! #{00}] 'id)
+    ('illegal-zero-byte = pick trap [as-text #{00}] 'id)
+    ('illegal-zero-byte = pick trap [as-text/strict #{00}] 'id)
+]
+
+; Ren-C DELINE allows either all LF or all CR LF
+; (Rationale: enforce sanity, and do not disincentivize people from 
+; "upgrading" CR LF files to just LF for fear of breaking scripts
+; that had thrown in DELINE for tolerance.)
+[
+    (
+        str: "^M^/"
+        did all [
+            "^/" = deline str
+            "^/" = str  comment {Modifies}
+        ]
+    )
+
+    ("^/" = deline "^/")
+
+    ('illegal-cr = pick trap [deline "^M"] 'id)
+    ('mixed-cr-lf-found = pick trap [deline "a^/b^M^/c"] 'id)
+]
+
+; Ren-C ENLINE is strict about requiring no CR on the input string
+[
+    ("^M^/" = enline "^/")
+    ("a^M^/b" = enline "a^/b")
+    ("a^M^/b^M^/" = enline "a^/b^/")
+    ("^M^/a^M^/b" = enline "^/a^/b")
+
+    ('illegal-cr = pick trap [enline "^M"] 'id)
+    ('illegal-cr = pick trap [enline "^M^/"] 'id)
+    ('illegal-cr = pick trap [enline "^/^M"] 'id)
+]
+
+[
+    (
+        comment {WRITE of TEXT! disallows CR by default}
+        'illegal-cr = pick trap [write %enlined.tmp enline "a^/b"] 'id
+    )
+    (
+        comment {Bypass by writing BINARY!, *but* ENLINE modifies}
+        str: "a^/b" 
+        write %enlined.tmp as binary! enline str
+        did all [
+            #{610D0A62} = read %enlined.tmp
+            str = "a^M^/b"
+        ]
+    )
+    (
+        comment {WRITE-ENLINED doesn't modify, easy interface}
+        str: "a^/b"
+        write-enlined %enlined.tmp str
+        did all [
+            #{610D0A62} = read %enlined.tmp
+            str = "a^/b"
+        ]
+    )
+
+    ('illegal-cr = pick trap [read/string %enlined.tmp] 'id)
+    ('illegal-cr = pick trap [to text! read %enlined.tmp] 'id)
+    ("a^M^/b" = as text! read %enlined.tmp)
+    ("a^/b" = deline read %enlined.tmp)
+]
+
+; The scanner expects files to be in the LF-only format
+[
+    ('illegal-cr = pick trap [do "1^M^/+ 2"] 'id)
+    ('illegal-cr = pick trap [load "1^M^/+ 2"] 'id)
+    ('illegal-cr = pick trap [load unspaced ["{a" "^M^/" "b}"]] 'id)
+    ({a^M^/b} = load "{a^^M^^/b}")
+]
+
+
+[#648
+    (["a"] = deline/lines "a")
+]
+[#1794
+    (1 = length of deline/lines "Slovenščina")
+]
+
+[https://github.com/metaeducation/ren-c/issues/923
+    (
+        a: copy #{60}
+        repeat i 16 [
+            append a a
+            deline to-text a
+        ]
+        did all [
+            (length of a) = 65536
+            every b a [b = 96]
+        ]
+    )
+]
+
+

--- a/tools/bootstrap-shim.r
+++ b/tools/bootstrap-shim.r
@@ -320,15 +320,6 @@ transcode: function [  ; !!! TBD: migrate this shim to redbol.reb
     return pos
 ]
 
-
-; https://github.com/metaeducation/ren-c/issues/923
-;
-deline: specialize 'replace [
-    all: true
-    pattern: unspaced [CR LF]
-    replacement: LF
-]
-
 reeval: :eval
 eval: func [] [
     fail 'return [

--- a/tools/make-headers.r
+++ b/tools/make-headers.r
@@ -126,8 +126,7 @@ process: function [
     file
     <with> the-file  ; global we set
 ][
-    ; !!! is DELINE necessary?
-    data: deline to-text read the-file: file
+    data: read/string the-file: file
 
     proto-parser/emit-proto: :emit-proto
     proto-parser/emit-directive: :emit-directive

--- a/tools/make-natives.r
+++ b/tools/make-natives.r
@@ -19,8 +19,6 @@ do %native-emitters.r ;for emit-native-proto
 
 print "------ Generate tmp-natives.r"
 
-r3: system/version > 2.100.0
-
 src-dir: %../src
 output-dir: system/options/path/prep
 mkdir/deep output-dir/boot
@@ -36,8 +34,7 @@ process: function [
     the-file: file
     if verbose [probe [file]]
 
-    source.text: read join src-dir/core/% file
-    if r3 [source.text: deline to-text source.text]
+    source.text: read/string join src-dir/core/% file
     proto-parser/emit-proto: :emit-native-proto
     proto-parser/process source.text
 ]

--- a/tools/prep-extension.r
+++ b/tools/prep-extension.r
@@ -77,10 +77,7 @@ verbose: false
 proto-count: 0
 module-header: _
 
-source.text: read c-src
-if system/version > 2.100.0 [  ; !!! Why is this necessary?
-    source.text: deline to-text source.text
-] 
+source.text: read/string c-src
 
 ; When the header information in the comments at the top of the file is
 ; seen, save it into a variable.


### PR DESCRIPTION
This commit tries to build on Rebol's historical concept of unifying
strings within the system to use LF-only.  But rather than try "magic"
to filter out CR LF sequences (and "magically" put them back later), it
adds in speedbumps to try and stop CR from casually getting into
strings.  Then it encourages active involvement at the source level
with functions like ENLINE and DELINE when a circumstance can't be
solved by standardizing the data sources themselves:

https://forum.rebol.info/t/1264

It also revises Ren-C's rules to be  prescriptive about disallowing 0
bytes in strings, to more safely use the rebSpell() API, which only
returns a pointer and must interoperate with C.  It enforces the use of
BINARY! if you want to embed 0 bytes (and using the rebBytes() API,
which always returns a size.)