### PR TITLE
Require space before `;` is considered a comment

### DIFF
--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -208,62 +208,66 @@ REBNATIVE(enhex)
             encoded_size = 1;
 
             switch (GET_LEX_CLASS(c)) {
-            case LEX_CLASS_DELIMIT:
+              case LEX_CLASS_DELIMIT:
                 switch (GET_LEX_VALUE(c)) {
-                case LEX_DELIMIT_LEFT_PAREN:
-                case LEX_DELIMIT_RIGHT_PAREN:
-                case LEX_DELIMIT_LEFT_BRACKET:
-                case LEX_DELIMIT_RIGHT_BRACKET:
-                case LEX_DELIMIT_SLASH:
-                case LEX_DELIMIT_PERIOD:
-                case LEX_DELIMIT_SEMICOLON:
+                  case LEX_DELIMIT_LEFT_PAREN:
+                  case LEX_DELIMIT_RIGHT_PAREN:
+                  case LEX_DELIMIT_LEFT_BRACKET:
+                  case LEX_DELIMIT_RIGHT_BRACKET:
+                  case LEX_DELIMIT_SLASH:
+                  case LEX_DELIMIT_PERIOD:
                     goto leave_as_is;
 
-                case LEX_DELIMIT_SPACE: // includes control characters
-                case LEX_DELIMIT_END: // 00 null terminator
-                case LEX_DELIMIT_LINEFEED:
-                case LEX_DELIMIT_RETURN: // e.g. ^M
-                case LEX_DELIMIT_LEFT_BRACE:
-                case LEX_DELIMIT_RIGHT_BRACE:
-                case LEX_DELIMIT_DOUBLE_QUOTE:
+                  case LEX_DELIMIT_SPACE:  // includes control characters
+                  case LEX_DELIMIT_END:  // 00 null terminator
+                  case LEX_DELIMIT_LINEFEED:
+                  case LEX_DELIMIT_RETURN:  // e.g. ^M
+                  case LEX_DELIMIT_LEFT_BRACE:
+                  case LEX_DELIMIT_RIGHT_BRACE:
+                  case LEX_DELIMIT_DOUBLE_QUOTE:
                     goto needs_encoding;
 
-                case LEX_DELIMIT_UTF8_ERROR: // not for c < 0x80
-                default:
+                  case LEX_DELIMIT_UTF8_ERROR:  // not for c < 0x80
+                  default:
                     panic ("Internal LEX_DELIMIT table error");
                 }
                 goto leave_as_is;
 
-            case LEX_CLASS_SPECIAL:
+              case LEX_CLASS_SPECIAL:
                 switch (GET_LEX_VALUE(c)) {
-                case LEX_SPECIAL_AT:
-                case LEX_SPECIAL_COLON:
-                case LEX_SPECIAL_APOSTROPHE:
-                case LEX_SPECIAL_PLUS:
-                case LEX_SPECIAL_MINUS:
-                case LEX_SPECIAL_BLANK:
-                case LEX_SPECIAL_COMMA:
-                case LEX_SPECIAL_POUND:
-                case LEX_SPECIAL_DOLLAR:
+                  case LEX_SPECIAL_AT:
+                  case LEX_SPECIAL_COLON:
+                  case LEX_SPECIAL_APOSTROPHE:
+                  case LEX_SPECIAL_PLUS:
+                  case LEX_SPECIAL_MINUS:
+                  case LEX_SPECIAL_BLANK:
+                  case LEX_SPECIAL_COMMA:
+                  case LEX_SPECIAL_POUND:
+                  case LEX_SPECIAL_DOLLAR:
+                  case LEX_SPECIAL_SEMICOLON:
                     goto leave_as_is;
 
-                default:
-                    goto needs_encoding; // what is LEX_SPECIAL_WORD?
+                  case LEX_SPECIAL_WORD:
+                    assert(false);  // only occurs in use w/Prescan_Token()
+                    goto leave_as_is;
+
+                  default:
+                    goto needs_encoding;
                 }
                 goto leave_as_is;
 
-            case LEX_CLASS_WORD:
+              case LEX_CLASS_WORD:
                 if (
                     (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z')
                     or c == '?' or c == '!' or c == '&'
                     or c == '*' or c == '=' or c == '~'
                 ){
-                    goto leave_as_is; // this is all that's leftover
+                    goto leave_as_is;  // this is all that's leftover
                 }
                 goto needs_encoding;
 
-            case LEX_CLASS_NUMBER:
-                goto leave_as_is; // 0-9 needs no encoding.
+              case LEX_CLASS_NUMBER:
+                goto leave_as_is;  // 0-9 needs no encoding.
             }
 
         leave_as_is:;

--- a/src/include/sys-scan.h
+++ b/src/include/sys-scan.h
@@ -92,7 +92,6 @@ enum LEX_DELIMIT_ENUM {
     LEX_DELIMIT_RIGHT_PAREN,        /* 29 ) */
     LEX_DELIMIT_LEFT_BRACKET,       /* 5B [ */
     LEX_DELIMIT_RIGHT_BRACKET,      /* 5D ] */
-    LEX_DELIMIT_SEMICOLON,          /* 3B ; */
 
     // As a step toward "Plan -4", the above delimiters are considered to
     // always terminate, e.g. a URL `http://example.com/a)` will not pick up
@@ -113,6 +112,9 @@ enum LEX_DELIMIT_ENUM {
 
     LEX_DELIMIT_MAX
 };
+
+STATIC_ASSERT(LEX_DELIMIT_MAX <= 16);
+
 
 
 /*
@@ -179,7 +181,7 @@ enum LEX_SPECIAL_ENUM {             /* The order is important! */
     LEX_SPECIAL_COMMA,              /* 2C , - decimal number */
     LEX_SPECIAL_POUND,              /* 23 # - hex number */
     LEX_SPECIAL_DOLLAR,             /* 24 $ - money */
-    LEX_SPECIAL_14,                 /* unused */
+    LEX_SPECIAL_SEMICOLON,          /* 3B ; - comment */
 
     // LEX_SPECIAL_WORD is not a LEX_VALUE() of anything in LEX_CLASS_SPECIAL,
     // it is used to set a flag by Prescan_Token().
@@ -190,6 +192,9 @@ enum LEX_SPECIAL_ENUM {             /* The order is important! */
 
     LEX_SPECIAL_MAX
 };
+
+STATIC_ASSERT(LEX_SPECIAL_MAX <= 16);
+
 
 /*
 **  Special Encodings
@@ -213,7 +218,8 @@ enum LEX_SPECIAL_ENUM {             /* The order is important! */
                         LEX_FLAG(LEX_SPECIAL_COMMA) |           \
                         LEX_FLAG(LEX_SPECIAL_POUND) |           \
                         LEX_FLAG(LEX_SPECIAL_DOLLAR) |          \
-                        LEX_FLAG(LEX_SPECIAL_COLON))
+                        LEX_FLAG(LEX_SPECIAL_COLON) |           \
+                        LEX_FLAG(LEX_SPECIAL_SEMICOLON))
 
 enum rebol_esc_codes {
     // Must match Esc_Names[]!

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -212,6 +212,7 @@
 %reflectors/body-of.test.reb
 
 %scanner/path-tuple.test.reb
+%scanner/source-comment.test.reb
 
 %secure/const.test.reb
 %secure/protect.test.reb

--- a/tests/datatypes/issue.test.reb
+++ b/tests/datatypes/issue.test.reb
@@ -40,7 +40,7 @@
         #! #@ ## #$ #% {#^^} #& #* {#(} {#)} #_ #+  ; caret used for escaping
         "#{" "#}" #|  ; #{xx} will become "ISSUE!" when BINARY! is &{xx}
         {#[} {#]} #\
-        {#;} #'  ; scanner checks specially for `#;` to error
+        #; #'  ; as with URL!, semicolons are allowed in the token
         #: {#"}  ; quotes for ISSUE! with internal spaces (braces in future)
         #, #. #/
         #< #> #?

--- a/tests/scanner/source-comment.test.reb
+++ b/tests/scanner/source-comment.test.reb
@@ -1,0 +1,51 @@
+; %source-comment.test.reb
+;
+; Test for semicolon-based comments.  One key difference in Ren-C with these
+; comments is that a comment must have space between it and another token,
+; otherwise the semicolon is considered part of the token:
+;
+;     >> #; ; comment after a one-codepoint issue for `;`
+;     == #;
+;
+;     >> # ; comment after a zero-codepoint issue
+;     == #
+;
+;     >> 'a ; comment after a quoted word
+;     == 'a
+;
+;     >> 'a; illegal quoted word
+;     ** Syntax Error: invalid "word" -- "a;"
+;
+; This differs from Rebol2 and Red.  (R3-Alpha had an exception for URL!s, as
+; semicolons are legal in URL content.)
+
+(
+    issue: load "#; ; comment after a one-codepoint issue"
+    did all [
+        issue? issue
+        1 = length of issue
+        59 = codepoint of issue
+        ";" = to text! issue
+    ]
+)(
+    issue: load "# ; comment after a zero-codepoint issue"
+    did all [
+        issue? issue
+        0 = length of issue
+        0 = codepoint of issue
+        'illegal-zero-byte = (trap [to text! issue])/id
+    ]
+)
+
+(
+    q-word: load "'a ; comment after a quoted word"
+    did all [
+        quoted? q-word
+        (first [a]) = unquote q-word
+        'a = unquote q-word
+        "a" = to text! unquote q-word
+    ]
+)(
+    'scan-invalid = (trap [load "'a; illegal quoted word"])/id
+)
+        


### PR DESCRIPTION
Historically, Rebol allowed semicolons to abut directly against
other tokens in order to start a comment:

    rebol2>> load "a;b"
    == a

This was relaxed in Ren-C for URL!, given that semicolon is a valid
character in urls:

    >> load "http://example.com/a;b.html"
    == http://example.com/a;b.html

With the introduction of ISSUE!, there is now another type that could
benefit from allowing semicolons that are not "spaced out" to merge
into the token itself:

    >> if #; = second "a;b" [print "Convenient."]
    Convenient.

However, a policy of "sometimes merging with the token and sometimes
not" seems shaky.

Given the overall theme of space significance in the lexical model,
this makes the shift to where semicolons are only considered comments
when they are spaced out.  Token types that don't accept semicolon
will now raise errors:

    >> load "a;b"
    ** Syntax Error: invalid "word" -- "a;b"

Empirically it does not seem like the idea of such "tight" comments
was very popular (and the Ren-C coding standards prescribe *TWO*
spaces off of the code for line comments).