### PR TITLE
:X :Y/Y :(Z) subvert quoting, not :X :Y/Y (Z)

### DIFF
--- a/scripts/encap.reb
+++ b/scripts/encap.reb
@@ -1332,11 +1332,11 @@ get-encap: function [
 ][
     trap [
         read/part rebol-path 1
-    ] then (func [e <with> return] [
+    ] then e -> [
         print [e]
         print ["Can't check for embedded code in Rebol path:" rebol-path]
         return blank
-    ])
+    ]
 
     compressed-data: any [
         elf-format/get-embedding rebol-path

--- a/src/boot/types.r
+++ b/src/boot/types.r
@@ -74,7 +74,7 @@ void        "returned by actions with no result (neither true nor false)"
             unit        -       -       +       []
 
 blank       "placeholder unit type which acts as conditionally false"
-            unit        +       -       +       []
+            unit        +       -       +       [branch]
 
 ; </ANY-UNIT>
 
@@ -223,19 +223,19 @@ varargs     "evaluator position for variable numbers of arguments"
 ; <ANY-SYM> (order matters, see UNSETIFY_ANY_XXX_KIND())
 
 sym-block   "alternative form of block (that also doesn't evaluate)"
-            array       *       *       *       [block array series]
+            array       *       *       *       [block array series branch]
 
 sym-group   "symbolic form of group! that does not evaluate"
-            array       *       *       *       [group array series]
+            array       *       *       *       [group array series branch]
 
 sym-path    "symbolic form of path! that does not evaluate"
-            sequence    *       *       *       [path sequence]
+            sequence    *       *       *       [path sequence branch]
 
 sym-tuple   "symbolic form of tuple! that does not evaluate"
-            sequence    *       *       *       [tuple sequence]
+            sequence    *       *       *       [tuple sequence branch]
 
 sym-word    "symbolic form of word! that does not evaluate"
-            word        -       *       +       [word]
+            word        -       *       +       [word branch]
 
 ; <ANY-SYM> (order matters, see UNSETIFY_ANY_XXX_KIND())
 
@@ -243,14 +243,14 @@ sym-word    "symbolic form of word! that does not evaluate"
 ; <ANY-PLAIN> (order matters, see UNSETIFY_ANY_XXX_KIND())
 
 block       "array of values that blocks evaluation unless DO is used"
-            array       *       *       *       [block array series]
+            array       *       *       *       [block array series branch]
 
 ; ============================================================================
 ; BEGIN EVALUATOR ACTIVE TYPES, SEE ANY_EVALUATIVE()
 ; ============================================================================
 
 group       "array that evaluates expressions as an isolated group"
-            array       *       *       *       [group array series]
+            array       *       *       *       [group array series branch]
 
 path        "member or refinement selection with execution bias"
             sequence    *       *       *       [path sequence]
@@ -293,13 +293,13 @@ get-group   "array that evaluates and runs GET on the resulting word/path"
             array       *       *       *       [group array series]
 
 get-path    "the value of a path"
-            sequence    *       *       *       [path sequence]
+            sequence    *       *       *       [path sequence branch]
 
 get-tuple   "the value of a tuple"
             sequence    *       *       *       [tuple sequence]
 
 get-word    "the value of a word (variable)"
-            word        -       *       +       [word]
+            word        -       *       +       [word branch]
 
 ; </ANY-GET> (except for ISSUE!)
 
@@ -307,7 +307,7 @@ get-word    "the value of a word (variable)"
 ; ACTION! is the "OneFunction" type in Ren-C https://forum.rebol.info/t/596
 
 action      "an invokable Rebol subroutine"
-            action      +       +       +       []
+            action      +       +       +       [branch]
 
 ; ============================================================================
 ; BEGIN QUOTED RANGE (> 64) AND PSEUDOTYPES (REB_QUOTED < type < 64)
@@ -318,4 +318,4 @@ action      "an invokable Rebol subroutine"
 ; which use the value + REB_64, + REB_64*2, or + REB_64*3)
 
 quoted     "container for arbitrary levels of quoting"
-            quoted       +       +       -      [quoted]
+            quoted       +       +       -      [branch]

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -27,6 +27,7 @@ any-series!
 any-string!
 any-context!
 any-array!  ; replacement for ANY-BLOCK! that doesn't conflate with BLOCK!
