### PR TITLE
NULL Isotopes (The End of Voidfication!)

### DIFF
--- a/extensions/console/ext-console-init.reb
+++ b/extensions/console/ext-console-init.reb
@@ -129,8 +129,8 @@ console!: make object! [
         ]
 
         case [
-            null? :v [
-                print "; null"  ; no representation, use comment
+            null? :v [  ; no representation, use comment
+                print ["; null" if isotope? 'v [#-2]]
             ]
 
             free? :v [
@@ -611,7 +611,7 @@ ext-console-impl: function [
     === HANDLE RESULT FROM EXECUTION OF CODE ON USER'S BEHALF ===
 
     if group? prior [
-        emit [system/console/print-result (<*> result)]
+        emit [system/console/print-result (<*> get/any 'result)]
         return <prompt>
     ]
 

--- a/scripts/prot-tls.r
+++ b/scripts/prot-tls.r
@@ -195,7 +195,7 @@ debug: (comment [:print] blank)
 emit: function [
     {Emits binary data, optionally marking positions with SET-WORD!}
 
-    return: [void!]
+    return: <void>
     ctx [object!]
     code [block! binary!]
     <local> result

--- a/src/core/d-gc.c
+++ b/src/core/d-gc.c
@@ -428,6 +428,10 @@ void Assert_Cell_Marked_Correctly(unstable const RELVAL *v)
 
     enum Reb_Kind kind = CELL_KIND(cast(REBCEL(const*), v));
     switch (kind) {
+      case REB_NULL:
+        assert(heart == REB_NULL or heart == REB_BLANK);  // may be "isotope"
+        break;
+
       case REB_TUPLE:
       case REB_SET_TUPLE:
       case REB_GET_TUPLE:

--- a/src/core/evaluator/c-action.c
+++ b/src/core/evaluator/c-action.c
@@ -143,14 +143,11 @@ bool Lookahead_To_Sync_Enfix_Defer_Flag(struct Reb_Feed *feed) {
 //
 static bool Handle_Modal_In_Out_Throws(REBFRM *f) {
     switch (VAL_TYPE(f->out)) {
-      case REB_SYM_WORD:
-      case REB_SYM_PATH:
-        Getify(f->out);  // don't run @append or @append/only
-        goto enable_modal;
-
-      case REB_SYM_GROUP:
-      case REB_SYM_BLOCK:
-        Plainify(f->out);  // run GROUP!, pass block as-is
+      case REB_SYM_WORD:  // run @APPEND
+      case REB_SYM_PATH:  // run @APPEND/ONLY
+      case REB_SYM_GROUP:  // run @(GR O UP)
+      case REB_SYM_BLOCK:  // pass @[BL O CK] as-is
+        Plainify(f->out);
         goto enable_modal;
 
       default:

--- a/src/core/evaluator/c-eval.c
+++ b/src/core/evaluator/c-eval.c
@@ -637,6 +637,7 @@ bool Eval_Maybe_Stale_Throws(REBFRM * const f)
             fail (Error_Need_Non_Void_Core(v, f_specifier, unwrap(gotten)));
 
         Move_Value(f->out, unwrap(gotten));  // no copy CELL_FLAG_UNEVALUATED
+        Decay_If_Nulled(f->out);
         break;
 
 
@@ -678,6 +679,7 @@ bool Eval_Maybe_Stale_Throws(REBFRM * const f)
             fail (Error_Need_Non_Void_Core(v, f_specifier, unwrap(gotten)));
 
         Move_Value(f->out, unwrap(gotten));
+        Decay_If_Nulled(f->out);
 
         if (IS_ACTION(unwrap(gotten)))  // cache the word's label in the cell
             INIT_ACTION_LABEL(f->out, VAL_WORD_SPELLING(v));
@@ -863,6 +865,7 @@ bool Eval_Maybe_Stale_Throws(REBFRM * const f)
             Move_Value(f->out, where);  // won't move CELL_FLAG_UNEVALUATED
         else
             CLEAR_CELL_FLAG(f->out, UNEVALUATED);
+        Decay_If_Nulled(f->out);
         break; }
 
 
@@ -945,6 +948,7 @@ bool Eval_Maybe_Stale_Throws(REBFRM * const f)
         //
         /* assert(NOT_CELL_FLAG(f->out, CELL_FLAG_UNEVALUATED)); */
         CLEAR_CELL_FLAG(f->out, UNEVALUATED);
+        Decay_If_Nulled(f->out);
         break;
 
 

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -540,6 +540,9 @@ inline static void Get_Var_May_Fail(
 
     if (IS_VOID(out) and not any)
         fail (Error_Need_Non_Void_Core(source_orig, specifier, out));
+
+    if (not any)  // default to not letting NULL-2 out unless /ANY is used
+        Decay_If_Nulled(out);
 }
 
 
@@ -1666,6 +1669,55 @@ REBNATIVE(null_q)
     INCLUDE_PARAMS_OF_NULL_Q;
 
     return Init_Logic(D_OUT, IS_NULLED(ARG(optional)));
+}
+
+
+//
+//  null-2: native [
+//
+//  {Make the heavy form of NULL (can't be WORD!-fetched, must be ACTION!)}
+//
+//      return: [<opt>]
+//  ]
+//
+REBNATIVE(null_2) {
+    INCLUDE_PARAMS_OF_NULL_2;
+
+    return Init_Heavy_Nulled(D_OUT);
+}
+
+
+//
+//  null-2?: native [
+//
+//  "Tells you if the argument is the heavy isotope of NULL (triggers THEN)"
+//
+//      return: [logic!]
+//      optional [<opt> any-value!]
+//  ]
+//
+REBNATIVE(null_2_q)
+{
+    INCLUDE_PARAMS_OF_NULL_2_Q;
+
+    return Init_Logic(D_OUT, Is_Heavy_Nulled(ARG(optional)));
+}
+
+
+//
+//  isotope?: native [
+//
+//  {Determine if a NULL is an isotope}
+//
+//      return: [logic!]
+//      var [word!]
+//  ]
+//
+REBNATIVE(isotope_q) {
+    INCLUDE_PARAMS_OF_ISOTOPE_Q;
+
+    const REBVAL *var = Lookup_Word_May_Fail(ARG(var), SPECIFIED);
+    return Init_Logic(D_OUT, Is_Heavy_Nulled(var));
 }
 
 

--- a/src/core/n-error.c
+++ b/src/core/n-error.c
@@ -114,9 +114,6 @@ REBNATIVE(entrap)
 {
     INCLUDE_PARAMS_OF_ENTRAP;
 
-    if (IS_BLOCK(ARG(code)))
-        Symify(ARG(code));  // request that branch is not voidified
-
     REB_R error = rebRescue(cast(REBDNG*, &Entrap_Dangerous), frame_);
     UNUSED(ARG(code)); // gets used by the above call, via the frame_ pointer
 

--- a/src/include/datatypes/sys-void.h
+++ b/src/include/datatypes/sys-void.h
@@ -87,29 +87,6 @@ inline static bool Is_Void_With_Sym(unstable const RELVAL *v, REBSYM sym) {
 }
 
 
-// Many loop constructs use BLANK! as a unique signal that the loop body
-// never ran, e.g. `for-each x [] [<unreturned>]` or `loop 0 [<unreturned>]`.
-// It's more valuable to have that signal be unique and have it be falsey
-// than it is to be able to return BLANK! from a loop, so blanks are voidified
-// alongside NULL (reserved for BREAKing)
-//
-inline static REBVAL *Voidify_If_Nulled_Or_Blank(unstable_ok REBVAL *cell) {
-    if (IS_NULLED(cell))
-        Init_Void(cell, SYM_NULLED);
-    else if (IS_BLANK(cell))
-        Init_Void(cell, SYM_BLANKED);
-    return cell;
-}
-
-#ifdef DEBUG_UNSTABLE_CELLS
-    inline static unstable REBVAL *Voidify_If_Nulled_Or_Blank(
-        unstable REBVAL *cell
-    ){
-        return Voidify_If_Nulled_Or_Blank(STABLE(cell));
-    }
-#endif
-
-
 #if !defined(DEBUG_UNREADABLE_VOIDS)  // release behavior, same as plain VOID!
     #define Init_Unreadable_Void(v) \
         Init_Unlabeled_Void(v)

--- a/src/include/sys-do.h
+++ b/src/include/sys-do.h
@@ -187,7 +187,7 @@ inline static bool Do_Branch_Core_Throws(
     assert(branch != out and condition != out);
 
     enum Reb_Kind kind = VAL_TYPE(branch);
-    bool voidify = not (kind == REB_QUOTED or ANY_SYM_KIND(kind));
+    bool as_is = (kind == REB_QUOTED or ANY_SYM_KIND(kind));
 
   redo:
 
@@ -240,22 +240,21 @@ inline static bool Do_Branch_Core_Throws(
     }
 
     // If we're not returning the branch result purely "as-is" then we change
-    // not just NULL to `~branched~`, but also any other void.  So:
+    // NULL to NULL-2:
     //
     //     >> if true [null]
-    //     == ~branched~
+    //     ; null-2
     //
-    //     >> if true [print "relabeled"]
-    //     test
-    //     == ~branched~
+    // To get things to pass through unmodified, you have to use the @ forms:
     //
-    // To get the original void label, you have to use the @ forms:
+    //     >> if true @[null]
+    //     ; null
     //
-    //     >> if true @[print "not relabeled"]
-    //     == ~void~  ; specific void result of PRINT
+    // The corollary is that RETURN will strip off the isotope status of
+    // values unless the RETURN @(...) form is used.
     //
-    if (voidify and IS_NULLED_OR_VOID(out))
-        Init_Void(out, SYM_BRANCHED);
+    if (not as_is)
+        Isotopify_If_Nulled(out);
 
     return false;
 }

--- a/src/mezz/base-constants.r
+++ b/src/mezz/base-constants.r
@@ -59,6 +59,8 @@ abs: :absolute
 ; Note: NULL symbol is in lib context slot 1, is initialized on boot
 blank: _   ; e.g. sometimes `return blank` reads better than `return _`
 
+null-1?: :else?
+
 ; Note: VOID would have to be a function that returned ~void~, since plain
 ; `void: ~void~` would error on access.  In practice, this causes confusion
 ; because `type of get/any 'void` winds up being ACTION!...and that isn't

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -601,7 +601,7 @@ print: func* [
         return write-stdout line
     ]
 
-    (write-stdout try spaced line) then @[write-stdout newline]
+    (write-stdout try spaced line) then [write-stdout newline]
 ]
 
 

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -72,15 +72,15 @@ description-of: function [
     v [<blank> any-value!]
 ][
     switch type of get/any 'v [
-        void! @[null]  ; don't voidify, want actual NULL
+        void! [null]
         any-array! [spaced ["array of length:" length of v]]
         image! [spaced ["size:" v/size]]
-        datatype! @[
+        datatype! [
             spec: ensure object! spec of v  ; "type specs" need simplifying
             opt copy spec/title
         ]
-        action! @[  ; want null when IF doesn't match
-            if meta: meta-of :v @[
+        action! [
+            if meta: meta-of :v [
                 opt copy get 'meta/description  ; can be BLANK!
             ]
         ]
@@ -113,8 +113,7 @@ help: function [
     if undefined? 'topic [
         ;
         ; !!! This should lead to a web page that offers help on the nature
-        ; of specific void usages, e.g. to explain what ~branched~ is and
-        ; how to use @[...] branches to avoid it.
+        ; of specific void usages.
         ;
         print [mold get/any 'topic "is a literal VOID! value"]
         return

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -450,7 +450,7 @@ collect*: func [
             f [frame!]
             <with> out
         ][
-            (get/any 'f/value) then @[  ; null won't run block (not collected)
+            (get/any 'f/value) then [  ; null won't run block (not collected)
                 f/series: out: default [make block! 16]  ; no null return now
                 get/any 'f/value  ; ELIDE leaves as result
                 elide do f  ; would invalidate f/value (hence ELIDE)

--- a/tests/control/all.test.reb
+++ b/tests/control/all.test.reb
@@ -354,5 +354,5 @@
 (15 = all .not.even? [1 + 2, 3 + 4 5 + 6, 7 + 8,])
 
 (_ = all .not [false null _])
-(~all~ = all .not [false _ null])
+(null-2? all .not [false _ null])
 ("this is why" = all .not [false _ null] then ["this is why"])

--- a/tests/control/any.test.reb
+++ b/tests/control/any.test.reb
@@ -356,5 +356,5 @@
 (10 = any .not.odd? [1 + 2, 3 + 4 comment "No Comma" 5 + 5, 6 + 7])
 
 (_ = any .not [1 _ 2])
-(~any~ = any .not [1 null 2])
+(null-2? any .not [1 null 2])
 ("this is why" = any .not [1 null 2] then ["this is why"])

--- a/tests/control/either.test.reb
+++ b/tests/control/either.test.reb
@@ -10,11 +10,11 @@
 (1 = either true [1] [2])
 (2 = either false [1] [2])
 
-(void? either true [null] [1])
-(void? either false [1] [null])
+(null-2? either true [null] [1])
+(null-2? either false [1] [null])
 
-(null? either true @[null] [1])
-(null? either false [1] @[null])
+(null-1? either true @[null] [1])
+(null-1? either false [1] @[null])
 
 (error? either true [trap [1 / 0]] [])
 (error? either false [] [trap [1 / 0]])

--- a/tests/control/every.test.reb
+++ b/tests/control/every.test.reb
@@ -47,4 +47,4 @@
     ]
 )
 
-(_ = every x [] [<unused>])
+(null-2? every x [] [<unused>])

--- a/tests/control/if.test.reb
+++ b/tests/control/if.test.reb
@@ -80,7 +80,7 @@
 
 ; recursive behaviour
 
-(void? if true [if false [1]])
+(null-2? if true [if false [1]])
 (1 = if true [if true [1]])
 
 ; infinite recursion

--- a/tests/control/loop.test.reb
+++ b/tests/control/loop.test.reb
@@ -83,7 +83,7 @@
 ; leave the gathered material in the mold buffer
 ;
 (
-    void? loop 2 [unspaced ["abc" continue]]
+    null-2? loop 2 [unspaced ["abc" continue]]
 )
 
 ; Test ACTION! as branch
@@ -91,7 +91,7 @@
 [
     (did branch: does [if nbreak = n [break] n: n + 1])
 
-    (nbreak: ('...), n: 0, blank? loop 0 :branch)
+    (nbreak: ('...), n: 0, null-2? loop 0 :branch)
     (nbreak: ('...), n: 0, 3 = loop 3 :branch)
     (nbreak: 2, n: 0, null? loop 3 :branch)
 ]

--- a/tests/control/reduce.test.reb
+++ b/tests/control/reduce.test.reb
@@ -11,7 +11,7 @@
 [#1760 ; unwind functions should stop evaluation
     (null? loop 1 [reduce [break]])
 ]
-(void? loop 1 [reduce [continue]])
+(null-2? loop 1 [reduce [continue]])
 (1 = catch [reduce [throw 1]])
 ([a 1] = catch/name [reduce [throw/name 1 'a]] 'a)
 (1 = reeval func [] [reduce [return 1 2] 2])

--- a/tests/control/while.test.reb
+++ b/tests/control/while.test.reb
@@ -9,7 +9,7 @@
     num: 0
     1 = while [num < 1] [num: num + 1]
 )]
-(blank? while [false] [])
+(null-2? while [false] [])
 ; zero repetition
 (
     success: true

--- a/tests/datatypes/null.test.reb
+++ b/tests/datatypes/null.test.reb
@@ -33,3 +33,37 @@
     e: trap [form null]
     'arg-required = e/id
 )
+
+; There are two "isotopes" of NULL (NULL-1 and NULL-2).
+; Both answer to being NULL?  A variable assigned with NULL-2 will decay
+; to a regular NULL when accessed via a WORD!/GET-WORD!/etc.
+;
+; The specific role of NULL-2 is to be reactive with THEN and not ELSE, so
+; that branches may be purposefully NULL.
+[
+    (null? null)
+    (null? null-2)
+    (null-1? null)
+    (null-2? null-2)
+
+    (x: null-2, null-1? x)
+    (x: null-2, null-1? :x)
+
+    (304 = (null then [1020] else [304]))
+    (1020 = (null-2 then [1020] else [304]))
+]
+
+; Conditionals return NULL-1 on failure, and NULL-2 on a branch that executes
+; and evaluates to either NULL-1 or NULL-2.  If the branch wishes to pass
+; the null "as-is" it should use the @ forms.
+[
+    (null-2? if true [null])
+    (null-2? if true [null-2])
+    (~ = if true [])
+    (~custom~ = if true [~custom~])
+
+    (null-1? if true @[null])
+    (null-2? if true @[null-2])
+    (~ = if true @[])
+    (~custom~ = if true @[~custom~])
+]

--- a/tests/datatypes/void.test.reb
+++ b/tests/datatypes/void.test.reb
@@ -73,19 +73,6 @@
     (null = cycle [break])
 ]
 
-; ~branched~ is used both as a way to give conditionals whose branches yield
-; NULL a non-null result, as well as a "relabeling" of voids that are in
-; the branch.  To avoid the relabeling, use the @ forms of branch.
-[
-    (~branched~ = if true [null])
-    (~branched~ = if true [])
-    (~branched~ = if true [~overwritten~])
-
-    (null = if true @[null])
-    (~ = if true @[])
-    (~untouched~ = if true @[~untouched~])
-]
-
 ; ~quit~ is the label of the VOID! you get by default from QUIT
 ; Note: DO of BLOCK! does not catch quits, so TEXT! is used here.
 [

--- a/tests/functions/oneshot.test.reb
+++ b/tests/functions/oneshot.test.reb
@@ -16,5 +16,5 @@
     ]
 )(
     once: oneshot
-    void? once [null]
+    null-2? once [null]
 )


### PR DESCRIPTION
Historically there has been a struggle over the potential conflation of
NULL as a special signal ("no branch ran", "loop encountered a BREAK")
and "branch/body evaluated to null".

The "simple" technique used to help distinguish these cases was to
reserve NULL for the signal, and mutate any branch or body result to
a VOID! value so it would not collide:

    >> if false [<whatever>]
    ; null

    >> if true [null]
    == ~branched~

This was known as voidification, and it successfully avoided the
behavior of inadvertently running a branch along with an ELSE clause:

    >> if true [print "branch", null] else [print "this shouldn't run"]
    branch
    == ~branched~

However, it caused collateral damage to the return result.  The
answer given for users who did not want voidification applied was to
mark branches "as-is" using @:

    >> if true @[null]
    ; null

Despite the availability of a workaround, every branch usage in the
system wound up paying a tax for the feature.  A new approach was
sought, and ultimately found...which builds on the old ideas.

The new concept of "NULL ISOTOPES" means there are two versions of
NULL, where most users need not worry which version they are using.
Basically wherever a voidification would have occurred before, a
NULL is canonized as the "heavy" version (NULL-2) that will trigger
a THEN but not an ELSE:

    >> if false [<whatever>]
    ; null

    >> if true [null]
    ; null-2

    >> null? if true [null]
    == #[true]  ; NULL-2 answers true to NULL?

    >> if true [null] else [print "ELSE not triggered"]
    ; null-2

The NULL-2 "isotope" undergoes "radioactive decay" to the common form,
when fetched from a variable.

    >> x: if true [null]
    ; null-2

    >> x
    ; null

It also cannot escape a function unless the "as-is" form of return is
used:

    >> foo: func [] [return null-2]
    >> foo
    ; null

    >> bar: func [] [return @(null-2)]
    >> bar
    ; null-2

This means casual users who are not writing control constructs that
may need to distinguish NULL-from-code and NULL-as-signal should not
be bothered by it.  All their NULLs will be signal NULLs unless they
wish to get otherwise involved.