### PR TITLE
Limit ADAPT/ENCLOSE/ETC to ACTION!, no WORD!/PATH!

### DIFF
--- a/extensions/console/ext-console-init.reb
+++ b/extensions/console/ext-console-init.reb
@@ -53,14 +53,14 @@ boot-print: redescribe [
     "Prints during boot when not quiet."
 ](
     ; !!! Duplicates code in %main-startup.reb, where this isn't exported.
-    enclose 'print func [f] [if not system/options/quiet [do f]]
+    enclose :print func [f] [if not system/options/quiet [do f]]
 )
 
 loud-print: redescribe [
     "Prints during boot when verbose."
 ](
     ; !!! Duplicates code in %main-startup.reb, where this isn't exported.
-    enclose 'print func [f] [if system/options/verbose [do f]]
+    enclose :print func [f] [if system/options/verbose [do f]]
 )
 
 

--- a/extensions/debugger/ext-debugger-init.reb
+++ b/extensions/debugger/ext-debugger-init.reb
@@ -312,7 +312,7 @@ backtrace: function [
 ; message.  (By using ADAPT you won't see both BREAKPOINT and BREAKPOINT* on
 ; the stack during BACKTRACE...it uses only one frame.)
 ;
-breakpoint: adapt 'breakpoint* [
+breakpoint: adapt :breakpoint* [
     system/console/print-info "BREAKPOINT hit"
 ]
 
@@ -327,7 +327,7 @@ breakpoint: adapt 'breakpoint* [
 ; thin air by using INTERRUPT, which is like a breakpoint but that the
 ; backtrace mechanics can choose not to show.
 ;
-interrupt: adapt 'breakpoint* [
+interrupt: adapt :breakpoint* [
     ;
     ; !!! INTERRUPT doesn't currently print anything; it's assumed that
     ; changing the prompt would be enough (though a status bar message would
@@ -359,7 +359,7 @@ locals: function [return: <void>] [
 ]
 
 
-debug-console: adapt 'console [
+debug-console: adapt :console [
     resumable: true
 
     ; The debug skin is made as a global object, so changes to the skin will

--- a/extensions/event/ext-event-init.reb
+++ b/extensions/event/ext-event-init.reb
@@ -34,7 +34,7 @@ register-event-hooks
 
 ; WAIT* expects block to be pre-reduced, to ease stackless implementation
 ;
-wait: adapt 'wait* [if block? :value [value: reduce value]]
+wait: adapt :wait* [if block? :value [value: reduce value]]
 
 
 sys/make-scheme [

--- a/extensions/javascript/prep-libr3-js.reb
+++ b/extensions/javascript/prep-libr3-js.reb
@@ -896,7 +896,7 @@ e-cwrap/write-emitted
 
 json-collect: function [body [block!]] [
     results: collect compose [
-        keep: adapt 'keep [  ; Emscripten prefixes functions w/underscore
+        keep: adapt :keep [  ; Emscripten prefixes functions w/underscore
             value: unspaced [{"} {_} value {"}]
         ]
         ((body))

--- a/extensions/locale/ext-locale-init.reb
+++ b/extensions/locale/ext-locale-init.reb
@@ -451,7 +451,7 @@ if 'Windows <> first system/platform [
     "za" "Zhuang; Chuang"
     "zu" "Zulu" ]
 
-    hijack 'locale function [
+    hijack :locale function [
         type [word!]
         <static>
         iso-639 (iso-639-table)

--- a/extensions/process/ext-process-init.reb
+++ b/extensions/process/ext-process-init.reb
@@ -11,7 +11,7 @@ REBOL [
 ; amount of C code that CALL has to run.  So things like transforming any
 ; FILE! into local paths are done here.
 ;
-call*: adapt 'call-internal* [
+call*: adapt :call-internal* [
     command: switch type of command [
         text! [
             ; A TEXT! is passed through as-is, and will be interpreted by
@@ -141,6 +141,6 @@ browse*: function [
     fail "Could not open web browser"
 ]
 
-hijack 'browse :browse*
+hijack :browse :browse*
 
 sys/export [call call*]

--- a/extensions/process/tests/call.test.reb
+++ b/extensions/process/tests/call.test.reb
@@ -56,7 +56,7 @@
 
 ; Tests feeding input and taking output from various sources
 [
-    (did echoer: enclose specialize 'call/input/output [
+    (did echoer: enclose specialize :call/input/output [
         command: spaced [
             file-to-local system/options/boot {--suppress "*"} {-qs}
             {--do} {"write-stdout read system/ports/input"}

--- a/extensions/stdio/ext-stdio-init.reb
+++ b/extensions/stdio/ext-stdio-init.reb
@@ -25,7 +25,7 @@ system/ports/input: open [scheme: 'console]
 ; We use HIJACK because if we just overwrote LIB/WRITE-STDOUT with the new
 ; function, it would not affect existing specializations and usages.
 
-hijack 'lib/write-stdout :write-stdout
+hijack :lib/write-stdout :write-stdout
 
 
 ; This is the tab-complete command.  It may be that managing the state as a

--- a/extensions/tcc/tests/tcc-to-disk.r
+++ b/extensions/tcc/tests/tcc-to-disk.r
@@ -30,7 +30,7 @@ write %hello-tcc.c trim/auto {
     }
 }
 
-c99-logged: enclose 'c99 function [f [frame!]] [
+c99-logged: enclose :c99 function [f [frame!]] [
     ; f/runtime: "..."  ; set this to override CONFIG_TCCDIR
 
     fdebug: copy f

--- a/scripts/encap.reb
+++ b/scripts/encap.reb
@@ -1143,7 +1143,10 @@ pe-format: context [
         return (head of exe-data, elide reset)
     ]
 
-    update-embedding: specialize 'update-section [section-name: encap-section-name]
+    update-embedding: specialize :update-section [
+        section-name: encap-section-name
+    ]
+
     get-embedding: function [
         return: [<opt> binary!]
         file [file!]

--- a/scripts/prot-tls.r
+++ b/scripts/prot-tls.r
@@ -406,7 +406,7 @@ update-state: function [
     ctx/mode: new
 ]
 
-update-read-state: specialize 'update-state [
+update-read-state: specialize :update-state [
     direction: 'read
     transitions: [
         <client-hello> [<server-hello>]
@@ -422,7 +422,7 @@ update-read-state: specialize 'update-state [
     ]
 ]
 
-update-write-state: specialize 'update-state [
+update-write-state: specialize :update-state [
     direction: 'write
     transitions: [
         #server-hello-done [<client-key-exchange>]
@@ -997,7 +997,7 @@ grab: enfixed func [
     return set left result  ; must manually assign if SET-WORD! overridden
 ]
 
-grab-int: enfixed enclose 'grab func [f [frame!]] [
+grab-int: enfixed enclose :grab func [f [frame!]] [
     return set f/left (debin [be +] do copy f)
 ]
 

--- a/scripts/r2warn.reb
+++ b/scripts/r2warn.reb
@@ -164,7 +164,7 @@ unless: checked [
 ]
 
 switch: checked [
-    adapt 'switch [
+    adapt :switch [
         for-each c cases [
             lib/all [  ; SWITCH's /ALL would override
                 match [word! path!] c
@@ -249,7 +249,7 @@ op?: deprecated [
 ]
 
 also: checked [
-    adapt 'also [
+    adapt :also [
         all [
             block? :branch
             not semiquoted? 'branch
@@ -287,7 +287,7 @@ exit: deprecated [
 ]
 
 try: checked [
-    adapt 'try [
+    adapt :try [
         ;
         ; Most historical usages of TRY took literal blocks as arguments.
         ; This is a good way of catching them, while allowing new usages.

--- a/scripts/redbol.reb
+++ b/scripts/redbol.reb
@@ -73,11 +73,11 @@ function?: emulate [:action?]
 
 string!: emulate [text!]
 string?: emulate [:text?]
-to-string: emulate [specialize 'to [type: text!]]
+to-string: emulate [specialize :to [type: text!]]
 
 paren!: emulate [group!]
 paren?: emulate [:group?]
-to-paren: emulate [specialize 'to [type: group!]]
+to-paren: emulate [specialize :to [type: group!]]
 
 number!: emulate [any-number!]
 number?: emulate [:any-number?]
@@ -230,7 +230,7 @@ rewrite-spec-and-body: helper [
         ; add support for an EXIT that's a synonym for returning void.
         ;
         insert body [
-            exit: specialize 'return [value: ~unset!~]
+            exit: specialize :return [value: ~unset!~]
         ]
         append spec [<local> exit]  ; FUNC needs it (function doesn't...)
     ]
@@ -566,7 +566,7 @@ do: emulate [
 ]
 
 to: emulate [
-    adapt 'to [
+    adapt :to [
         all [
             :value = group!
             find any-word! type
@@ -721,7 +721,7 @@ collect: emulate [
         let out: any [into, make block! 16]
 
         let keeper: specialize* (
-            enclose* 'insert func* [
+            enclose* :insert func* [
                 f [frame!]
                 <with> out
             ][
@@ -876,7 +876,7 @@ quit: emulate [
 ]
 
 does: emulate [
-    specialize 'redbol-func [spec: []]
+    specialize :redbol-func [spec: []]
 ]
 
 has: emulate [
@@ -895,7 +895,7 @@ has: emulate [
 ; https://forum.rebol.info/t/has-hasnt-worked-rethink-construct/1058
 ;
 object: emulate [
-    specialize 'make [type: object!]
+    specialize :make [type: object!]
 ]
 
 construct: emulate [
@@ -1051,11 +1051,11 @@ denuller: helper [
 ]
 
 if: emulate [denuller :if]
-unless: emulate [denuller adapt 'if [condition: not :condition]]
+unless: emulate [denuller adapt :if [condition: not :condition]]
 case: emulate [denuller :case]
 
 switch: emulate [  ; Ren-C evaluates cases: https://trello.com/c/9ChhSWC4/
-    enclose (augment 'switch [
+    enclose (augment :switch [
         /default "Default case if no others are found"
             [block!]
     ]) func [f [frame!]] [
@@ -1131,7 +1131,7 @@ pick: emulate [denuller :pick]
 
 first: emulate [denuller :first]
 first+: emulate [
-    enclose 'first func [f] [
+    enclose :first func [f] [
         use [loc] [
             loc: f/location
             do f
@@ -1151,8 +1151,8 @@ tenth: emulate [denuller :tenth]
 
 query: emulate [denuller :query]
 wait: emulate [denuller :wait]
-bind?: emulate [denuller specialize 'of [property: 'binding]]
-bound?: emulate [denuller specialize 'of [property: 'binding]]
+bind?: emulate [denuller specialize :of [property: 'binding]]
+bound?: emulate [denuller specialize :of [property: 'binding]]
 
 
 ; https://forum.rebol.info/t/justifiable-asymmetry-to-on-block/751
@@ -1273,7 +1273,7 @@ decloak: emulate [
     redescribe [
         {Decodes a binary string scrambled previously by encloak.}
     ](
-        specialize 'cloaker [decode: true]
+        specialize :cloaker [decode: true]
     )
 ]
 
@@ -1281,13 +1281,13 @@ encloak: emulate [
     redescribe [
         {Scrambles a binary string based on a key.}
     ](
-        specialize 'cloaker [decode: false]
+        specialize :cloaker [decode: false]
     )
 ]
 
 
 write: emulate [
-    adapt (augment 'write [
+    adapt (augment :write [
         /binary "Preserves contents exactly."
         /direct "Opens the port without buffering."
         /no-wait "Returns immediately without waiting if no data."
@@ -1319,7 +1319,7 @@ write: emulate [
 ]
 
 read: emulate [
-    enclose (augment 'read [
+    enclose (augment :read [
         /binary "Preserves contents exactly."
         /direct "Opens the port without buffering."
         /no-wait "Returns immediately without waiting if no data."
@@ -1367,7 +1367,7 @@ read: emulate [
 ; interpretation.  This means bad UTF-8 input that isn't Latin1 will be
 ; misinterpreted...but since Rebol2 would accept any bytes, it's no worse.
 ;
-hijack 'lib/transcode enclose copy :lib/transcode function [f [frame!]] [
+hijack :lib/transcode enclose copy :lib/transcode function [f [frame!]] [
     trap [
         result: lib/do copy f  ; COPY so we can DO it again if needed
     ] then e -> [

--- a/src/core/c-error.c
+++ b/src/core/c-error.c
@@ -999,7 +999,7 @@ REBCTX *Error_Need_Non_Null_Core(const RELVAL *target, REBSPC *specifier) {
 // !!! This error is a placeholder for addressing the issue of using a value
 // to set a refinement that's not a good fit for the refinement type, e.g.
 //
-//     specialize 'append [only: 10]
+//     specialize :append [only: 10]
 //
 // It seems that LOGIC! should be usable, and for purposes of chaining a
 // refinement-style PATH! should be usable too (for using one refinement to

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -1361,7 +1361,7 @@ REB_R Dummy_Dispatcher(REBFRM *f)
 //     ** Script error: append is missing its series argument
 //
 // If push_refinements is used, then it avoids intermediate specializations...
-// e.g. `specialize 'append/dup [part: true]` can be done with one FRAME!.
+// e.g. `specialize :append/dup [part: true]` can be done with one FRAME!.
 //
 bool Get_If_Word_Or_Path_Throws(
     REBVAL *out,

--- a/src/core/functionals/c-adapt.c
+++ b/src/core/functionals/c-adapt.c
@@ -23,7 +23,7 @@
 // that does some amount of pre-processing (which can include modifying the
 // arguments), before the original implementation is called:
 //
-//     >> ap1: adapt 'append [if integer? :value [value: value + 716]]
+//     >> ap1: adapt :append [if integer? :value [value: value + 716]]
 //
 //     >> ap1 [a b c] 304
 //     == [a b c 1020]
@@ -34,7 +34,7 @@
 // "adaptee", as failure to do so could pass bad bit patterns to natives
 // and lead to crashes.
 //
-//    >> negbad: adapt 'negate [number: to text! number]
+//    >> negbad: adapt :negate [number: to text! number]
 //
 //    >> negbad 1020
 //    ** Error: Internal phase disallows TEXT! for its `number` argument
@@ -105,8 +105,8 @@ REB_R Adapter_Dispatcher(REBFRM *f)
 //  {Create a variant of an ACTION! that preprocesses its arguments}
 //
 //      return: [action!]
-//      adaptee "Function or specifying word (preserves word for debug info)"
-//          [action! word! path!]
+//      adaptee "Function to be run after the prelude is complete"
+//          [action!]
 //      prelude "Code to run in constructed frame before adaptee runs"
 //          [block!]
 //  ]
@@ -116,20 +116,6 @@ REBNATIVE(adapt_p)  // see extended definition ADAPT in %base-defs.r
     INCLUDE_PARAMS_OF_ADAPT_P;
 
     REBVAL *adaptee = ARG(adaptee);
-
-    const bool push_refinements = false;
-    if (Get_If_Word_Or_Path_Throws(
-        D_OUT,
-        adaptee,
-        SPECIFIED,
-        push_refinements
-    )){
-        return R_THROWN;
-    }
-
-    if (not IS_ACTION(D_OUT))
-        fail (PAR(adaptee));
-    Move_Value(adaptee, D_OUT);  // Frees D_OUT, and GC safe (in ARG slot)
 
     REBARR *paramlist = Copy_Array_Shallow_Flags(
         VAL_ACT_PARAMLIST(adaptee),  // same interface as head of pipeline

--- a/src/core/functionals/c-augment.c
+++ b/src/core/functionals/c-augment.c
@@ -23,7 +23,7 @@
 // frame, adding new parameters.  It does so without affecting the execution:
 //
 //     >> foo-x: func [x [integer!]] [print ["x is" x]]
-//     >> foo-xy: augment 'foo-x [y [integer!]]
+//     >> foo-xy: augment :foo-x [y [integer!]]
 //
 //     >> foo-x 10
 //     x is 10
@@ -38,7 +38,7 @@
 // is only useful when combined with something like ADAPT or ENCLOSE... to
 // inject in phases of code at a higher level that see these parameters:
 //
-//     >> foo-xy: adapt (augment 'foo-x [y [integer!]]) [print ["y is" y]]
+//     >> foo-xy: adapt (augment :foo-x [y [integer!]]) [print ["y is" y]]
 //
 //     >> foo-xy 10 20
 //     y is 20
@@ -86,10 +86,10 @@ REB_R Augmenter_Dispatcher(REBFRM *f)
 //  {Create an ACTION! variant that acts the same, but has added parameters}
 //
 //      return: [action!]
-//      augmentee [action! word! path!]
-//          "Function or specifying word (preserves word name for debug info)"
-//      spec [block!]
-//          "Spec dialect for words to add to the derived function"
+//      augmentee "Function whose implementation is to be augmented"
+//          [action!]
+//      spec "Spec dialect for words to add to the derived function"
+//          [block!]
 //  ]
 //
 REBNATIVE(augment_p)  // see extended definition AUGMENT in %base-defs.r
@@ -97,20 +97,6 @@ REBNATIVE(augment_p)  // see extended definition AUGMENT in %base-defs.r
     INCLUDE_PARAMS_OF_AUGMENT_P;
 
     REBVAL *augmentee = ARG(augmentee);
-
-    const bool push_refinements = false;
-    if (Get_If_Word_Or_Path_Throws(
-        D_OUT,
-        augmentee,
-        SPECIFIED,
-        push_refinements
-    )){
-        return R_THROWN;
-    }
-
-    if (not IS_ACTION(D_OUT))
-        fail (PAR(augmentee));
-    Move_Value(augmentee, D_OUT);  // Frees D_OUT, and GC safe (in ARG slot)
 
     // We reuse the process from Make_Paramlist_Managed_May_Fail(), which
     // pushes parameters to the stack in groups of three items per parameter.

--- a/src/core/functionals/c-does.c
+++ b/src/core/functionals/c-does.c
@@ -66,7 +66,7 @@ enum {
 // don't need to do anything special to a BLOCK! passed to DO...no copying
 // or otherwise.  Just run it when the function gets called.
 //
-// Yet `does [...]` isn't *quite* like `specialize 'do [source: [...]]`.  The
+// Yet `does [...]` isn't *quite* like `specialize :do [source: [...]]`.  The
 // difference is subtle, but important when interacting with bindings to
 // fields in derived objects.  That interaction cannot currently resolve such
 // bindings without a copy, so it is made on demand.

--- a/src/core/functionals/c-enclose.c
+++ b/src/core/functionals/c-enclose.c
@@ -21,11 +21,11 @@
 //
 // ENCLOSE gives a fully generic ability to make a function that wraps the
 // execution of another.  When the enclosure is executed, a frame is built
-// for the wrapped function--but not executed.  Then that frame is passed to
-// an "outer" function, which can modify the frame arguments and also operate
-// upon the result:
+// for the "inner" (wrapped) function--but not executed.  Then that frame is
+// passed to an "outer" function, which can modify the frame arguments and
+// also operate upon the result:
 //
-//     >> add2x3x+1: enclose 'add func [f [frame!]] [
+//     >> add2x3x+1: enclose :add func [f [frame!]] [
 //            f/value1: f/value1 * 2
 //            f/value2: f/value2 * 3
 //            return 1 + do f
@@ -39,7 +39,7 @@
 // Given the mechanics of FRAME!, it's also possible to COPY the frame for
 // multiple invocations.
 //
-//     >> print2x: enclose 'print func [f [frame!]] [
+//     >> print2x: enclose :print func [f [frame!]] [
 //            do copy f
 //            f/value: append f/value "again!"
 //            do f
@@ -147,9 +147,9 @@ REB_R Encloser_Dispatcher(REBFRM *f)
 //
 //      return: [action!]
 //      inner "Action that a FRAME! will be built for, then passed to OUTER"
-//          [action! word! path!]
+//          [action!]
 //      outer "Gets a FRAME! for INNER before invocation, can DO it (or not)"
-//          [action! word! path!]
+//          [action!]
 //  ]
 //
 REBNATIVE(enclose_p)  // see extended definition ENCLOSE in %base-defs.r
@@ -157,33 +157,7 @@ REBNATIVE(enclose_p)  // see extended definition ENCLOSE in %base-defs.r
     INCLUDE_PARAMS_OF_ENCLOSE_P;
 
     REBVAL *inner = ARG(inner);
-    const bool push_refinements = false;
-    if (Get_If_Word_Or_Path_Throws(
-        D_OUT,
-        inner,
-        SPECIFIED,
-        push_refinements
-    )){
-        return R_THROWN;
-    }
-
-    if (not IS_ACTION(D_OUT))
-        fail (PAR(inner));
-    Move_Value(inner, D_OUT); // Frees D_OUT, and GC safe (in ARG slot)
-
     REBVAL *outer = ARG(outer);
-    if (Get_If_Word_Or_Path_Throws(
-        D_OUT,
-        outer,
-        SPECIFIED,
-        push_refinements
-    )){
-        return R_THROWN;
-    }
-
-    if (not IS_ACTION(D_OUT))
-        fail (PAR(outer));
-    Move_Value(outer, D_OUT);  // Frees D_OUT, and GC safe (in ARG slot)
 
     REBARR *paramlist = Copy_Array_Shallow_Flags(
         VAL_ACT_PARAMLIST(inner),  // new function same interface as `inner`

--- a/src/core/functionals/c-hijack.c
+++ b/src/core/functionals/c-hijack.c
@@ -39,7 +39,7 @@
 //     >> old-foo 10
 //     == 11
 //
-//     >> hijack 'foo func [x] [(old-foo x) + 20]
+//     >> hijack :foo func [x] [(old-foo x) + 20]
 //
 //     >> foo 10
 //     == 31  ; HIJACK'd!
@@ -199,12 +199,12 @@ REB_R Hijacker_Dispatcher(REBFRM *f)
 //
 //  {Cause all existing references to an ACTION! to invoke another ACTION!}
 //
-//      return: [<opt> action!]
-//          {The hijacked action value, null if self-hijack (no-op)}
-//      victim [action! word! path!]
-//          {Action value whose references are to be affected.}
-//      hijacker [action! word! path!]
-//          {The action to run in its place}
+//      return: "The hijacked action value, null if self-hijack (no-op)"
+//          [<opt> action!]
+//      victim "Action whose references are to be affected"
+//          [action!]
+//      hijacker "The action to run in its place"
+//          [action!]
 //  ]
 //
 REBNATIVE(hijack)
@@ -218,34 +218,8 @@ REBNATIVE(hijack)
 {
     INCLUDE_PARAMS_OF_HIJACK;
 
-    const bool push_refinements = false;
-    if (Get_If_Word_Or_Path_Throws(
-        D_OUT,
-        ARG(victim),
-        SPECIFIED,
-        push_refinements
-    )){
-        return R_THROWN;
-    }
-
-    if (not IS_ACTION(D_OUT))
-        fail ("Victim of HIJACK must be an ACTION!");
-    Move_Value(ARG(victim), D_OUT);  // Frees up D_OUT
-    REBACT *victim = VAL_ACTION(ARG(victim));  // GC safe (in ARG slot)
-
-    if (Get_If_Word_Or_Path_Throws(
-        D_OUT,
-        ARG(hijacker),
-        SPECIFIED,
-        push_refinements
-    )){
-        return R_THROWN;
-    }
-
-    if (not IS_ACTION(D_OUT))
-        fail ("Hijacker in HIJACK must be an ACTION!");
-    Move_Value(ARG(hijacker), D_OUT);  // Frees up D_OUT
-    REBACT *hijacker = VAL_ACTION(ARG(hijacker));  // GC safe (in ARG slot)
+    REBACT *victim = VAL_ACTION(ARG(victim));
+    REBACT *hijacker = VAL_ACTION(ARG(hijacker));
 
     if (victim == hijacker)
         return nullptr;  // permitting no-op hijack has some practical uses

--- a/src/core/functionals/c-reframer.c
+++ b/src/core/functionals/c-reframer.c
@@ -20,10 +20,10 @@
 //=////////////////////////////////////////////////////////////////////////=//
 //
 // REFRAMER allows one to define a function that does generalized transforms
-// on the input of other functions.  Unlike ENCLOSE, it does not specify the
-// exact function it does surgery on the frame of ahead of time.  Instead,
-// each invocation of the reframing action interacts with the instance that
-// follows it at the callsite.
+// on the input (and output) of other functions.  Unlike ENCLOSE, it does not
+// specify an exact function it does surgery on the frame of ahead of time.
+// Instead, each invocation of the reframing action interacts with the
+// instance that follows it at the callsite.
 //
 // A simple example is a function which removes quotes from the first
 // parameter to a function, and adds them back for the result:

--- a/src/core/t-function.c
+++ b/src/core/t-function.c
@@ -189,8 +189,8 @@ void MF_Action(REB_MOLD *mo, REBCEL(const*) v, bool form)
 //
 REBTYPE(Action)
 {
-    REBVAL *value = D_ARG(1);
-    REBACT *act = VAL_ACTION(value);
+    REBVAL *action = D_ARG(1);
+    REBACT *act = VAL_ACTION(action);
 
     switch (VAL_WORD_SYM(verb)) {
       case SYM_COPY: {
@@ -243,7 +243,7 @@ REBTYPE(Action)
             Blit_Relative(dest, src);
         TERM_ARRAY_LEN(ACT_DETAILS(proxy), details_len);
 
-        Init_Action(D_OUT, proxy, VAL_ACTION_LABEL(value), VAL_BINDING(value));
+        Init_Action(D_OUT, proxy, VAL_ACTION_LABEL(action), VAL_BINDING(action));
         return D_OUT; }
 
       case SYM_REFLECT: {
@@ -254,26 +254,32 @@ REBTYPE(Action)
         REBSYM sym = VAL_WORD_SYM(property);
         switch (sym) {
           case SYM_BINDING: {
-            if (Did_Get_Binding_Of(D_OUT, value))
+            if (Did_Get_Binding_Of(D_OUT, action))
                 return D_OUT;
             return nullptr; }
+
+          case SYM_LABEL: {
+            const REBSTR *label = VAL_ACTION_LABEL(action);
+            if (not label)
+                return nullptr;
+            return Init_Word(D_OUT, label); }
 
           case SYM_WORDS:
           case SYM_PARAMETERS: {
             bool just_words = (sym == SYM_WORDS);
             return Init_Block(
                 D_OUT,
-                Make_Action_Parameters_Arr(VAL_ACTION(value), just_words)
+                Make_Action_Parameters_Arr(act, just_words)
             ); }
 
           case SYM_TYPESETS:
             return Init_Block(
                 D_OUT,
-                Make_Action_Typesets_Arr(VAL_ACTION(value))
+                Make_Action_Typesets_Arr(act)
             );
 
           case SYM_BODY:
-            Get_Maybe_Fake_Action_Body(D_OUT, value);
+            Get_Maybe_Fake_Action_Body(D_OUT, action);
             return D_OUT;
 
           case SYM_TYPES: {

--- a/src/main/main-startup.reb
+++ b/src/main/main-startup.reb
@@ -37,13 +37,13 @@ host-prot: default [_]
 boot-print: redescribe [
     "Prints during boot when not quiet."
 ](
-    enclose 'print func [f] [if not system/options/quiet [do f]]
+    enclose :print func [f] [if not system/options/quiet [do f]]
 )
 
 loud-print: redescribe [
     "Prints during boot when verbose."
 ](
-    enclose 'print func [f] [if system/options/verbose [do f]]
+    enclose :print func [f] [if system/options/verbose [do f]]
 )
 
 make-banner: function [
@@ -324,12 +324,12 @@ main-startup: function [
     ; calls, the rebPanic() API dispatches to PANIC and PANIC-VALUE.  Hook
     ; them just to show we can...use I/O to print a message.
     ;
-    hijack 'panic adapt (copy :panic) [
+    hijack :panic adapt (copy :panic) [
         print "PANIC ACTION! called (explicitly or by rebPanic() API)"
         ;
         ; ...adaptation falls through to our copy of the original PANIC
     ]
-    hijack 'panic-value adapt (copy :panic-value) [
+    hijack :panic-value adapt (copy :panic-value) [
         print "PANIC-VALUE ACTION! called (explicitly or by rebPanic() API)"
         ;
         ; ...adaptation falls through to our copy of the original PANIC-VALUE

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -284,23 +284,23 @@ inherit-meta: func* [
     return get 'derived  ; no :derived name cache
 ]
 
-enclose: enclose* 'enclose* func* [f] [  ; uses low-level ENCLOSE* to make
+enclose: enclose* :enclose* func* [f] [  ; uses low-level ENCLOSE* to make
     let inner: f/inner: compose :f/inner
     inherit-meta do f get 'inner  ; no :inner name cache
 ]
-inherit-meta :enclose 'enclose*  ; needed since we used ENCLOSE*
+inherit-meta :enclose :enclose*  ; needed since we used ENCLOSE*
 
-specialize: enclose 'specialize* func* [f] [  ; now we have high-level ENCLOSE
+specialize: enclose :specialize* func* [f] [  ; now we have high-level ENCLOSE
     let specializee: f/specializee: compose :f/specializee
     inherit-meta do f get 'specializee  ; no :specializee name cache
 ]
 
-adapt: enclose 'adapt* func* [f] [
+adapt: enclose :adapt* func* [f] [
     let adaptee: f/adaptee: compose :f/adaptee
     inherit-meta do f get 'adaptee  ; no :adaptee name cache
 ]
 
-chain: enclose 'chain* func* [f] [
+chain: enclose :chain* func* [f] [
     ;
     ; !!! Historically CHAIN supported | for "pipe" but it was really just an
     ; expression barrier.  Review this idea, but for now let it work in a
@@ -318,13 +318,13 @@ chain: enclose 'chain* func* [f] [
     inherit-meta do f pick pipeline 1
 ]
 
-augment: enclose 'augment* func* [f] [
+augment: enclose :augment* func* [f] [
     let augmentee: f/augmentee: compose :f/augmentee
     let spec: :f/spec
     inherit-meta/augment do f get 'augmentee spec  ; no :augmentee name cache
 ]
 
-reframer: enclose 'reframer* func* [f] [
+reframer: enclose :reframer* func* [f] [
     let shim: f/shim: compose :f/shim
     inherit-meta do f get 'shim
 ]
@@ -333,7 +333,7 @@ reframer: enclose 'reframer* func* [f] [
 ; the higher level one uses a block.  Specialize out the action, and then
 ; overwrite it in the enclosure with an action taken out of the block.
 ;
-pointfree: enclose (specialize* 'pointfree* [
+pointfree: enclose (specialize* :pointfree* [
     action: :panic-value  ; gets overwritten, best to make it something mean
 ]) func* [f] [
     let action: f/action: (match action! any [
@@ -401,19 +401,19 @@ requote: reframer func* [
 ; specializations they don't fit easily into the NEXT OF SERIES model--this
 ; is a problem which hasn't been addressed.
 ;
-next: specialize 'skip [offset: 1]
-back: specialize 'skip [offset: -1]
+next: specialize :skip [offset: 1]
+back: specialize :skip [offset: -1]
 
-bound?: chain [specialize 'reflect [property: 'binding] | :value?]
+bound?: chain [specialize :reflect [property: 'binding] | :value?]
 
-unspaced: specialize 'delimit [delimiter: null]
-unspaced-text: chain [:unspaced | specialize 'else [branch: [copy ""]]]
+unspaced: specialize :delimit [delimiter: null]
+unspaced-text: chain [:unspaced | specialize :else [branch: [copy ""]]]
 
-spaced: specialize 'delimit [delimiter: space]
-spaced-text: chain [:spaced | specialize 'else [branch: [copy ""]]]
+spaced: specialize :delimit [delimiter: space]
+spaced-text: chain [:spaced | specialize :else [branch: [copy ""]]]
 
 newlined: chain [
-    adapt specialize 'delimit [delimiter: newline] [
+    adapt specialize :delimit [delimiter: newline] [
         if text? :line [
             fail 'line "NEWLINED on TEXT! semantics being debated"
         ]
@@ -451,10 +451,10 @@ an: func* [
 ; {Returns TRUE if port is open.}
 ; port [port!]
 
-head?: specialize 'reflect [property: 'head?]
-tail?: specialize 'reflect [property: 'tail?]
-past?: specialize 'reflect [property: 'past?]
-open?: specialize 'reflect [property: 'open?]
+head?: specialize :reflect [property: 'head?]
+tail?: specialize :reflect [property: 'tail?]
+past?: specialize :reflect [property: 'past?]
+open?: specialize :reflect [property: 'open?]
 
 
 empty?: func* [

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -455,7 +455,7 @@ redescribe [
 unset: redescribe [
     {Clear the value of a word to null (in its current context.)}
 ](
-    specialize 'set [value: null]
+    specialize :set [value: null]
 )
 
 
@@ -484,8 +484,8 @@ unset: redescribe [
 ;    == 7
 ;
 >-: enfixed :shove
->--: enfixed specialize '>- [prefix: true]
-->-: enfixed specialize '>- [prefix: false]
+>--: enfixed specialize :>- [prefix: true]
+->-: enfixed specialize :>- [prefix: false]
 
 
 ; The -- and ++ operators were deemed too "C-like", so ME was created to allow
@@ -497,13 +497,13 @@ me: enfixed redescribe [
 ](
     ; /ENFIX so `x: 1, x: me + 1 * 10` is 20, not 11
     ;
-    specialize 'shove/set [prefix: false]
+    specialize :shove/set [prefix: false]
 )
 
 my: enfixed redescribe [
     {Update variable using it as the first argument to a prefix operator}
 ](
-    specialize 'shove/set [prefix: true]
+    specialize :shove/set [prefix: true]
 )
 
 so: enfixed func [
@@ -574,31 +574,31 @@ tweak :was 'postpone on
 zdeflate: redescribe [
     {Deflates data with zlib envelope: https://en.wikipedia.org/wiki/ZLIB}
 ](
-    specialize 'deflate [envelope: 'zlib]
+    specialize :deflate [envelope: 'zlib]
 )
 
 zinflate: redescribe [
     {Inflates data with zlib envelope: https://en.wikipedia.org/wiki/ZLIB}
 ](
-    specialize 'inflate [envelope: 'zlib]
+    specialize :inflate [envelope: 'zlib]
 )
 
 gzip: redescribe [
     {Deflates data with gzip envelope: https://en.wikipedia.org/wiki/Gzip}
 ](
-    specialize 'deflate [envelope: 'gzip]
+    specialize :deflate [envelope: 'gzip]
 )
 
 gunzip: redescribe [
     {Inflates data with gzip envelope: https://en.wikipedia.org/wiki/Gzip}
 ](
-    specialize 'inflate [envelope: 'gzip]  ; What about GZIP-BADSIZE?
+    specialize :inflate [envelope: 'gzip]  ; What about GZIP-BADSIZE?
 )
 
 ensure: redescribe [
     {Pass through value if it matches test, otherwise trigger a FAIL}
 ](
-    specialize 'either-match [
+    specialize :either-match [
         branch: func [arg [<opt> any-value!]] [
             ;
             ; !!! Can't use FAIL/WHERE until there is a good way to SPECIALIZE
@@ -617,7 +617,8 @@ ensure: redescribe [
 non: redescribe [
     {Pass through value if it *doesn't* match test, otherwise trigger a FAIL}
 ](
-    specialize 'either-match/not [
+    specialize :either-match [
+        not: #
         branch: func [arg [<opt> any-value!]] [
             ;
             ; !!! Can't use FAIL/WHERE until there is a good way to SPECIALIZE
@@ -651,8 +652,8 @@ really: func [
     :value
 ]
 
-oneshot: specialize 'n-shot [n: 1]
-upshot: specialize 'n-shot [n: -1]
+oneshot: specialize :n-shot [n: 1]
+upshot: specialize :n-shot [n: -1]
 
 ;
 ; !!! The /REVERSE and /LAST refinements of FIND and SELECT caused a lot of
@@ -663,13 +664,13 @@ upshot: specialize 'n-shot [n: -1]
 find-reverse: redescribe [
     {Variant of FIND that uses a /SKIP of -1}
 ](
-    specialize 'find [skip: -1]
+    specialize :find [skip: -1]
 )
 
 find-last: redescribe [
     {Variant of FIND that uses a /SKIP of -1 and seeks the TAIL of a series}
 ](
-    adapt 'find-reverse [
+    adapt :find-reverse [
         if not any-series? series [
             fail 'series "Can only use FIND-LAST on ANY-SERIES!"
         ]
@@ -694,19 +695,19 @@ attempt: func [
 for-next: redescribe [
     "Evaluates a block for each position until the end, using NEXT to skip"
 ](
-    specialize 'for-skip [skip: 1]
+    specialize :for-skip [skip: 1]
 )
 
 for-back: redescribe [
     "Evaluates a block for each position until the start, using BACK to skip"
 ](
-    specialize 'for-skip [skip: -1]
+    specialize :for-skip [skip: -1]
 )
 
 iterate-skip: redescribe [
     "Variant of FOR-SKIP that directly modifies a series variable in a word"
 ](
-    specialize enclose 'for-skip func [f] [
+    specialize enclose :for-skip func [f] [
         if blank? let word: f/word [return null]
         f/word: quote to word! word  ; do not create new virtual binding
         let saved: f/series: get word
@@ -732,26 +733,26 @@ iterate-skip: redescribe [
 iterate: iterate-next: redescribe [
     "Variant of FOR-NEXT that directly modifies a series variable in a word"
 ](
-    specialize 'iterate-skip [skip: 1]
+    specialize :iterate-skip [skip: 1]
 )
 
 iterate-back: redescribe [
     "Variant of FOR-BACK that directly modifies a series variable in a word"
 ](
-    specialize 'iterate-skip [skip: -1]
+    specialize :iterate-skip [skip: -1]
 )
 
 
 count-up: redescribe [
     "Loop the body, setting a word from 1 up to the end value given"
 ](
-    specialize 'for [start: 1, bump: 1]
+    specialize :for [start: 1, bump: 1]
 )
 
 count-down: redescribe [
     "Loop the body, setting a word from the end value given down to 1"
 ](
-    specialize adapt 'for [
+    specialize adapt :for [
         start: end
         end: 1
     ][
@@ -1077,7 +1078,7 @@ fail: func [
     do ensure error! error  ; raise to nearest TRAP up the stack (if any)
 ]
 
-unreachable: specialize 'fail [reason: "Unreachable code"]
+unreachable: specialize :fail [reason: "Unreachable code"]
 
 
 generate: func [ "Make a generator."

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -22,7 +22,7 @@ reeval function [:terms [tag! set-word! <variadic>]] [
         set w redescribe reduce [
             spaced [{Returns the} to word! w {value of a series}]
         ](
-            specialize 'pick [picker: n]
+            specialize :pick [picker: n]
         )
         n: n + 1
     ]
@@ -36,7 +36,7 @@ reeval function [:terms [tag! set-word! <variadic>]] [
 last: redescribe [
     {Returns the last value of a series.}
 ](
-    specialize adapt 'pick [
+    specialize adapt :pick [
         picker: length of get lit location:
     ][
         picker: <removed-parameter>
@@ -51,7 +51,7 @@ last: redescribe [
 repend: redescribe [
     "APPEND a reduced value to a series."
 ](
-    adapt 'append [
+    adapt :append [
         if set? 'value [
             value: reduce :value
         ]

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -64,7 +64,7 @@ verify: function [
 ; copies of the function made at layer boundaries.
 ;
 native-assert: copy :assert
-hijack 'assert :verify
+hijack :assert :verify
 
 
 delta-time: function [
@@ -160,7 +160,7 @@ net-trace: function [
     val [logic!]
 ][
     either val [
-        hijack 'net-log func [txt /C /S][
+        hijack :net-log func [txt /C /S][
             print [
                 (if c ["C:"]) (if s ["S:"])
                     either block? txt [spaced txt] [txt]
@@ -169,6 +169,6 @@ net-trace: function [
         ]
         print "Net-trace is now on"
     ][
-        hijack 'net-log func [txt /C /S][txt]
+        hijack :net-log func [txt /C /S][txt]
     ]
 ]

--- a/src/mezz/mezz-dump.r
+++ b/src/mezz/mezz-dump.r
@@ -25,7 +25,7 @@ dump: function [
 
     <static> enablements (make map! [])
 ][
-    print: adapt 'lib/print [
+    print: adapt :lib/print [
         if prefix [
             if select enablements prefix <> #on [return]
             write-stdout prefix
@@ -116,7 +116,7 @@ contains-newline: function [return: [logic!] pos [block! group!]] [
     return false
 ]
 
-dump-to-newline: adapt 'dump [
+dump-to-newline: adapt :dump [
     if not tail? extra [
         ;
         ; Mutate VARARGS! into a BLOCK!, with passed-in value at the head
@@ -150,7 +150,7 @@ dumps: enfixed function [
         [<opt> any-value! <variadic>]
 ][
     if issue? value [
-        d: specialize 'dump-to-newline [prefix: as text! name]
+        d: specialize :dump-to-newline [prefix: as text! name]
         if value <> #off [d #on]  ; note: d hard quotes its argument
     ] else [
         ; Make it easy to declare and dump a variable at the same time.
@@ -170,7 +170,7 @@ dumps: enfixed function [
         ;
         d: function [return: <elide> /on /off <static> d'] compose/deep [
             d': default [
-                d'': specialize 'dump [prefix: (as text! name)]
+                d'': specialize :dump [prefix: (as text! name)]
                 d'' #on
             ]
             case [

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -108,7 +108,7 @@ help: function [
         "WORD! whose value to explain, or other HELP target (try HELP HELP)"
     /doc "Open web browser to related documentation."
 ][
-    return: specialize 'return [value: ~]  ; unlabeled for no console display
+    return: specialize :return [value: ~]  ; unlabeled for no console display
 
     if undefined? 'topic [
         ;
@@ -365,7 +365,7 @@ help: function [
     print newline
 
     print "DESCRIPTION:"
-    print [_ _ _ _ (:meta/description or '{(undocumented)})]
+    print [_ _ _ _ any [meta/description {(undocumented)}]]
     print [_ _ _ _ (uppercase mold topic) {is an ACTION!}]
 
     print-args: function [list /indent-words] [

--- a/src/mezz/mezz-legacy.r
+++ b/src/mezz/mezz-legacy.r
@@ -95,7 +95,7 @@ library?: typechecker library!
 ; ability to tolerate a spec of `[a:]` by transforming it to `[a: none].
 ; Ren-C hasn't decided yet, but will likely support `construct [a: b: c:]`
 ;
-context: specialize 'make [type: object!]
+context: specialize :make [type: object!]
 
 
 uneval: func [] [
@@ -127,23 +127,23 @@ uneval: func [] [
 ; no information about specific return types, which could be given here
 ; with REDESCRIBE.
 ;
-length-of: specialize 'reflect [property: 'length]
-words-of: specialize 'reflect [property: 'words]
-values-of: specialize 'reflect [property: 'values]
-index-of: specialize 'reflect [property: 'index]
-type-of: specialize 'reflect [property: 'type]
-binding-of: specialize 'reflect [property: 'binding]
-head-of: specialize 'reflect [property: 'head]
-tail-of: specialize 'reflect [property: 'tail]
-file-of: specialize 'reflect [property: 'file]
-line-of: specialize 'reflect [property: 'line]
-body-of: specialize 'reflect [property: 'body]
+length-of: specialize :reflect [property: 'length]
+words-of: specialize :reflect [property: 'words]
+values-of: specialize :reflect [property: 'values]
+index-of: specialize :reflect [property: 'index]
+type-of: specialize :reflect [property: 'type]
+binding-of: specialize :reflect [property: 'binding]
+head-of: specialize :reflect [property: 'head]
+tail-of: specialize :reflect [property: 'tail]
+file-of: specialize :reflect [property: 'file]
+line-of: specialize :reflect [property: 'line]
+body-of: specialize :reflect [property: 'body]
 
 
 ; General renamings away from non-LOGIC!-ending-in-?-functions
 ; https://trello.com/c/DVXmdtIb
 ;
-index?: specialize 'reflect [property: 'index]
+index?: specialize :reflect [property: 'index]
 offset?: :offset-of
 sign?: :sign-of
 suffix?: :suffix-of
@@ -254,7 +254,7 @@ apply: func [dummy:] [
 ]
 
 
-hijack 'find adapt copy :find [
+hijack :find adapt copy :find [
     if reverse or last [
         fail 'reverse [
             {/REVERSE and /LAST on FIND have been deprecated.  Use FIND-LAST}

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -87,13 +87,13 @@ extreme-of: func [
 minimum-of: redescribe [
     {Finds the smallest value in a series}
 ](
-    specialize 'extreme-of [comparator: :lesser?]
+    specialize :extreme-of [comparator: :lesser?]
 )
 
 maximum-of: redescribe [
     {Finds the largest value in a series}
 ](
-    specialize 'extreme-of [comparator: :greater?]
+    specialize :extreme-of [comparator: :greater?]
 )
 
 

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -22,7 +22,7 @@ REBOL [
 write-enlined: redescribe [
     {Write out a TEXT! with its LF sequences translated to CR LF}
 ](
-    adapt 'write [
+    adapt :write [
         if not text? data [
             fail ["WRITE-ENLINED only works on TEXT! data"]
         ]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -66,7 +66,7 @@ join-all: function [
 remold: redescribe [
     {Reduces and converts a value to a REBOL-readable string.}
 ](
-    adapt 'mold [
+    adapt :mold [
         value: reduce :value
     ]
 )
@@ -464,7 +464,7 @@ collect*: func [
 ][
     let out: null
     let keeper: specialize* (  ; SPECIALIZE to hide series argument
-        enclose* 'append func* [  ; Derive from APPEND for /ONLY /LINE /DUP
+        enclose* :append func* [  ; Derive from APPEND for /ONLY /LINE /DUP
             f [frame!]
             <with> out
         ][
@@ -498,15 +498,17 @@ collect: redescribe [
 ] chain [  ; Gives empty block instead of null if no keeps
     :collect*
         |
-    specialize 'else [branch: [copy []]]
+    specialize :else [branch: [copy []]]
 ]
 
 collect-lines: redescribe [
     {Evaluate body, and return block of values collected via KEEP function.
     KEEPed blocks become spaced TEXT!.}
-] adapt 'collect [  ; https://forum.rebol.info/t/945/1
+] adapt :collect [  ; https://forum.rebol.info/t/945/1
     body: compose [
-        keep: adapt* specialize* 'keep/line/only [  ; specialize removes args
+        keep: adapt* specialize* :keep [
+            line: #
+            only: #
             part: null
         ][
             value: spaced try :value
@@ -519,9 +521,9 @@ collect-text: redescribe [
     {Evaluate body, and return block of values collected via KEEP function.
     Returns all values as a single spaced TEXT!, individual KEEPed blocks get UNSPACED.}
 ] chain [  ; https://forum.rebol.info/t/945/2
-    adapt 'collect [
+    adapt :collect [
         body: compose [
-            keep: adapt* specialize* 'keep [  ; specialize removes args
+            keep: adapt* specialize* :keep [
                 line: null
                 only: null
                 part: null
@@ -534,7 +536,7 @@ collect-text: redescribe [
         |
     :spaced
         |
-    specialize* 'else [branch: [copy ""]]
+    specialize* :else [branch: [copy ""]]
 ]
 
 format: function [

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -49,7 +49,7 @@ use [word] [
             set word redescribe compose [
                 (spaced ["Converts to" form type "value."])
             ](
-                specialize 'to [type: get type]
+                specialize :to [type: get type]
             )
         ]
     ]

--- a/tests/control/do.test.reb
+++ b/tests/control/do.test.reb
@@ -160,7 +160,7 @@
 (true = reeval true)
 (false = reeval false)
 ($1 == reeval $1)
-(null? reeval (specialize 'of [property: 'type]) null)
+(null? reeval (specialize :of [property: 'type]) null)
 (null? do _)
 (
     a-value: make object! []

--- a/tests/control/if.test.reb
+++ b/tests/control/if.test.reb
@@ -60,7 +60,7 @@
 (if true [true])
 (null? if false [true])
 (if $1 [true])
-(if (specialize 'of [property: 'type]) [true])
+(if (specialize :of [property: 'type]) [true])
 (null? if blank [true])
 (if make object! [] [true])
 (if get '+ [true])

--- a/tests/datatypes/action.test.reb
+++ b/tests/datatypes/action.test.reb
@@ -7,3 +7,31 @@
 [#1659
     (1 == do reduce [:abs -1])
 ]
+
+; Actions should store labels of the last GET-WORD! or GET-PATH! that was
+; used to retrieve them.  Using GET subverts changing the name.
+[
+    ('append = label of :append)
+    ('append = label of :lib/append)
+
+    (
+        new-name: :append
+        did all [
+            'new-name = label of :new-name
+            'append = label of get 'new-name
+        ]
+    )
+
+    (
+        no-get-word: func [] []
+        null = label of get 'no-get-word
+    )
+
+    (
+        f: make frame! :append
+        did all [
+            'append = label of f
+            'append = label of make action! f
+        ]
+    )
+]

--- a/tests/datatypes/frame.test.reb
+++ b/tests/datatypes/frame.test.reb
@@ -40,7 +40,7 @@
     (
         f-inside-prelude: ~
         private: <not-in-prelude>
-        adapted-foo: adapt 'foo [
+        adapted-foo: adapt :foo [
             f-inside-prelude: binding of 'public
             assert [private = <not-in-prelude>]  ; should not be bound
         ]
@@ -78,7 +78,7 @@
         f-inside-augment: ~
         private: <not-in-prelude>
 
-        augmented-foo: adapt (augment 'adapted-foo [
+        augmented-foo: adapt (augment :adapted-foo [
             additional [integer!]
             /private [tag!]  ; reusing name, for different variable!
         ]) [
@@ -125,7 +125,7 @@
 
         f-prelude: null
 
-        bar: adapt augment 'foo [/private [tag!]] [
+        bar: adapt augment :foo [/private [tag!]] [
             f-prelude: binding of 'private
         ]
 

--- a/tests/datatypes/varargs.test.reb
+++ b/tests/datatypes/varargs.test.reb
@@ -150,7 +150,7 @@
 
 (
     vblock: collect [
-        log: adapt 'keep [value: reduce value]
+        log: adapt :keep [value: reduce value]
         variadic2: func [v [any-value! <variadic>]] [
            log [<1> take v]
            log [<2> take v]
@@ -162,7 +162,7 @@
     ]
 
     nblock: collect [
-        log: adapt 'keep [value: reduce value]
+        log: adapt :keep [value: reduce value]
         normal2: func [n1 n2] [
             log [<1> n1 <2> n2]
             return "returned"

--- a/tests/functions/adapt.test.reb
+++ b/tests/functions/adapt.test.reb
@@ -2,13 +2,13 @@
 
 (
     x: 10
-    foo: adapt 'any [x: 20]
+    foo: adapt :any [x: 20]
     foo [1 2 3]
     x = 20
 )
 (
     capture: blank
-    foo: adapt 'any [capture: block]
+    foo: adapt :any [capture: block]
     did all [
       foo [1 2 3]
       capture = [1 2 3]
@@ -16,10 +16,10 @@
 )
 (
     v: copy []
-    append-v: specialize 'append [
+    append-v: specialize :append [
         series: v
     ]
-    adapted-append-v: adapt 'append-v [
+    adapted-append-v: adapt :append-v [
         value: to integer! value
     ]
     adapted-append-v "10"

--- a/tests/functions/augment.test.reb
+++ b/tests/functions/augment.test.reb
@@ -3,7 +3,7 @@
 
 (
     foo: func [x] [x]
-    bar: augment 'foo [y]
+    bar: augment :foo [y]
     did all [
         [x y] = parameters of :bar
         10 = bar 10 20
@@ -35,7 +35,7 @@
 
 ; Tests with ENCLOSE
 [
-    (switch-d: enclose (augment 'switch [
+    (switch-d: enclose (augment :switch [
         /default "Default case if no others are found"
             [block!]
     ]) func [f [frame!]] [
@@ -54,9 +54,9 @@
     two-a-plus-three-b: func [a [integer!] /b [integer!]] [
         (2 * a) + either b [3 * b] [0]
     ]
-    two-a-plus-six: specialize 'two-a-plus-three-b [b: 2]
+    two-a-plus-six: specialize :two-a-plus-three-b [b: 2]
 
-    two-a-plus-six-plus-four-c: enclose augment 'two-a-plus-six [
+    two-a-plus-six-plus-four-c: enclose augment :two-a-plus-six [
         /c [integer!]
     ] func [f [frame!]] [
         let old-c: f/c

--- a/tests/functions/chain.test.reb
+++ b/tests/functions/chain.test.reb
@@ -8,7 +8,7 @@
 (
     add-one: func [x] [x + 1]
     mp-ad-ad: chain [:multiply | :add-one | :add-one]
-    sub-one: specialize 'subtract [value2: 1]
+    sub-one: specialize :subtract [value2: 1]
     mp-normal: chain [:mp-ad-ad | :sub-one | :sub-one]
     200 = (mp-normal 10 20)
 )

--- a/tests/functions/enclose.test.reb
+++ b/tests/functions/enclose.test.reb
@@ -1,7 +1,7 @@
 ; better-than-nothing ENCLOSE tests
 
 (
-    e-multiply: enclose 'multiply function [f [frame!]] [
+    e-multiply: enclose :multiply function [f [frame!]] [
         diff: abs (f/value1 - f/value2)
         result: do f
         return result + diff
@@ -10,7 +10,7 @@
     73 = e-multiply 7 10
 )
 (
-    n-add: enclose 'add function [f [frame!]] [
+    n-add: enclose :add function [f [frame!]] [
         if 10 = f/value1 [return blank]
         f/value1: 5
         do f

--- a/tests/functions/hijack.test.reb
+++ b/tests/functions/hijack.test.reb
@@ -8,7 +8,7 @@
 
     did all [
         (old-foo 10) = 11
-        hijack 'foo func [x] [(old-foo x) + 20]
+        hijack :foo func [x] [(old-foo x) + 20]
         (old-foo 10) = 11
         (foo 10) = 31
         (another-foo 10) = 31
@@ -29,12 +29,12 @@
     (
         old-three: copy :three
 
-        two-30: specialize 'three [z: 30]
+        two-30: specialize :three [z: 30]
         60 = (two-30 10 20)
     )
 
     (
-        hijack 'three func [
+        hijack :three func [
             a b c /unavailable /available "mul me" [integer!]
         ][
             a * b * c * either available [available] [1]
@@ -52,9 +52,9 @@
     (240000 = (two-30/available 10 20 40))
 
     (
-        one-20: specialize 'two-30 [y: 20]
+        one-20: specialize :two-30 [y: 20]
 
-        hijack 'three func [q r s] [
+        hijack :three func [q r s] [
             q - r - s
         ]
 
@@ -64,7 +64,7 @@
     (-40 = (one-20 10))
 
     (
-        hijack 'three 'old-three
+        hijack :three :old-three
         true
     )
 
@@ -76,7 +76,7 @@
 ; HIJACK of a specialization (needs to notice paramlist has "hidden" params)
 (
     two: func [a b] [a + b]
-    one: specialize 'two [a: 10]
-    hijack 'one func [b] [20 - b]
+    one: specialize :two [a: 10]
+    hijack :one func [b] [20 - b]
     0 = one 20
 )

--- a/tests/functions/native.test.reb
+++ b/tests/functions/native.test.reb
@@ -5,6 +5,6 @@
 [#1659 (
     ; natives are active
     same? blank! do reduce [
-        (specialize 'of [property: 'type]) blank
+        (specialize :of [property: 'type]) blank
     ]
 )]

--- a/tests/functions/redescribe.test.reb
+++ b/tests/functions/redescribe.test.reb
@@ -8,7 +8,7 @@
 (
     returns-int: func [return: [integer!] x] [x]
 
-    returns-text: enclose 'returns-int func [f] [f/x: me + 1 to text! do f]
+    returns-text: enclose :returns-int func [f] [f/x: me + 1 to text! do f]
     returns-text-check: reskinned [return: [integer!]] :returns-text
 
     skin: reskinned [return: [integer! text!]] :returns-text-check

--- a/tests/functions/redo.test.reb
+++ b/tests/functions/redo.test.reb
@@ -73,7 +73,7 @@
         redo 'n  comment {should redo INNER, not outer}
     ]
 
-    outer: adapt 'inner [
+    outer: adapt :inner [
         if n = 0 [
             return "outer phase run by redo"
         ]
@@ -91,7 +91,7 @@
         redo captured-frame  comment {should redo OUTER, not INNER}
     ]
 
-    outer: adapt 'inner [
+    outer: adapt :inner [
         if n = 0 [
             return <success>
         ]
@@ -179,7 +179,7 @@
     ]
 
     c: chain [
-        adapt 'base [
+        adapt :base [
            log [{C} n delta]
 
            captured-frame: binding of 'n
@@ -197,7 +197,7 @@
         ]
     ]
 
-    s: specialize adapt 'base [
+    s: specialize adapt :base [
         log [{S} n delta]
 
         if n = 1 [n: 10]

--- a/tests/functions/specialize.test.reb
+++ b/tests/functions/specialize.test.reb
@@ -3,7 +3,7 @@
 ; Note: GET-PATH! for partial specialization uses basically the same code
 ; path as SPECIALIZE does, e.g. these run the same code:
 ;
-;     specialize 'append/dup/part []
+;     specialize :append/dup/part []
 ;     :append/dup/part
 
 [
@@ -41,7 +41,7 @@
     [a b c [1 2 3] [1 2 3]] = append-123-twice copy [a b c]
 )
 (
-    append-10: specialize 'append [value: 10]
+    append-10: specialize :append [value: 10]
     f: make frame! :append-10
     f/series: copy [a b c]
 
@@ -57,7 +57,7 @@
 )
 (
     foo: func [] [
-        return-5: specialize 'return [value: 5]
+        return-5: specialize :return [value: 5]
         return-5
         "this shouldn't be returned"
     ]
@@ -67,8 +67,8 @@
 [
     (
         apd: :append/part/dup
-        apd3: specialize 'apd [dup: 3]
-        ap2d: specialize 'apd [part: 2]
+        apd3: specialize :apd [dup: 3]
+        ap2d: specialize :apd [part: 2]
 
         xy: [<X> #Y]
         abc: [A B C]
@@ -89,8 +89,8 @@
 [
     (
         adp: :append/dup/part
-        adp2: specialize 'adp [part: 2]
-        ad3p: specialize 'adp [dup: 3]
+        adp2: specialize :adp [part: 2]
+        ad3p: specialize :adp [dup: 3]
 
         xy: [<X> #Y]
         abc: [A B C]
@@ -109,7 +109,7 @@
 ]
 
 (
-    aopd3: specialize lit (specialize 'append/only [])/part [
+    aopd3: specialize lit (specialize :append/only [])/part [
         dup: 3
         part: 1
     ]
@@ -126,9 +126,9 @@
     is-bad: true
 
     for-each code [
-        [specialize 'append/only/only []]
-        [specialize 'append/asdf []]
-        [specialize lit (specialize 'append/only [])/only []]
+        [specialize :append/only/only []]
+        [specialize :append/asdf []]
+        [specialize lit (specialize :append/only [])/only []]
     ][
         is-bad: me and ['bad-refine = (trap [do code])/id]
     ]
@@ -138,7 +138,7 @@
 
 
 (
-    ap10d: specialize 'append/dup [value: 10]
+    ap10d: specialize :append/dup [value: 10]
     f: make frame! :ap10d
     f/series: copy [a b c]
     did all [

--- a/tests/functions/unwind.test.reb
+++ b/tests/functions/unwind.test.reb
@@ -19,7 +19,7 @@
 ; Related to #1519
 (
     cycle?: true
-    if-not: adapt 'if [condition: not :condition]
+    if-not: adapt :if [condition: not :condition]
     f1: does [
         if-not 1 > 2 [
             while [if cycle? [unwind :if-not <ret>] cycle?] [cycle?: false 2]

--- a/tests/redbol/redbol-apply.test.reb
+++ b/tests/redbol/redbol-apply.test.reb
@@ -83,12 +83,12 @@
 (use [a] [a: false null == redbol-apply func [/a] [a] [a]])
 (use [a] [a: false # = redbol-apply func [/a] [a] [/a]])
 (use [a] [a: false # = redbol-apply/only func [/a] [/a] [/a]])
-(group! == redbol-apply/only (specialize 'of [property: 'type]) [()])
+(group! == redbol-apply/only (specialize :of [property: 'type]) [()])
 ([1] == head of redbol-apply :insert [copy [] [1] blank blank])
 ([1] == head of redbol-apply :insert [copy [] [1] blank false])
 ([[1]] == head of redbol-apply :insert [copy [] [1] blank true])
-(action! == redbol-apply (specialize 'of [property: 'type]) [:print])
-(get-word! == redbol-apply/only (specialize 'of [property: 'type]) [:print])
+(action! == redbol-apply (specialize :of [property: 'type]) [:print])
+(get-word! == redbol-apply/only (specialize :of [property: 'type]) [:print])
 
 [
     #1760

--- a/tests/source/source-tools.reb
+++ b/tests/source/source-tools.reb
@@ -158,7 +158,7 @@ rebsource: context [
                 data [binary!]
             ][
                 analysis: analyse/text file data
-                emit: specialize 'log-emit [log: analysis]
+                emit: specialize :log-emit [log: analysis]
 
                 data: as text! data
 
@@ -289,7 +289,7 @@ rebsource: context [
             data
         ][
             analysis: copy []
-            emit: specialize 'log-emit [log: analysis]
+            emit: specialize :log-emit [log: analysis]
 
             data: read src-folder/:file
 

--- a/tools/bootstrap-shim.r
+++ b/tools/bootstrap-shim.r
@@ -72,7 +72,7 @@ unset first [=>]
 ; SET was changed to accept VOID!, use SET VAR NON VOID! (...EXPRESSION...)
 ; if that is what was intended.
 ;
-set: specialize 'lib/set [opt: true]
+set: specialize :lib/set [opt: true]
 
 ; PRINT was changed to tolerate NEWLINE to mean print a newline only
 ;
@@ -209,13 +209,13 @@ modernize-action: function [
     return reduce [spec body]
 ]
 
-func: adapt 'func [set [spec body] modernize-action spec body]
-function: adapt 'function [set [spec body] modernize-action spec body]
+func: adapt :func [set [spec body] modernize-action spec body]
+function: adapt :function [set [spec body] modernize-action spec body]
 
-meth: enfixed adapt 'meth [set [spec body] modernize-action spec body]
-method: enfixed adapt 'method [set [spec body] modernize-action spec body]
+meth: enfixed adapt :meth [set [spec body] modernize-action spec body]
+method: enfixed adapt :method [set [spec body] modernize-action spec body]
 
-trim: adapt 'trim [  ; there's a bug in TRIM/AUTO in 8994d23
+trim: adapt :trim [  ; there's a bug in TRIM/AUTO in 8994d23
     if auto [
         while [(not tail? series) and [series/1 = LF]] [
             take series
@@ -268,7 +268,7 @@ has: null
 const?: func [x] [return false]
 
 call*: :call
-call: specialize 'call* [wait: true]
+call: specialize :call* [wait: true]
 
 ; Due to various weaknesses in the historical Rebol APPLY, a frame-based
 ; method retook the name.  A usermode emulation of the old APPLY was written
@@ -284,7 +284,7 @@ redbol-apply: :applique
 applique: :apply
 apply: :redbol-apply
 
-find-reverse: specialize 'find [
+find-reverse: specialize :find [
     reverse: true
 
     ; !!! Specialize out /SKIP because it was not compatible--R3-Alpha
@@ -293,7 +293,7 @@ find-reverse: specialize 'find [
     skip: false
 ]
 
-find-last: specialize 'find [
+find-last: specialize :find [
     ;
     ; !!! Old Ren-C committed for bootstrap had a bug of its own (a big reason
     ; to kill these refinements): `find/reverse tail "abcd" "bc"` was blank.
@@ -311,7 +311,7 @@ find-last: specialize 'find [
 ; So augment the READ with a bit more information.
 ;
 lib-read: copy :lib/read
-lib/read: read: enclose 'lib-read function [f [frame!]] [
+lib/read: read: enclose :lib-read function [f [frame!]] [
     saved-source: :f/source
     if e: trap [bin: do f] [
         parse e/message [
@@ -441,8 +441,8 @@ delimit: func [
     text
 ]
 
-unspaced: specialize 'delimit [delimiter: _]
-spaced: specialize 'delimit [delimiter: space]
+unspaced: specialize :delimit [delimiter: _]
+spaced: specialize :delimit [delimiter: space]
 
 dequote: func [x] [
     switch type of x [


### PR DESCRIPTION
When functions like ADAPT were being first designed, all ACTION!s
were fully anonymous.  So there was no label known for them.

To get around this, an alternative was offered to passing in an
ACTION!.  Instead, you could pass in a WORD! or PATH!, that would
be processed in such a way as to preserve the name:

    >> specialize :append [value: 10]
    ; ^-- this SPECIALIZE couldn't know the name "append"

    >> specialize 'append [value: 10]
    ; ^-- this SPECIALIZE has the WORD! in hand, does the GET
    ; hence it can also know the name

Yet new features have made this obsolete!  ACTION!s hold labels that
come from them being obtained through GET-WORD!s or GET-PATH!s.  These
labels live in cells and are trickily moved around to persist with
the actions.

This means the confusing type signature and quoting mechanics no longer
make sense.  This changes to only allow ACTION!.