### PR TITLE
ENBIN + DEBIN draft/sketch implementation

### DIFF
--- a/extensions/serial/ext-serial-init.reb
+++ b/extensions/serial/ext-serial-init.reb
@@ -19,7 +19,7 @@ sys/make-scheme [
                 copy path [to slash | end] skip
                 copy speed to end
             ]
-            attempt [port/spec/speed: to-integer/unsigned speed]
+            attempt [port/spec/speed: to-integer speed]
             port/spec/path: to file! path
         ]
         return

--- a/scripts/prot-http.r
+++ b/scripts/prot-http.r
@@ -301,8 +301,9 @@ check-response: function [port] [
         info/headers: headers: construct/with/only d1 http-response-headers
         info/name: to file! any [spec/path %/]
         if headers/content-length [
-            info/size: (headers/content-length:
-                    to-integer/unsigned headers/content-length)
+            info/size: (
+                headers/content-length: to-integer headers/content-length
+            )
         ]
         if headers/last-modified [
             info/date: try attempt [idate-to-date headers/last-modified]
@@ -577,10 +578,10 @@ check-data: function [
                 copy chunk-size some hex-digits thru crlfbin mk1: to end
             ]][
                 ; The chunk size is in the byte stream as ASCII chars
-                ; forming a hex string.  ISSUE! can decode that.
-                chunk-size: (
-                    to-integer/unsigned to issue! to text! chunk-size
-                )
+                ; forming a hex string.  DEBASE to get a BINARY! and then
+                ; DEBIN to get an integer.
+                ;
+                chunk-size: debin [be +] (debase/base as text! chunk-size 16)
 
                 if chunk-size = 0 [
                     parse mk1 [

--- a/scripts/unzip.reb
+++ b/scripts/unzip.reb
@@ -57,40 +57,13 @@ ctx-zip: context [
     end-of-central-sig: #{504B0506}
     data-descriptor-sig: #{504B0708}
 
-    to-ilong: func [
-        "Converts an integer to a little-endian long."
-        value [integer!] "AnyValue to convert"
-    ][
-        copy reverse skip to binary! value 4
-    ]
+    to-ilong: (=> enbin [LE + 4])  ; Little endian 4-byte positive integer
+    get-ilong: (=> debin [LE + 4])
 
-    to-ishort: func [
-        "Converts an integer to a little-endian short."
-        value [integer!] "AnyValue to convert"
-    ][
-        copy/part reverse skip to binary! value 4 2
-    ]
+    to-ishort: (=> enbin [LE + 2])  ; Little endian 2-byte positive integer
+    get-ishort: (=> debin [LE + 2])
 
-    to-long: func [
-        "Converts an integer to a big-endian long."
-        value [integer!] "AnyValue to convert"
-    ][
-        copy skip to binary! value 4
-    ]
-
-    get-ishort: func [
-        "Converts a little-endian short to an integer."
-        value [binary! port!] "AnyValue to convert"
-    ][
-        to integer! reverse copy/part value 2
-    ]
-
-    get-ilong: func [
-        "Converts a little-endian long to an integer."
-        value [binary! port!] "AnyValue to convert"
-    ][
-        to integer! reverse copy/part value 4
-    ]
+    to-long: (=> enbin [BE + 4])  ; Big endian 4-byte positive integer
 
     to-msdos-time: func [
         "Converts to a msdos time."

--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -138,11 +138,6 @@ options: make object! [  ; Options supplied to REBOL during startup
     file-types: copy [
         %.reb %.r3 %.r rebol
     ]
-
-    ; Legacy Behaviors Options (paid attention to only by debug builds)
-
-    forever-64-bit-ints: false
-    unlocked-source: false
 ]
 
 script: make object! [

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -439,22 +439,6 @@ inline static void SET_SIGNAL(REBFLGS f) { // used in %sys-series.h
 #include "reb-device.h"
 
 
-
-// Most of Ren-C's backwards compatibility with R3-Alpha is attempted through
-// usermode "shim" functions.  But some things affect fundamental mechanics
-// and can't be done that way.  So in the debug build, system/options
-// contains some flags that enable the old behavior to be turned on.
-//
-// !!! These are not meant to be kept around long term.
-//
-#if !defined(NDEBUG)
-    #define LEGACY(option) ( \
-        (PG_Boot_Phase >= BOOT_ERRORS) \
-        and IS_TRUTHY(Get_System(SYS_OPTIONS, (option))) \
-    )
-#endif
-
-
 #include "sys-eval.h"  // low-level single-step evaluation API
 #include "sys-do.h"  // higher-level evaluate-until-end API
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -250,3 +250,20 @@ hijack 'find adapt copy :find [
         ]
     ]
 ]
+
+
+to-integer: func [
+    {Deprecated overload: see https://forum.rebol.info/t/1270}
+
+    value [
+       integer! decimal! percent! money! char! time!
+       issue! binary! any-string!
+    ]
+    /unsigned "For BINARY! interpret as unsigned, otherwise error if signed."
+][
+    either binary? value [
+        debin [be (either unsigned ['+] ['+/-])] value
+    ][
+        to integer! value  ; could check for error, but deprecated
+    ]
+]

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -21,10 +21,10 @@ REBOL [
 ; These must be listed explicitly in order for the words to be collected
 ; as legal "globals" for the mezzanine context (otherwise SET would fail)
 
-; Note that TO-LOGIC, TO-INTEGER, and TO-TEXT are currently their own natives
-; (even with additional refinements), and thus should not be overwritten here.
+; Note that TO-LOGIC and TO-TEXT are currently their own natives (even with
+; additional refinements), and thus should not be overwritten here.
 
-to-decimal: to-percent: to-money: to-char: to-pair:
+to-integer: to-decimal: to-percent: to-money: to-char: to-pair:
 to-tuple: to-time: to-date: to-binary: to-file: to-email: to-url: to-tag:
 to-bitset: to-image: to-vector: to-block: to-group:
 to-path: to-set-path: to-get-path: to-map: to-datatype: to-typeset:
@@ -51,6 +51,7 @@ use [word] [
         ]
     ]
 ]
+
 
 ; !!! Refinements are actually PATH! now, but TO PATH! of a WORD! assumes you
 ; want a 2-element path with a blank at the head that looks like a refinement

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -125,7 +125,7 @@ make-port*: function [
                 opt [
                     ":" copy s2 digits (
                         append out compose [
-                            port-id: (to-integer/unsigned s2)
+                            port-id: (to-integer s2)
                         ]
                     )
                 ] (

--- a/tests/convert/enbin.test.reb
+++ b/tests/convert/enbin.test.reb
@@ -1,0 +1,38 @@
+; Tests for the ENBIN and DEBIN functions
+;
+; !!! The design of these dialects is under construction at time of writing
+; writing, but they are to replace most BINARY! <=> INTEGER! conversions
+
+(#{00000020} = enbin [be + 4] 32) 
+(#{20000000} = enbin [le + 4] 32) 
+(32 = debin [be + 4] #{00000020})
+(32 = debin [le + 4] #{20000000})
+(32 = debin [be +] #{00000020})
+(32 = debin [le +] #{20000000})
+
+(
+    random/seed {Reproducible Permutations!}
+    loop 1000 [
+        endian: random/only [be le]
+        signedness: random/only [+ +/-]
+        num-bytes: random 8
+
+        settings: reduce [endian signedness num-bytes]
+        r: random power 256 num-bytes
+        either signedness = '+ [
+            if num-bytes = 8 [r: r / 2 - 1]  ; 63-bit limit
+        ][
+            r: r - ((power 256 num-bytes) / 2)
+        ]
+        value: to integer! r    
+        bin: enbin settings value
+        check: debin settings bin 
+        if value != check [
+            fail [value "didn't round trip ENBIN/DEBIN:" settings]
+        ]
+        comment [
+            print [mold settings value "=>" mold bin "=>" value]
+        ]
+     ]
+     true
+)

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -133,6 +133,7 @@
 %control/quit.test.reb
 %convert/as-binary.test.reb
 %convert/as-string.test.reb
+%convert/enbin.test.reb
 %convert/encode.test.reb
 %convert/load.test.reb
 %convert/mold.test.reb


### PR DESCRIPTION
Rebol2 had an asymmetrical sense of conversion for BINARY! and INTEGER!

    rebol2>> to binary! 32
    == #{3332}  ; #{33} is ASCII "3", #{32} is ASCII "2"

    rebol2>> to integer! #{3332}
    == 13106  ; 0x3332 is the internal big endian form of 13106

R3-Alpha "corrected" this unusual behavior by changing TO BINARY!.  The
conventional wisdom seemed to be that `TO BINARY! TO STRING! 32` was
not a common desire, but easy enough to express if you wanted it.  The
harder conversion for users (which was "easy" for Rebol to do) involved
the internal byte representations of native C integers:

    r3-alpha>> to binary! 32
    == #{0000000000000020}  ; 0x20 is 32 in hexadecimal

    r3-alpha>> to integer! #{0000000000000020}
    == 32

While this might seem more sensible on the surface, it was awkward for
users to get the INTEGER! <> BINARY! conversions they wanted...where
details of signedness, byte-size, and byte ordering vary considerably.
Users might want #{FF00} to mean little-endian 255, big-endian
unsigned 65280, or big-endian signed -256.  Getting these results from
a fixed 8-byte signed big-endian conversion was hard and error prone.

An added concern is that Ren-C's philosphy is that a futureproof
language at Rebol's level of concern should always work with integers
that can scale to arbitrary-precision.  The goal is to finesse the
nature of immutable and mutable INTEGER! in the design so that when
immutable integers fit in a value cell, they can be operated on
efficiently...then only mutable integers would need BigNum "nodes"
pointed to by the cell.  If care is taken to make immutability the
common case, this could provide the best of both worlds.

Yet when Ren-C tried out an unusual way to make TO BINARY! of an
INTEGER! return a variable number of bytes, that didn't wind up
helping much.  This commit introduces two new tools--tentatively
called ENBIN and DEBIN--which take a BLOCK! describing the encoding
or decoding of a binary to integer that is desired:

    >> enbin [be + 4] 32
    #{00000020}  ; big-endian, 4 byte, unsigned

    >> enbin [le + 2] 32
    #{2000}  ; little-endian, 4 byte, unsigned

    >> enbin [le +/- 3] -2
    == #{FEFFFF}  ; little-endian, 3 byte, signed

    >> enbin [le + 3] 16777214
    == #{FEFFFF}  ; little endian 3 byte, this time unsigned

    >> enbin [le +/- 3] 16777214
    ** Error: 16777214 aliases a negative value with signed
           encoding of only 3 bytes

DEBIN is ENBIN's complement which uses the same dialect but goes the
other way:

    >> debin [le + 3] #{FEFFFF}
    == 16777214  ; reverse of above example

The dialect choice was made with the endianness first to possibly
suggest compatibility with WORD!-based codecs and ENCODE/DECODE if they
took a block (encode/decode are nicer words then enbin/debin, but this
is just a test for now so not conflating them).  The sign is in the
middle because unlike ENBIN, DEBIN can guess the size accurately from
the length of the input.

This is a prelude to possibly walking back the TO BINARY! of an integer
semantics to Rebol2 and making TO INTEGER! of a BINARY! reverse *that*.

https://forum.rebol.info/t/1270