### PR TITLE
Remove DEFAULT behavior for CASE/SWITCH

### DIFF
--- a/extensions/console/ext-console-init.reb
+++ b/extensions/console/ext-console-init.reb
@@ -254,8 +254,7 @@ start-console: function [
     skin-file: case [
         file? skin [skin]
         object? skin [blank]
-        default [%console-skin.reb]
-    ]
+    ] else [%console-skin.reb]
 
     loud-print "Starting console..."
     loud-print newline
@@ -440,9 +439,8 @@ ext-console-impl: function [
             handle! [  ; means "evaluator hook request" (handle is the hook)
                 state
             ]
-            default [
-                emit [fail [{Bad console instruction:} (<*> mold state)]]
-            ]
+        ] else [
+            emit [fail [{Bad console instruction:} (<*> mold state)]]
         ]
     ]
 
@@ -498,8 +496,8 @@ ext-console-impl: function [
             integer! [result/arg1]  ; Note: may be too big for status range
 
             error! [1]  ; currently there's no default error-to-int mapping
-
-            default [1]  ; generic error code
+        ] else [
+            1  ; generic error code
         ]
     ]
 

--- a/extensions/event/make-spec.r
+++ b/extensions/event/make-spec.r
@@ -12,9 +12,7 @@ depends: compose [
         'Windows [
             [%event/event-windows.c]
         ]
-
-        default [
-            [%event/event-posix.c]
-        ]
+    ] else [
+        [%event/event-posix.c]
     ])
 ]

--- a/extensions/filesystem/make-spec.r
+++ b/extensions/filesystem/make-spec.r
@@ -14,14 +14,12 @@ depends: compose [
         'Windows [
             [%filesystem/file-windows.c]
         ]
-
-        default [
-            ; Linux and OS/X stick to POSIX for file I/O for now
-            ; Other options exist, e.g. "aio.h"
-            ; https://fwheel.net/aio.html
-            ;
-            [%filesystem/file-posix.c]
-        ]
+    ] else [
+        ; Linux and OS/X stick to POSIX for file I/O for now
+        ; Other options exist, e.g. "aio.h"
+        ; https://fwheel.net/aio.html
+        ;
+        [%filesystem/file-posix.c]
     ])
 
     (if "1" = get-env "USE_BACKDATED_GLIBC" [

--- a/extensions/gif/mod-gif.c
+++ b/extensions/gif/mod-gif.c
@@ -362,8 +362,7 @@ REBNATIVE(decode_gif)
     REBVAL *result = rebValue("case [",
         "empty?", frames, "[FAIL {No frames found in GIF}]",
         "1 = length of", frames, "[first", frames, "]",
-        "default [", frames, "]",
-    "]", rebEND);
+    "] else [", frames, "]", rebEND);
 
     rebRelease(frames);
 

--- a/extensions/javascript/prep-libr3-js.reb
+++ b/extensions/javascript/prep-libr3-js.reb
@@ -424,7 +424,7 @@ map-each-api [
         ] else [
             copy {}
         ]
-        append return-code trim/auto copy switch js-returns [
+        append return-code trim/auto copy (switch js-returns [
           "'string'" [
             ;
             ; If `char *` is returned, it was rebAlloc'd and needs to be freed
@@ -448,14 +448,12 @@ map-each-api [
                 })
             }
           ]
+        ] else [
+            ; !!! Doing return and argument transformation needs more work!
+            ; See suggestions: https://forum.rebol.info/t/817
 
-          ; !!! Doing return and argument transformation needs more work!
-          ; See suggestions: https://forum.rebol.info/t/817
-
-          default [
             {return a}
-          ]
-        ]
+        ])
 
         e-cwrap/emit cscape/with {
             reb.$<No-Reb-Name>_qlevel = function() {

--- a/extensions/library/make-spec.r
+++ b/extensions/library/make-spec.r
@@ -11,9 +11,7 @@ depends: compose [
         'Windows [
             [%library/library-windows.c]
         ]
-
-        default [
-            [%library/library-posix.c]
-        ]
+    ] else [
+        [%library/library-posix.c]
     ])
 ]

