### PR TITLE
/ and other ISSUE! chars, make # space (not empty)

### DIFF
--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1207,6 +1207,7 @@ static enum Reb_Token Locate_Token_May_Push_Mold(
             HAS_LEX_FLAG(flags, LEX_SPECIAL_AT)  // @ anywhere but at the head
             and *cp != '<'  // want <foo="@"> to be a TAG!, not an EMAIL!
             and *cp != '\''  // want '@foo to be a SYM-WORD!
+            and *cp != '#'  // want #@ to be an ISSUE! (charlike)
         ){
             if (*cp == '@')  // consider `@a@b`, `@@`, etc. ambiguous
                 fail (Error_Syntax(ss, TOKEN_EMAIL));
@@ -1230,21 +1231,37 @@ static enum Reb_Token Locate_Token_May_Push_Mold(
             goto scanword;
 
           case LEX_SPECIAL_PERCENT:  // %filename
+            token = TOKEN_FILE;
+
+          issue_or_file_token:  // issue jumps here, should set `token`
+            assert(token == TOKEN_FILE or token == TOKEN_ISSUE);
+
             cp = ss->end;
+            if (*cp == ';') {
+                //
+                // !!! Help catch errors when writing `#;` which is an easy
+                // mistake to make thinking it's like `#:` and a way to make
+                // a single character.
+                //
+                ss->end = cp;
+                fail (Error_Syntax(ss, token));
+            }
             if (*cp == '"') {
                 cp = Scan_Quote_Push_Mold(mo, cp, ss);
                 if (not cp)
-                    fail (Error_Syntax(ss, TOKEN_FILE));
+                    fail (Error_Syntax(ss, token));
                 ss->end = cp;
-                return TOKEN_FILE;
+                return token;
             }
             while (*cp == '/') {  // deal with path delimiter
                 cp++;
+
                 while (IS_LEX_NOT_DELIMIT(*cp))
                     ++cp;
             }
+
             ss->end = cp;
-            return TOKEN_FILE;
+            return token;
 
           case LEX_SPECIAL_COLON:  // :word :12 (time)
             if (cp[1] == '(') {
@@ -1386,8 +1403,11 @@ static enum Reb_Token Locate_Token_May_Push_Mold(
                 //
                 fail (Error_Missing(level, '}'));
             }
-            if (cp - 1 == ss->begin)
-                return TOKEN_ISSUE;
+            if (cp - 1 == ss->begin) {
+                --cp;
+                token = TOKEN_ISSUE;
+                goto issue_or_file_token;  // same policies on including `/`
+            }
 
             fail (Error_Syntax(ss, TOKEN_INTEGER));
 
@@ -2889,10 +2909,20 @@ const REBYTE *Scan_Any_Word(
 // Scan an issue word, allowing special characters.
 // Returning null should trigger an error in the caller.
 //
+// Passed in buffer and size does not count the leading `#` so that the code
+// can be used to create issues from buffers without it (e.g. TO-HEX).
+//
+// !!! Since this follows the same rules as FILE!, the code should merge,
+// though FILE! will make mutable strings and not have in-cell optimization.
+//
 const REBYTE *Scan_Issue(RELVAL *out, const REBYTE *cp, REBLEN len)
 {
-    if (len == 0)
-        return nullptr;
+    if (len == 0) {  // Lone `#` means "space" issue!
+        REBSTR *str = Make_String(1);
+        Append_Codepoint(str, ' ');
+        Init_Issue(out, str);
+        return cp;
+    }
 
     while (IS_LEX_SPACE(*cp))  // skip whitespace
         ++cp;
@@ -2901,40 +2931,35 @@ const REBYTE *Scan_Issue(RELVAL *out, const REBYTE *cp, REBLEN len)
 
     REBLEN l = len;
     while (l > 0) {
+        //
+        // Allows nearly every visible character that isn't a delimiter
+        // as a char surrogate, e.g. #\ or #@ are legal, as are #<< and #>>
+        //
         switch (GET_LEX_CLASS(*bp)) {
           case LEX_CLASS_DELIMIT:
-            return nullptr;
+            switch (GET_LEX_VALUE(*bp)) {
+              case LEX_DELIMIT_SLASH:  // internal slashes are legal
+              case LEX_DELIMIT_SEMICOLON:  // treat `#;` internal, like #";"
+                break;
 
-          case LEX_CLASS_SPECIAL: {  // Flag all but first special char
-            REBLEN c = GET_LEX_VALUE(*bp);
-            if (
-                LEX_SPECIAL_APOSTROPHE != c
-                and LEX_SPECIAL_COMMA != c
-                and LEX_SPECIAL_PERIOD != c
-                and LEX_SPECIAL_PLUS != c
-                and LEX_SPECIAL_MINUS != c
-                and LEX_SPECIAL_BAR != c
-                and LEX_SPECIAL_BLANK != c
-                and LEX_SPECIAL_COLON != c
-
-                // !!! R3-Alpha didn't allow #<< or #>>, but this was used
-                // in things like pdf-maker.r - and Red allows it.  Ren-C
-                // aims to make ISSUE!s back into strings, so allow it here.
-                //
-                and LEX_SPECIAL_GREATER != c
-                and LEX_SPECIAL_LESSER != c
-            ){
-                return nullptr;
+              default:
+                // ultimately #{...} and #"..." should be "ISSUECHAR!"
+                return nullptr;  // other purposes, `#(` `#[`, etc.
             }
-            goto lex_word_or_number; }
+            break;
 
-          lex_word_or_number:
           case LEX_CLASS_WORD:
+            if (*bp == '^')
+                return nullptr;  // TBD: #^(NN) for light-looking escapes
+            break;
+
+          case LEX_CLASS_SPECIAL:  // includes `<` and '>'
           case LEX_CLASS_NUMBER:
-            ++bp;
-            --l;
             break;
         }
+
+        ++bp;
+        --l;
     }
 
     Init_Issue(out, Make_Sized_String_UTF8(cs_cast(cp), len));

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -1037,7 +1037,18 @@ void MF_String(REB_MOLD *mo, REBCEL(const*) v, bool form)
 
       case REB_ISSUE:
         Append_Codepoint(mo->series, '#');
-        Append_String(mo->series, v, VAL_LEN_AT(v));
+
+        if (VAL_LEN_AT(v) == 0) {
+            Append_Ascii(mo->series, "\"\"");  // !!! alternate #{} TBD...
+        }
+        else if (VAL_LEN_AT(v) == 1 and *VAL_UTF8_AT(nullptr, v) == ' ') {
+            //
+            // This is a special case, that `#` is actually the representation
+            // for a space character (#" "), not an empty issue (#"").  It's
+            // a *very* advantageous decision, e.g. `unspaced [x # y]`.
+        }
+        else
+            Append_String(mo->series, v, VAL_LEN_AT(v));
         break;
 
       default:

--- a/tests/datatypes/issue.test.reb
+++ b/tests/datatypes/issue.test.reb
@@ -1,6 +1,61 @@
 ; datatypes/issue.r
+
 (issue? #aa)
+
 (not issue? 1)
+(issue? #1)
+
 (issue! = type of #aa)
-; minimum
+
 (issue? #a)
+
+; Issues follow the rules for FILE! scanning, so they allow internal slashes.
+;
+("/" = to text! #/)
+("/" = as text! #/)
+(#/ = as issue! "/")
+(#/ = to issue! "/")
+("iss/ue/nonpath" = as text! #iss/ue/nonpath)
+("issue/3" = as text! #issue/3)
+
+; These are examples of something used in %pdf-maker.r
+;
+(issue? #<<)
+(issue? #>>)
+
+; Empty-looking issues are actually the single character "space".
+;
+(" " = as text! #)
+("#" = mold as issue! " ")
+;({#""} = mold #"")  ; currently an invalid char
+({#""} = mold clear #clearme)  ; loading this would make an invalid char atm
+
+; Intent is to merge ISSUE! and CHAR! into cell-packable UTF-8 immutable
+; and atomic type.  This means a wide range of visible characters are allowed
+; in the ISSUE! for convenience as a CHAR! representation.
+(
+    for-each x [  ; TEXT! values are tested as *invalid* issues
+        #~ #`
+        #1 #2 #3 #4 #5 #6 #7 #8 #9 #1 #0 #- #=
+        #! #@ ## #$ #% {#^^} #& #* {#(} {#)} #_ #+  ; caret used for escaping
+        "#{" "#}" #|  ; #{xx} will become "ISSUE!" when BINARY! is &{xx}
+        {#[} {#]} #\
+        {#;} #'  ; scanner checks specially for `#;` to error
+        #: {#"}  ; quotes for ISSUE! with internal spaces (braces in future)
+        #, #. #/
+        #< #> #?
+    ][
+        case [
+            issue? x [
+                assert [1 = length of as text! x]
+                assert [x = as issue! load mold x]
+            ]
+            text? x [
+                id: (match error! trap [load x])/id
+                assert [find [scan-invalid scan-extra scan-missing] id]
+            ]
+            fail "wrong type"
+        ]
+    ]
+    true
+)

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -177,9 +177,6 @@
     ((/refinement)/2 = 'refinement)
     (r: /refinement | r/2 = 'refinement)
 ][
-    (#iss/ue/path = to path! [#iss ue path])
-    (#issue/3 = to path! [#issue 3])
-][
     ("te"/xt/path = to path! ["te" xt path])
     ("text"/3 = to path! ["text" 3])
     (("text")/3 = #"x")


### PR DESCRIPTION
Rebol2 and R3-Alpha break issues to become refinements at slash:

    rebol2>> load "#ab/cd"
    == [#ab /cd
    ]

This changes it to follow the same load rules as FILE!, and include
the slashes:

    >> x: load "#ab/cd"
    == #ab/cd

    >> type of x
    == #[datatype! issue!]

It also makes more characters in ISSUE! legal.  This is designed
to allow it evolve into the "cleaner" form of CHAR!, ultimately
replacing the CHAR! datatype entirely.

    >> ensure issue! #:
    == #:

    >> ensure issue! #<
    == #<

While it looks sensible that `#;` would be an ISSUE!, the ; is
a comment anywhere at this time.  In order to help catch cases
that would forget and use `#;` like `#:` and cause hard to find
bugs of code getting commented out, this makes that case error.

It also makes the choice that `#` means an issue containing a space,
not the empty issue.  This offers a convenient alternative to
expressing space, that is shorter than #" " or the word `space`.