### PR TITLE
HELP NEEDED: Transition to MAKE-FILE (%%)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -619,7 +619,7 @@ script:
   #
   - |
     echo "Note: CONFIG_TCCDIR is ${CONFIG_TCCDIR}"
-    export LIBREBOL_INCLUDE_DIR="${TOP_DIR}/build/prep/include"
+    export LIBREBOL_INCLUDE_DIR="${TOP_DIR}/build/prep/include/"
     if [[ (! -z $TCC) && ($TCC != no) ]]; then
       if [[ $OS_ID = 0.4.40 ]]; then
         $RUNNER ./r3 ../extensions/tcc/tests/fib.r

--- a/build.sh
+++ b/build.sh
@@ -442,8 +442,8 @@ echo "$R3_EXIT_STATUS"
 #
 # (export is so that the child process can see the environment variable)
 #
-echo "Note: CONFIG_TCCDIR is ${CONFIG_TCCDIR}"
-export LIBREBOL_INCLUDE_DIR="${TOP_DIR}/build/prep/include"
+echo "Note: CONFIG_TCCDIR is ${CONFIG_TCCDIR} (missing tail slash allowed)"
+export LIBREBOL_INCLUDE_DIR="${TOP_DIR}/build/prep/include/"
 if [[ (! -z $TCC) && ($TCC != no) ]]; then
   if [[ $OS_ID = 0.4.40 ]]; then
     $RUNNER ./r3 ../extensions/tcc/tests/fib.r