--- a/extensions/odbc/make-spec.r
+++ b/extensions/odbc/make-spec.r
@@ -1,6 +1,7 @@
 REBOL []
 
 name: 'ODBC
+
 source: [
     %odbc/mod-odbc.c
 
@@ -21,21 +22,21 @@ source: [
     ;
     <msc:/wd4201>
 ]
+
 includes: [
     %prep/extensions/odbc ;for %tmp-ext-odbc-init.inc
 ]
+
 libraries: switch system-config/os-base [
     'Windows [
         [%odbc32]
     ]
-
+] else [
     ; On some systems (32-bit Ubuntu 12.04), odbc requires ltdl
     ;
-    default [
-        append copy [%odbc] all [
-            not find [no false off _ #[false]] user-config/odbc-requires-ltdl
-            %ltdl
-        ]
+    append copy [%odbc] all [
+        not find [no false off _ #[false]] user-config/odbc-requires-ltdl
+        %ltdl
     ]
 ]
 

--- a/extensions/odbc/mod-odbc.c
+++ b/extensions/odbc/mod-odbc.c
@@ -503,8 +503,7 @@ SQLRETURN ODBC_BindParameter(
                 v, "> 4294967295 [", rebI(SQL_C_UBIGINT), "]",
                 v, "> 2147483647 [", rebI(SQL_C_ULONG), "]",
                 v, "< -2147483648 [", rebI(SQL_C_SBIGINT), "]",
-                "default [", rebI(SQL_C_LONG), "]",
-            "]",
+            "] else [", rebI(SQL_C_LONG), "]",
         "]",
         "decimal! [", rebI(SQL_C_DOUBLE), "]",
         "time! [", rebI(SQL_C_TYPE_TIME), "]",
@@ -517,7 +516,8 @@ SQLRETURN ODBC_BindParameter(
         "]",
         "text! [", rebI(SQL_C_WCHAR), "]",
         "binary! [", rebI(SQL_C_BINARY), "]",
-        "default [ fail {Non-SQL-mappable type used in parameter binding} ]",
+
+        "fail {Non-SQL-mappable type used in parameter binding}",
     "]");
 
     SQLSMALLINT sql_type;

--- a/extensions/process/make-spec.r
+++ b/extensions/process/make-spec.r
@@ -12,10 +12,8 @@ depends: switch system-config/os-base [
     'Windows [
         [%process/call-windows.c]
     ]
-
-    default [
-        [%process/call-posix.c]
-    ]
+] else [
+    [%process/call-posix.c]
 ]
 
 includes: copy [

--- a/extensions/serial/make-spec.r
+++ b/extensions/serial/make-spec.r
@@ -11,10 +11,8 @@ depends: compose [
         'Windows [
             [%serial/serial-windows.c]
         ]
-
-        default [
-            [%serial/serial-posix.c]
-        ]
+    ] else [
+        [%serial/serial-posix.c]
     ])
 ]
 

--- a/extensions/stdio/make-spec.r
+++ b/extensions/stdio/make-spec.r
@@ -13,9 +13,7 @@ depends: compose [
         'Windows [
             [%stdio/stdio-windows.c %stdio/readline-windows.c]
         ]
-
-        default [
-            [%stdio/stdio-posix.c %stdio/readline-posix.c]
-        ]
+    ] else [
+        [%stdio/stdio-posix.c %stdio/readline-posix.c]
     ]))
 ]

--- a/extensions/stdio/p-stdio.c
+++ b/extensions/stdio/p-stdio.c
@@ -144,8 +144,7 @@ REBVAL *Read_Line(STD_TERM *t)
 
                     "'clear [#c]",
 
