### PR TITLE
BLANK! as space character in DELIMIT/UNSPACED/SPACED

### DIFF
--- a/extensions/console/ext-console-init.reb
+++ b/extensions/console/ext-console-init.reb
@@ -676,7 +676,7 @@ ext-console-impl: function [
                 ; transcripts, potentially to replay them without running
                 ; program output or evaluation results.
                 ;
-                write-stdout unspaced [unclosed #"\" space space]
+                write-stdout unspaced [unclosed "\" _ _]
                 emit [reduce [  ; reduce will runs in sandbox
                     ((<*> result))  ; splice previous inert literal lines
                     system/console/input-hook  ; hook to run in sandbox

--- a/extensions/javascript/prep-libr3-js.reb
+++ b/extensions/javascript/prep-libr3-js.reb
@@ -931,7 +931,7 @@ write output-dir/libr3.exports.json json-collect [
 write/lines output-dir/asyncify-blacklist.json collect-lines [
     keep "["
     for-next names load %asyncify-blacklist.r [
-        keep unspaced [{    "} names/1 {"} if not last? names [","]]
+        keep unspaced [_ _ _ _ {"} names/1 {"} if not last? names [","]]
     ]
     keep "]"
 ]

--- a/extensions/uuid/make-libuuid.reb
+++ b/extensions/uuid/make-libuuid.reb
@@ -129,7 +129,7 @@ fix-gen_uuid.c: function [
                 copy unused: [
                     {static unsigned char variant_bits[]}
                   ]
-                  (target: unspaced [{// } to text! unused])
+                  (target: unspaced [{//} _ to text! unused])
                 ] target
 
             | skip

--- a/scripts/changes-file/changes-file.reb
+++ b/scripts/changes-file/changes-file.reb
@@ -255,7 +255,7 @@ make-changes-file: function [
         if find [{* } {- }] copy/part text 2 [remove/part text 2]
 
         unspaced [
-            {``` } text { ```} space
+            {```} _ text _ {```} _
 
             ; github username or git author name
             " *" github-user-name co/author "* | "

--- a/scripts/prot-http.r
+++ b/scripts/prot-http.r
@@ -194,12 +194,12 @@ make-http-request: func [
         space "HTTP/1.0" CR LF
     ]
     for-each [word string] headers [
-        append result unspaced [mold word space string CR LF]
+        append result unspaced [mold word _ string CR LF]
     ]
     if content [
         content: as binary! content
         append result unspaced [
-            "Content-Length:" space (length of content) CR LF
+            "Content-Length:" _ length of content CR LF
         ]
     ]
     append result unspaced [CR LF]
@@ -317,8 +317,8 @@ check-response: function [port] [
                 body: to text! conn/data
                 dump body
             ] then [
-                print unspaced [
-                    "S: " length of conn/data " binary bytes in buffer ..."
+                print spaced [
+                    "S:" length of conn/data "binary bytes in buffer ..."
                 ]
             ]
         ]

--- a/scripts/unzip.reb
+++ b/scripts/unzip.reb
@@ -447,7 +447,7 @@ ctx-zip: context [
                     ]
 
                     either uncompressed-data [
-                        info unspaced ["^- -> ok [" method "]^/"]
+                        info unspaced [_ _ _ _ "-> ok [" method "]^/"]
                     ][
                         num-errors: me + 1
                     ]

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -326,7 +326,7 @@ back: specialize 'skip [
 
 bound?: chain [specialize 'reflect [property: 'binding] | :value?]
 
-unspaced: specialize 'delimit [delimiter: _]
+unspaced: adapt specialize 'delimit [delimiter: "null-me"] [delimiter: null]
 unspaced-text: chain [:unspaced | specialize 'else [branch: [copy ""]]]
 
 spaced: specialize 'delimit [delimiter: space]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -329,8 +329,6 @@ help: function [
     ; help for complex function derivations is a research project in its
     ; own right.  So it tends to break--test it as much as possible.
 
-    space4: unspaced [space space space space]  ; use instead of tab
-
     print "USAGE:"
 
     args: _  ; plain arguments
@@ -346,13 +344,9 @@ help: function [
     ; !!! Should refinement args be shown for enfixed case??
     ;
     if enfixed and [not empty? args] [
-        print unspaced [
-            space4 spaced [args/1 (uppercase mold topic) next args]
-        ]
+        print [_ _ _ _ args/1 (uppercase mold topic) next args]
     ] else [
-        print unspaced [
-            space4 spaced [(uppercase mold topic) args refinements]
-        ]
+        print [_ _ _ _ (uppercase mold topic) args refinements]
     ]
 
     meta: try meta-of :value
@@ -360,32 +354,23 @@ help: function [
     print newline
 
     print "DESCRIPTION:"
-    print unspaced [space4 (:meta/description or '{(undocumented)})]
-    print unspaced [
-        space4 spaced [(uppercase mold topic) {is an ACTION!}]
-    ]
+    print [_ _ _ _ (:meta/description or '{(undocumented)})]
+    print [_ _ _ _ (uppercase mold topic) {is an ACTION!}]
 
     print-args: function [list /indent-words] [
         for-each param list [
-            type: try ensure [<opt> block!] (
+            type: ensure [<opt> block!] (
                 select try :meta/parameter-types to-word param
             )
-            note: try ensure [<opt> text!] (
+            note: ensure [<opt> text!] (
                 select try :meta/parameter-notes to-word param
             )
 
-            ; parameter name and type line
-            if type [
-                print unspaced [space4 param space "[" type "]"]
-            ] else [
-                print unspaced [space4 param]
-            ]
-
+            print [_ _ _ _ param (if type [unspaced ["[" type "]"]])]
             if note [
-                print unspaced [space4 space4 note]
+                print [_ _ _ _ _ _ _ _ note]
             ]
         ]
-        null
     ]
 
     print newline
@@ -394,7 +379,7 @@ help: function [
         either :meta/return-type [mold :meta/return-type] ["(undocumented)"]
     ]
     if :meta/return-note [
-        print unspaced [space4 meta/return-note]
+        print [_ _ _ _ meta/return-note]
     ]
 
     if not empty? args [
@@ -456,7 +441,7 @@ source: function [
     ; from combining the the META-OF information.
 
     write-stdout unspaced [
-        mold name ":" space "make action! [" space mold spec-of :f
+        mold name ":" _ "make action! [" _ mold spec-of :f
     ]
 
     ; While all interfaces as far as invocation is concerned has been unified

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -147,7 +147,7 @@ save: function [
         ]
 
         header [
-            insert data unspaced [{REBOL} space (mold header) newline]
+            insert data unspaced [{REBOL} _ (mold header) newline]
         ]
     ]
 

--- a/tests/misc/shttpd.r
+++ b/tests/misc/shttpd.r
@@ -20,9 +20,9 @@ error-response: func [code uri <local> values] [
 start-response: func [port res <local> code text type body] [
     set [code type body] res
     write port unspaced [
-        "HTTP/1.0" space code space code-map/:code CR LF
-        "Content-type:" space type CR LF
-        "Content-length:" space (length of body) CR LF
+        "HTTP/1.0" _ code _ code-map/:code CR LF
+        "Content-type:" _ type CR LF
+        "Content-length:" _ (length of body) CR LF
         CR LF
     ]
     ; Manual chunking is only necessary because of several bugs in R3's

--- a/tests/red/run-red-test.reb
+++ b/tests/red/run-red-test.reb
@@ -56,7 +56,7 @@ runner: function [
     :look [<opt> any-value! <...>]
 ][
     if name [
-        write-stdout unspaced ["#" name space]
+        write-stdout unspaced ["#" name _]
     ]
 
     any-newlines: _

--- a/tests/series/delimit.test.reb
+++ b/tests/series/delimit.test.reb
@@ -8,5 +8,5 @@
 ("1^/^/2" = delimit #"^/" ["1^/" "2"])
 
 ; Empty text is distinct from BLANK/null
-("A" = delimit ":" [_ "A" null])
+(" A" = delimit ":" [_ "A" null])
 (":A:" = delimit ":" ["" "A" ""])

--- a/tests/system/gc.test.reb
+++ b/tests/system/gc.test.reb
@@ -27,7 +27,7 @@
 ; Nested unspaced
 (
     nested-unspaced: func [n] [
-        either n <= 1 [n] [unspaced [n space nested-unspaced n - 1]]
+        either n <= 1 [n] [unspaced [n _ nested-unspaced n - 1]]
     ]
     "9 8 7 6 5 4 3 2 1" = nested-unspaced 9
 )

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -60,8 +60,8 @@ emit-native-proto: function [
             ]
         ] unspaced [
             newline newline
-            {; !!! DO NOT EDIT HERE! This is generated from }
-            mold the-file { line } line newline
+            {; !!! DO NOT EDIT HERE! This is generated from} _
+                mold the-file _ {line} _ line newline
             mold/only proto-parser/data
         ]
 


### PR DESCRIPTION
This embraces the concept of "what space is to strings, BLANK! is to
blocks", by taking that notion forward to let a BLANK! be rendered
as a space character:

    >> unspaced ["a" "b" _ "c"]
    == "ab c"

Having a shorthand notation for a space improves visibility while
saving on characters (over typing `space` out as a word):

    >> unspaced ["x:" space first block space "+ 10"]
    vs.
    >> unspaced ["x:" _ first block _ "+ 10"]

It also can be preferable to tacking spaces in with adjoining string
parts (in cases where that is possible).  Because they are the same
character in the language used to separate values themselves.  This
makes it sometimes hard to see where a string beginning or end is:

    >> unspaced ["x: " first block " + 10"]
    ; ...at a glance, `" first block "` might look like a string
    ; vs.
    >> unspaced ["x:" _ first block _ "+ 10"]

So it offers advantages there too.

This idea had been tried before and rejected in favor of making BLANK!
a synonym for NULL.  The reason was that early designs of NULL unified
it with VOID!, so it was the way of saying a variable was undefined.
This meant that despite its status as the true "non-value" which
couldn't be confused with something you might want to put into a block,
it was "ornery" to deal with.  This led many cases for "opting out" to
favor the idea of opting out with BLANK! and considering NULL an error.

As time went on, BLANK! increasingly seemed to be the "reified NULL"
where NULL was representative of a "soft error" condition that could
be defused by transforming nulls to blanks via TRY.  This furthered
the idea that dialects should likely make the two mean the same thing
(if both nulls and blanks were to be permitted), otherwise error on
NULL and use blanks as their proxy.

Slowly, however, the ornery-ness of NULL was chipped away.  It was
decided to be too convenient to use IF in PRINT statements without
having to "TRY" to defuse the case when the branch did not run and
it produced NULL.  Eventually, this went all the way and NULL no
longer would cause errors when either assigned via SET-WORD! or fetched
via normal WORD! access.

With NULL being able to "mean what it means" as the true absence of
a value, it opens the floor for letting BLANK! mean something else.