### PR TITLE
Functions can be invisible sometimes, vs always

### DIFF
--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -564,6 +564,7 @@ REBARR *Pop_Paramlist_With_Meta_May_Fail(
                 REB_P_LOCAL,
                 Canon(SYM_RETURN),
                 TS_OPT_VALUE
+                    | FLAGIT_KIND(REB_TS_INVISIBLE)  // return @() intentional
             );
             definitional_return_dsp = DSP;
 

--- a/src/core/functionals/c-adapt.c
+++ b/src/core/functionals/c-adapt.c
@@ -75,9 +75,16 @@ REB_R Adapter_Dispatcher(REBFRM *f)
 
     assert(IDX_ADAPTER_PRELUDE == 0);  // same location as interpreted bodies
 
-    if (Interpreted_Dispatch_Details_0_Throws(discarded, f)) {
+    bool returned;
+    if (Interpreted_Dispatch_Details_0_Throws(&returned, discarded, f)) {
         Move_Value(f->out, discarded);
         return R_THROWN;
+    }
+
+    if (returned) {
+        if (IS_ENDISH_NULLED(discarded))
+            return f->out;
+        return Move_Value(f->out, discarded);
     }
 
     // The second thing to do is update the phase and binding to run the

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -39,7 +39,7 @@
 //
 //  {Process an evaluated argument *inline* as the evaluator loop would}
 //
-//      return: [<opt> any-value!]
+//      return: [<opt> <invisible> any-value!]
 //      value [any-value!]
 //          {BLOCK! passes-thru, ACTION! runs, SET-WORD! assigns...}
 //      expressions [<opt> any-value! <variadic>]
@@ -60,7 +60,7 @@ REBNATIVE(reeval)
 
     REBFLGS flags = EVAL_MASK_DEFAULT;
     if (Reevaluate_In_Subframe_Maybe_Stale_Throws(
-        Init_Void(D_OUT),  // `eval lit (comment "this gives void vs. error")`
+        D_OUT,  // reeval :comment "this should leave old input"
         frame_,
         ARG(value),
         flags,
@@ -68,8 +68,7 @@ REBNATIVE(reeval)
     ))
         return R_THROWN;
 
-    CLEAR_CELL_FLAG(D_OUT, OUT_MARKED_STALE);
-    return D_OUT;
+    return D_OUT;  // don't clear stale flag...act invisibly
 }
 
 

--- a/src/include/datatypes/sys-frame.h
+++ b/src/include/datatypes/sys-frame.h
@@ -1022,3 +1022,12 @@ inline static void FAIL_IF_BAD_RETURN_TYPE(REBFRM *f) {
     if (not Typecheck_Including_Constraints(typeset, f->out))
         fail (Error_Bad_Return_Type(f, VAL_TYPE(f->out)));
 }
+
+inline static void FAIL_IF_NO_INVISIBLE_RETURN(REBFRM *f) {
+    REBACT *phase = FRM_PHASE(f);
+    REBVAL *typeset = ACT_PARAMS_HEAD(phase);
+    assert(VAL_PARAM_SYM(typeset) == SYM_RETURN);
+
+    if (not TYPE_CHECK(typeset, REB_TS_INVISIBLE))
+        fail (Error_Bad_Invisible(f));
+}

--- a/src/include/sys-throw.h
+++ b/src/include/sys-throw.h
@@ -107,6 +107,9 @@ inline static REB_R Init_Thrown_With_Label(
   #endif
 
     Move_Value(&TG_Thrown_Arg, arg);
+    if (GET_CELL_FLAG(arg, UNEVALUATED))
+        SET_CELL_FLAG(&TG_Thrown_Arg, UNEVALUATED);  // for invisible RETURN
+
     return R_THROWN; // for chaining to dispatcher output
 }
 
@@ -118,6 +121,8 @@ static inline void CATCH_THROWN(
 
     UNUSED(thrown);
     Move_Value(arg_out, &TG_Thrown_Arg);
+    if (GET_CELL_FLAG(&TG_Thrown_Arg, UNEVALUATED))
+        SET_CELL_FLAG(arg_out, UNEVALUATED);  // indicates invisible RETURN
 
   #if !defined(NDEBUG)
     SET_END(&TG_Thrown_Arg);

--- a/src/mezz/mezz-dump.r
+++ b/src/mezz/mezz-dump.r
@@ -293,7 +293,7 @@ summarize-obj: function [
         all [
             any-array? :value
             contains-newline value
-            return
+            return @()
         ]
     ]
 ]

--- a/tests/scanner/source-comment.test.reb
+++ b/tests/scanner/source-comment.test.reb
@@ -16,8 +16,7 @@
 ;     >> 'a; illegal quoted word
 ;     ** Syntax Error: invalid "word" -- "a;"
 ;
-; This differs from Rebol2 and Red.  (R3-Alpha had an exception for URL!s, as
-; semicolons are legal in URL content.)
+; This differs from Rebol2 and Red.
 
 (
     issue: load "#; ; comment after a one-codepoint issue"
@@ -47,4 +46,19 @@
     ]
 )(
     'scan-invalid = (trap [load "'a; illegal quoted word"])/id
+)
+
+; Semicolons are technically legal in URL (though many things that auto-scan
+; code to find URLs in text won't include period, semicolon, quotes...)
+(
+    url: load "http://abc;"
+    http://abc; = url
+)
+
+(
+    b: load ";"
+    did all [
+        b = []
+        not new-line? b
+    ]
 )


### PR DESCRIPTION
This makes invisibility a return state that a function can have...but
it can decide that while it is running.  (Previously a function could
be either fully invisible or not at all invisible, based on the
return spec being `return: []` or not.)

Returning invisibly is done by providing the return value via code
to run inside of a @(...) hence just returning invisibly an be done
as easily as @():

     >> foo: func [x] [print [x] return @()]

     >> <before> foo 10
     10
     == <before>

The likely-temporary way to indicate that invisibility is one of the
return options in a spec is by saying `<invisible>`:

    >> vanish-if-odd: func [return: [<invisible> integer!] x] [
           if even? x [return x]
           return @()
       ]

    >> <test> vanish-if-odd 2
    == 2

    >> <test> vanish-if-odd 1
    == <test>

The benefit of having the form for invisible-enabled return done as
giving code is that it can chain, e.g. if you have another function
that is sometimes-invisible and sometimes-not, you can put the call
to that function inside the @(...) and it will be proxied:

    >> vanish-if-even: func [return: [<invisible> integer!] y] [
           return @(vanish-if-odd y + 1)
       ]

    >> <test> vanish-if-even 2
    == <test>

    >> <test> vanish-if-even 1
    == 2

Note that plain RETURN could not do this, because the vanishing case
would appear to be just the same as `RETURN`, which would return void.