-                    "default [#]",
-                "]",
+                "] else [#]",  // unboxes as '\0'
             rebEND);
 
             switch (c) {

--- a/extensions/tcc/ext-tcc-init.reb
+++ b/extensions/tcc/ext-tcc-init.reb
@@ -313,9 +313,7 @@ compile: function [
             file! [  ; Just an example idea... reading disk files?
                 as text! read item
             ]
-            default [
-                fail ["COMPILABLES currently must be TEXT!/ACTION!/FILE!"]
-            ]
+            fail ["COMPILABLES currently must be TEXT!/ACTION!/FILE!"]
         ]
     ]
 
@@ -364,9 +362,7 @@ compile: function [
                     {(e.g. in %make/prep/include)}
                 ]
             ]
-            default [
-                fail ["Invalid LIBREBOL_INCLUDE_DIR:" config/librebol-path]
-            ]
+            fail ["Invalid LIBREBOL_INCLUDE_DIR:" config/librebol-path]
         ]
 
         if not exists? config/librebol-path/rebol.h [

--- a/extensions/time/make-spec.r
+++ b/extensions/time/make-spec.r
@@ -11,10 +11,8 @@ depends: compose [
         'Windows [
             [%time/time-windows.c]
         ]
-
-        default [
-            [%time/time-posix.c]
-        ]
+    ] else [
+        [%time/time-posix.c]
     ])
 ]
 

--- a/extensions/zeromq/make-spec.r
+++ b/extensions/zeromq/make-spec.r
@@ -6,10 +6,12 @@ source: [
 
     ; !!! Put things like <msc:/wdXXXX> here if needed
 ]
+
 includes: [
     %prep/extensions/zeromq ;for %tmp-ext-zeromq-init.inc
     ;"C:\Program Files\ZeroMQ 4.0.4\include"
 ]
+
 libraries: switch system-config/os-base [
     'Windows [
         [
@@ -17,9 +19,8 @@ libraries: switch system-config/os-base [
             ;"C:\Program Files\ZeroMQ 4.0.4\lib\libzmq-v120-mt-gd-4_0_4.lib"
         ]
     ]
-    default [
-        [%zmq]
-    ]
+] else [
+    [%zmq]
 ]
 
 options: [

--- a/make.r
+++ b/make.r
@@ -119,10 +119,9 @@ for-each [name value] options [
                 ]
             ]
         ]
-        default [
-            set in user-config (to-word replace/all to text! name #"_" #"-")
-                attempt [load value] else [value]
-        ]
+    ] else [
+        set in user-config (to-word replace/all to text! name #"_" #"-")
+            attempt [load value] else [value]
     ]
 ]
 
@@ -577,7 +576,7 @@ gen-obj: func [
     ;
     if block? s [
         for-each flag next s [
-            append flags opt switch flag [
+            append flags opt (switch flag [  ; weird bootstrap ELSE needs ()
                 <no-uninitialized> [
                     [
                         <gnu:-Wno-uninitialized>
@@ -633,11 +632,9 @@ gen-obj: func [
                     standard: 'c
                     _
                 ]
-
-                default [
-                    ensure [text! tag!] flag
-                ]
-            ]
+            ] else [
+                try ensure [text! tag!] flag
+            ])
         ]
         s: s/1
     ]
@@ -649,8 +646,10 @@ gen-obj: func [
         source: to-file case [
             dir [join dir s]
             main [s]
-            default [join src-dir s]
+        ] else [
+            join src-dir s
         ]
+
         output: to-obj-path to text! ;\
             either main [
                 join %main/ (last ensure path! s)
@@ -934,7 +933,8 @@ help: function [topic [text! blank!]] [
         msg: select help-topics topic [
             print msg
         ]
-        default [print help-topics/usage]
+    ] else [
+        print help-topics/usage
     ]
 ]
 
@@ -1439,10 +1439,8 @@ process-module: func [
                     ; #object-library has already been taken care of above
                     ; if s/class = #object-library [s]
                 ]
-                default [
-                    dump s
-                    fail [type of s "can't be a dependency of a module"]
-                ]
+                (elide dump s)
+                fail [type of s "can't be a dependency of a module"]
             ]
         ]
         libraries: try all [
@@ -1459,12 +1457,7 @@ process-module: func [
                     ][
                         lib
                     ]
-                    default [
-                        fail [
-                            "unrecognized module library" lib
-                            "in module" mod
-                        ]
-                    ]
+                    fail ["unrecognized library" lib "in module" mod]
                 ]
             ]
         ]
