### PR TITLE
Simplistic combinator-based COLLECT+KEEP in UPARSE

### DIFF
--- a/tests/parse/uparse.test.reb
+++ b/tests/parse/uparse.test.reb
@@ -65,3 +65,32 @@
         i = 1020
     ]
 )
+
+; COLLECT is currently implemented to conspire with the BLOCK! combinator to
+; do rollback between its alternates.  But since anyone can write combinators
+; that do alternates (in theory), those would have to participate in the
+; protocol of rollback too.
+;
+; Test the very non-generic rollback mechanism.  The only two constructs that
+; do any rollback are BLOCK! and COLLECT itself.
+[(
+    x: <before>
+    did all [
+        uparse [1 2] [x: collect [
+            keep integer! keep tag! | keep integer! keep integer!
+        ]]
+        x = [1 2]
+    ]
+)(
+    x: <before>
+    did all [  ; semi-nonsensical use of BETWEEN just because it takes 2 rules
+        uparse "(abc)" [x: collect between keep "(" keep ")"]
+        x = ["(" ")"]
+    ]
+)(
+    x: <before>
+    did all [  ; semi-nonsensical use of BETWEEN just because it takes 2 rules
+        not uparse "(abc}" [x: collect between keep "(" keep ")"]
+        x = <before>
+    ]
+)]


### PR DESCRIPTION
The combinator-based approach to parsing breaks each parse keyword or
datatype behavior out into a "parser function".

This is a simple implementation of COLLECT and KEEP combinators that
collaborate with the BLOCK! combinator to do rollback.  It would be
preferable to have some kind of "generic rollback facility", but this
is more or less what the C code was doing to implement the feature.

The PARSE as a whole maintains a block that it collects, and marks the
high-water point on each block recursion...so that if an alternate
fails it just drops the mark down.