### PR TITLE
Changes to FRAME! and Refinement Model, + REFRAMER

### DIFF
--- a/extensions/ffi/t-routine.c
+++ b/extensions/ffi/t-routine.c
@@ -950,7 +950,7 @@ static REBVAL *callback_dispatcher_core(struct Reb_Callback_Invocation *inv)
         assert(IS_BLANK(RIN_RET_SCHEMA(inv->rin)));
     else {
         DECLARE_LOCAL (param);
-        Init_Param(param, REB_P_NORMAL, Canon(SYM_RETURN), 0);
+        Init_Param(param, REB_P_LOCAL, Canon(SYM_RETURN), FLAGIT_KIND(REB_TS_HIDDEN));
         arg_to_ffi(
             nullptr,  // store must be null if dest is non-null,
             inv->ret,  // destination pointer

--- a/extensions/filesystem/file-posix.c
+++ b/extensions/filesystem/file-posix.c
@@ -330,7 +330,7 @@ static int Read_Directory(REBREQ *dir, REBREQ *file)
     ReqFile(file)->path = rebValue(
         "applique 'local-to-file [",
             "path:", rebT(file_utf8),
-            "dir:", rebL(file_req->modes & RFM_DIR),
+            "dir: if", rebL(file_req->modes & RFM_DIR), "'#",
         "]", rebEND
     );
 
@@ -394,10 +394,9 @@ DEVICE_CMD Open_File(REBREQ *file)
     // printf("Open: %s %d %d\n", path, modes, access);
 
     char *path_utf8 = rebSpell(
-        "applique 'file-to-local [",
+        "applique 'file-to-local/full [",
             "path:", ReqFile(file)->path,
-            "wild:", rebL(req->modes & RFM_DIR),  // !!! necessary?
-            "full: true"
+            "wild: if", rebL(req->modes & RFM_DIR), "'#",  // !!! necessary?
         "]", rebEND
     );
 

--- a/extensions/filesystem/file-windows.c
+++ b/extensions/filesystem/file-windows.c
@@ -196,7 +196,7 @@ static int Read_Directory(REBREQ *dir_req, REBREQ *file_req)
     ReqFile(file_req)->path = rebValue(
         "applique 'local-to-file [",
             "path:", rebR(rebTextWide(info.cFileName)),
-            "dir:", rebL(file->modes & RFM_DIR),
+            "dir: if", rebL(file->modes & RFM_DIR), "'#",
         "]", rebEND
     );
 
@@ -266,10 +266,9 @@ DEVICE_CMD Open_File(REBREQ *file)
         rebJumps("FAIL {No access modes provided to Open_File()}", rebEND);
 
     WCHAR *path_wide = rebSpellWideQ(
-        "applique 'file-to-local [",
+        "applique 'file-to-local/full [",
             "path:", ReqFile(file)->path,
-            "wild:", rebL(req->modes & RFM_DIR),
-            "full: true",
+            "wild: if", rebL(req->modes & RFM_DIR), "'#",
         "]",
     rebEND);
 

--- a/extensions/gob/t-gob.c
+++ b/extensions/gob/t-gob.c
@@ -835,7 +835,8 @@ REB_R PD_Gob(
 
     if (IS_INTEGER(picker))
         return rebValueQ(
-            rebU(NATIVE_VAL(pick)), SPECIFIC(ARR_AT(gob, IDX_GOB_PANE)), picker,
+            rebU(NATIVE_VAL(pick)),
+                SPECIFIC(ARR_AT(gob, IDX_GOB_PANE)), SPECIFIC(picker),
         rebEND);
 
     return R_UNHANDLED;

--- a/extensions/javascript/ext-javascript-init.reb
+++ b/extensions/javascript/ext-javascript-init.reb
@@ -16,6 +16,6 @@ REBOL [
 init-javascript-extension
 
 
-js-awaiter: specialize 'js-native [awaiter: true]
+js-awaiter: :js-native/awaiter
 
 sys/export [js-native js-awaiter]  ; !!! Hacky export scheme

--- a/extensions/process/ext-process-init.reb
+++ b/extensions/process/ext-process-init.reb
@@ -55,7 +55,7 @@ call*: adapt 'call-internal* [
 ; ahead and keeps the asynchronous behavior in a lower level and chooses to
 ; /WAIT by default.
 ;
-call: specialize 'call* [wait: true]
+call: :call*/wait
 
 parse-command-to-argv*: function [
     {Helper for when POSIX gets a TEXT! and the /SHELL refinement not used}

--- a/extensions/tcc/ext-tcc-init.reb
+++ b/extensions/tcc/ext-tcc-init.reb
@@ -297,14 +297,14 @@ compile: function [
     ; would be to encap the executable you already have as a copy with the
     ; natives loaded into it.
 
-    librebol: _
+    librebol: false
 
     compilables: map-each item compilables [
         item: maybe if match [word! path!] :item [get item]
 
         switch type of :item [
             action! [
-                librebol: /librebol
+                librebol: true
                 :item
             ]
             text! [
@@ -381,7 +381,13 @@ compile: function [
     config/runtime-path: my file-to-local/full
     config/librebol-path: <taken-into-account>  ; COMPILE* does not read
 
-    result: compile*/(files)/(inspect)/(librebol) compilables config
+    result: applique 'compile* [
+        compilables: compilables
+        config: config
+        files: files
+        inspect: inspect
+        librebol: if librebol [#]
+    ]
 
     if inspect [
         print "== COMPILE/INSPECT CONFIGURATION =="
@@ -539,7 +545,7 @@ c99: function [
         print mold settings
     ]
 
-    compile/files/(inspect)/settings compilables settings
+    compile/files/(if inspect [/inspect])/settings compilables settings
     return 0  ; must translate errors into integer codes...
 ]
 

--- a/src/core/c-bind.c
+++ b/src/core/c-bind.c
@@ -496,7 +496,7 @@ REBARR *Copy_And_Bind_Relative_Deep_Managed(
             REBDSP dsp = dsp_orig;
             while (dsp != DSP) {
                 const REBSTR *spelling = VAL_WORD_SPELLING(DS_AT(dsp + 1));
-                Init_Param(param, REB_P_LOCAL, spelling, 0);
+                Init_Param(param, REB_P_LOCAL, spelling, FLAGIT_KIND(REB_TS_HIDDEN));
                 ++dsp;
                 ++param;
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -344,6 +344,8 @@ void Push_Paramlist_Triads_May_Fail(
             );
             if (was_refinement)
                 TYPE_SET(param, REB_TS_REFINEMENT);
+            if (VAL_PARAM_CLASS(param) == REB_P_LOCAL)
+                TYPE_SET(param, REB_TS_HIDDEN);
 
             *flags |= MKF_HAS_TYPES;
             continue;
@@ -474,7 +476,16 @@ void Push_Paramlist_Triads_May_Fail(
         // If the typeset bits contain REB_NULL, that indicates <opt>.
         // But Is_Param_Endable() indicates <end>.
 
-        if (refinement) {
+        if (pclass == REB_P_LOCAL) {
+            Init_Param(
+                DS_PUSH(),
+                REB_P_LOCAL,
+                spelling,  // don't canonize, see #2258
+                TS_OPT_VALUE
+                    | FLAGIT_KIND(REB_TS_HIDDEN)  // must preserve if type block
+            );
+        }
+        else if (refinement) {
             Init_Param(
                 DS_PUSH(),
                 pclass,
@@ -560,6 +571,7 @@ REBARR *Pop_Paramlist_With_Meta_May_Fail(
                 Canon(SYM_RETURN),
                 TS_OPT_VALUE
                     | FLAGIT_KIND(REB_TS_INVISIBLE)  // return @() intentional
+                    | FLAGIT_KIND(REB_TS_HIDDEN)
             );
             definitional_return_dsp = DSP;
 

--- a/src/core/evaluator/c-action.c
+++ b/src/core/evaluator/c-action.c
@@ -113,7 +113,7 @@ inline static void Finalize_Arg(REBFRM *f) {
         and TYPE_CHECK(f->param, REB_TS_NOOP_IF_BLANK)  // e.g. <blank> param
     ){
         SET_CELL_FLAG(f->arg, ARG_MARKED_CHECKED);
-        SET_EVAL_FLAG(f, FULFILL_ONLY);
+        SET_EVAL_FLAG(f, TYPECHECK_ONLY);
         return;
     }
 
@@ -926,6 +926,11 @@ bool Process_Action_Maybe_Stale_Throws(REBFRM * const f)
             fail (Error_Literal_Left_Path_Raw());
     }
 
+    if (GET_EVAL_FLAG(f, FULFILL_ONLY)) {  // only fulfillment, no typecheck
+        assert(GET_CELL_FLAG(f->out, OUT_MARKED_STALE));  // didn't touch out
+        goto skip_output_check;
+    }
+
   //=//// ACTION! ARGUMENTS NOW GATHERED, DO TYPECHECK PASS ///////////////=//
 
     // It might seem convenient to type check arguments while they are being
@@ -1043,8 +1048,8 @@ bool Process_Action_Maybe_Stale_Throws(REBFRM * const f)
         or IS_VALUE_IN_ARRAY_DEBUG(f->feed->array, f_next)
     );
 
-    if (GET_EVAL_FLAG(f, FULFILL_ONLY)) {
-        Init_Nulled(f->out);
+    if (GET_EVAL_FLAG(f, TYPECHECK_ONLY)) {  // <blank> uses this
+        Init_Nulled(f->out);  // by convention: BLANK! in, NULL out
         goto skip_output_check;
     }
 

--- a/src/core/f-extension.c
+++ b/src/core/f-extension.c
@@ -170,10 +170,12 @@ REBNATIVE(load_extension)
     // in the original extension model was very twisty and was a barrier
     // to enhancement.  So trying a monolithic rewrite for starters.
 
-    const RELVAL *script_compressed = ARR_AT(details, IDX_COLLATOR_SCRIPT);
-    const RELVAL *specs_compressed = ARR_AT(details, IDX_COLLATOR_SPECS);
-    const RELVAL *dispatchers_handle
-        = ARR_AT(details, IDX_COLLATOR_DISPATCHERS);
+    const REBVAL *script_compressed
+        = SPECIFIC(ARR_AT(details, IDX_COLLATOR_SCRIPT));
+    const REBVAL *specs_compressed
+        = SPECIFIC(ARR_AT(details, IDX_COLLATOR_SPECS));
+    const REBVAL *dispatchers_handle
+        = SPECIFIC(ARR_AT(details, IDX_COLLATOR_DISPATCHERS));
 
     REBLEN num_natives = VAL_HANDLE_LEN(dispatchers_handle);
     REBNAT *dispatchers = VAL_HANDLE_POINTER(REBNAT, dispatchers_handle);

--- a/src/core/functionals/c-augment.c
+++ b/src/core/functionals/c-augment.c
@@ -185,14 +185,14 @@ REBNATIVE(augment_p)  // see extended definition AUGMENT in %base-defs.r
         SER(varlist)->info.bits = SER(old_varlist)->info.bits;
         INIT_VAL_CONTEXT_VARLIST(ARR_HEAD(varlist), varlist);
 
-        // We fill in the added parameters in the specialization as null for
-        // starters.  They are unspecialized.
+        // We fill in the added parameters in the specialization as undefined
+        // starters.  This is considered to be "unspecialized".
         //
         blockscope {
             RELVAL *temp = ARR_AT(varlist, old_len);
             REBLEN i;
             for (i = 0; i < delta; ++i) {
-                Init_Nulled(temp);
+                Init_Void(temp, SYM_UNDEFINED);
                 temp = temp + 1;
             }
             TERM_ARRAY_LEN(varlist, ARR_LEN(paramlist));

--- a/src/core/functionals/c-hijack.c
+++ b/src/core/functionals/c-hijack.c
@@ -110,7 +110,10 @@ bool Redo_Action_Throws_Maybe_Stale(REBVAL *out, REBFRM *f, REBACT *run)
 
     for (; NOT_END(f->param); ++f->param, ++f->arg, ++f->special) {
         if (Is_Param_Hidden(f->param)) {  // specialized-out parameter
-            assert(GET_CELL_FLAG(f->special, ARG_MARKED_CHECKED));
+            assert(
+                GET_CELL_FLAG(f->special, ARG_MARKED_CHECKED)
+                or VAL_PARAM_CLASS(f->param) == REB_P_LOCAL
+            );
             continue;
         }
 

--- a/src/core/functionals/c-reframer.c
+++ b/src/core/functionals/c-reframer.c
@@ -1,0 +1,237 @@
+//
+//  File: %c-reframer.c
+//  Summary: "Function that can transform arbitrary callsite functions"
+//  Section: datatypes
+//  Project: "Ren-C Language Interpreter and Run-time Environment"
+//  Homepage: https://github.com/metaeducation/ren-c/
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// Copyright 2020 Ren-C Open Source Contributors
+//
+// See README.md and CREDITS.md for more information.
+//
+// Licensed under the GNU Lesser General Public License (LGPL), Version 3.0.
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//=////////////////////////////////////////////////////////////////////////=//
+//
+// REFRAMER allows one to define a function that does generalized transforms
+// on the input of other functions.  Unlike ENCLOSE, it does not specify the
+// exact function it does surgery on the frame of ahead of time.  Instead,
+// each invocation of the reframing action interacts with the instance that
+// follows it at the callsite.
+//
+// A simple example is a function which removes quotes from the first
+// parameter to a function, and adds them back for the result:
+//
+//     requote: reframer func [f [frame!]] [
+//         p: first words of f
+//         num-quotes: quotes of f/(p)
+//
+//         f/(p): dequote f/(p)
+//
+//         return quote/depth do f num-quotes
+//     ]
+//
+//     >> item: first ['''[a b c]]
+//
+//     >> requote append item <d>  ; append doesn't accept QUOTED! items
+//     == '''[a b c <d>]   ; munging frame and result makes it seem to
+//
+// !!! Due to the way that REFRAMER works today, it cannot support a chain
+// of reframers.  e.g. with MY implemented as a reframer, you couldn't say:
+//
+//     >> item: my requote append <d>
+//
+// Being able to do so would require some kind of "compound frame" that could
+// allow MY to push through REQUOTE to see APPEND's arguments.  This sounds
+// technically difficult, though perhaps pared down versions could be made
+// in the near term (e.g. in cases like this, where the reframer takes no
+// arguments of its own)
+//
+
+#include "sys-core.h"
+
+enum {
+    IDX_REFRAMER_SHIM = 0,  // action that can manipulate the reframed frame
+    IDX_REFRAMER_PARAM_INDEX = 1,  // index in shim that receives FRAME!
+    IDX_REFRAMER_MAX
+};
+
+
+// The REFRAMER native specializes out the FRAME! argument of the function
+// being modified when it builds the interface.
+//
+// So the next thing to do is to fulfill the next function's frame without
+// running it, in order to build a frame to put into that specialized slot.
+// Then we run the reframer.
+//
+// !!! As a first cut we build on top of specialize, and look for the
+// parameter by means of a particular labeled void.
+//
+REB_R Reframer_Dispatcher(REBFRM *f)
+{
+    REBARR *details = ACT_DETAILS(FRM_PHASE(f));
+    assert(ARR_LEN(details) == IDX_REFRAMER_MAX);
+
+    REBVAL* shim = SPECIFIC(ARR_AT(details, IDX_REFRAMER_SHIM));
+    assert(IS_ACTION(shim));
+
+    REBVAL* param_index = SPECIFIC(ARR_AT(details, IDX_REFRAMER_PARAM_INDEX));
+    assert(IS_INTEGER(param_index));
+
+    if (IS_END(f_value) or not (IS_WORD(f_value) or IS_PATH(f_value)))
+        fail ("REFRAMER can only currently run on subsequent WORD!/PATH!");
+
+    // First run ahead and make the frame we want from the feed.  We push
+    // the frame so that we can fold the refinements used into it, without
+    // needing to create an intermediate specialized function in the process.
+    //
+    // Note: We do not overwrite f->out in case of invisibility.
+
+    DECLARE_FRAME (sub, f->feed, EVAL_MASK_DEFAULT);
+    Push_Frame(f_spare, sub);
+
+    if (Get_If_Word_Or_Path_Throws(
+        sub->out,  // e.g. f_spare
+        f_value,
+        f_specifier,
+        true  // push_refinements = true (DECLARE_FRAME captured original DSP)
+    )){
+        Drop_Frame(sub);
+        return R_THROWN;
+    }
+
+    if (not IS_ACTION(sub->out))
+        fail (rebUnrelativize(f_value));
+
+    Fetch_Next_Forget_Lookback(sub);  // now, onto the arguments...
+
+    const REBSTR *label = VAL_ACTION_LABEL(sub->out);
+
+    DECLARE_LOCAL (action);
+    Move_Value(action, sub->out);
+    PUSH_GC_GUARD(action);
+
+    REBVAL *first_arg;
+    if (Make_Invocation_Frame_Throws(sub, &first_arg, action)) {
+        DROP_GC_GUARD(action);
+        return R_THROWN;
+    }
+
+    UNUSED(first_arg); // MATCH uses to get its answer faster, we don't need
+
+    REBACT *act = VAL_ACTION(action);
+
+    assert(NOT_SERIES_FLAG(sub->varlist, MANAGED)); // not invoked yet
+    assert(FRM_BINDING(sub) == VAL_BINDING(action));
+
+    REBCTX *stolen = Steal_Context_Vars(CTX(sub->varlist), NOD(act));
+    assert(ACT_NUM_PARAMS(act) == CTX_LEN(stolen));
+
+    INIT_LINK_KEYSOURCE(stolen, NOD(act));
+
+    SET_SERIES_FLAG(sub->varlist, MANAGED); // is inaccessible
+    sub->varlist = nullptr; // just let it GC, for now
+
+    // May not be at end or thrown, e.g. (x: does lit y x = 'y)
+    //
+    DROP_GC_GUARD(action);  // before drop to balance at right time
+    Drop_Frame(sub);
+
+    // The exemplar may or may not be managed as of yet.  We want it
+    // managed, but Push_Action() does not use ordinary series creation to
+    // make its nodes, so manual ones don't wind up in the tracking list.
+    //
+    SET_SERIES_FLAG(stolen, MANAGED); // can't use Manage_Series
+
+    REBVAL *arg = FRM_ARGS_HEAD(f) + VAL_INT32(param_index);
+    Init_Frame(arg, stolen, label);
+
+    INIT_FRM_PHASE(f, VAL_ACTION(shim));
+    FRM_BINDING(f) = VAL_BINDING(shim);
+
+    return R_REDO_CHECKED;  // the redo will use the updated phase & binding
+}
+
+
+//
+//  reframer*: native [
+//
+//  {Make a function that manipulate other actions at the callsite}
+//
+//      return: [action!]
+//      shim "The action that has a FRAME! argument to supply"
+//          [action!]
+//      /parameter "Which parameter of the shim gets given the FRAME!"
+//          [word!]
+//  ]
+//
+REBNATIVE(reframer_p)
+{
+    INCLUDE_PARAMS_OF_REFRAMER_P;
+
+    REBVAL *shim = ARG(shim);
+
+    // Make action as a copy of the input function, with enough space to
+    // store the implementation phase and which parameter to fill with the
+    // frame.
+    //
+    REBARR *paramlist = Copy_Array_Shallow_Flags(
+        VAL_ACT_PARAMLIST(shim),  // same interface as head of pipeline
+        SPECIFIED,
+        SERIES_MASK_PARAMLIST
+            | (SER(VAL_ACTION(shim))->header.bits & PARAMLIST_MASK_INHERIT)
+            | NODE_FLAG_MANAGED
+    );
+    Sync_Paramlist_Archetype(paramlist);  // [0] cell must hold copied pointer
+    MISC_META_NODE(paramlist) = nullptr;  // defaults to being trash
+
+    REBACT *underlying = ACT_UNDERLYING(VAL_ACTION(shim));
+
+    REBACT *reframer = Make_Action(
+        paramlist,
+        &Reframer_Dispatcher,
+        underlying,  // same underlying as shim
+        ACT_EXEMPLAR(VAL_ACTION(shim)),  // same exemplar as shim
+        IDX_REFRAMER_MAX  // details array capacity => [shim, param_index]
+    );
+
+    // Find the parameter they want to overwrite with the frame, or default
+    // to the last unspecialized parameter.
+    //
+    REBVAL *param = nullptr;
+    if (REF(parameter)) {
+        const REBSTR *canon = VAL_WORD_CANON(REF(parameter));
+        REBVAL *temp = ACT_PARAMS_HEAD(reframer);
+        for (; NOT_END(temp); ++temp) {
+            if (VAL_PARAM_CANON(temp) == canon) {
+                param = temp;
+                break;
+            }
+        }
+    }
+    else {  // default parameter to the last unspecialized one
+        param = Last_Unspecialized_Param(reframer);
+    }
+
+    // Set the type bits so that we can get the dispatcher to the point of
+    // running even though we haven't filled in a frame yet.
+    //
+    if (not param)
+        fail ("Could not find parameter for REFRAMER");
+    TYPE_SET(param, REB_TS_HIDDEN);
+    mutable_KIND3Q_BYTE(param) = REB_P_LOCAL;  // so it gets voided
+
+    REBLEN param_index = param - ACT_PARAMS_HEAD(reframer);
+
+    REBARR *details = ACT_DETAILS(reframer);
+    Move_Value(ARR_AT(details, IDX_REFRAMER_SHIM), shim);
+    Init_Integer(ARR_AT(details, IDX_REFRAMER_PARAM_INDEX), param_index);
+
+    return Init_Action(D_OUT, reframer, VAL_ACTION_LABEL(shim), UNBOUND);
+}

--- a/src/core/functionals/c-specialize.c
+++ b/src/core/functionals/c-specialize.c
@@ -155,6 +155,12 @@ REBCTX *Make_Context_For_Action_Push_Partials(
     for (; NOT_END(param); ++param, ++arg, ++special, ++index) {
         Prep_Cell(arg);
 
+        if (VAL_PARAM_CLASS(param) == REB_P_LOCAL) {
+            Init_Void(arg, SYM_LOCAL);
+            SET_CELL_FLAG(arg, ARG_MARKED_CHECKED);
+            continue;
+        }
+
         if (Is_Param_Hidden(param)) {  // specialized out
             assert(GET_CELL_FLAG(special, ARG_MARKED_CHECKED));
             Move_Value(arg, special); // doesn't copy ARG_MARKED_CHECKED
@@ -442,8 +448,8 @@ bool Specialize_Action_Throws(
 
         switch (VAL_PARAM_CLASS(param)) {
           case REB_P_LOCAL:
-            assert(IS_NULLED(arg));  // no bindings, you can't set these
-            goto unspecialized_arg;
+            assert(IS_VOID(arg));  // no bindings, you can't set these
+            goto specialized_arg_no_typecheck;
 
           default:
             break;

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -812,6 +812,13 @@ REBNATIVE(applique)
             continue; // shouldn't have been in the binder
         if (Is_Param_Hidden(key))
             continue; // was part of a specialization internal to the action
+
+        // !!! This is another case where if you want to literaly apply
+        // with ~undefined~ you have to manually hide the frame key.
+        //
+        if (Is_Void_With_Sym(var, SYM_UNDEFINED))
+            Init_Nulled(var);
+
         if (GET_CELL_FLAG(var, ARG_MARKED_CHECKED))
             continue;  // refined in argument
         Remove_Binder_Index(&binder, VAL_KEY_CANON(key));

--- a/src/core/n-do.c
+++ b/src/core/n-do.c
@@ -812,6 +812,8 @@ REBNATIVE(applique)
             continue; // shouldn't have been in the binder
         if (Is_Param_Hidden(key))
             continue; // was part of a specialization internal to the action
+        if (GET_CELL_FLAG(var, ARG_MARKED_CHECKED))
+            continue;  // refined in argument
         Remove_Binder_Index(&binder, VAL_KEY_CANON(key));
     }
     SHUTDOWN_BINDER(&binder); // must do before running code that might BIND

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -1679,7 +1679,7 @@ REBNATIVE(until)
             // continue to run the loop.
         }
 
-        if (not REF(predicate)) {
+        if (IS_NULLED(predicate)) {
             if (IS_TRUTHY(D_OUT))  // fail on voids (neither true nor false)
                 return D_OUT;  // body evaluated truthily, return value
         }

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -199,8 +199,13 @@ REB_R MAKE_Decimal(
 
         DECLARE_LOCAL (temp1);  // decompress path from cell into values
         DECLARE_LOCAL (temp2);
-        const RELVAL *numerator = VAL_SEQUENCE_AT(temp1, arg, 0);
-        const RELVAL *denominator = VAL_SEQUENCE_AT(temp2, arg, 1);
+        const RELVAL *num = VAL_SEQUENCE_AT(temp1, arg, 0);
+        const RELVAL *den = VAL_SEQUENCE_AT(temp2, arg, 1);
+
+        DECLARE_LOCAL (numerator);
+        DECLARE_LOCAL (denominator);
+        Derelativize(numerator, num, VAL_SEQUENCE_SPECIFIER(arg));
+        Derelativize(denominator, den, VAL_SEQUENCE_SPECIFIER(arg));
         PUSH_GC_GUARD(numerator);  // might be GROUP!, so (1.2)/4
         PUSH_GC_GUARD(denominator);
 

--- a/src/core/t-typeset.c
+++ b/src/core/t-typeset.c
@@ -140,17 +140,23 @@ bool Add_Typeset_Bits_Core(
         else
             item = maybe_word; // wasn't variable
 
-        if (IS_TUPLE(item) and rebDidQ("equal?", item, "'<...>", rebEND)) {
-            //
-            // !!! The actual final notation for variadics is not decided
-            // on, so there is compatibility for now with the <...> form
-            // from when that was a TAG! vs. a 5-element TUPLE!  While
-            // core sources were changed to `<variadic>`, asking users
-            // to shuffle should only be done once (when final is known).
-            //
-            TYPE_SET(typeset, REB_TS_VARIADIC);
+        if (IS_TUPLE(item)) {
+            DECLARE_LOCAL (specific);
+            Derelativize(specific, item, VAL_SEQUENCE_SPECIFIER(item));
+            if (rebDidQ("equal?", specific, "'<...>", rebEND)) {
+                //
+                // !!! The actual final notation for variadics is not decided
+                // on, so there is compatibility for now with the <...> form
+                // from when that was a TAG! vs. a 5-element TUPLE!  While
+                // core sources were changed to `<variadic>`, asking users
+                // to shuffle should only be done once (when final is known).
+                //
+                TYPE_SET(typeset, REB_TS_VARIADIC);
+                continue;
+            }
         }
-        else if (IS_TAG(item)) {
+
+        if (IS_TAG(item)) {
             bool strict = false;
 
             if (

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -278,8 +278,8 @@ static bool Subparse_Throws(
 
     // Locals in frame would be void on entry if called by action dispatch.
     //
-    Init_Void(Prep_Cell(ARG(num_quotes)), SYM_LOCAL);
-    Init_Void(Prep_Cell(ARG(position)), SYM_LOCAL);
+    Init_Void(Prep_Cell(ARG(num_quotes)), SYM_UNDEFINED);
+    Init_Void(Prep_Cell(ARG(position)), SYM_UNDEFINED);
 
     // !!! By calling the subparse native here directly from its C function
     // vs. going through the evaluator, we don't get the opportunity to do

--- a/src/include/datatypes/sys-token.h
+++ b/src/include/datatypes/sys-token.h
@@ -188,6 +188,9 @@ inline static REBVAL *Init_Char_May_Fail(RELVAL *out, REBUNI c) {
 // it is also length 0.
 //
 
+#define Init_Blackhole(out) \
+    Init_Char_Unchecked(out, 0)
+
 inline static bool Is_Blackhole(const RELVAL *v) {
     if (not IS_CHAR(v))
         return false;

--- a/src/include/datatypes/sys-typeset.h
+++ b/src/include/datatypes/sys-typeset.h
@@ -451,10 +451,7 @@ inline static bool Is_Typeset_Empty(const RELVAL *param) {
 // dequoting and requoting, etc.  Those are evaluator mechanics for filling
 // the slot--this happens after that.
 //
-inline static void Typecheck_Refinement_And_Canonize(
-    const RELVAL *param,
-    REBVAL *arg
-){
+inline static void Typecheck_Refinement(const RELVAL *param, REBVAL *arg) {
     assert(NOT_CELL_FLAG(arg, ARG_MARKED_CHECKED));
     assert(TYPE_CHECK(param, REB_TS_REFINEMENT));
 
@@ -463,33 +460,8 @@ inline static void Typecheck_Refinement_And_Canonize(
         // Not in use
     }
     else if (Is_Typeset_Empty(param)) {
-        //
-        // Refinements that don't have a corresponding argument are in a
-        // sense LOGIC!-based.  But for convenience, Ren-C canonizes them as
-        // either a NULL or a refinement-style PATH!--providing logical
-        // false/true behavior while making it easier to chain them, e.g.
-        //
-        //    keep: func [value /only] [... append/(only) ...]
-        //
-        // It might be argued that any truthy value should be fair game for
-        // being canonized, but be a bit more conservative to try and catch
-        // likely mistakes.  Accepting refinement-style paths means accepting
-        // one's own canonizations (which seems important) or being able to
-        // use one logic-seeming refinement to assign another.
-        if (
-            (IS_LOGIC(arg) and VAL_LOGIC(arg))
-            or IS_PATH(arg)  // !!! Is this too lax?
-        ){
-            Refinify(Init_Word(arg, VAL_PARAM_SPELLING(param)));
-        }
-        else if (IS_LOGIC(arg)) {
-            assert(not VAL_LOGIC(arg));
-            Init_Nulled(arg);
-        }
-        else if (IS_BLANK(arg))  // give an error to show where this is
-            fail ("Use NULL/FALSE for unused refinements, not BLANK!");
-        else
-            fail (Error_Invalid_Type(VAL_TYPE(arg)));
+        if (not Is_Blackhole(arg))
+            fail ("Parameterless Refinements Must be either # or NULL");
     }
     else if (not Typecheck_Including_Constraints(param, arg))
         fail (Error_Invalid_Type(VAL_TYPE(arg)));

--- a/src/include/datatypes/sys-varargs.h
+++ b/src/include/datatypes/sys-varargs.h
@@ -64,6 +64,36 @@
 #define VAL_VARARGS_PHASE(v) \
     ACT(VAL_VARARGS_PHASE_NODE(v))
 
+inline static REBVAL *Init_Varargs_Untyped_Normal(RELVAL *out, REBFRM *f) {
+    RESET_CELL(out, REB_VARARGS, CELL_MASK_VARARGS);
+    INIT_BINDING(out, f->varlist);  // frame-based VARARGS!
+    UNUSED(VAL_VARARGS_SIGNED_PARAM_INDEX(out));
+    VAL_VARARGS_PHASE_NODE(out) = nullptr;  // set in typecheck
+    return cast(REBVAL*, out);
+}
+
+inline static REBVAL *Init_Varargs_Untyped_Enfix(
+    RELVAL *out,
+    const REBVAL *single
+){
+    REBARR *array1;
+    if (IS_END(single))
+        array1 = EMPTY_ARRAY;
+    else {
+        REBARR *feed = Alloc_Singular(NODE_FLAG_MANAGED);
+        Move_Value(ARR_SINGLE(feed), single);
+
+        array1 = Alloc_Singular(NODE_FLAG_MANAGED);
+        Init_Block(ARR_SINGLE(array1), feed);  // index 0
+    }
+
+    RESET_CELL(out, REB_VARARGS, CELL_MASK_VARARGS);
+    INIT_BINDING(out, array1);
+    UNUSED(VAL_VARARGS_SIGNED_PARAM_INDEX(out));
+    VAL_VARARGS_PHASE_NODE(out) = nullptr;  // set in typecheck
+    return cast(REBVAL*, out);
+}
+
 
 inline static bool Is_Block_Style_Varargs(
     REBVAL **shared_out,

--- a/src/include/datatypes/sys-void.h
+++ b/src/include/datatypes/sys-void.h
@@ -74,6 +74,19 @@ inline static const REBSTR *VAL_VOID_OPT_LABEL(REBCEL(const*) v) {
     return cast(const REBSTR*, VAL_NODE(v));
 }
 
+// Don't let SYM_0 be used for unlabeled void, in case checking for a match
+// with a symbol extracted from a WORD! which has no symbol shorthand.
+//
+inline static bool Is_Void_With_Sym(const RELVAL *v, REBSYM sym) {
+    assert(sym != SYM_0);
+    if (not IS_VOID(v))
+        return false;
+    const REBSTR *label = VAL_VOID_OPT_LABEL(v);
+    if (not label)
+        return false;  // unlabeled
+    return cast(REBLEN, sym) == cast(REBLEN, STR_SYMBOL(label));
+}
+
 
 // Many loop constructs use BLANK! as a unique signal that the loop body
 // never ran, e.g. `for-each x [] [<unreturned>]` or `loop 0 [<unreturned>]`.

--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -263,14 +263,6 @@ Special internal defines used by RT, not Host-Kit developers:
     //
     #define DEBUG_TRACK_CELLS
 
-    // OUT_MARKED_STALE uses the same bit as ARG_MARKED_CHECKED.  But arg
-    // fulfillment uses END as the signal of when no evaluations are done,
-    // it doesn't need the stale bit.  The bit is cleared when evaluating in
-    // an arg slot in the debug build, to make it more rigorous to know that
-    // it was actually typechecked...vs just carrying the OUT_FLAG_STALE over.
-    //
-    #define DEBUG_STALE_ARGS
-
     // See debugbreak.h and REBNATIVE(c_debug_break)...useful!
     //
     #define INCLUDE_C_DEBUG_BREAK_NATIVE

--- a/src/include/sys-rebfrm.h
+++ b/src/include/sys-rebfrm.h
@@ -315,9 +315,12 @@ STATIC_ASSERT(EVAL_FLAG_7_IS_TRUE == NODE_FLAG_CELL);
     FLAG_LEFT_BIT(27)
 
 
-//=//// EVAL_FLAG_28 //////////////////////////////////////////////////////=//
+//=//// EVAL_FLAG_TYPECHECK_ONLY //////////////////////////////////////////=//
 //
-#define EVAL_FLAG_28 \
+// This is used by <blank> to indicate that once the frame is fulfilled, the
+// only thing that should be done is typechecking...don't run the action.
+//
+#define EVAL_FLAG_TYPECHECK_ONLY \
     FLAG_LEFT_BIT(28)
 
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -268,7 +268,7 @@ inherit-meta: func* [
             m2/parameter-notes: make frame! :derived
             for-each [key value] :m1/parameter-notes [
                 if in m2/parameter-notes key [
-                    m2/parameter-notes/(key): :value
+                    m2/parameter-notes/(key): get* 'value  ; !!! VOID!s
                 ]
             ]
         ]
@@ -276,7 +276,7 @@ inherit-meta: func* [
             m2/parameter-types: make frame! :derived
             for-each [key value] :m1/parameter-types [
                 if in m2/parameter-types key [
-                    m2/parameter-types/(key): :value
+                    m2/parameter-types/(key): get* 'value  ; !!! VOID!s
                 ]
             ]
         ]

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -324,6 +324,11 @@ augment: enclose 'augment* func* [f] [
     inherit-meta/augment do f get 'augmentee spec  ; no :augmentee name cache
 ]
 
+reframer: enclose 'reframer* func* [f] [
+    let shim: f/shim: compose :f/shim
+    inherit-meta do f get 'shim
+]
+
 ; The lower-level pointfree function separates out the action it takes, but
 ; the higher level one uses a block.  Specialize out the action, and then
 ; overwrite it in the enclosure with an action taken out of the block.
@@ -342,6 +347,24 @@ pointfree: enclose (specialize* 'pointfree* [
     f/block: skip f/block 1  ; Note: NEXT not defined yet
 
     inherit-meta do f get 'action  ; no :action name cache
+]
+
+
+; REQUOTE is helpful when functions do not accept QUOTED! values.
+;
+requote: reframer func* [
+    {Remove Quoting Levels From First Argument and Re-Apply to Result}
+    f [frame!]
+    <local> p num-quotes result
+][
+    p: first words of f
+    num-quotes: quotes of f/(p)
+
+    f/(p): dequote f/(p)
+    
+    if null? result: do f [return null]
+
+    return quote/depth get/any 'result num-quotes
 ]
 
 

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -38,12 +38,12 @@ probe: func* [
     value [<opt> any-value!]
 ][
     either set? 'value [
-        write-stdout mold :value
+        write-stdout mold get/any 'value
     ][
         write-stdout "; null"  ; MOLD won't take nulls
     ]
     write-stdout newline
-    :value
+    get/any 'value
 ]
 
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -497,15 +497,14 @@ me: enfixed redescribe [
 ](
     ; /ENFIX so `x: 1, x: me + 1 * 10` is 20, not 11
     ;
-    specialize 'shove [set: true, prefix: false]
+    specialize 'shove/set [prefix: false]
 )
 
 my: enfixed redescribe [
     {Update variable using it as the first argument to a prefix operator}
 ](
-    specialize 'shove [set: true, prefix: true]
+    specialize 'shove/set [prefix: true]
 )
-
 
 so: enfixed func [
     {Postfix assertion which won't keep running if left expression is false}
@@ -801,7 +800,7 @@ meth: enfixed func [
         fail [member "must be bound to an ANY-CONTEXT! to use METHOD"]
     ]
     set member bind (
-        func/(gather) compose [((spec)) <in> (context)] body
+        func/(if gather '/gather) compose [((spec)) <in> (context)] body
     ) context
 ]
 

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -84,7 +84,12 @@ description-of: function [
                 copy get 'meta/description
             ]
         ]
-        gob! [spaced ["offset:" v/offset "size:" v/size]]
+        gob! [
+            print ["GOB! is" mold get/any 'v]
+            print ["TYPE is" mold type of get/any 'v]
+            print ["GOB! itself is" mold gob!]
+            spaced ["offset:" v/offset "size:" v/size]
+        ]
         object! [mold words of v]
         typeset! [mold make block! v]
         port! [mold reduce [v/spec/title v/spec/ref]]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -84,12 +84,7 @@ description-of: function [
                 copy get 'meta/description
             ]
         ]
-        gob! [
-            print ["GOB! is" mold get/any 'v]
-            print ["TYPE is" mold type of get/any 'v]
-            print ["GOB! itself is" mold gob!]
-            spaced ["offset:" v/offset "size:" v/size]
-        ]
+        gob! [spaced ["offset:" v/offset "size:" v/size]]
         object! [mold words of v]
         typeset! [mold make block! v]
         port! [mold reduce [v/spec/title v/spec/ref]]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -468,10 +468,10 @@ collect*: func [
             f [frame!]
             <with> out
         ][
-            :f/value then [  ; null won't run block, nor "count" as collected
+            (get/any 'f/value) then @[  ; null won't run block (not collected)
                 f/series: out: default [make block! 16]  ; no null return now
-                :f/value  ; ELIDE leaves as result (DO F invalidates F/VALUE)
-                elide do f
+                get/any 'f/value  ; ELIDE leaves as result
+                elide do f  ; would invalidate f/value (hence ELIDE)
             ]
             ; ^-- failed THEN returns NULL
         ]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -173,7 +173,7 @@ replace: function [
         any-array? :pattern [length of :pattern]
     ]
 
-    while [pos: find/(case_REPLACE) target :pattern] [
+    while [pos: find/(if case_REPLACE [/case]) target :pattern] [
         either action? :replacement [
             ;
             ; If arity-0 action, value gets replacement and pos discarded
@@ -506,9 +506,12 @@ collect-lines: redescribe [
     KEEPed blocks become spaced TEXT!.}
 ] adapt 'collect [  ; https://forum.rebol.info/t/945/1
     body: compose [
-        keep: adapt* specialize* 'keep [
-            line: true, only: false, part: _
-        ] [value: spaced try :value]
+        keep: adapt* specialize* 'keep/line/only [  ; specialize removes args
+            part: 1  ; will be changed to unused
+        ][
+            part: null
+            value: spaced try :value
+        ]
         (as group! body)
     ]
 ]
@@ -519,9 +522,12 @@ collect-text: redescribe [
 ] chain [  ; https://forum.rebol.info/t/945/2
     adapt 'collect [
         body: compose [
-            keep: adapt* specialize* 'keep [
-                line: false, only: false, part: _
+            keep: adapt* specialize* 'keep [  ; specialize removes args
+                line: #  ; will be changed to unused
+                only: #  ; will be changed to unused
+                part: 1  ; will be changed to unused
             ][
+                line: part: only: null
                 value: unspaced try :value
             ]
             (as group! body)

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -507,9 +507,8 @@ collect-lines: redescribe [
 ] adapt 'collect [  ; https://forum.rebol.info/t/945/1
     body: compose [
         keep: adapt* specialize* 'keep/line/only [  ; specialize removes args
-            part: 1  ; will be changed to unused
-        ][
             part: null
+        ][
             value: spaced try :value
         ]
         (as group! body)
@@ -523,11 +522,10 @@ collect-text: redescribe [
     adapt 'collect [
         body: compose [
             keep: adapt* specialize* 'keep [  ; specialize removes args
-                line: #  ; will be changed to unused
-                only: #  ; will be changed to unused
-                part: 1  ; will be changed to unused
+                line: null
+                only: null
+                part: null
             ][
-                line: part: only: null
                 value: unspaced try :value
             ]
             (as group! body)

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -926,7 +926,7 @@ import: function [
             no-share: :no-share
             no-lib: :no-lib
             no-user: :no-user
-            block: true
+            block: #
         ]
     ]
 
@@ -935,7 +935,7 @@ import: function [
         version: version
         no-share: no-share
         no-lib: no-lib
-        import: true  ; !!! original code always passed /IMPORT, should it?
+        import: #  ; !!! original code always passed /IMPORT, should it?
     ]
 
     case [

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -163,6 +163,7 @@
 %functions/predicate.test.reb
 %functions/redescribe.test.reb
 %functions/redo.test.reb
+%functions/reframer.test.reb
 %functions/specialize.test.reb
 %functions/unwind.test.reb
 

--- a/tests/datatypes/quoted.test.reb
+++ b/tests/datatypes/quoted.test.reb
@@ -121,22 +121,23 @@
 ((type of lit ''[a b c]) = quote/depth block! 2)
 
 
-; Some generic actions have been tweaked to know to extend their
-; behavior and incorporate escaping into their results.  This is
-; not necessarily such a "weird" idea, given that you could do
-; things like append to a LIT-PATH!.  However, it should be
-; controlled by something in the function spec vs. be a random
-; list that added the behavior.
+; REQUOTE is a reframing action that removes quoting levels and then puts
+; them back on to the result.
 
-((lit ''''3) == add lit ''''1 2)
+((lit ''''3) == requote add lit ''''1 2)
 
-((lit '''[b c d]) == find ''''[a b c d] 'b)
+((lit '''[b c d]) == requote find ''''[a b c d] 'b)
 
-(null == find ''''[a b c d] 'q)
+(null == requote find ''''[a b c d] 'q)  ; nulls exempt
 
+((lit '(1 2 3 <four>)) == requote append ''(1 2 3) <four>)
+
+('''a/b/c/d/e/f = requote join lit '''a/b/c 'd/e/f)
+
+
+; COPY should be implemented for all types, QUOTED! included.
+;
 ((lit '''[a b c]) == copy lit '''[a b c])
-
-((lit '(1 2 3 <four>)) == append ''(1 2 3) <four>)
 
 
 ; All escaped values are truthy, regardless of what it is they are escaping
@@ -147,12 +148,6 @@
 (did lit ''''''''_)
 (did lit ''''''''#[false])
 (did lit '''''''')
-
-
-; Spliced-oriented processing should "see through" the quote of the appended
-; item, but preserve the quoting level of the appended-to item:
-
-('''a/b/c/d/e/f = join lit '''a/b/c 'd/e/f)
 
 
 ; An escaped word that can't fit in a cell and has to do an additional

--- a/tests/datatypes/void.test.reb
+++ b/tests/datatypes/void.test.reb
@@ -94,6 +94,11 @@
     (~unmodified~ = do "quit ~unmodified~")
 ]
 
+; It's tougher to write generic routines that handle VOID! than to error on
+; them, but a good general routine should probably do it.
+;
+([~abc~ ~def~] = collect [keep ~abc~, keep ~def~])
+
 ; Erroring modes of VOID! are being fetched by WORD! and logic tests.
 ; They are inert values otherwise, so PARSE should treat them such.
 ;

--- a/tests/datatypes/void.test.reb
+++ b/tests/datatypes/void.test.reb
@@ -49,10 +49,10 @@
 (~void~ = applique 'foo [])
 (~void~ = do :foo)
 
-; ~local~ is the type of locals before they are assigned
+; ~undefined~ is the type of locals before they are assigned
 (
     f: func [<local> loc] [get/any 'loc]
-    f = ~local~
+    f = ~undefined~
 )
 
 ; ~undefined~ is the type of things that just were never declared

--- a/tests/functions/modal.test.reb
+++ b/tests/functions/modal.test.reb
@@ -9,27 +9,27 @@
     ])
 
     ([3 ~nulled~] = foo 3)
-    ([3 /y] = foo @(1 + 2))
+    ([3 #] = foo @(1 + 2))
     ([@(1 + 2) ~nulled~] = foo '@(1 + 2))
 
     (did item: 300)
 
     ([304 ~nulled~] = foo item + 4)
-    ([304 /y] = foo @(item + 4))
+    ([304 #] = foo @(item + 4))
     ([@(item + 4) ~nulled~] = foo '@(item + 4))
 
     ([300 ~nulled~] = foo item)
-    ([300 /y] = foo @item)
+    ([300 #] = foo @item)
     ([@item ~nulled~] = foo '@item)
 
     ([[a b] ~nulled~] = foo [a b])
-    ([[a b] /y] = foo @[a b])
+    ([[a b] #] = foo @[a b])
     ([@[a b] ~nulled~] = foo '@[a b])
 
     (did obj: make object! [field: 1020])
 
     ([1020 ~nulled~] = foo obj/field)
-    ([1020 /y] = foo @obj/field)
+    ([1020 #] = foo @obj/field)
     ([@obj/field ~nulled~] = foo '@obj/field)
 ]
 
@@ -41,23 +41,23 @@
     ])
 
     (3 bar = [3 ~nulled~])
-    (@(1 + 2) bar = [3 /y])
+    (@(1 + 2) bar = [3 #])
 
     (did item: 300)
 
     ((item + 4) bar = [304 ~nulled~])
-    (@(item + 4) bar = [304 /y])
+    (@(item + 4) bar = [304 #])
 
     (item bar = [300 ~nulled~])
-    (@item bar = [300 /y])
+    (@item bar = [300 #])
 
     ([a b] bar = [[a b] ~nulled~])
-    (@[a b] bar = [[a b] /y])
+    (@[a b] bar = [[a b] #])
 
     (did obj: make object! [field: 1020])
 
     (obj/field bar = [1020 ~nulled~])
-    (@obj/field bar = [1020 /y])
+    (@obj/field bar = [1020 #])
 ]
 
 [
@@ -70,12 +70,12 @@
     ([a @x /y] = parameters of :foo)
 
     ([10 20 ~nulled~] = foo 10 20)
-    ([10 20 /y] = foo 10 @(20))
+    ([10 20 #] = foo 10 @(20))
 
     (did fooy: :foo/y)
 
     ([a x] = parameters of :fooy)
-    ([10 20 /y] = fooy 10 20)
+    ([10 20 #] = fooy 10 20)
     (
         'bad-refine = (trap [
             fooy/y 10 20
@@ -94,13 +94,13 @@
 ; argument "dissolved", so they can differentiate @(comment "hi") and @(null)
 ; The mechanism used is much like how <end> and <opt> are distinguished.
 [
-    (sensor: func [@arg [<opt> any-value!] /modal] [
+    (sensor: func [@arg [<opt> <end> any-value!] /modal] [
         reduce .try [arg modal semiquoted? 'arg]
     ] true)
 
-    ([_ /modal #[false]] = sensor @(null))
-    ([_ /modal #[true]] = sensor @())
-    ([_ /modal #[true]] = sensor @(comment "hi"))
+    ([_ # #[false]] = sensor @(null))
+    ([_ # #[true]] = sensor @())
+    ([_ # #[true]] = sensor @(comment "hi"))
 
-    ; ([_ /modal #[true]] = sensor @nihil)  ; !!! maybe this should work?
+    ; ([_ # #[true]] = sensor @nihil)  ; !!! maybe this should work?
 ]

--- a/tests/functions/reframer.test.reb
+++ b/tests/functions/reframer.test.reb
@@ -1,0 +1,45 @@
+; reframer.test.reb
+;
+; REQUOTE is implemented as a REFRAMER, and tested with QUOTED!
+; This is where to put additional tests.
+
+
+; Simple test: make sure a reframer which does nothing but echo
+; the built frame matches what we'd expect by building manually.
+(
+    f1: make frame! :append
+    f1/series: [a b c]
+    f1/value: <d>
+    f1/part: null
+    f1/dup: null
+    f1/only: null
+    f1/line: null
+
+    mirror: reframer func [f [frame!]] [f]
+    f1 = mirror append [a b c] <d>
+)
+
+
+; Executing frames is the typical mode of a reframer.
+; It may also execute frames more than once.
+(
+    two-times: reframer func [f [frame!]] [do copy f, do f]
+
+    [a b c <d> <d>] = two-times append [a b c] <d>
+)
+
+
+; Reframers with their own arguments are possible
+(
+    data: []
+
+    bracketer: reframer func [msg f] [
+        append data msg
+        do f
+        append data msg
+    ]
+
+    bracketer "Aloha!" append data <middle>
+
+    data = ["Aloha!" <middle> "Aloha!"]
+)

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -32,11 +32,11 @@
 ]
 
 (
-    append-123: specialize :append [value: [1 2 3] only: true]
+    append-123: specialize :append [value: [1 2 3] only: #]
     [a b c [1 2 3] [1 2 3]] = append-123/dup copy [a b c] 2
 )
 (
-    append-123: specialize :append [value: [1 2 3] only: true]
+    append-123: specialize :append/only [value: [1 2 3]]
     append-123-twice: specialize :append-123 [dup: 2]
     [a b c [1 2 3] [1 2 3]] = append-123-twice copy [a b c]
 )

--- a/tests/redbol/redbol-apply.test.reb
+++ b/tests/redbol/redbol-apply.test.reb
@@ -68,22 +68,21 @@
 
 (error? redbol-apply :make [error! ""])
 
-(/a = redbol-apply func [/a] [a] [#[true]])
+(# = redbol-apply func [/a] [a] [#[true]])
 (null = redbol-apply func [/a] [a] [#[false]])
 (null = redbol-apply func [/a] [a] [])
-(/a = redbol-apply/only func [/a] [a] [#[true]])
+(# = redbol-apply/only func [/a] [a] [#[true]])
 
 (
-    comment {The WORD! false, not #[false]}
+    comment {The WORD! false, not #[false], but allowed in Rebol2}
 
-    e: trap [/a = redbol-apply/only func [/a] [a] [false]]
-    e/id = 'invalid-type
+    # = redbol-apply/only func [/a] [a] [false]
 )
 (null == redbol-apply/only func [/a] [a] [])
-(use [a] [a: true /a = redbol-apply func [/a] [a] [a]])
+(use [a] [a: true # = redbol-apply func [/a] [a] [a]])
 (use [a] [a: false null == redbol-apply func [/a] [a] [a]])
-(use [a] [a: false /a = redbol-apply func [/a] [a] [/a]])
-(use [a] [a: false /a = redbol-apply/only func [/a] [/a] [/a]])
+(use [a] [a: false # = redbol-apply func [/a] [a] [/a]])
+(use [a] [a: false # = redbol-apply/only func [/a] [/a] [/a]])
 (group! == redbol-apply/only (specialize 'of [property: 'type]) [()])
 ([1] == head of redbol-apply :insert [copy [] [1] blank blank])
 ([1] == head of redbol-apply :insert [copy [] [1] blank false])

--- a/tests/scanner/path-tuple.test.reb
+++ b/tests/scanner/path-tuple.test.reb
@@ -95,15 +95,15 @@
             group! sym-group!
         ])
     ][
-        mtype: select/skip mapping (type of value) 2
+        mtype: select/skip mapping (type of get/any 'value) 2
         if mtype [
             value: to mtype collect [
                 for index 1 (length of value) 1 [
-                    keep transform value/(index)
+                    keep transform pick value index
                 ]
             ]
         ]
-        return value
+        return get/any 'value
     ]
 
 

--- a/tools/file-base.r
+++ b/tools/file-base.r
@@ -34,6 +34,7 @@ core: [
     functionals/n-function.c
     functionals/c-hijack.c
     functionals/c-oneshot.c
+    functionals/c-reframer.c
     functionals/c-reskin.c
     functionals/c-specialize.c
     functionals/c-typechecker.c

--- a/tools/make-reb-lib.r
+++ b/tools/make-reb-lib.r
@@ -775,27 +775,33 @@ e-lib/emit {
         #include <string>
         #include <type_traits>
 
+        inline static const void *to_rebarg(nullptr_t val)
+          { return val; }
+
         inline static const void *to_rebarg(const REBVAL *val)
-            { return val; }
+          { return val; }
 
         inline static const void *to_rebarg(const REBINS *ins)
-            { return ins; }
+          { return ins; }
 
         inline static const void *to_rebarg(const char *source)
-            { return source; }  /* not TEXT!, but LOADable source code */
+          { return source; }  /* not TEXT!, but LOADable source code */
 
         inline static const void *to_rebarg(bool b)
-            { return rebL(b); }
+          { return rebL(b); }
 
         inline static const void *to_rebarg(int i)
-            { return rebI(i); }
+          { return rebI(i); }
 
         inline static const void *to_rebarg(double d)
-            { return rebR(rebDecimal(d)); }
+          { return rebR(rebDecimal(d)); }
 
         inline static const void *to_rebarg(const std::string &text)
           { return rebT(text.c_str()); }  /* std::string acts as TEXT! */
 
+        /* !!! ideally this would not be included, but rebEND has to be
+         * handled, and it needs to be a void* (any alignment).  See remarks.
+         */
         inline static const void *to_rebarg(const void *end)
           { return end; }
 


### PR DESCRIPTION
This is a set of changes that will cause a bit of disruption for specializations, but paves the way for new tools.

One of those tools is REFRAMER, explained here:

https://forum.rebol.info/t/introducing-reframer-close-cousin-to-enclose/1395

But what changes here are a couple of things...

**MAKE FRAME! now has `~undefined~` in the unspecialized slots, not NULL**

Previously, it was hard to specialize out arguments.  Now it is easier, because when you assign NULL to something it takes that to mean it is specialized.

     >> parameters of :append
     == [series value /part /only /dup /line]

     >> append-no-part: specialize 'append [part: null]
     >> parameters of :append-no-part
     == [series value /only /dup /line]

This turns it around so that `~undefined~` is now the difficult state to specialize with.  But that's only *one* labeled void... you can still specialize with voids of other labels.

*(Historical Note: When MAKE FRAME! was created, there was no VOID!.  So NULL was what was used.  Had VOID! been around, it probably would have been the natural choice at the time.)*

**Refinements With No Arguments Will be `#` or NULL**

Due to the previous point about NULL being considered a specialized state, this means assigning refinements can be pretty easy.

     f: make frame! :append
     f/only: if condition [#]  ; null if not true, # if true
     a: make action! f  ; will see the NULL or # as specialized

It's easy, though I know it's not as easy as just being able to assign a LOGIC! to f/only.  And I also know that `#` doesn't carry information of the name of the refinement, which breaks the idea of being able to conveniently use it for chaining to call another function with that refinement name.  *(You have to say **whatever/(if refinement [/refinement])** instead of just **whatever/(refinement)**)*.

**But this is for a very good reason that has been thought about deeply.**  Firstly, a refinement which takes a LOGIC! is a very conceptually different thing from a used-or-not refinement.

     foo: func [/ref [logic!]] [ref]

     true = foo/ref true
     false = foo/ref false
     null = foo

That's a tristate.   And we want the NULL state to mean "unspecified" across the board.

So when it comes to the answer for a refinement with *no* arguments, it's going to have to be NULL-and-something.  And we don't want to have to mutate the result to canonize it.

This gives people something that's easy to set to, cheap cell bits, and truthy.

Let me know if this causes any confusion.