@@ -1665,10 +1658,8 @@ add-new-obj-folders: function [
             #object-library [
                 lib: lib/depends
             ]
-            default [
-                dump lib
-                fail ["unexpected class"]
-            ]
+            (elide dump lib)
+            fail ["unexpected class"]
         ]
 
         for-each obj lib [

--- a/scripts/prot-http.r
+++ b/scripts/prot-http.r
@@ -99,8 +99,7 @@ read-sync-awake: function [return: [logic!] event [event!]] [
             event/port/error: _
             fail error
         ]
-        default [false]
-    ]
+    ] else [false]
 ]
 
 http-awake: function [return: [logic!] event [event!]] [
@@ -160,8 +159,7 @@ http-awake: function [return: [logic!] event [event!]] [
             close http-port
             res
         ]
-        default [true]
-    ]
+    ] else [true]
 ]
 
 make-http-error: func [

--- a/scripts/prot-tls.r
+++ b/scripts/prot-tls.r
@@ -1176,10 +1176,10 @@ parse-messages: function [
                                         curve-list-length: grab-int 'bin 2
                                         curve-list: grab 'bin curve-list-length
                                     ]
-                                    default [
-                                        dummy: grab 'bin extension-length
-                                    ]
+                                ] else [
+                                    dummy: grab 'bin extension-length
                                 ]
+
                             ]
                             assert [check-length = extensions-list-length]
                         ]

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -844,9 +844,8 @@ redbol-form: form: emulate [
                     redbol-form :item
                 ]
             ]
-            default [
-                form value
-            ]
+        ] else [
+            form value
         ]
     ]
 ]
@@ -858,7 +857,8 @@ print: emulate [
     ][
         write-stdout case [
             block? :value [spaced value]
-            default [form :value]
+        ] else [
+            form :value
         ]
         write-stdout newline
     ]

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -1190,24 +1190,16 @@ REBNATIVE(switch)
 //      return: "Former value or branch result, can only be null if no target"
 //          [<opt> any-value!]
 //      :target "Word or path which might be set--no target always branches"
-//          [<skip> set-word! set-path!]
+//          [set-word! set-path!]
 //      'branch "If target not set already, this is evaluated and stored there"
 //          [any-branch!]
-//      :look "Variadic lookahead used to make sure at end if no target"
-//          [<variadic>]
 //      /only "Consider target being BLANK! to be a value not to overwrite"
 //  ][
-//      if unset? 'target [  ; `case [... default [...]]`
-//          if not tail? look [
-//              fail ["DEFAULT usage with no left hand side must be at <end>"]
-//          ]
-//          return do :branch
-//      ]
 //      if set-path? target [target: compose target]
 //      let gotten
 //      either all [
 //          value? gotten: get/hard target
-//          any [only | not blank? :gotten]
+//          any [only  not blank? :gotten]  ; no comma in bootstrap
 //      ][
 //          :gotten  ; so that `x: y: default z` leads to `x = y`
 //      ][
@@ -1220,17 +1212,6 @@ REBNATIVE(default)
     INCLUDE_PARAMS_OF_DEFAULT;
 
     REBVAL *target = ARG(target);
-
-    if (IS_NULLED(target)) { // e.g. `case [... default [...]]`
-        UNUSED(ARG(look));
-        if (NOT_END(frame_->feed->value))  // !!! shortcut w/variadic for now
-            fail ("DEFAULT usage with no left hand side must be at <end>");
-
-        if (Do_Branch_Throws(D_OUT, D_SPARE, ARG(branch)))
-            return R_THROWN;
-
-        return D_OUT; // NULL is okay in this case
-    }
 
     if (IS_SET_WORD(target))
         Move_Value(D_OUT, Lookup_Word_May_Fail(target, SPECIFIED));

