### PR TITLE
Save parse position with POS: HERE, seek with SEEK POS

### DIFF
--- a/extensions/uuid/make-libuuid.reb
+++ b/extensions/uuid/make-libuuid.reb
@@ -42,7 +42,7 @@ comment-out-includes: [
             ] (insert pos {//} pos: skip pos 2)
             | skip
         ] (pos: skip pos 8)
-    ] :pos
+    ] seek pos
 ]
 
 

--- a/scripts/encap.reb
+++ b/scripts/encap.reb
@@ -267,9 +267,9 @@ elf-format: context [
 
         parse skip executable e_phoff [
             e_phnum [
-                (mode: 'read) pos: program-header-rule
+                (mode: 'read) pos: here, program-header-rule
                 (if p_offset >= offset [p_offset: p_offset + delta])
-                (mode: 'write) :pos program-header-rule
+                (mode: 'write) seek pos, program-header-rule
             ]
             to end
         ] else [
@@ -281,9 +281,9 @@ elf-format: context [
         let pos
         parse skip executable e_shoff [
             e_shnum [
-                (mode: 'read) pos: section-header-rule
+                (mode: 'read) pos: here, section-header-rule
                 (if sh_offset >= offset [sh_offset: sh_offset + delta])
-                (mode: 'write) :pos section-header-rule
+                (mode: 'write) seek pos, section-header-rule
             ]
             to end
         ] else [
@@ -407,12 +407,12 @@ elf-format: context [
             ; Update string table size in its corresponding header.
             ;
             parse skip executable string-header-offset [
-                (mode: 'read) pos: section-header-rule
+                (mode: 'read) pos: here, section-header-rule
                 (
                     assert [sh_offset = string-section-offset]
                     sh_size: sh_size + (1 + length of encap-section-name)
                 )
-                (mode: 'write) :pos section-header-rule
+                (mode: 'write) seek pos, section-header-rule
                 to end
             ] else [
                 fail "Error updating string table size in string header"
@@ -662,7 +662,7 @@ pe-format: context [
             | #{6602} (machine: 'MIPS16)
         ]
         u16-le (machine-value: u16)
-        pos: u16-le (
+        pos: here, u16-le (
             number-of-sections: u16
             number-of-sections-offset: (index of pos) - 1
         )
@@ -706,8 +706,10 @@ pe-format: context [
         u16-le (major-subsystem-version: u16)
         u16-le (minor-subsystem-version: u16)
         u32-le (win32-version-value: u32)
-        pos: u32-le (image-size: u32
-                image-size-offset: (index of pos) - 1)
+        pos: here, u32-le (
+            image-size: u32
+            image-size-offset: (index of pos) - 1
+        )
         u32-le (size-of-headers: u32)
         u32-le (checksum: u32)
         and [
@@ -724,7 +726,7 @@ pe-format: context [
             | #{1300} (subsystem: 'EFI-ROM)
             | #{1400} (subsystem: 'Xbox)
             | #{1600} (subsystem: 'Windows-Boot-application)
-            | fail-at: (err: 'unrecoginized-subsystem) fail
+            | fail-at: here, (err: 'unrecoginized-subsystem), false
         ]
         u16-le (subsystem-value: u16)
         u16-le (dll-characteristics: u16)
@@ -760,15 +762,16 @@ pe-format: context [
     end-of-section-header: _
 
     exe-rule: [
-        DOS-header-rule pos: (garbage: DOS-header/e-lfanew + 1 - index of pos)
+        DOS-header-rule
+        pos: here, (garbage: DOS-header/e-lfanew + 1 - index of pos)
         garbage skip
         PE-header-rule
         COFF-header-rule
         PE-optional-header-rule
         PE-optional-header/number-of-RVA-and-sizes data-directory-rule
-        start-of-section-header:
+        start-of-section-header: here
         COFF-header/number-of-sections section-rule
-        end-of-section-header:
+        end-of-section-header: here
 
         ; !!! stop here, no END ?
     ]

--- a/scripts/unzip.reb
+++ b/scripts/unzip.reb
@@ -337,7 +337,7 @@ ctx-zip: context [
         num-entries: 0
         parse source [some [
             to central-file-sig 4 skip
-            central-header:
+            central-header: here
             [
                 ; check coerence between central file header
                 ; and local file header
@@ -393,7 +393,7 @@ ctx-zip: context [
                     (compressed-size: get-ilong compressed-size)
                 copy uncompressed-size-raw: 4 skip
                     (uncompressed-size: get-ilong uncompressed-size-raw)
-                :local-header
+                seek local-header
                 local-file-sig
                 2 skip ; version
                 copy tmp: 2 skip
@@ -413,7 +413,7 @@ ctx-zip: context [
                 copy tmp: name-length skip
                 (assert [name = to-file tmp])
                 extrafield-length skip
-                data: compressed-size skip
+                data: here, compressed-size skip
                 (
                     uncompressed-data: catch [
 

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -199,7 +199,7 @@ split-path: func [
     pos: _
     parse target [
         [#"/" | 1 2 #"." opt #"/"] end (dir: dirize target) |
-        pos: any [thru #"/" [end | pos:]] (
+        pos: here, any [thru #"/" [end | pos: here]] (
             all [
                 empty? dir: copy/part target (at head of target index of pos),
                 dir: %./

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -176,7 +176,7 @@ func: func* [
             )
         ])
     |
-        other:
+        other: here
         group! (
             if not var [
                 fail [

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -269,7 +269,7 @@ trim: function [
             remove [any LF]
 
             (indent: 0)
-            s: some rule e:
+            s: here, some rule, e: here
             (indent: (index of e) - (index of s))
 
             end

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -225,7 +225,7 @@ reword: function [
         make typeset! [char! any-string! integer! word! binary!]
     )
 ][
-    case_REWORD: case
+    case_REWORD: if case [/case]
     case: :lib/case
 
     out: make (type of source) length of source
@@ -319,10 +319,10 @@ reword: function [
     ]
 
     rule: [
-        a:  ; Begin marking text to copy verbatim to output
+        a: here  ; Begin marking text to copy verbatim to output
         any [
             to prefix  ; seek to prefix (may be blank!, this could be a no-op)
-            b:  ; End marking text to copy verbatim to output
+            b: here  ; End marking text to copy verbatim to output
             prefix  ; consume prefix (if no-op, may not be at start of match)
             [
                 [
@@ -343,7 +343,7 @@ reword: function [
                             :v
                         ]
                     )
-                    a:  ; Restart mark of text to copy verbatim to output
+                    a: here  ; Restart mark of text to copy verbatim to output
                 ]
                     |
                 skip  ; if wasn't at match, keep the ANY rule scanning ahead
@@ -639,7 +639,7 @@ split: function [
             ;
 
             [
-                any [mk1: while [mk2: [dlm | end] break | skip] (
+                any [mk1: here, while [mk2: here, [dlm | end] break | skip] (
                     keep/only copy/part mk1 mk2
                 )]
                 end

--- a/tests/comparison/sameq.test.reb
+++ b/tests/comparison/sameq.test.reb
@@ -117,7 +117,7 @@
     ; https://forum.rebol.info/t/1084
     (
         a-value: first [a/b]
-        parse as block! :a-value [b-value: end]
+        parse as block! :a-value [b-value: here, end]
         same? as block! :a-value :b-value
     )
 ]
@@ -127,13 +127,13 @@
 (equal? same? [] blank same? blank [])
 [#1068 #1066 (
     a-value: first [()]
-    parse a-value [b-value: end]
+    parse a-value [b-value: here, end]
     same? a-value b-value
 )]
 ; symmetry
 (
     a-value: first [()]
-    parse a-value [b-value: end]
+    parse a-value [b-value: here, end]
     equal? same? a-value b-value same? b-value a-value
 )
 (not same? any-number! integer!)

--- a/tests/comparison/strict-equalq.test.reb
+++ b/tests/comparison/strict-equalq.test.reb
@@ -119,7 +119,7 @@
 (equal? strict-equal? [] blank strict-equal? blank [])
 [#1068 #1066 (
     a-value: first [()]
-    parse a-value [b-value: end]
+    parse a-value [b-value: here, end]
     strict-equal? a-value b-value
 )]
 (not strict-equal? any-number! integer!)

--- a/tests/context/virtual-bind.test.reb
+++ b/tests/context/virtual-bind.test.reb
@@ -27,7 +27,7 @@
     make-rule: func [/make-rule] [  ; refinement helps recognize in C Probe()
         use [rule position][
             rule: compose/deep [
-                [[position: "a"]]
+                [[position: here, "a"]]
             ]
             use [x] compose/deep [
                 [(as group! rule) rule]

--- a/tests/parse/parse.test.reb
+++ b/tests/parse/parse.test.reb
@@ -86,31 +86,31 @@
 ; SET-WORD! (store current input position)
 
 (
-    res: did parse ser: [x y] [pos: skip skip]
+    res: did parse ser: [x y] [pos: here, skip, skip]
     all [res, pos = ser]
 )
 (
-    res: did parse ser: [x y] [skip pos: skip]
+    res: did parse ser: [x y] [skip, pos: here, skip]
     all [res, pos = next ser]
 )
 (
-    res: did parse ser: [x y] [skip skip pos:]
+    res: did parse ser: [x y] [skip, skip, pos: here]
     all [res, pos = tail of ser]
 )
 [#2130 (
-    res: did parse ser: [x] [set val pos: word!]
+    res: did parse ser: [x] [pos: here, set val word!]
     all [res, val = 'x, pos = ser]
 )]
 [#2130 (
-    res: did parse ser: [x] [set val: pos: word!]
+    res: did parse ser: [x] [pos: here, set val: word!]
     all [res, val = 'x, pos = ser]
 )]
 [#2130 (
-    res: did parse ser: "foo" [copy val pos: skip]
+    res: did parse ser: "foo" [pos: here, copy val skip]
     all [not res, val = "f", pos = ser]
 )]
 [#2130 (
-    res: did parse ser: "foo" [copy val: pos: skip]
+    res: did parse ser: "foo" [pos: here, copy val: skip]
     all [not res, val = "f", pos = ser]
 )]
 
@@ -194,8 +194,8 @@
 [#1267 (
     b: "abc"
     c: ["a" | "b"]
-    a2: [any [b e: (d: [:e]) then fail | [c | (d: [fail]) fail]] d]
-    a4: [any [b then e: (d: [:e]) fail | [c | (d: [fail]) fail]] d]
+    a2: [any [b, e: here, (d: [seek e]) then fail | [c | (d: [fail]) fail]] d]
+    a4: [any [b then e: here (d: [seek e]) fail | [c | (d: [fail]) fail]] d]
     equal? parse "aaaaabc" a2 parse "aaaaabc" a4
 )]
 
@@ -269,12 +269,12 @@
 ; PATH! cannot be PARSE'd due to restrictions of the implementation
 (
     a-value: first [a/b]
-    parse as block! a-value [b-value:]
+    parse as block! a-value [b-value: here]
     a-value = to path! b-value
 )
 (
     a-value: first [()]
-    parse a-value [b-value:]
+    parse a-value [b-value: here]
     same? a-value b-value
 )
 

--- a/tests/source/source-tools.reb
+++ b/tests/source/source-tools.reb
@@ -163,7 +163,7 @@ rebsource: context [
 
                 malloc-found: copy []
 
-                malloc-check: [
+                malloc-check: here, [
                     and identifier "malloc" (
                         append malloc-found try text-line-of position
                     )
@@ -171,7 +171,7 @@ rebsource: context [
 
                 parse/case data [
                     some [
-                        position:
+                        position: here
                         malloc-check
                         | c-pp-token
                     ]
@@ -325,7 +325,7 @@ rebsource: context [
                     ]
                     line: 1 + line
                 )
-                bol:
+                bol: here
             ]
 
             tabbed: copy []
@@ -336,13 +336,16 @@ rebsource: context [
 
             parse/case data [
 
-                last-pos:
+                last-pos: here
 
-                opt [bol: skip (line: 1) :bol]
+                opt [
+                    bol: here, skip (line: 1)
+                    seek :bol  ; !!! GET-WORD! for bootstrap (SEEK is no-op)
+                ]
 
                 any [
                     to stop-char
-                    position:
+                    position: here
                     [
                         eol count-line
                         | #"^-" (append tabbed line)
@@ -352,7 +355,7 @@ rebsource: context [
                         | skip
                     ]
                 ]
-                position:
+                position: here
 
                 to end
             ]

--- a/tests/test-parsing.r
+++ b/tests/test-parsing.r
@@ -33,7 +33,7 @@ make object! [
 
     set 'test-source-rule [
         any [
-            position:
+            position: here
 
             ["{" | {"}] (  ; handle string using TRANSCODE
                 success-rule: trap [
@@ -41,11 +41,11 @@ make object! [
                 ] then [
                     [end skip]
                 ] else [
-                    [:position]
+                    [seek position]
                 ]
             ) success-rule
                 |
-            ["{" | {"}] :position break
+            ["{" | {"}] seek position, break
                 |
             "[" test-source-rule "]"  ; plain BLOCK! in code for a test
                 |
@@ -58,9 +58,9 @@ make object! [
             ; too far".  It's either a syntax error, or the closing bracket of
             ; a multi-test block.
             ;
-            "]" :position break
+            "]", seek position, break
                 |
-            ")" :position break
+            ")", seek position, break
                 |
             skip
         ]
@@ -166,7 +166,7 @@ make object! [
         ]
 
         token: [
-            position:
+            position: here
 
             (type: value: _)
 
@@ -195,14 +195,14 @@ make object! [
         ]
 
         emit-token: [
-            token-end: (
+            token-end: here, (
                 comment [
                     prin "emit: " probe compose [
                         (type) (to text! copy/part position token-end)
                     ]
                 ]
             )
-            position: (type: value: _)
+            position: here, (type: value: _)
         ]
 
         rule: [any token]
@@ -275,7 +275,7 @@ make object! [
                     (fail "collect-logs - log file parsing problem")
                 ] position: guard break ; Break when error detected.
                     |
-                :position
+                seek position
             ]
             end
         ]

--- a/tools/common-parsers.r
+++ b/tools/common-parsers.r
@@ -295,8 +295,10 @@ rewrite-if-directives: function [
                     change ["#if" thru newline "#endif" thru newline] ""
                     | change ["#elif" thru newline "#endif"] "#endif"
                     | change ["#else" thru newline "#endif"] "#endif"
-                ] (rewritten: true) :position
-                | thru newline
+                ] (rewritten: true)
+                seek :position  ; GET-WORD! for bootstrap (SEEK is no-op)
+
+              | thru newline
             ]
             end
         ]

--- a/tools/parsing-tools.reb
+++ b/tools/parsing-tools.reb
@@ -18,6 +18,8 @@ REBOL [
     }
 ]
 
+seek: []  ; Temporary measure, SEEK as no-op in bootstrap
+here: []  ; Temporary measure, HERE as no-op in bootstrap
 
 parsing-at: func [
     {Defines a rule which evaluates a block for the next input position, fails otherwise.}
@@ -32,10 +34,10 @@ parsing-at: func [
             block: compose/deep [try if not tail? (word) [((block))]]
         ]
         block: compose/deep [
-            result: either position: ((block)) [[:position]] [[end skip]]
+            result: either position: ((block)) [[seek :position]] [[end skip]]
         ]
         use compose [(word)] compose/deep [
-            [(as set-word! :word) (as group! block) result]
+            [(as set-word! :word) here (as group! block) result]
         ]
     ]
 ]

--- a/tools/text-lines.reb
+++ b/tools/text-lines.reb
@@ -20,7 +20,12 @@ decode-lines: function [
 ] [
     pattern: compose/only [(line-prefix)]
     if not empty? indent [append pattern compose/only [opt (indent)]]
-    line: [pos: pattern rest: (rest: remove/part pos rest) :rest thru newline]
+    line: [
+        pos: here pattern rest: here
+        (rest: remove/part pos rest)
+        seek :rest  ; GET-WORD! for bootstrap (SEEK is no-op)
+        thru newline
+    ]
     parse text [any line end] else [
         fail [
             {Expected line} (try text-line-of text pos)
@@ -45,8 +50,11 @@ encode-lines: func [
     bol: join line-prefix indent
     parse text [
         any [
-            thru newline pos:
-            [newline (pos: insert pos line-prefix) | (pos: insert pos bol)] :pos
+            thru newline pos: here
+            [
+                newline (pos: insert pos line-prefix)
+              | (pos: insert pos bol)
+            ] seek :pos  ; GET-WORD! for bootstrap (SEEK is no-op)
         ]
         end
     ]
@@ -107,8 +115,8 @@ lines-exceeding: function [  ; !!! Doesn't appear used, except in tests (?)
     ]
 
     parse text [
-        any [bol: to newline eol: skip count-line]
-        bol: skip to end eol: count-line
+        any [bol: here to newline eol: here skip count-line]
+        bol: here skip to end eol: here count-line
         end
     ]
 
@@ -131,7 +139,7 @@ text-line-of: function [
 
     parse text [
         any [
-            to newline cursor:
+            to newline cursor: here
 
             ; IF deprecated in Ren-C, but :(...) with logic not available
             ; in the bootstrap build.
@@ -161,7 +169,7 @@ text-location-of: function [
     idx: index of position
     line: 0
 
-    advance: [eol: skip (line: line + 1)]
+    advance: [eol: here skip (line: line + 1)]
 
     parse text [
         any [


### PR DESCRIPTION
This is a small step toward broadening the applications of SET-WORD!
and GET-WORD! in the parse dialect.  The idea is that SET-WORD! will
be used for capturing more than just parse positions, so the general
purpose HERE rule can be used in the case that the parse position is
what you want.

If you use a lone SET-WORD! without HERE after it, the near-term
behavior for that will be to raise an error at the offending location.
So long as you are updating, consider how commas might make the
rules more readable, e.g.

     pos: any [integer! | text!]
     =>
     pos: here, any [integer! | text!]

That case is a good example showing the immediate readability benefits
the change brings.  What it ultimately is intended for--however--is
to broaden the application of SET-WORD! in the dialect as a whole.

The analogous change for GET-WORD! behavior is now to use SEEK.

     :pos any [integer! | text!]
     =>
     seek pos, any [integer! | text!]

This offers an immediate benefit in clarity as well.  But also, it
means that GET-WORD! can find a more general use in PARSE as well.

Compatibility with the old PARSE rules is being pursued in the UPARSE
implementation.  This will be used with Redbol...although conceivably
it could apply to anyone else who wanted to twist the meanings of
SET-WORD! or GET-WORD!.