### PR TITLE
Tune DELIMIT and PARSE handling of BLANK!, ISSUE!

### DIFF
--- a/src/core/n-reduce.c
+++ b/src/core/n-reduce.c
@@ -61,13 +61,14 @@ bool Reduce_To_Stack_Throws(
             continue;  // `reduce [comment "hi"]`
         }
 
-        // We can't put nulls into array cells, so we put BLANK!.  This is
-        // compatible with historical behavior of `reduce [if 1 = 2 [<x>]]`
-        // which produced `[#[none]]`, and is generally more useful than
-        // putting VOID!, as more operations skip blanks vs. erroring.
+        // We can't put nulls into array cells, so we put VOID!.  This is
+        // conservative to try and notice mistakes based on expectations of
+        // the number of slots (COMPOSE is an alternative for such uses).
+        // This should be overrideable by a predicate to process the value
+        // before it is put in the result array.
         //
         if (IS_NULLED(out))
-            Init_Blank(DS_PUSH());
+            Init_Void(DS_PUSH());
         else
             Move_Value(DS_PUSH(), out);
 

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -231,8 +231,8 @@ reword: function [
 
     out: make (type of source) length of source
 
-    prefix: _
-    suffix: _
+    prefix: null
+    suffix: null
     case [
         null? escape [prefix: "$"]  ; refinement not used, so use default
 
@@ -240,7 +240,7 @@ reword: function [
             escape = ""
             escape = []
         ][
-            prefix: _  ; pure search and replace, no prefix/suffix
+            prefix: null  ; pure search and replace, no prefix/suffix
         ]
 
         block? escape [
@@ -297,23 +297,23 @@ reword: function [
     ;         | "10" (keyword-match: '10)
     ;    ] suffix  ; ...but then it's at "0>" and not ">", so it fails
     ;
-    keyword-match: _  ; variable that gets set by rule
+    keyword-match: null  ; variable that gets set by rule
     any-keyword-suffix-rule: collect [
         for-each [keyword value] values [
             if not match keyword-types keyword [
                 fail ["Invalid keyword type:" keyword]
             ]
 
-            keep reduce [
-                if match [integer! word!] keyword [
+            keep compose/deep <*> [
+                (<*> if match [integer! word!] keyword [
                     to-text keyword  ; `parse "a1" ['a '1]` illegal for now
                 ] else [
                     keyword
-                ]
+                ])
 
-                suffix
+                (<*> suffix)
 
-                compose '(keyword-match: '(keyword))
+                (keyword-match: '(<*> keyword))
             ]
 
             keep/line '|

--- a/tests/context/set.test.reb
+++ b/tests/context/set.test.reb
@@ -2,14 +2,14 @@
 [#1763
     (
         a: <before>
-        [_] = set [a] reduce [null]
+        [#[void]] = set/any [a] reduce [null]
         blank? :a
     )
 ]
 (
     a: <a-before>
     b: <b-before>
-    [2 _] = set [a b] reduce [2 null]
+    [2 #[void]] = set/any [a b] reduce [2 null]
     a = 2
     blank? :b
 )

--- a/tests/control/reduce.test.reb
+++ b/tests/control/reduce.test.reb
@@ -6,7 +6,7 @@
     success
 )
 ([] = reduce [])
-(blank? first reduce [null])
+(void? first reduce [null])
 ("1 + 1" = reduce "1 + 1")
 (error? first reduce [trap [1 / 0]])
 [#1760 ; unwind functions should stop evaluation
@@ -24,7 +24,7 @@
     error? trap blk
 )
 
-([3 _ 300] = reduce [1 + 2 if false [10 + 20] 100 + 200])
+([3 #[void] 300] = reduce [1 + 2 if false [10 + 20] 100 + 200])
 
 ; Quick flatten test, here for now
 (

--- a/tests/functions/modal.test.reb
+++ b/tests/functions/modal.test.reb
@@ -8,29 +8,29 @@
         reduce [x y]
     ])
 
-    ([3 _] = foo 3)
+    ([3 #[void]] = foo 3)
     ([3 /y] = foo @(1 + 2))
-    ([@(1 + 2) _] = foo '@(1 + 2))
+    ([@(1 + 2) #[void]] = foo '@(1 + 2))
 
     (did item: 300)
 
-    ([304 _] = foo item + 4)
+    ([304 #[void]] = foo item + 4)
     ([304 /y] = foo @(item + 4))
-    ([@(item + 4) _] = foo '@(item + 4))
+    ([@(item + 4) #[void]] = foo '@(item + 4))
 
-    ([300 _] = foo item)
+    ([300 #[void]] = foo item)
     ([300 /y] = foo @item)
-    ([@item _] = foo '@item)
+    ([@item #[void]] = foo '@item)
 
-    ([[a b] _] = foo [a b])
+    ([[a b] #[void]] = foo [a b])
     ([[a b] /y] = foo @[a b])
-    ([@[a b] _] = foo '@[a b])
+    ([@[a b] #[void]] = foo '@[a b])
 
     (did obj: make object! [field: 1020])
 
-    ([1020 _] = foo obj/field)
+    ([1020 #[void]] = foo obj/field)
     ([1020 /y] = foo @obj/field)
-    ([@obj/field _] = foo '@obj/field)
+    ([@obj/field #[void]] = foo '@obj/field)
 ]
 
 [
@@ -40,23 +40,23 @@
         reduce [x y]
     ])
 
-    (3 bar = [3 _])
+    (3 bar = [3 #[void]])
     (@(1 + 2) bar = [3 /y])
 
     (did item: 300)
 
-    ((item + 4) bar = [304 _])
+    ((item + 4) bar = [304 #[void]])
     (@(item + 4) bar = [304 /y])
 
-    (item bar = [300 _])
+    (item bar = [300 #[void]])
     (@item bar = [300 /y])
 
-    ([a b] bar = [[a b] _])
+    ([a b] bar = [[a b] #[void]])
     (@[a b] bar = [[a b] /y])
 
     (did obj: make object! [field: 1020])
 
-    (obj/field bar = [1020 _])
+    (obj/field bar = [1020 #[void]])
     (@obj/field bar = [1020 /y])
 ]
 
@@ -69,7 +69,7 @@
 
     ([a @x /y] = parameters of :foo)
 
-    ([10 20 _] = foo 10 20)
+    ([10 20 #[void]] = foo 10 20)
     ([10 20 /y] = foo 10 @(20))
 
     (did fooy: :foo/y)

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -160,14 +160,14 @@
         true
     )
 
-    ([/A _ /B word] = (word foob |))
-    ([/A _ /B _] = (<not a word> foob |))
+    ([/A #[void] /B word] = (word foob |))
+    ([/A #[void] /B _] = (<not a word> foob |))
     ([/A 20 /B word] = (word ->- foob/a 20))
 
     (comment [
         {Currently SHOVE and <skip> don't work together, maybe shouldn't}
         https://github.com/metaeducation/ren-c/issues/909
-        [/A 20 /B _] = (<not a word> ->- foob/a 20)
+        [/A 20 /B #[void]] = (<not a word> ->- foob/a 20)
     ] true)
 ]
 

--- a/tests/misc/assert.test.reb
+++ b/tests/misc/assert.test.reb
@@ -61,10 +61,10 @@
 )
 
 ; Invisibles
-(
-    assert []
-    assert [comment "hi" 1]
-    assert [1 elide 2 + 3]
-    assert [comment "hi" (true)]
-    assert [(true) elide 2 + 3]
-)
+[
+    (assert [] true)
+    (assert [comment "hi" 1] true)
+    (assert [1 elide 2 + 3] true)
+    (assert [comment "hi" (true)] true)
+    (assert [(true) elide 2 + 3] true)
+]

--- a/tests/parse/parse.test.reb
+++ b/tests/parse/parse.test.reb
@@ -39,26 +39,47 @@
 ]
 
 
-; Are null rules raising the right error?
-
+; Plain voids cause an error, quoted voids match literal voids
 (
-    foo: null
+    foo: void
     e: trap [parse "a" [foo]]
-    e/id = 'no-value
+    e/id = 'need-non-void
+)(
+    foo: quote void
+    did parse compose [(void)] [foo end]
 )
 
-; Blank and empty block case handling
+; Empty block case handling
 
 (did parse [] [end])
 (did parse [] [[[]] end])
-(did parse [] [_ _ _ end])
 (not parse [x] [end])
-(not parse [x] [_ _ _ end])
 (not parse [x] [[[]] end])
-(did parse [] [[[_ _ _] end]])
-(did parse [x] ['x _ end])
-(did parse [x] [_ 'x end])
 (did parse [x] [[] 'x [] end])
+
+; Literal blank vs. fetched blank/null handling.
+; Literal blank means "skip" at source level, but if retrieved from a variable
+; it means the same as null.
+; https://forum.rebol.info/t/1348
+[
+    (did parse [x] ['x null end])
+    (did parse [x] [blank 'x end])
+
+    (did parse [] [blank blank blank end])
+    (not parse [] [_ _ _ end])
+    (did parse [x <y> "z"] [_ _ _ end])
+
+    (not parse [x <y> "z"] ['_ '_ '_ end])
+    (did parse [_ _ _] ['_ '_ '_ end])
+    (
+        q-blank: quote _
+        did parse [_ _ _] [q-blank q-blank q-blank end]
+    )
+
+    (not parse [] [[[_ _ _] end]])
+    (did parse [] [[[blank blank blank] end]])
+    (did parse [] [[[null null null] end]])
+]
 
 ; SET-WORD! (store current input position)
 

--- a/tests/series/delimit.test.reb
+++ b/tests/series/delimit.test.reb
@@ -10,3 +10,21 @@
 ; Empty text is distinct from BLANK/null
 (" A" = delimit ":" [_ "A" null])
 (":A:" = delimit ":" ["" "A" ""])
+
+; literal blanks act as spaces, fetched ones act as nulls
+[
+    ("a  c" = spaced ["a" _ comment <b> _ "c"])
+    ("a c" = spaced ["a" blank comment <b> blank "c"])
+    ("a c" = spaced ["a" null comment <b> null "c"])
+]
+
+; ISSUE! is to be merged with CHAR! and does not space
+(
+    project: 'Ren-C
+    bad-thing: "Software Complexity"
+    new?: does [project <> 'Rebol]
+
+    str: spaced [#<< project #>> _ {The} (if new? 'NEW) {War On} bad-thing]
+
+    str = "<<Ren-C>> The NEW War On Software Complexity"
+)


### PR DESCRIPTION
This tweaks the handling of BLANK! to allow it to be used at "source
level" in dialects, while prescribing it as a synonym for NULL if
it is fetched from evaluation or a variable.

Being able to discern a "source" blank from a fetched one is thus
important, and the previous commit's tweak is used to move in steps
that allow blanks after comments to be discerned as source or not:

    >> spaced ["a" _ comment <b> _ "c"]
    == "a  c"

    >> spaced ["a" blank comment <b> blank "c"]
    == "a c"   ; acts as if you'd written `spaced ["a" "c"]`

DELIMIT is also modified to use tight spacing for ISSUE!, which is
an aspect of the transition to a merged ISSUE!/CHAR! datatype.  This
integrates well with the source-level spacing feature, for clear
results that don't require mixing SPACED and UNSPACED calls, and
thus can work cleanly with PRINT:

    project: 'Ren-C
    bad-thing: "Software Complexity"
    new?: does [project <> 'Rebol]

    >> print [#<< project #>> _ {The} (if new? 'NEW) {War On} bad-thing]
    <<Ren-C>> The NEW War On Software Complexity

This also changes PARSE to embrace the feature of source-level BLANK!
representing a synonym for SKIP:

    >> did parse [1 <two> "three"] [integer! _ text!]
    == #[true]

While fetched blanks act as NULL-equivalents:

    >> subrule: _

    >> did parse [1 <two>] [integer! subrule tag!]
    == #[true]

It was actually the case that PARSE was not allowing NULL parse rules
when it should (due to not being sync'd with the void-as-misspelled
change).  So routines like REWORD were using BLANK! for nulling out
rules made via reduce.  Changing to NULL was the easy fix, but the
usage of REDUCE made it fail in a tricky way...so this provided the
critical momentum for REDUCE to mutate NULL into VOID! by default.
Predicates will allow usage of `reduce .try [...]` to get blanks from
nulls, or `reduce . [...]` to use the identity function and dissolve
the nulls.