--- a/src/main/main-startup.reb
+++ b/src/main/main-startup.reb
@@ -313,9 +313,8 @@ main-startup: function [
                 assert [empty? instruction]
                 state
             ]
-            default [
-                emit [fail [{Bad console instruction:} (<*> mold state)]]
-            ]
+        ] else [
+            emit [fail [{Bad console instruction:} (<*> mold state)]]
         ]
     ]
 

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -80,10 +80,9 @@ join: function [
     case [
         find any-sequence! type [base: to block! base]
         issue! = type [base: to text! base]
-        default [
-            base: copy base
-            type: _  ; don't apply any conversion at end
-        ]
+    ] else [
+        base: copy base
+        type: _  ; don't apply any conversion at end
     ]
 
     result: switch type of :value [
@@ -94,9 +93,8 @@ join: function [
         action! [
             fail 'base "Can't JOIN an ACTION! onto a series (use APPEND)."
         ]
-        default [
-            append/only base :value
-        ]
+    ] else [
+        append/only base :value
     ]
 
     if type [
@@ -202,7 +200,8 @@ trim: function [
             rule: case [
                 null? with [charset reduce [space tab]]
                 bitset? with [with]
-                default [charset with]
+            ] else [
+                charset with
             ]
 
             if any [all_TRIM lines head_TRIM tail_TRIM] [append rule newline]
@@ -216,7 +215,8 @@ trim: function [
             rule: case [
                 not with [#{00}]
                 bitset? with [with]
-                default [charset with]
+            ] else [
+                charset with
             ]
 
             if not any [head_TRIM tail_TRIM] [

--- a/src/mezz/mezz-dump.r
+++ b/src/mezz/mezz-dump.r
@@ -37,12 +37,11 @@ dump: function [
         case [
             null? :val ["\null\"]
             object? :val [unspaced ["make object! [" (summarize-obj val) "]"]]
-            default [
-                trunc: ~void~
-                append (
-                    mold/limit/truncated :val system/options/dump-size 'trunc
-                ) if trunc ["..."]
-            ]
+        ] else [
+            trunc: ~void~
+            append (
+                mold/limit/truncated :val system/options/dump-size 'trunc
+            ) if trunc ["..."]
         ]
     ]
 
@@ -97,8 +96,8 @@ dump: function [
                 ]
             ]
         ]
-
-        default [dump-one :value]
+    ] else [
+        dump-one :value
     ]
 ]
 

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -71,16 +71,16 @@ description-of: function [
     return: [<opt> text!]
     v [<blank> any-value!]
 ][
-    opt switch type of get/any 'v [
-        void! [blank]
+    switch type of get/any 'v [
+        void! @[null]  ; don't voidify, want actual NULL
         any-array! [spaced ["array of length:" length of v]]
         image! [spaced ["size:" v/size]]
         datatype! [
             spec: ensure object! spec of v  ; "type specs" need simplifying
             copy spec/title
         ]
-        action! [
-            try if meta: meta-of :v [
+        action! @[  ; want null when IF doesn't match
+            if meta: meta-of :v [
                 copy get 'meta/description
             ]
         ]
@@ -88,7 +88,6 @@ description-of: function [
         object! [mold words of v]
         typeset! [mold make block! v]
         port! [mold reduce [v/spec/title v/spec/ref]]
-        default [blank]
     ]
 ]
 

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -176,8 +176,8 @@ prin: function [
         null [return]
         text! char! [value]
         block! [spaced value]
-
-        default [form :value]
+    ] else [
+        form :value
     ]
 ]
 

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -61,8 +61,7 @@ sign-of: func [
     case [
         positive? number [1]
         negative? number [-1]
-        default [0]
-    ]
+    ] else [0]
 ]
 
 extreme-of: func [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -107,9 +107,8 @@ array: function [
         action? :initial [
             loop size [append/only block initial]  ; Called every time
         ]
-        default [
-            append/only/dup block :initial size
-        ]
+    ] else [
+        append/only/dup block :initial size
     ]
     return block
 ]
@@ -252,10 +251,8 @@ reword: function [
                 fail ["Invalid /ESCAPE delimiter block" escape]
             ]
         ]
-
-        default [
-            prefix: ensure delimiter-types escape
-        ]
+    ] else [
+        prefix: ensure delimiter-types escape
     ]
 
     ; To be used in a parse rule, words must be turned into strings, though
@@ -342,7 +339,8 @@ reword: function [
                                 :result
                             ]
                             block! [do :v]
-                            default [:v]
+                        ] else [
+                            :v
                         ]
                     )
                     a:  ; Restart mark of text to copy verbatim to output
