### PR TITLE
TRANSCODE redesign with multi-return, error improvements

### DIFF
--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -499,10 +499,12 @@ void Set_Location_Of_Error(
         REBLIN line = MISC(f->feed->array).line;
 
         REBSYM file_sym = STR_SYMBOL(file);
-        if (file_sym != SYM___ANONYMOUS__)
-            Init_Word(&vars->file, file);
-        if (line != 0)
-            Init_Integer(&vars->line, line);
+        if (IS_NULLED_OR_BLANK(&vars->file)) {
+            if (file_sym != SYM___ANONYMOUS__)
+                Init_Word(&vars->file, file);
+            if (line != 0)
+                Init_Integer(&vars->line, line);
+        }
     }
 }
 

--- a/src/include/sys-feed.h
+++ b/src/include/sys-feed.h
@@ -250,9 +250,11 @@ inline static const RELVAL *Detect_Feed_Pointer_Maybe_Fetch(
 
         feed->specifier = SPECIFIED;
 
+        SCAN_LEVEL level;
         SCAN_STATE ss;
         const REBLIN start_line = 1;
-        Init_Va_Scan_State_Core(
+        Init_Va_Scan_Level_Core(
+            &level,
             &ss,
             Intern("sys-do.h"),
             start_line,
@@ -260,7 +262,7 @@ inline static const RELVAL *Detect_Feed_Pointer_Maybe_Fetch(
             feed
         );
 
-        REBVAL *error = rebRescue(cast(REBDNG*, &Scan_To_Stack), &ss);
+        REBVAL *error = rebRescue(cast(REBDNG*, &Scan_To_Stack), &level);
         Shutdown_Interning_Binder(&binder, feed->context);
 
         if (error) {

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -259,7 +259,7 @@ int main(int argc, char *argv_ansi[])
     //
     REBVAL *main_startup = rebValue(
         "use [code] [",
-            "transcode 'code", rebR(startup_bin),
+            "code: transcode", rebR(startup_bin),
             "bind/only/set code lib",  // only ADD top level set-word!s to lib
             "bind code lib",  // but BIND to anything else that exists in lib
             "do code",

--- a/tests/convert/load.test.reb
+++ b/tests/convert/load.test.reb
@@ -17,10 +17,7 @@
 ; LOAD/NEXT removed, see #1703
 ;
 (error? trap [load/next "1"])
-(did all [
-    #{} = transcode/next 'value to binary! "1"
-    value = 1
-])
+
 
 [#1122 (
     any [

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -256,6 +256,7 @@
 %string/encode.test.reb
 %string/decompress.test.reb
 %string/dehex.test.reb
+%string/transcode.test.reb
 %string/utf8.test.reb
 
 %system/system.test.reb

--- a/tests/string/transcode.test.reb
+++ b/tests/string/transcode.test.reb
@@ -1,0 +1,123 @@
+; TRANSCODE is an operation which exposes the scanner, and is the basis of LOAD
+; It lets you take in UTF-8 text and gives back a BLOCK! of data
+;
+; The interface is historically controversial for its complexity:
+; https://github.com/rebol/rebol-issues/issues/1916
+;
+; Ren-C attempts to make it easier.  Plain TRANSCODE with no options will simply
+; load a string or binary of UTF-8 in its entirety as the sole return result.
+; The multiple-return-awareness kicks it into a more progressive mode, so that
+; it returns partial results and can actually give a position of an error.
+;
+; However, the /RELAX option in Ren-C for error recovery is limited to top-level
+; scanning only--as if there were any depth (such as inside a BLOCK! or GROUP!)
+; then recovery wouldn't be meaningfully possible.  The hope is to transition
+; a recovery-based scan into being done via PARSE or similar, so that a concept
+; of resumable state in a parsing heirarchy could be implemented for both.
+
+; Default is to scan a whole block's worth of values
+([1 [2] <3>] = transcode "1 [2] <3>")
+
+; When asking for a block's worth of values, an empty string gives empty block
+(did all [
+    result: transcode ""
+    [] = result
+    not new-line? result
+])
+(did all [
+    result: transcode "^/    ^/    ^/"
+    [] = result
+    new-line? result
+])
+
+; Requesting a position to be returned is implicitly a request to go value
+; by value...
+(
+    did all [
+        1 = [value pos]: transcode "1 [2] <3>"
+        value = 1
+        pos = " [2] <3>"
+
+        [2] = [value pos]: transcode pos
+        value = [2]
+        pos = " <3>"
+
+        <3> = [value pos]: transcode pos
+        value = <3>
+        pos = ""
+
+        null = [value pos]: transcode pos
+        value = null
+        pos = ""
+    ]
+)
+(
+    ; Same as above, just using /NEXT instead of multiple returns
+    ; Test used in shimming older Ren-Cs
+    ;
+    did all [
+        1 = transcode/next "1 [2] <3>" 'pos
+        pos = " [2] <3>"
+
+        [2] = transcode/next pos 'pos
+        pos = " <3>"
+
+        <3> = transcode/next pos 'pos
+        pos = ""
+
+        null = transcode/next pos 'pos
+        pos = ""
+    ]
+)
+
+; Asking for error positions is possible, at the top level only
+(
+    did all [
+        null = [value pos err]: transcode "^M^/a b c"
+        value = null
+        pos = "^/a b c"
+        err/id = 'illegal-cr
+    ]
+)
+(
+    err-trapped: trap [[value pos err]: transcode "[^M^/ a] b c"]
+    err-trapped/id = 'illegal-cr
+)
+
+(did all [
+    1 = transcode/next to binary! "1" 'pos
+    pos = #{}
+])
+
+(
+    str: "Cat😺: [😺 😺] (😺)"
+
+    did all [
+        'Cat😺: = [value pos]: transcode str
+        set-word? value
+        value = 'Cat😺:
+        pos = " [😺 😺] (😺)"
+
+        [[😺 😺] (😺)] = value: transcode pos  ; no position, read to end
+        block? value
+        value = [[😺 😺] (😺)]  ; no position out always gets block
+    ]
+)
+
+; Do the same thing, but with UTF-8 binary...
+(
+    bin: as binary! "Cat😺: [😺 😺] (😺)"
+    bin =  #{436174F09F98BA3A205BF09F98BA20F09F98BA5D2028F09F98BA29}
+
+    did all [
+        'Cat😺: = [value pos]: transcode bin
+        set-word? value
+        value = 'Cat😺:
+        pos = #{205BF09F98BA20F09F98BA5D2028F09F98BA29}
+        (as text! pos) = " [😺 😺] (😺)"
+
+        [[😺 😺] (😺)] = value: transcode pos  ; no position, read to end
+        block? value
+        value = [[😺 😺] (😺)]  ; no position out always gets block
+    ]
+)

--- a/tests/system/gc.test.reb
+++ b/tests/system/gc.test.reb
@@ -54,8 +54,7 @@
 )
 ; transcode...
 (
-    transcode 'block to binary! "a [b c]"
-    (unspaced ["<" mold block ">"])
+    (unspaced ["<" mold transcode to binary! "a [b c]" ">"])
         = "<[a [b c]]>"
 )
 ; ...

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -167,9 +167,8 @@ make object! compose [
                         any whitespace
                         [
                             position: "%" (
-                                next-position:
-                                    transcode/next 'value
-                                    position
+                                next_position: _  ; !!! for SET-WORD! gather
+                                [value next-position]: transcode position
                             )
                             :next-position
                                 |

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -35,10 +35,9 @@ make object! [
         any [
             position:
 
-            ["{" | {"}] (
-                ; handle string using TRANSCODE
+            ["{" | {"}] (  ; handle string using TRANSCODE
                 success-rule: trap [
-                    position: transcode/next 'dummy position
+                    [_ position]: transcode position
                 ] then [
                     [end skip]
                 ] else [
@@ -123,7 +122,9 @@ make object! [
 
         single-value: parsing-at x [
             trap [
-                next-position: transcode/next (lit value:) x
+                value: _  ; !!! for collecting with SET-WORD!, evolving
+                next-position: _  ; !!! ...same
+                [value next-position]: transcode x
             ] else [
                 type: in types 'val
                 next-position

--- a/tools/common-parsers.r
+++ b/tools/common-parsers.r
@@ -76,11 +76,15 @@ load-until-blank: function [
     text [text!]
     /next {Return values and next position.}
 ] [
-
     wsp: compose [some (charset { ^-})]
 
+    res: _  ; !!! collect as SET-WORD!s for locals, evolving...
     rebol-value: parsing-at x [
-        res: try attempt [transcode/next (lit dummy:) x]
+        ;
+        ; !!! SET-BLOCK! not bootstrap
+        ;
+        attempt [transcode/next x 'res] else [res: blank]
+        res
     ]
 
     terminator: [opt wsp newline opt wsp newline]


### PR DESCRIPTION
Much of LOAD was written in userspace and built on top of TRANSCODE.
In R3-Alpha, this meant the scanner was limited in what it could
report for errors...it was receiving strings and knew what line on
the string it was on, but did not know the filename to report any
errors on.  Also, it only knew the line offset within the string...
so when headers were scanned separately the line numbers were off
by the number of lines in the header.

Ren-C had tunneled in a line number variable to TRANSCODE to resolve
the line number issue.  However, the filename was not threaded through
the loading machinery...which was difficult to navigate and read.

This commit attempts to get to the bottom of the issue by making LOAD
account for the filename.  As part of the process, this involves
improving LOAD and LOAD-HEADER to use a revamped variation of
TRANSCODE which takes advantage of multiple return values.

    value: transcode data  ; transcodes the entire thing
    [value pos]: trancode data  ; transcode one value, give next pos
    [value pos err]: transcode data  ; same but recover from errors

Error recovery (the TRANSCODE/RELAX option) was never very well
mapped out in R3-Alpha... nor was the /ONLY option.  The intended
feature is presumably some kind of "recoverable" scan--which cannot
be done with multiple calls to TRANSCODE when the scanning state has
been abandoned.  A deeper design for that would be necessary (and
would be desirable to have in PARSE as well; to suspend and resume
an in progress parse stack).

However, this preserves a variant of the /RELAX feature by allowing
recovery as long as the error is at the outermost depth level of
the transcode.  It repairs an issue where deeper errors in the scan
were being casually suppressed in an undetectable way, leading to
confusing or absent error reports when /RELAX was used.