+any-branch!
 
 ;-----------------------------------------------------------------------------
 ; Signal that every earlier numbered symbol is for a typeset or datatype...

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -638,7 +638,7 @@ void Virtual_Bind_Deep_To_New_Context(
     REBCTX **context_out,
     const REBVAL *spec
 ) {
-    assert(IS_BLOCK(body_in_out));
+    assert(IS_BLOCK(body_in_out) or IS_SYM_BLOCK(body_in_out));
 
     REBLEN num_vars = IS_BLOCK(spec) ? VAL_LEN_AT(spec) : 1;
     if (num_vars == 0)
@@ -689,8 +689,9 @@ void Virtual_Bind_Deep_To_New_Context(
         // go BACK on it before the index.
         //
         bool in_const = GET_CELL_FLAG(body_in_out, CONST);
-        Init_Block(
+        Init_Any_Array(
             body_in_out,
+            VAL_TYPE(body_in_out),
             Copy_Array_Core_Managed(
                 VAL_ARRAY(body_in_out),
                 VAL_INDEX(body_in_out), // at

--- a/src/core/evaluator/c-eval.c
+++ b/src/core/evaluator/c-eval.c
@@ -960,7 +960,7 @@ bool Eval_Maybe_Stale_Throws(REBFRM * const f)
     // cleaner way of saying the same thing.  So instead, it's given the same
     // meaning in the evaluator as plain GROUP!...which seems wasteful on the
     // surface, but it means dialects can be free to use it to make a
-    // distinction.  Branches use it to mean "do not voidify the result".
+    // distinction.  For instance, it's used to escape soft quoted slots.
 
       case REB_GET_GROUP:
         goto eval_group;
@@ -1138,9 +1138,9 @@ bool Eval_Maybe_Stale_Throws(REBFRM * const f)
                         "set f/(output) void",
                     "]",
                 "]",
-                "either first", f->out, "[",
+                "either first", f->out, "@[",
                     "set first", f->out, "do f",
-                "] [do f]",
+                "] @[do f]",
             "]",
         rebEND);
 

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -113,6 +113,9 @@ REBNATIVE(entrap)
 {
     INCLUDE_PARAMS_OF_ENTRAP;
 
+    if (IS_BLOCK(ARG(code)))
+        Symify(ARG(code));  // request that branch is not voidified
+
     REB_R error = rebRescue(cast(REBDNG*, &Entrap_Dangerous), frame_);
     UNUSED(ARG(code)); // gets used by the above call, via the frame_ pointer
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -1388,6 +1388,9 @@ REBNATIVE(remove_each)
 {
     INCLUDE_PARAMS_OF_REMOVE_EACH;
 
+    if (IS_BLOCK(ARG(body)))
+        Symify(ARG(body));  // request that body "branch" not be voidified
+
     struct Remove_Each_State res;
     res.data = ARG(data);
 
@@ -1518,7 +1521,9 @@ REBNATIVE(map_each)
     INCLUDE_PARAMS_OF_MAP_EACH;
     UNUSED(PAR(vars));
     UNUSED(PAR(data));
-    UNUSED(PAR(body));
+
+    if (IS_BLOCK(ARG(body)))
+        Symify(ARG(body));  // request not to voidify body execution as branch 
 
     return Loop_Each(
         frame_,
@@ -1654,6 +1659,9 @@ REBNATIVE(until)
     if (Cache_Predicate_Throws(D_OUT, predicate))
         return R_THROWN;
 
+    if (IS_BLOCK(ARG(body)))
+        Symify(ARG(body));  // request no branch voidification
+
     do {
         if (Do_Branch_Throws(D_OUT, nullptr, ARG(body))) {
             bool broke;
@@ -1700,6 +1708,9 @@ REBNATIVE(while)
     INCLUDE_PARAMS_OF_WHILE;
 
     Init_Blank(D_OUT); // result if body never runs
+
+    if (IS_BLOCK(ARG(condition)))
+        Symify(ARG(condition));  // request no branch voidification
 
     do {
         if (Do_Branch_Throws(D_SPARE, nullptr, ARG(condition))) {

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -55,6 +55,7 @@ const struct {
     {SYM_ANY_STRING_X, TS_STRING},
     {SYM_ANY_CONTEXT_X, TS_CONTEXT},
     {SYM_ANY_ARRAY_X, TS_ARRAY},
+    {SYM_ANY_BRANCH_X, TS_BRANCH},
 
     {SYM_0, 0}
 };

--- a/src/include/datatypes/sys-frame.h
+++ b/src/include/datatypes/sys-frame.h
@@ -40,7 +40,7 @@
 // !!! Find a better place for this!
 //
 inline static bool IS_QUOTABLY_SOFT(const RELVAL *v) {
-    return IS_GROUP(v) or IS_GET_WORD(v) or IS_GET_PATH(v);
+    return IS_GET_GROUP(v) or IS_GET_WORD(v) or IS_GET_PATH(v);
 }
 
 

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -176,75 +176,61 @@ inline static bool Do_Branch_Core_Throws(
     assert(branch != out and condition != out);
 
     enum Reb_Kind kind = VAL_TYPE(branch);
+    bool voidify = not (kind == REB_QUOTED or ANY_SYM_KIND(kind));
 
   redo:
 
     switch (kind) {
+      case REB_BLANK:
+        Init_Nulled(out);  // !!! Is this a good idea?  Gets voidified...
+        break;
+
       case REB_QUOTED:
         Unquotify(Move_Value(out, branch), 1);
-        return false;
+        break;
 
       case REB_BLOCK:
-        return Do_Any_Array_At_Throws(out, branch, SPECIFIED);
+      case REB_SYM_BLOCK:
+        if (Do_Any_Array_At_Throws(out, branch, SPECIFIED))
+            return true;
+        break;
 
       case REB_ACTION:
-        return RunQ_Throws(
+        if (RunQ_Throws(
             out,
             false, // !fully, e.g. arity-0 functions can ignore condition
             rebU(branch),
             condition, // may be an END marker, if not Do_Branch_With() case
             rebEND // ...but if condition wasn't an END marker, we need one
-        );
-
-      case REB_BLANK:
-        Init_Nulled(out);
-        return false;
-
-      case REB_SYM_WORD:
-      case REB_SYM_PATH: {
-        const bool push_refinements = false;
-        if (Get_If_Word_Or_Path_Throws(
-            out,
-            branch,
-            SPECIFIED,
-            push_refinements
-        )) {
+        )){
             return true;
         }
+        break;
 
-        if (IS_VOID(out))  // need `[:x]` if it's void (unset)
-            fail (Error_Need_Non_Void_Core(branch, SPECIFIED));
+      case REB_SYM_WORD:
+      case REB_SYM_PATH:
+        Plainify(Move_Value(cell, branch));
+        if (Eval_Value_Throws(out, cell, SPECIFIED))
+            return true;
+        break;
 
-        return false; }
-
-      case REB_SYM_GROUP: {
-        assert(cell != nullptr);  // needs GC-safe cell for this case
-
-        // A SYM-GROUP! can be used for opportunistic double-evaluation, e.g.
-        // code which generates a branch -but- that code is run only if the
-        // branch is applicable:
-        //
-        //    >> either 1 (print "prints" [2 + 3]) (print "this too" [4 + 5])
-        //    prints
-        //    this too
-        //    == 5
-        //
-        //    >> either 1 @(print "prints" [2 + 3]) @(print "doesn't" [4 + 5])
-        //    prints
-        //    == 5
-        //
+      case REB_SYM_GROUP:
+      case REB_GROUP:
         if (Do_Any_Array_At_Throws(cell, branch, SPECIFIED))
             return true;
-
+        if (ANY_GROUP(cell))
+            fail ("Branch evaluation cannot produce GROUP!");
         branch = cell;
         kind = VAL_TYPE(branch);
-        goto redo; }  // Note: Could potentially infinite loop if SYM-GROUP!
+        goto redo;
 
       default:
-        break;
+        fail ("Bad branch type");
     }
 
-    fail ("Bad branch type");
+    if (voidify)
+        Voidify_If_Nulled(out);
+    return false;
 }
 
 #define Do_Branch_With_Throws(out,cell,branch,condition) \

--- a/tests/control/either.test.reb
+++ b/tests/control/either.test.reb
@@ -10,8 +10,11 @@
 (1 = either true [1] [2])
 (2 = either false [1] [2])
 
-(null? either true [null] [1])
-(null? either false [1] [null])
+(void? either true [null] [1])
+(void? either false [1] [null])
+
+(null? either true @[null] [1])
+(null? either false [1] @[null])
 
 (error? either true [trap [1 / 0]] [])
 (error? either false [] [trap [1 / 0]])

--- a/tests/control/for-each.test.reb
+++ b/tests/control/for-each.test.reb
@@ -109,7 +109,7 @@
     did all [
         error? trap [for-each [x x] [1 2 3 4] [sum: sum + x]]
         error? trap [
-            for-each (compose [  ; see above
+            for-each :(compose [  ; see above
                 x (bind lit 'x obj1)
             ])[
                 1 2 3 4
@@ -118,7 +118,7 @@
             ]
         ]
         error? trap [
-            for-each (compose [  ; see above
+            for-each :(compose [  ; see above
                 (bind lit 'x obj2) x
             ])[
                 1 2 3 4
@@ -127,7 +127,7 @@
             ]
         ]
         not error? trap [
-            for-each (compose [  ; see above
+            for-each :(compose [  ; see above
                 (bind lit 'x obj1) (bind lit 'x obj2)
             ])[
                 1 2 3 4

--- a/tests/datatypes/function.test.reb
+++ b/tests/datatypes/function.test.reb
@@ -289,7 +289,7 @@
     (lit 'a == litf 'a)
     (a: 10 | 10 == litf :a)
     (lit a: == litf a:)
-    (30 == litf (10 + 20))
+    (30 == litf :(10 + 20))
     (
         o: context [f: 10]
         10 == litf :o/f
@@ -328,7 +328,7 @@
 ]
 ; inline function test
 [#1659 (
-    f: does (reduce [does [true]])
+    f: does :(reduce [does [true]])
     f
 )]
 

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -88,7 +88,7 @@
         a: void
         (trap [a soft])/id = 'need-non-void
     )
-    ([7] = do [(1 + 2) (3 + 4) soft])
+    ([7] = do [:(1 + 2) :(3 + 4) soft])
 ][
     (
         hard: enfixed function [:v [any-value! <variadic>]] [
@@ -199,7 +199,7 @@
             ]
         ]
 
-        either-match (take args) (take args-normal) [null]
+        either-match :(take args) (take args-normal) @null
     ]
     true)
 

--- a/tests/test-framework.r
+++ b/tests/test-framework.r
@@ -54,24 +54,22 @@ make object! compose [
             elide (
                 print mold test-block  ; !!! make this an option
 
-                result: entrap test-block
+                [error result]: trap test-block
                 recycle
             )
 
+            error [
+                spaced ["error" any [to text! error/id | "w/no ID"]]
+            ]
+
+            undefined? 'result [
+                "test returned void"
+            ]
             null? :result [
                 "test returned null"
             ]
-            error? :result [
-                spaced ["error" any [to text! result/id | "w/no ID"]]
-            ]
-
-            elide (result: first result)
-
-            void? :result [
-                "test returned void"
-            ]
             not logic? :result [
-                spaced ["was" (an type of get/any 'result) ", not logic!"]
+                spaced ["was" (an type of :result) ", not logic!"]
             ]
             not :result [
                 "test returned #[false]"

--- a/tools/bootstrap-shim.r
+++ b/tools/bootstrap-shim.r
@@ -49,7 +49,8 @@ trap [
     ; Bypass the voidification for the refinement sake.
     ;
     opt: func [v [<opt> any-value!]] [
-        either blank? :v [null] [:v]
+        if blank? :v [return null]
+        return :v
     ]
 
     QUIT


### PR DESCRIPTION
GET-WORD! and GET-PATH! would subvert "soft quoting" in Rebol2:

    rebol2>> foo: func ['a] [print mold a]

    rebol2>> x: 10

    rebol2>> foo x
    x

    rebol2>> foo :x
    10

However, groups (PAREN!) did not subvert the quoting:

    rebol2>> foo (1 + 2)
    (1 + 2)

This was changed in R3-Alpha in order to allow more complex calculations
to escape quoted slots...at the cost of requiring a slot to be "hard
quoted" in order to get at an actual GROUP!:

    r3-alpha>> foo: func ['a] [print mold a]

    r3-alpha>> foo (1 + 2)
    3

But Ren-C offers a new datatype in the GET-GROUP!.  This means that
"normal-looking" groups can be "quoted normally", while colon-prefixed
groups can be escaped:

    >> foo: func ['a] [print mold a]

    >> foo (1 + 2)
    (1 + 2)

    >> foo :(1 + 2)
    3

This makes the quoting subversion have more of a consistency with the
GET-XXX! types.  And having it possible to have plain GROUP!s be
quoted in a partially evaluative slot opens the doors to making
branching constructs not evaluate plain GROUP!s unless the branch runs:

    >> branchy: func [n] [pick [[<a>] [<b>]] n]

    >> either true (print "a" branchy 1) (print "b" branchy 2)
    a
    == <a>

Those wishing the historical behavior where a GROUP! would run at the
callsite regardless of the branching can still get it, using escaping:

    >> either true :(print "a" branchy 1) :(print "b" branchy 2)
    a
    b
    == <a>

With the behavior for GET-GROUP! understood for branching, this opens
the door for defining what the SYM-GROUP! variations would do.  So
they now allow a branch to request their results "as-is" with no
voidification:

    >> type of (if true [null])
    == #[datatype! void!]

    >> type of (if true @[null])
    ; null