@@ -559,8 +557,7 @@ format: function [
             integer! [abs rule]
             text! [length of rule]
             char! [1]
-            default [0]
-        ]
+        ] else [0]
     ]
 
     out: make text! val
@@ -660,16 +657,15 @@ split: function [
                 end
             ]
         ]
-        default [
-            ensure [bitset! text! char! word! tag!] dlm
-            [
-                some [
-                    copy mk1: [to dlm | to end]
-                    (keep/only mk1)
-                    opt thru dlm
-                ]
-                end
+    ] else [
+        ensure [bitset! text! char! word! tag!] dlm
+        [
+            some [
+                copy mk1: [to dlm | to end]
+                (keep/only mk1)
+                opt thru dlm
             ]
+            end
         ]
     ]]
 

--- a/tests/control/case.test.reb
+++ b/tests/control/case.test.reb
@@ -109,7 +109,7 @@
 
 (<a> = case .not [1 = 2 [<a>]])
 (<b> = case .even? [1 [<a>] 2 [<b>]])
-(<b> = case .not [1 = 1 [<a>] default [<b>]])
+(<b> = case .not [1 = 1 [<a>]] else [<b>])
 
 ; Errors on bad branches
 (

--- a/tests/functions/enfix.test.reb
+++ b/tests/functions/enfix.test.reb
@@ -244,7 +244,7 @@
             fail [
                 {enifoo should not run; when arguments are skipped this}
                 {defers the enfix until the next evaluator step.  Otherwise}
-                {`case [1 = 1 [print "good"] default [print "bad"]`}
+                {`case [1 = 1 [print "good"]] else [print "bad"]`}
                 {would print both `good` and `bad`.}
             ]
         ]
@@ -310,7 +310,7 @@
             fail {
                 When arguments are skipped, this defers the enfix until the
                 next evaluator step.  Doing otherwise would mean that
-                `case [1 = 1 [print "good"] default [print "bad"]` would
+                `case [1 = 1 [print "good"]] else [print "bad"]` would
                 print both `good` and `bad`.
             }
         ]

--- a/tools/common-emitter.r
+++ b/tools/common-emitter.r
@@ -129,7 +129,8 @@ cscape: function [
                     case [
                         blank? sub [blank]
                         block? sub [unspaced sub]
-                        default [form sub]
+                    ] else [
+                        form sub
                     ]
                 ]
                 #delimit [try delimit (unspaced [suffix newline]) sub]