--- a/extensions/crypt/make-spec.r
+++ b/extensions/crypt/make-spec.r
@@ -4,9 +4,9 @@ name: 'Crypt
 loadable: no ;tls depends on this, so it has to be builtin
 source: %crypt/mod-crypt.c
 includes: reduce [
-    repo-dir/extensions/crypt
-    repo-dir/extensions/crypt/mbedtls/include  ; w/subdir %mbedtls
-    %prep/extensions/crypt  ; for %tmp-extensions-crypt-init.inc
+    make-file [(repo-dir) extensions/crypt /]
+    make-file [(repo-dir) extensions/crypt/mbedtls/include /]  ; sub %mbedtls/
+    %prep/extensions/crypt/  ; for %tmp-extensions-crypt-init.inc
 ]
 definitions: [
     {MBEDTLS_CONFIG_FILE="mbedtls-rebol-config.h"}

--- a/extensions/ffi/make-spec.r
+++ b/extensions/ffi/make-spec.r
@@ -45,7 +45,7 @@ comment [
 ]
 
 includes: compose [
-    %prep/extensions/ffi
+    %prep/extensions/ffi/
 
     ; For the FFI to be used, you pretty much require the ability to load a
     ; DLL or shared library.  Currently the `Find_Function()` API is linked
@@ -54,7 +54,7 @@ includes: compose [
     ; pointer can be extracted).  Hence headers must be directly included.
     ; But that could be changed.
     ;
-    (repo-dir/extensions/library)
+    (make-file [(repo-dir) extensions/library /])
 
     ; Vectors are used to model C array structures, and thus for the moment
     ; one must build the vector extension into the executable if you want
@@ -64,7 +64,7 @@ includes: compose [
     ; to do this via libRebol, asking for a HANDLE! memory pointer for the
     ; vector...but for now we go through the internal includes of the type.
     ;
-    (repo-dir/extensions/vector)
+    (make-file [(repo-dir) extensions/vector /])
 ]
 
 definitions: []

--- a/extensions/javascript/prep-libr3-js.reb
+++ b/extensions/javascript/prep-libr3-js.reb
@@ -35,7 +35,7 @@ REBOL [
 ]
 
 e-cwrap: (make-emitter
-    "JavaScript C Wrapper functions" output-dir/reb-lib.js
+    "JavaScript C Wrapper functions" make-file [(output-dir) reb-lib.js]
 )
 
 === ASYNCIFY_BLACKLIST TOLERANT CWRAP ===
@@ -908,7 +908,7 @@ json-collect: function [body [block!]] [
     } 'results
 ]
 
-write output-dir/libr3.exports.json json-collect [
+write make-file [(output-dir) libr3.exports.json] json-collect [
     map-each-api [keep unspaced ["RL_" name]]
 ]
 
@@ -939,7 +939,7 @@ write output-dir/libr3.exports.json json-collect [
 ; the final return value of a JS-AWAITER can be returned with it.
 ; </review>
 
-write/lines output-dir/asyncify-blacklist.json collect-lines [
+write/lines make-file [(output-dir) asyncify-blacklist.json] collect-lines [
     keep "["
     for-next names load %asyncify-blacklist.r [
         keep unspaced [_ _ _ _ {"} names/1 {"} if not last? names [","]]
@@ -947,7 +947,7 @@ write/lines output-dir/asyncify-blacklist.json collect-lines [
     keep "]"
 ]
 
-write output-dir/emterpreter.blacklist.json json-collect [
+write make-file [(output-dir) emterpreter.blacklist.json] json-collect [
     map-each-api [
         all [
             is-variadic
@@ -1010,7 +1010,7 @@ write output-dir/emterpreter.blacklist.json json-collect [
 ;
 
 e-node-preload: (make-emitter
-    "Emterpreter Preload for Node.js" output-dir/node-preload.js
+    "Emterpreter Preload for Node.js" make-file [(output-dir) node-preload.js]
 )
 
 e-node-preload/emit {

--- a/extensions/tcc/encap-tcc-resources.reb
+++ b/extensions/tcc/encap-tcc-resources.reb
@@ -146,7 +146,7 @@ encap: compose [
 ]
 
 
-print ["MAKING ZIP FILE:" output-dir/tcc-encap.zip]
-zip/deep/verbose output-dir/tcc-encap.zip encap
+print ["MAKING ZIP FILE:" make-file [(output-dir) tcc-encap.zip]]
+zip/deep/verbose make-file [(output-dir) tcc-encap.zip] encap
 
 print ["(ULTIMATELY WE WANT TO ENCAP THAT DIRECTLY INTO THE TCC EXTENSION)"]

--- a/extensions/tcc/prep-libr3-tcc.reb
+++ b/extensions/tcc/prep-libr3-tcc.reb
@@ -36,7 +36,8 @@ REBOL [
 ]
 
 e: (make-emitter
-    "libRebol exports for tcc_add_symbol()" output-dir/tmp-librebol-symbols.inc
+    "libRebol exports for tcc_add_symbol()"
+        make-file [(output-dir) tmp-librebol-symbols.inc]
 )
 
 map-each-api [

--- a/extensions/tcc/tests/fib.r
+++ b/extensions/tcc/tests/fib.r
@@ -57,10 +57,11 @@ opts: [
     ; This can be specified with LIBREBOL_INCLUDE_DIR as an environment
     ; variable, but you can also do it here for convenience.
     ;
-    ;;librebol-path %/home/hostilefork/Projects/ren-c/build/prep/include
+    ;;librebol-path %/home/hostilefork/Projects/ren-c/build/prep/include/
 
     ; This can be specified with CONFIG_TCCDIR as an environment variable,
-    ; but you can also do it here for convenience.
+    ; but you can also do it here for convenience.  Lack of a trailing
+    ; slash is tolerated as that is CONFIG_TCCDIR convention in TCC.
     ;
     ;;runtime-path %/home/hostilefork/Projects/tcc
 ]

--- a/extensions/uuid/make-spec.r
+++ b/extensions/uuid/make-spec.r
@@ -3,7 +3,7 @@ REBOL []
 name: 'UUID
 source: %uuid/mod-uuid.c
 includes: reduce [
-    repo-dir/extensions/uuid/libuuid
+    make-file [(repo-dir) extensions/uuid/libuuid /]
     %prep/extensions/uuid ;for %tmp-extensions-uuid-init.inc
 ]
 depends: try switch system-config/os-base [

--- a/scripts/shell.r
+++ b/scripts/shell.r
@@ -1,0 +1,220 @@
+REBOL [
+    System: "Ren-C Interpreter and Run-time Environment"
+    Title: "OS Shell Interaction Dialect"
+    Rights: {
+        Copyright 2015-2020 hostilefork.com
+        Copyright 2020 Ren-C Open Source Contributors
+
+        See README.md and CREDITS.md for more information.
+    }
+    License: {LGPL 3.0}
+    History: {
+        SHELL originated in the Ren Garden UI Experiment:
+        https://youtu.be/0exDvv5WEv4?t=553
+    }
+    Description: {
+        The premise of this dialect is to make it possible to write shell
+        commands in as natural a way as possible.  This means that WORD!s
+        act as their literal spellings...needing GROUP!s to run Ren-C code
+        or fetch Ren-C variables:
+
+            >> extension: "txt"
+            >> shell [ls -alF *.(extension)]
+            ; acts equivalent to `ls -alF *.txt`
+
+        TEXT! strings will literally include their quotes, and GROUP!s imply
+        quotation as well.  In order to "splice in" a TEXT! without putting
+        it in quotes, use a GET-GROUP!
+
+            >> command: "ls -alF"
+            >> shell [(command)]
+            ; acts equivalent to `"ls -alF"`
+
+            >> command "ls -alF"
+            >> shell [:(command)]
+            ; acts equivalent to `ls -alF` (no quotes)
+
+        For a literal form that does not escape with quotes, ISSUE! may be
+        used.  Hence `#"foo bar"` acts the same as `:("foo bar")`.
+    }
+    Notes: {
+        * A disadvantage of this implementation (compared to the Ren Garden
+          implementation) is that each call to SHELL forgets the environment
+          variable settings from the previous call.  If the CALL process could
+          be held open (e.g. as a PORT!) then this could be addressed.  That
+          is something that is definitely desired.
+    }
+]
+
+
+%%: func [ ; %make-file.r shared with bootstrap, can't load %%
+    {Quoting MAKE FILE! Operator}
+    'value [word! path! tuple! block! group!]
+][
+    if group? value [value: do value]
+    make-file value
+]
+
+
+shell: func [
+    {Run code in the shell dialect}
+    code "Dialected shell code"
+        [block!]
+    /pipe
+    /inspect "Return the shell command as TEXT!"
+][
+    ; NOTE: We don't use GET-ENV to fill in <ENV> variables, because this
+    ; code runs before the CALL and wouldn't pick up changes to the
+    ; environment.
+    ;
+    let shellify-block: func [block [block!]] [
+        if 1 <> length of block [
+            fail ["SHELL expects BLOCK!s to have one item:" mold block]
+        ]
+
+        let item: first block
+        if group? item [item: do item]
+
+        return switch type of item [
+            text! word! [unspaced ["${" item "}"]]
+
+            fail ["SHELL expects [ENV] blocks to be WORD! or TEXT!:" mold item]
+        ]
+    ]
+
+    ; TAG! is treated as an environment variable lookup.  We don't use the
+    ; GET-ENV function here, because we haven't run the shell code yet...and
+    ; the environment might change by the time it is reached.
+    ;
+    let shellify-tag: func [value [any-value!]] [
+        either-match/not tag! get/any 'value [
+            if system/version/4 = 3 [   ; Windows
+                unspaced ["%" as text! value "%"]
+            ] else [
+                unspaced ["${" as text! value "}"]
+            ]
+        ]
+    ]
+
+    ; The MAKE-FILE logic is targeting being built into the system, so it is
+    ; not intended to be connected to things like environment variables.
+    ; But we want to be able to substitute environment variables as parts of
+    ; the expressions.
+    ;
+    let process-tag: func [container [path! tuple! block!]] [
+        to type-of-container map-each item container [
+            if group? get/any 'item [
+                item: do item
+            ]
+
+            switch type of get/any 'item [
+                void! []  ; ~/foo is legal
+                tag! [item: shellify-tag item]
+            ]
+
+            get/any 'item
+        ]
+    ]
+
+    let command: spaced collect [for-next pos code [
+        while [new-line? pos] [
+            if pos/1 = '... [
+                pos: next pos  ; skip, don't output new-line
+                continue
+            ]
+            keep newline
+            break
+        ]
+
+        ; Make tilde easier to work with early on, e.g. `cd ~`, so the rest
+        ; of the code need not go through GET/ANY every time
+        ;
+        let item: either-match/not void! get/any 'pos/1 [#~]
+
+        ; The default behaviors for each type may either splice or not.
+        ; But when you use a GROUP! or a BLOCK!, it will put things in quotes.
+        ; To bypass this behavior, use GET-GROUP! or GET-BLOCK!
+
+        let splice: <default>
+        item: maybe switch type of item [
+            group! [splice: false, try do item]
+
+            get-group! [splice: true, try do item]
+            get-block! [splice: true, as block! item]
+        ]
+        let needs-quotes?: func [item] [
+            if match [word! issue!] item [return false]  ; never quoted
+            if file? item [
+                return find item space  ; !!! should check for other escapes
+            ]
+            if splice = false [return true]
+            if splice = true [return false]  ; e.g. even TEXT! has no quotes
+            return text? item  ; plain `$ ls "/foo"` puts quotes on "/foo"
+        ] 
+
+        item: switch type of item [
+            blank! [continue]  ; !!! should you have to use #_ for undercore?
+
+            integer! decimal! [form item]
+
+            word! issue! [item]  ; never quoted or escaped
+
+            text! [replace/all copy item {"} {\"}]  ; sometimes spliced
+
+            file! [item]
+
+            tag! [shellify-tag item]
+            path! tuple! block! [
+                file-to-local make-file/predicate item :shellify-tag
+            ]
+
+            fail ["SHELL doesn't know what this means:" mold item]
+        ]
+
+        if needs-quotes? item [
+            if file? item [item: file-to-local item]
+            keep unspaced [{"} form item {"}]  ; !!! better escape for strings
+        ] else [
+            if file? item [item: file-to-local item]
+            keep form item
+        ]
+    ]]
+
+    if inspect [
+        return command
+    ]
+
+    if not command [return null]  ; SPACED components all vaporized
+
+    if not pipe [
+        lib/call/shell command  ; must use LIB (binding issue)
+        return ~  ; don't show any result in console
+    ]
+
+    let output: copy ""
+    lib/call/shell/output command output  ; must use LIB (binding issue)
+    return output
+]
+
+
+$: func [
+    {Run SHELL code to end of line (or continue on next line with `...`)}
+    :args "See documentation for SHELL"
+        [any-value! <variadic>]
+    /inspect
+    /pipe
+    <local> code item
+][
+    code: collect [
+        cycle [
+            ; We pass the ... through to the shell dialect, which knows how
+            ; to handle it as a line continuation.
+            ;
+            all [new-line? args, '... <> first args] then [break]
+
+            keep take args else [break]
+        ]
+    ]
+
+    shell/(if inspect [/inspect])/(if pipe [/pipe]) code
+]

--- a/scripts/unzip.reb
+++ b/scripts/unzip.reb
@@ -238,7 +238,7 @@ ctx-zip: context [
             root+name: if find "\/" name/1 [
                 info ["Warning: absolute path" name]
                 name
-            ] else [root/:name]
+            ] else [%% (root)/(name)]
 
             no-modes: did any [url? root+name, dir? root+name]
 
@@ -246,7 +246,7 @@ ctx-zip: context [
                 name: dirize name
                 files: ensure block! read root+name
                 for-each file files [
-                    append source name/:file
+                    append source %% (name)/(file)
                 ]
                 continue
             ]
@@ -455,27 +455,27 @@ ctx-zip: context [
 
                     either any-array? where [
                         where: insert where name
-                        where: insert where either all [
+                        where: insert where all [
                             #"/" = last name
                             empty? uncompressed-data
-                        ][blank][uncompressed-data]
+                        ] then [blank] else [uncompressed-data]
                     ][
                         ; make directory and/or write file
                         either #"/" = last name [
-                            if not exists? where/:name [
-                                make-dir/deep where/:name
+                            if not exists? %% (where)/(name) [
+                                make-dir/deep %%(where)/(name)
                             ]
                         ][
                             set [path: file:] split-path name
-                            if not exists? where/:path [
-                                make-dir/deep where/:path
+                            if not exists? %% (where)/(path) [
+                                make-dir/deep %% (where)/(path)
                             ]
                             if uncompressed-data [
-                                write where/:name uncompressed-data
+                                write %% (where)/(name) uncompressed-data
 
                                 ; !!! R3-Alpha didn't support SET-MODES
                                 comment [
-                                    set-modes where/:name [
+                                    set-modes %% (where)/(name) [
                                         modification-date: date
                                     ]
                                 ]

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -1262,6 +1262,15 @@ static enum Reb_Token Locate_Token_May_Push_Mold(
             panic ("@ dead end");
 
           case LEX_SPECIAL_PERCENT:  // %filename
+            if (cp[1] == '%') {  // %% is WORD! exception
+                if (not IS_LEX_DELIMIT(cp[2]) and cp[2] != ':') {
+                    ss->end = cp + 3;
+                    fail (Error_Syntax(ss, TOKEN_FILE));
+                }
+                ss->end = cp + 2;
+                return TOKEN_WORD;
+            }
+
             token = TOKEN_FILE;
 
           issue_or_file_token:  // issue jumps here, should set `token`

--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -415,76 +415,19 @@ REB_R PD_String(
             return pvs->out;
         }
 
-        if (IS_BLANK(picker)) {
-            //
-            // `f: %foo | f/bar/` should work
-            // https://github.com/rebol/rebol-issues/issues/2378
-            //
-            picker = EMPTY_TEXT;
-        }
-        else if (
-            not (IS_WORD(picker) or IS_TUPLE(picker) or ANY_STRING(picker))
+        if (
+            IS_BLANK(picker)
+            or IS_WORD(picker)
+            or IS_TUPLE(picker)
+            or ANY_STRING(picker)
         ){
-            return R_UNHANDLED;
+            fail (
+                "FILE! pathing replaced by %% and MAKE-FILE, see: "
+                "https://forum.rebol.info/t/1398"
+            );
         }
 
-        // !!! This is a historical and questionable feature, where path
-        // picking a string or word or otherwise out of a FILE! or URL! will
-        // generate a new FILE! or URL! with a slash in it.
-        //
-        //     >> x: %foo
-        //     >> type of 'x/bar
-        //     == path!
-        //
-        //     >> x/bar
-        //     == %foo/bar  ; a FILE!
-        //
-        // This can only be done with evaluations, since FILE! and URL! have
-        // slashes in their literal form:
-        //
-        //     >> type of '%foo/bar
-        //     == file!
-        //
-        // Because Ren-C unified picking and pathing, this somewhat odd
-        // feature is now part of PICKing a string from another string.
-
-        DECLARE_MOLD (mo);
-        Push_Mold(mo);
-
-        Form_Value(mo, pvs->out);
-
-        // This makes sure there's always a "/" at the end of the file before
-        // appending new material via a picker:
-        //
-        //     >> x: %foo
-        //     >> (x)/("bar")
-        //     == %foo/bar
-        //
-        if (STR_SIZE(mo->series) - mo->offset == 0)
-            Append_Codepoint(mo->series, '/');
-        else {
-            if (
-                *SER_AT(REBYTE, SER(mo->series), STR_SIZE(mo->series) - 1)
-                != '/'
-            ){
-                Append_Codepoint(mo->series, '/');
-            }
-        }
-
-        // !!! Code here previously would handle this case:
-        //
-        //     >> x/("/bar")
-        //     == %foo/bar
-        //
-        // It's changed, so now the way to do that would be to drop the last
-        // codepoint in the mold buffer, or advance the index position of the
-        // picker.  Punt on it for now, as it will be easier to write when
-        // UTF-8 Everywhere is actually in effect.
-
-        Form_Value(mo, picker);
-
-        Init_Any_String(pvs->out, VAL_TYPE(pvs->out), Pop_Molded_String(mo));
-        return pvs->out;
+        return R_UNHANDLED;
     }
 
     // Otherwise, POKE-ing

--- a/src/main/main-startup.reb
+++ b/src/main/main-startup.reb
@@ -748,12 +748,12 @@ main-startup: function [
     all [
         not find o/suppress %rebol.reb
         elide (loud-print ["Checking for rebol.reb file in" o/bin])
-        exists? o/bin/rebol.reb
+        exists? %% (o/bin)/rebol.reb
     ] then [
         trap [
-            do o/bin/rebol.reb
-            append o/loaded o/bin/rebol.reb
-            loud-print ["Finished evaluating script:" o/bin/rebol.reb]
+            do %% (o/bin)/rebol.reb
+            append o/loaded %% (o/bin)/rebol.reb
+            loud-print ["Finished evaluating script:" %% (o/bin)/rebol.reb]
         ] then e -> [
             die/error "Error found in rebol.reb script" e
         ]

--- a/src/main/prep-main.reb
+++ b/src/main/prep-main.reb
@@ -50,16 +50,17 @@ append/line buf "host-prot: ["
 
 
 for-each file [
-    %../../scripts/prot-tls.r  ; TLS (a.k.a. the "S" in HTTPS)
-    %../../scripts/prot-http.r  ; HTTP Client (HTTPS if used with TLS)
+    %prot-tls.r  ; TLS (a.k.a. the "S" in HTTPS)
+    %prot-http.r  ; HTTP Client (HTTPS if used with TLS)
 ][
     header: _  ; was a SET-WORD!...for locals gathering?
-    contents: stripload/header (join %../mezz/ file) 'header
+    contents: stripload/header (join %../../scripts/ file) 'header
 
     ; We go ahead and LOAD the header in this case, so we can write only the
     ; module fields we care about ("Description" is not needed, for instance.)
     ;
     header: load header
+
     append/line buf mold/flat compose [
         Title: (header/title)
         Version: (header/version)
@@ -86,6 +87,10 @@ append/line buf "]"
 for-each file [
     %../../scripts/encap.reb
     %../../scripts/unzip.reb
+
+    %../../scripts/make-file.r  ; Work in progress for FILE! conversion
+    %../../scripts/shell.r  ; SHELL dialect (requires CALL, here for editing)
+
     %main-startup.reb
 ][
     print ["loading:" file]
@@ -93,7 +98,7 @@ for-each file [
     header: _  ; !!! Was a SET-WORD!...for locals gathering?
     contents: stripload/header file 'header
 
-    is-module: false  ; currently none of these three files are modules
+    is-module: false  ; currently none of these files are modules
     if is-module [
         append/line buf "import module ["
         append/line buf header
@@ -122,7 +127,7 @@ write-if-changed make-file [(output-dir) main /tmp-main-startup.r] buf
 
 (e: make-emitter
     "r3 console executable embedded Rebol code bundle"
-    output-dir/main/tmp-main-startup.inc)
+    make-file [(output-dir) main/tmp-main-startup.inc])
 
 compressed: gzip buf
 

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -142,7 +142,7 @@ make-dir: func [
     ; Create directories forward:
     created: copy []
     for-each dir dirs [
-        path: either empty? path [dir][path/(dir)]
+        path: if empty? path [dir] else [join path dir]
         append path slash
         trap [make-dir path] then (lambda e [
             for-each dir created [attempt [delete dir]]

--- a/test-build.sh
+++ b/test-build.sh
@@ -51,8 +51,8 @@ echo "$R3_EXIT_STATUS"
 #
 # (export is so that the child process can see the environment variable)
 #
-echo "Note: CONFIG_TCCDIR is ${CONFIG_TCCDIR}"
-export LIBREBOL_INCLUDE_DIR="${TOP_DIR}/build/prep/include"
+echo "Note: CONFIG_TCCDIR is ${CONFIG_TCCDIR} (missing tail slash allowed)"
+export LIBREBOL_INCLUDE_DIR="${TOP_DIR}/build/prep/include/"
 if [[ (! -z $TCC) && ($TCC != no) ]]; then
   if [[ $OS_ID = 0.4.40 ]]; then
     $RUNNER ./r3 ../extensions/tcc/tests/fib.r

--- a/tests/core-tests.r
+++ b/tests/core-tests.r
@@ -204,6 +204,7 @@
 %misc/assert.test.reb
 %misc/help.test.reb
 %misc/fail.test.reb
+%misc/make-file.test.reb
 
 %network/http.test.reb
 

--- a/tests/datatypes/file.test.reb
+++ b/tests/datatypes/file.test.reb
@@ -25,5 +25,5 @@
 
 [#2378 (
     some-file: %foo/baz/
-    %foo/baz/bar/ = some-file/bar/
+    error? trap [some-file/bar/]
 )]

--- a/tests/datatypes/path.test.reb
+++ b/tests/datatypes/path.test.reb
@@ -146,7 +146,7 @@
 
 [#71 (
     a: "abcd"
-    "abcd/x" = a/x
+    error? trap [a/x]
 )]
 
 [#1820 ; Word USER can't be selected with path syntax

--- a/tests/datatypes/word.test.reb
+++ b/tests/datatypes/word.test.reb
@@ -226,3 +226,22 @@
     ("$$" = as text! match word! '$$)
     ("$$$" = as text! match word! '$$$)
 ]
+
+; `%%` was added as a WORD! to serve as a quoting-based MAKE FILE! operator.
+;
+; Single % is not a good idea to have as a WORD!, because `%/foo` would be
+; ambiguous as a PATH! vs. FILE!.  Sacrificing %% as a shorthand for %"%"
+; and giving it to WORD! is worth it.  How many other forms would be worth
+; it is up in the air, so only %% is legal for now.
+[
+    ("%%" = as text! match word! '%%)
+    ("%%" = as text! match set-word! '%%:)
+    ("%%" = as text! match get-word! ':%%)
+    ("%%" = as text! match sym-word! '@%%)
+    ("%%" = as text! match word! first [%%])
+    ("%%" = as text! match set-word! first [%%:])
+    ("%%" = as text! match get-word! first [:%%])
+    ("%%" = as text! match sym-word! first [@%%])
+
+    ("%%/foo" = form match path! '%%/foo)
+]

--- a/tests/misc/make-file.test.reb
+++ b/tests/misc/make-file.test.reb
@@ -1,0 +1,73 @@
+; make-file.test.reb
+;
+; The MAKE-FILE facility is an experimental testbed for trying to use the
+; new forms of PATH! and TUPLE! in an effective way to create filenames.
+;
+; Because it is used by bootstrap, the implementation currently has to
+; accomodate systems that do not have generalized TUPLE! or PATH!.  They
+; use only the block form, e.g. `MAKE-FILE [(dir) / file.txt]`
+;
+; See the documentation in %make-file.r for the key design premises, which
+; involve some level of sanity checking spliced path components.
+
+
+; In newer Ren-C the operator `%%` is available as a quoting form, and is
+; used for brevity in this test file.
+[
+    (%*.txt = make-file '*.(if true ["txt"]))
+
+    (%*.txt = %% *.(if true ["txt"]))
+]
+
+
+; Inputs that do not have any GROUP! or BLOCK! in them just pass through.
+[
+    (%a = %% a)
+    (%a/b/c = %% a/b/c)
+    (%a.b.c = %% a.b.c)
+    (%/b/c = %% /b/c)
+    (%.b.c = %% .b.c)
+]
+
+
+; A design goal of MAKE FILE! is to use structural knowledge to help sanity
+; check path construction.  As a ground-zero example of usefulness, when
+; filling in a TUPLE! segment you can't put paths in it.
+[
+    (
+        extension: "txt/bad"
+
+        e: trap [%% a/b.(extension)]
+        e/id = 'embedded-file-slash
+    )
+]
+
+
+; The BLOCK! form of MAKE FILE! pushes parts together in an unspaced fashion,
+; and will run GROUP!s.  At this level, the protection is against doubled-up
+; slashes or dots, but that's its only structural guard.
+[
+    (%a/b/c = %% [a / b / c])
+    (%a/b/c = %% [a/b / c])
+    (%a/b/c = %% [a/b /c])
+    (%a/b/c = %% [a /b/c])
+
+    (%a/b/c/d/e/f = %% [a/b / c/d / e/f])
+
+    (%/b/c = %% [(if false ['a]) /b/c])
+    (%a/b/c = %% [(if true ['a]) /b/c])
+
+    (
+        e: trap [
+            %% [(if true ['a/b/]) /b/c]
+        ]
+        e/id = 'doubled-file-slash
+    )
+    
+    (
+        e: trap [
+            %% [(if true ["a/b/"]) /b/c]
+        ]
+        e/id = 'embedded-file-slash
+    )
+]

--- a/tests/source/source-tools.reb
+++ b/tests/source/source-tools.reb
@@ -37,21 +37,16 @@ REBOL [
 ; This script makes some assumptions about the structure of the repo.
 ;
 
-ren-c-repo: clean-path %../
-
 do %../../tools/common.r
 
-do make-file '(repo/tools)/common-parsers.r
-do make-file '(repo/tools)/text-lines.reb
-do make-file '(repo/tools)/read-deep.reb
+do %% (repo-dir)/tools/common-parsers.r
+do %% (repo-dir)/tools/text-lines.reb
+do %% (repo-dir)/tools/read-deep.reb
 
 ; rebsource is organised along the lines of a context sensitive vocabulary.
 ;
 
 rebsource: context [
-
-    src-folder: clean-path repo/source-root
-    ; Path to rebol source files.
 
     logfn: func [message][print mold new-line/all compose/only message false]
     log: :logfn
@@ -143,7 +138,8 @@ rebsource: context [
             all [
                 filetype: select extensions extension-of file
                 type: in source filetype
-                reeval (ensure action! get type) file (read src-folder/:file)
+                (reeval (ensure action! get type) file
+                    (read %% (repo-dir)/src/(file))
             ]
         ]
 
@@ -291,7 +287,7 @@ rebsource: context [
             analysis: copy []
             emit: specialize :log-emit [log: analysis]
 
-            data: read src-folder/:file
+            data: read %% (repo-dir)/src/(file)
 
             bol: _
             line: _
@@ -401,8 +397,6 @@ rebsource: context [
         source-files: function [
             {Retrieves a list of source files (relative paths).}
         ][
-            if not src-folder [fail {Configuration of src-folder required.}]
-
             files: read-deep/full/strategy source-paths :source-files-seq
 
             sort files
@@ -419,7 +413,7 @@ rebsource: context [
             item: ensure file! take queue
 
             if equal? #"/" last item [
-                contents: read join src-folder item
+                contents: read %% (repo-dir)/src/(item)
                 insert queue map-each x contents [join item x]
                 item: _
             ] else [

--- a/tests/source/text-lines.test.reb
+++ b/tests/source/text-lines.test.reb
@@ -3,7 +3,7 @@
 
 (; Setup test.
     do %../../tools/common.r
-    do repo/tools/text-lines.reb
+    do %% (repo-dir)/tools/text-lines.reb
     true
 )
 

--- a/tools/bootstrap-shim.r
+++ b/tools/bootstrap-shim.r
@@ -450,3 +450,9 @@ dequote: func [x] [
         lit-path! [to path! x]
     ] else [x]
 ]
+
+; This experimental MAKE-FILE is targeting behavior that should be in the
+; system core eventually.  Despite being very early in its design, it's
+; being built into new Ren-Cs to be tested...but bootstrap doesn't have it.
+;
+do %../scripts/make-file.r  ; Experimental!  Trying to replace PD_File...

--- a/tools/common.r
+++ b/tools/common.r
@@ -19,17 +19,12 @@ REBOL [
 
 do %bootstrap-shim.r
 
-do %make-file.r  ; Experimental!  Trying to replace PD_File...
 
 ; When you run a Rebol script, the `current-path` is the directory where the
 ; script is.  We assume that the Rebol source enlistment's root directory is
 ; one level above this file (which should be %tools/common.r)
 ;
-repo: context [
-    root: clean-path %../
-    source-root: root
-    tools: what-dir
-]
+repo-dir: clean-path %../
 
 spaced-tab: unspaced [space space space space]
 
@@ -325,29 +320,6 @@ parse-args: function [
     if empty? standalone [return ret]
     append ret '|
     append ret standalone
-]
-
-fix-win32-path: func [
-    path [file!]
-    <local> letter colon
-][
-    if 3 != fourth system/version [return path] ;non-windows system
-
-    drive: first path
-    colon: second path
-
-    all [
-        any [
-            (#"A" <= drive) and [#"Z" >= drive]
-            (#"a" <= drive) and [#"z" >= drive]
-        ]
-        #":" = colon
-    ] then [
-        insert path #"/"
-        remove skip path 2 ;remove ":"
-    ]
-
-    path
 ]
 
 uppercase-of: func [

--- a/tools/make-boot.r
+++ b/tools/make-boot.r
@@ -47,13 +47,11 @@ if args/GIT_COMMIT = "unknown" [
 
 === SETUP PATHS AND MAKE DIRECTORIES (IF NEEDED) ===
 
-output-dir: make-file [(system/options/path) prep /]
-inc: make-file [(output-dir) include /]
-core: make-file [(output-dir) core /]
-boot: make-file [(output-dir) boot /]
-mkdir/deep probe inc
-mkdir/deep probe boot
-mkdir/deep probe core
+prep-dir: make-file [(system/options/path) prep /]
+
+mkdir/deep make-file [(prep-dir) include /]
+mkdir/deep make-file [(prep-dir) boot /]
+mkdir/deep make-file [(prep-dir) core /]
 
 Title: {
     REBOL
@@ -108,7 +106,8 @@ comment [
 
 === MAKE VERSION INFORMATION AVAILABLE TO CORE C CODE ===
 
-e-version: make-emitter "Version Information" inc/tmp-version.h
+(e-version: make-emitter "Version Information"
+    make-file [(prep-dir) include/tmp-version.h])
 
 version: load %version.r
 version: to tuple! reduce [
@@ -147,7 +146,8 @@ e-version/write-emitted
 ; recompiled with changes to the core.  These symbols aren't in libRebol,
 ; however, so it only affects clients of the core API for now.
 
-e-symbols: make-emitter "Symbol Numbers" inc/tmp-symbols.h
+(e-symbols: make-emitter "Symbol Numbers"
+    make-file [(prep-dir) include/tmp-symbols.h])
 
 syms: copy []
 
@@ -180,7 +180,8 @@ add-sym: function [
 
 type-table: load %types.r
 
-e-types: make-emitter "Datatype Definitions" inc/tmp-kinds.h
+(e-types: make-emitter "Datatype Definitions"
+    make-file [(prep-dir) include/tmp-kinds.h])
 
 n: 0
 
@@ -437,7 +438,8 @@ e-types/write-emitted
 
 === BUILT-IN TYPE HOOKS TABLE ===
 
-e-hooks: make-emitter "Built-in Type Hooks" core/tmp-type-hooks.c
+(e-hooks: make-emitter "Built-in Type Hooks"
+    make-file [(prep-dir) core/tmp-type-hooks.c])
 
 hookname: enfixed func [
     return: [text!]
@@ -507,7 +509,7 @@ for-each word wordlist [
 
 first-generic-sym: sym-n
 
-boot-generics: load boot/tmp-generics.r
+boot-generics: load make-file [(prep-dir) boot/tmp-generics.r]
 for-each item boot-generics [
     if set-word? :item [
         if first-generic-sym < ((add-sym/exists to-word item) else [0]) [
@@ -519,7 +521,8 @@ for-each item boot-generics [
 
 === SYSTEM OBJECT SELECTORS ===
 
-e-sysobj: make-emitter "System Object" inc/tmp-sysobj.h
+(e-sysobj: make-emitter "System Object"
+    make-file [(prep-dir) include/tmp-sysobj.h])
 
 at-value: func ['field] [next find boot-sysobj to-set-word field]
 
@@ -621,7 +624,8 @@ evks: collect [
 
 === ERROR STRUCTURE AND CONSTANTS ===
 
-e-errfuncs: make-emitter "Error structure and functions" inc/tmp-error-funcs.h
+(e-errfuncs: make-emitter "Error structure and functions"
+    make-file [(prep-dir) include/tmp-error-funcs.h])
 
 fields: collect [
     keep {RELVAL self}
@@ -746,7 +750,8 @@ for-each section [boot-base boot-sys boot-mezz] [
     mezz-files: next mezz-files
 ]
 
-e-sysctx: make-emitter "Sys Context" inc/tmp-sysctx.h
+(e-sysctx: make-emitter "Sys Context"
+    make-file [(prep-dir) include/tmp-sysctx.h])
 
 ; We heuristically gather top level declarations in the system context, vs.
 ; trying to use LOAD and look at actual object keys.  Because this process
@@ -787,7 +792,8 @@ e-sysctx/write-emitted
 ; %tmp-boot-block.c is just a C file containing a literal constant of the
 ; compressed representation of %tmp-boot-block.r
 
-e-bootblock: make-emitter "Natives and Bootstrap" core/tmp-boot-block.c
+(e-bootblock: make-emitter "Natives and Bootstrap"
+    make-file [(prep-dir) core/tmp-boot-block.c])
 
 sections: [
     boot-types
@@ -802,7 +808,7 @@ sections: [
     :boot-mezz
 ]
 
-boot-natives: load boot/tmp-natives.r
+boot-natives: load make-file [(prep-dir) boot/tmp-natives.r]
 
 nats: collect [
     for-each val boot-natives [
@@ -848,7 +854,7 @@ for-each sec sections [
 ]
 append/line boot-molded "]"
 
-write-if-changed make-file [(boot) tmp-boot-block.r] boot-molded
+write-if-changed make-file [(prep-dir) boot/tmp-boot-block.r] boot-molded
 data: as binary! boot-molded
 
 compressed: gzip data
@@ -872,7 +878,8 @@ e-bootblock/write-emitted
 
 === BOOT HEADER FILE ===
 
-e-boot: make-emitter "Bootstrap Structure and Root Module" inc/tmp-boot.h
+(e-boot: make-emitter "Bootstrap Structure and Root Module"
+    make-file [(prep-dir) include/tmp-boot.h])
 
 nat-index: 0
 nids: collect [

--- a/tools/make-embedded-header.r
+++ b/tools/make-embedded-header.r
@@ -23,7 +23,7 @@ args: parse-args system/script/args  ; either from command line or DO/ARGS
 output-dir: system/options/path/prep
 mkdir/deep make-file [(output-dir) core /]
 
-inp: read fix-win32-path to file! output-dir/include/sys-core.i
+inp: read make-file [(output-dir) include/sys-core.i]
 replace/all inp "// #define" "#define"
 replace/all inp "// #undef" "#undef"
 replace/all inp "<ce>" "##" ;bug in tcc??
@@ -51,7 +51,7 @@ remove/part inp -1 + index? find inp to binary! "#define DEBUG_STDIO_OK"
 ;write %/tmp/sys-core.i inp
 
 e: (make-emitter
-    "Embedded sys-core.h" output-dir/core/tmp-embedded-header.c)
+    "Embedded sys-core.h" make-file [(output-dir) core/tmp-embedded-header.c])
 
 e/emit {
     #include "sys-core.h"

--- a/tools/make-headers.r
+++ b/tools/make-headers.r
@@ -31,7 +31,8 @@ change-dir %../src/core/
 
 print "------ Building headers"
 
-e-funcs: make-emitter "Internal API" output-dir/include/tmp-internals.h
+(e-funcs: make-emitter "Internal API"
+    make-file [(output-dir) include/tmp-internals.h])
 
 prototypes: make block! 10000 ; MAP! is buggy in R3-Alpha
 
@@ -142,7 +143,7 @@ process: function [
 ; more solid mechanism.
 
 
-boot-natives: load output-dir/boot/tmp-natives.r
+boot-natives: load make-file [(output-dir) boot/tmp-natives.r]
 
 e-funcs/emit {
     /*
@@ -302,9 +303,9 @@ sys-globals-parser/process read/string %../include/sys-globals.h
 
 e-params: (make-emitter
     "PARAM() and REFINE() Automatic Macros"
-    output-dir/include/tmp-paramlists.h)
+    make-file [(output-dir) include/tmp-paramlists.h])
 
-generic-list: load output-dir/boot/tmp-generics.r
+generic-list: load make-file [(output-dir) boot/tmp-generics.r]
 
 ; Search file for definition.  Will be `generic-name: generic [paramlist]`
 ;
@@ -317,7 +318,7 @@ iterate generic-list [
     ]
 ]
 
-native-list: load output-dir/boot/tmp-natives.r
+native-list: load make-file [(output-dir) boot/tmp-natives.r]
 parse native-list [
     some [
         opt 'export
@@ -341,7 +342,8 @@ e-params/write-emitted
 ;-------------------------------------------------------------------------
 
 e-strings: (make-emitter
-    "REBOL Constants with Global Linkage" output-dir/include/tmp-constants.h)
+    "REBOL Constants with Global Linkage"
+    make-file [(output-dir) include/tmp-constants.h])
 
 e-strings/emit {
     /*

--- a/tools/make-natives.r
+++ b/tools/make-natives.r
@@ -139,9 +139,9 @@ append output-buffer {REBOL [
 
 }
 
-boot-types: load src-dir/boot/types.r
+boot-types: load make-file [(src-dir) boot/types.r]
 
-append output-buffer mold/only load src-dir/boot/generics.r
+append output-buffer mold/only load make-file [(src-dir) boot/generics.r]
 
 append output-buffer unspaced [
     newline

--- a/tools/make-reb-lib.r
+++ b/tools/make-reb-lib.r
@@ -155,7 +155,7 @@ process: func [file] [
 
 src-dir: %../src/core/
 
-process src-dir/a-lib.c
+process make-file [(src-dir) a-lib.c]
 
 
 === GENERATE LISTS USED TO BUILD REBOL.H ===
@@ -357,7 +357,7 @@ c99-or-c++11-macros: collect [ map-each-api [
 ; edit, since the Rebol codebase at large uses `//`-style comments.
 
 e-lib: (make-emitter
-    "Rebol External Library Interface" output-dir/rebol.h)
+    "Rebol External Library Interface" make-file [(output-dir) rebol.h])
 
 e-lib/emit {
     #ifndef REBOL_H_1020_0304  /* "include guard" allows multiple #includes */
@@ -940,7 +940,8 @@ e-lib/write-emitted
 ; one instance of this table should be linked into Rebol.
 
 e-table: (make-emitter
-    "REBOL Interface Table Singleton" output-dir/tmp-reb-lib-table.inc)
+    "REBOL Interface Table Singleton"
+    make-file [(output-dir) tmp-reb-lib-table.inc])
 
 table-init-items: map-each-api [
     unspaced ["RL_" name]
@@ -970,6 +971,6 @@ e-table/write-emitted
 ; The JavaScript extension actually mutates the API table, so run the TCC hook
 ; first...
 ;
-do repo/tools/../extensions/tcc/prep-libr3-tcc.reb
+do make-file [(repo-dir) tools/../extensions/tcc/prep-libr3-tcc.reb]
 
-do repo/tools/../extensions/javascript/prep-libr3-js.reb
+do make-file [(repo-dir) tools/../extensions/javascript/prep-libr3-js.reb]

--- a/tools/prep-extension.r
+++ b/tools/prep-extension.r
@@ -49,7 +49,7 @@ do %native-emitters.r ; for emit-include-params-macro
 ; include path for the build of the extension
 
 args: parse-args system/script/args  ; either from command line or DO/ARGS
-src: fix-win32-path to file! :args/SRC
+src: to file! :args/SRC
 set [in-dir file-name] split-path src
 output-dir: make-file [(system/options/path) prep / (in-dir)]
 insert src %../
@@ -63,13 +63,13 @@ m-name: mod
 l-m-name: lowercase copy m-name
 u-m-name: uppercase copy m-name
 
-c-src: join %../ fix-win32-path to file! ensure text! args/SRC
+c-src: make-file [../ (as file! ensure text! args/SRC)]
 
 print ["building" m-name "from" c-src]
 
 
 e1: (make-emitter "Module C Header File Preface"
-    ensure file! join-all [output-dir/tmp-mod- l-m-name %.h])
+    make-file [(output-dir) tmp-mod- (l-m-name) .h])
 
 
 verbose: false
@@ -320,11 +320,7 @@ parse inc-name [
     ]  ; auto-generating version of initial (and poor) manual naming scheme
 ]
 
-dest: join output-dir inc-name
-
-if is-cpp [print [mold dest] wait 2]
-
-e: make-emitter "Ext custom init code" dest
+e: make-emitter "Ext custom init code" make-file [(output-dir) (inc-name)]
 
 ; Review: This does not use STRIPLOAD but encodes the script as C bytes
 ; verbatim--comments and whitespace and all.  That may be desirable if there

--- a/tools/rebmake.r
+++ b/tools/rebmake.r
@@ -1355,7 +1355,7 @@ makefile: make generator-class [
                         fail ["Unknown entry/target type" entry/target]
                     ]
                     for-each w (ensure [block! blank!] entry/depends) [
-                        switch w/class [
+                        switch pick (try match object! w) 'class [
                             #variable [
                                 keep ["$(" w/name ")"]
                             ]
@@ -1834,6 +1834,8 @@ visual-studio: make generator-class [
         output-dir [file!] {Solution directory}
         project [object!]
     ][
+        assert [dir? output-dir]
+
         project-name: if project/class = #entry [
             project/target
         ] else [
@@ -2186,7 +2188,7 @@ visual-studio: make generator-class [
 }
         ]
 
-        write out-file: output-dir/(unspaced [project-name ".vcxproj"]) xml
+        write (out-file: make-file [(output-dir) (project-name) .vcxproj]) xml
         ;print ["Wrote to" out-file]
     ]
 
@@ -2196,8 +2198,10 @@ visual-studio: make generator-class [
         solution [object!]
         /x86
     ][
-        buf: make binary! 2048
+        assert [dir? output-dir]
         assert [solution/class = #solution]
+
+        buf: make binary! 2048
 
         prepare solution
 
@@ -2271,7 +2275,7 @@ visual-studio: make generator-class [
 
         append buf "EndGlobal^/"
 
-        write output-dir/(unspaced [solution/name ".sln"]) buf
+        write (make-file [(output-dir) (solution/name) .sln]) buf
     ]
 ]
 


### PR DESCRIPTION
**[I've mentioned that it's time to start putting NewPath through its paces.](https://forum.rebol.info/t/make-file-and-unleashed-time-to-use-it/1398)**  This needs to be discussed, tested, and improved.

It's far from perfect, so replacing old **file/path/component** cases might hit speedbumps.  But those should be studied and then the code and tests adapted to show what it *should* do.

---

This moves the MAKE-FILE experimental code that has been used for
bootstrap into the main executable.  It uses generic PATH! and TUPLE!
as a template for composing filenames:

    >> extension: "txt"
    >> dir: %/home/test/

    >> make-file '(dir)/subdir/foo.(extension)
    == %/home/test/subdir/foo.txt

There is a shorthand quoting operator tied to the new `%%` WORD!

    >> %% (dir)/subdir/foo.(extension)
    == %/home/test/subdir/foo.txt

THE HISTORICAL ABILITY TO PATH PICK A FILE! TO CREATE A FILE! IS GONE.

    rebol2>> dir: %/home/test

    rebol2>> dir/subdir/foo
    == %/home/test/subdir/foo  ; this now fails

MAKE-FILE is not finalized in its abilities, so if using it to replace
instances of these calls doesn't seem like it works how it should,
it's time to address that.

MAKE-FILE is entirely user code (all extremely draft-level) so it can
be worked on.  Long term, it will be rethought and rewritten as native
code, or at least broken into some support natives that might be more
generally useful in PATH! and TUPLE! manipulation.

This commit also includes the beginnings of a SHELL dialect, which
needs significant design discussion to decide how it should work:

    >> dirs: [%/usr/local %/home]

    >> shell [ls -alF (first dirs)]
    ; acts as `call/shell "ls -alF /usr/local"`

    >> $ ls -alF (first dirs)
    ; variadic operator shorthand for the above