--- a/tools/common.r
+++ b/tools/common.r
@@ -104,28 +104,26 @@ to-c-name: function [
         "xor_eq" [copy "_xor_eq_"]
 
         "did" [copy "_did_"]  ; Ren-C addition, replaces not-not `!!`
+    ] else [
+        ;
+        ; If these symbols occur composite in a longer word, they use a
+        ; shorthand; e.g. `foo?` => `foo_q`
 
-        default [
-            ;
-            ; If these symbols occur composite in a longer word, they use a
-            ; shorthand; e.g. `foo?` => `foo_q`
+        for-each [reb c] [
+            #"'"  ""      ; isn't => isnt, don't => dont
+            -   "_"     ; foo-bar => foo_bar
+            *   "_p"    ; !!! because it symbolizes a (p)ointer in C??
+            .   "_"     ; !!! same as hyphen?
+            ?   "_q"    ; (q)uestion
+            !   "_x"    ; e(x)clamation
+            +   "_a"    ; (a)ddition
+            |   "_b"    ; (b)ar
 
-            for-each [reb c] [
-              #"'"  ""      ; isn't => isnt, don't => dont
-                -   "_"     ; foo-bar => foo_bar
-                *   "_p"    ; !!! because it symbolizes a (p)ointer in C??
-                .   "_"     ; !!! same as hyphen?
-                ?   "_q"    ; (q)uestion
-                !   "_x"    ; e(x)clamation
-                +   "_a"    ; (a)ddition
-                |   "_b"    ; (b)ar
-
-            ][
-                replace/all string (form reb) c
-            ]
-
-            string
+        ][
+            replace/all string (form reb) c
         ]
+
+        string
     ]
 
     if empty? string [

--- a/tools/make-boot.r
+++ b/tools/make-boot.r
@@ -445,15 +445,14 @@ hookname: enfixed func [
 ][
     if t/(column) = 0 [return "nullptr"]
 
-    unspaced [prefix propercase-of switch ensure word! t/(column) [
+    unspaced [prefix propercase-of (switch ensure word! t/(column) [
         '+ [as text! t/name]  ; type has its own unique hook
         '* [t/class]        ; type uses common hook for class
         '? ['unhooked]      ; datatype provided by extension
         '- ['fail]          ; service unavailable for type
-        default [
-            t/(column)      ; override with word in column
-        ]
-    ]]
+    ] else [
+        t/(column)      ; override with word in column
+    ])]
 ]
 
 n: 0

--- a/tools/make-file.r
+++ b/tools/make-file.r
@@ -80,11 +80,9 @@ make-file-block-parts: func [
                     ][
                         fail ["Doubled slash found in MAKE FILE! at" item]
                     ]
-
-                    default [
-                        last-was-slash: blank? last item
-                        keep to text! item
-                    ]
+                ] else [
+                    last-was-slash: blank? last item
+                    keep to text! item
                 ]
             ]
 
@@ -128,7 +126,8 @@ make-file-tuple-parts: func [
         item: switch type of tuple/1 [
             group! [do tuple/1]
             block! [fail "Blocks in tuples should reduce or something"]
-            default [tuple/1]
+        ] else [
+            tuple/1
         ]
 
         text: switch type of item [

--- a/tools/native-emitters.r
+++ b/tools/native-emitters.r
@@ -50,15 +50,13 @@ emit-native-proto: function [
             end
         ]
     ] then [
-        append case [
+        append (
             ;
             ; could do tests here to create special buffer categories to
             ; put certain natives first or last, etc. (not currently needed)
             ;
-            default [
-                unsorted-buffer
-            ]
-        ] unspaced [
+            unsorted-buffer
+        ) unspaced [
             newline newline
             {; !!! DO NOT EDIT HERE! This is generated from} _
                 mold the-file _ {line} _ line newline

--- a/tools/rebmake.r
+++ b/tools/rebmake.r
@@ -281,10 +281,9 @@ set-target-platform: func [
         'emscripten [
             target-platform: emscripten
         ]
-        default [
-            print ["Unknown platform:" platform "falling back to POSIX"]
-            target-platform: posix
-        ]
+    ] else [
+        print ["Unknown platform:" platform "falling back to POSIX"]
+        target-platform: posix
     ]
 ]
 
@@ -761,10 +760,9 @@ ld: make linker-class [
             #entry [
                 _
             ]
-            default [
-                dump dep
-                fail "unrecognized dependency"
-            ]
+        ] else [
+            dump dep
+            fail "unrecognized dependency"
         ]
     ]
 
@@ -856,10 +854,8 @@ llvm-link: make linker-class [
             #entry [
                 _
             ]
-            default [
-                dump dep
-                fail "unrecognized dependency"
-            ]
+            (elide dump dep)
+            fail "unrecognized dependency"
         ]
     ]
 ]
@@ -950,10 +946,8 @@ link: make linker-class [
             #entry [
                 _
             ]
-            default [
-                dump dep
-                fail "unrecognized dependency"
-            ]
+            (elide dump dep)
+            fail "unrecognized dependency"
         ]
     ]
 ]
@@ -1280,10 +1274,9 @@ generator-class: make object! [
                     copy project/output
                 ]
             ]
-            default [
-                basename: project/output
-                project/output: join basename suffix
-            ]
+        ] else [
+            basename: project/output
+            project/output: join basename suffix
         ]
 
         project/basename: basename
@@ -1312,10 +1305,7 @@ generator-class: make object! [
             #object-file [
                 setup-output project
             ]
-            default [
-                return
-            ]
-        ]
+        ] else [return]
     ]
 ]
 
@@ -1379,8 +1369,7 @@ makefile: make generator-class [
                             keep case [
                                 file? w [file-to-local w]
                                 file? w/output [file-to-local w/output]
-                                default [w/output]
-                            ]
+                            ] else [w/output]
                         ]
                     ]
                 ]
@@ -1473,10 +1462,8 @@ makefile: make generator-class [
                 #dynamic-extension #static-extension [
                     _
                 ]
-                default [
-                    dump dep
-                    fail ["unrecognized project type:" dep/class]
-                ]
+                (elide dump dep)
+                fail ["unrecognized project type:" dep/class]
             ]
         ]
     ]
@@ -1521,13 +1508,11 @@ Execution: make generator-class [
         'Linux [linux]
         'OSX [osx]
         'Android [android]
-
-        default [
-           print [
-               "Untested platform" system/platform "- assume POSIX compilant"
-           ]
-           posix
+    ] else [
+        print [
+            "Untested platform" system/platform "- assume POSIX compilant"
         ]
+        posix
     ]
 
     gen-cmd-create: :host/gen-cmd-create
@@ -1562,10 +1547,8 @@ Execution: make generator-class [
                     call/shell cmd
                 ]
             ]
-            default [
-                dump target
-                fail "Unrecognized target class"
-            ]
+            (elide dump target)
+            fail "Unrecognized target class"
         ]
     ]
 
@@ -1631,10 +1614,8 @@ Execution: make generator-class [
                     run dep
                 ]
             ]
-            default [
-                dump project
-                fail ["unrecognized project type:" project/class]
-            ]
+            (elide dump project)
+            fail ["unrecognized project type:" project/class]
         ]
     ]
 ]


### PR DESCRIPTION
A trick was explored which allowed DEFAULT to become a "skippable
left-quoting enfix operator".  It gained an additional feature of being
able to be used in CASE or SWITCH:

    case [
       1 = 2 [print "Not run"]
       default [print "This would run"]
    ]

The core of the trick was to make this behave exactly like:

    case [
       1 = 2 [print "Not run"]
       (print "This would run")
    ]

It simply noticed when its left-hand side wasn't a SET-WORD!, and
would decay to this behavior.  The behavior of CASE and SWITCH to let
the last condition value "fall out" if there was no associated code
block to run allowed it to work.

HOWEVER in the era of predicates, the issue becomes more complex.  As
a simple example:

     case .greater? [
         1 2 [print "Not run"]  ; 1 is not greater? than 2
         default [print "The intent would be that this run"]
     ]

The mechanim collapses.  It also points to a question about fallout
in general...showing it cannot let the *input* to the predicate fall
out, but only the *output*...which is less useful.

It also had a problem in its interaction with CASE/ALL, because it
meant the DEFAULT would be run as well...even if no other branches ran.

While exploring this feature was a good exercise, it stands in the way
of progress on predicate development.  And it's covered more rigorously
by ELSE.  Hence this removes this aspect of DEFAULT (it still works
when the left is a SET-WORD! for defaulting variables).